### PR TITLE
refactor(order): improve validation, performance, and code organization

### DIFF
--- a/apps/api/src/order/dto/order-preview.dto.ts
+++ b/apps/api/src/order/dto/order-preview.dto.ts
@@ -70,13 +70,19 @@ export class OrderPreviewDto {
   estimatedFee: number;
 
   @ApiProperty({
+    description: 'Fee rate as decimal (e.g., 0.001 for 0.1%)',
+    example: 0.001
+  })
+  feeRate: number;
+
+  @ApiProperty({
     description: 'Fee currency symbol',
     example: 'USDT'
   })
   feeCurrency: string;
 
   @ApiProperty({
-    description: 'Total required (cost + fees)',
+    description: 'Total required (cost + fees for BUY, cost for SELL)',
     example: 5005.0
   })
   totalRequired: number;
@@ -114,16 +120,32 @@ export class OrderPreviewDto {
   priceDeviation?: number;
 
   @ApiProperty({
+    description: 'Estimated slippage for market orders (percentage)',
+    example: 0.05,
+    required: false
+  })
+  estimatedSlippage?: number;
+
+  @ApiProperty({
     description: 'Warning messages about the order',
     type: [String],
     example: ['Price is 5% above market price'],
-    required: false
+    default: []
   })
-  warnings?: string[];
+  warnings: string[];
 
   @ApiProperty({
     description: 'Exchange where the order will be executed',
     example: 'binance_us'
   })
   exchange: string;
+
+  @ApiProperty({
+    description: 'Order types supported by this exchange',
+    type: [String],
+    enum: OrderType,
+    example: [OrderType.MARKET, OrderType.LIMIT],
+    required: false
+  })
+  supportedOrderTypes?: OrderType[];
 }

--- a/apps/api/src/order/dto/place-manual-order.dto.ts
+++ b/apps/api/src/order/dto/place-manual-order.dto.ts
@@ -1,15 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import {
-  IsEnum,
-  IsNotEmpty,
-  IsNumber,
-  IsOptional,
-  IsString,
-  IsUUID,
-  Min,
-  ValidateIf
-} from 'class-validator';
+import { IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, Min, ValidateIf } from 'class-validator';
 
 import { OrderSide, OrderType, TrailingType } from '../order.entity';
 
@@ -103,22 +94,22 @@ export class PlaceManualOrderDto {
   trailingType?: TrailingType;
 
   @ValidateIf((o) => o.orderType === OrderType.TAKE_PROFIT || o.orderType === OrderType.OCO)
-  @IsOptional()
+  @IsNotEmpty({ message: 'Take profit price is required for TAKE_PROFIT and OCO orders' })
   @IsNumber()
   @Min(0)
   @ApiProperty({
-    description: 'Take profit price (optional for TAKE_PROFIT, required for OCO orders)',
+    description: 'Take profit price (required for TAKE_PROFIT and OCO orders)',
     example: 55000.0,
     required: false
   })
   takeProfitPrice?: number;
 
   @ValidateIf((o) => o.orderType === OrderType.OCO)
-  @IsOptional()
+  @IsNotEmpty({ message: 'Stop loss price is required for OCO orders' })
   @IsNumber()
   @Min(0)
   @ApiProperty({
-    description: 'Stop loss price (optional for OCO orders)',
+    description: 'Stop loss price (required for OCO orders)',
     example: 45000.0,
     required: false
   })

--- a/apps/api/src/order/order.service.spec.ts
+++ b/apps/api/src/order/order.service.spec.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { In, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 
 import { OrderDto } from './dto/order.dto';
 import { Order, OrderSide, OrderStatus, OrderType } from './order.entity';
@@ -101,6 +101,22 @@ describe('OrderService', () => {
           }
         },
         {
+          provide: DataSource,
+          useValue: {
+            createQueryRunner: jest.fn().mockReturnValue({
+              connect: jest.fn(),
+              startTransaction: jest.fn(),
+              commitTransaction: jest.fn(),
+              rollbackTransaction: jest.fn(),
+              release: jest.fn(),
+              manager: {
+                create: jest.fn(),
+                save: jest.fn()
+              }
+            })
+          }
+        },
+        {
           provide: ExchangeService,
           useValue: {
             getExchangeById: jest.fn()
@@ -123,7 +139,8 @@ describe('OrderService', () => {
           provide: CoinService,
           useValue: {
             getCoinById: jest.fn(),
-            getCoinBySymbol: jest.fn()
+            getCoinBySymbol: jest.fn(),
+            getMultipleCoinsBySymbol: jest.fn()
           }
         },
         {

--- a/apps/chansey/src/app/shared/services/crypto-trading.service.ts
+++ b/apps/chansey/src/app/shared/services/crypto-trading.service.ts
@@ -5,13 +5,15 @@ import { BehaviorSubject } from 'rxjs';
 
 import {
   Coin,
-  CreateOrderRequest,
+  getExchangeOrderTypeSupport,
   Order,
   OrderPreview,
   OrderSide,
   OrderStatus,
   OrderType,
-  TickerPair
+  PlaceOrderRequest,
+  TickerPair,
+  TrailingType
 } from '@chansey/api-interfaces';
 
 import {
@@ -199,19 +201,21 @@ export class CryptoTradingService {
   }
 
   /**
-   * Create a new order
+   * Create a new order using the manual order endpoint
+   * This is the unified order creation method that uses exchangeKeyId and symbol
    */
   useCreateOrder() {
-    return useAuthMutation<Order, CreateOrderRequest>('/api/order', 'POST', {
+    return useAuthMutation<Order, PlaceOrderRequest>('/api/order/manual', 'POST', {
       invalidateQueries: [tradingKeys.orders, tradingKeys.activeOrders, tradingKeys.balances]
     });
   }
 
   /**
    * Preview an order to calculate fees and validate
+   * Uses the manual preview endpoint for accurate fee calculations
    */
   usePreviewOrder() {
-    return useAuthMutation<OrderPreview, CreateOrderRequest>('/api/order/preview', 'POST');
+    return useAuthMutation<OrderPreview, PlaceOrderRequest>('/api/order/manual/preview', 'POST');
   }
 
   /**
@@ -289,35 +293,141 @@ export class CryptoTradingService {
   // Validation helpers
 
   /**
-   * Validate order parameters
+   * Get supported order types for an exchange using shared configuration
+   * @param exchangeSlug The exchange slug (e.g., 'binanceus', 'coinbase')
    */
-  validateOrder(order: CreateOrderRequest, balance: Balance): { valid: boolean; errors: string[] } {
+  getExchangeSupport(exchangeSlug: string) {
+    return getExchangeOrderTypeSupport(exchangeSlug);
+  }
+
+  /**
+   * Validate order parameters before submission
+   * Returns validation errors if any
+   */
+  validateOrder(
+    order: PlaceOrderRequest,
+    balance: Balance,
+    supportedOrderTypes?: OrderType[]
+  ): { valid: boolean; errors: string[] } {
     const errors: string[] = [];
 
-    // Check if user has sufficient balance
-    const requiredBalance = parseFloat(order.quantity) * (parseFloat(order.price || '0') || 0);
-
-    if (order.side === OrderSide.BUY && balance.available < requiredBalance) {
-      errors.push('Insufficient balance for buy order');
+    // Check if order type is supported
+    if (supportedOrderTypes && !supportedOrderTypes.includes(order.orderType)) {
+      errors.push(`Order type "${order.orderType}" is not supported on this exchange`);
     }
 
-    if (order.side === OrderSide.SELL && balance.available < parseFloat(order.quantity)) {
-      errors.push('Insufficient balance for sell order');
-    }
-
-    // Check minimum order size
-    if (parseFloat(order.quantity) <= 0) {
+    // Check minimum quantity
+    if (order.quantity <= 0) {
       errors.push('Order quantity must be greater than 0');
     }
 
     // Check price for limit orders
-    if (order.type === OrderType.LIMIT && (!order.price || parseFloat(order.price) <= 0)) {
+    if (
+      (order.orderType === OrderType.LIMIT || order.orderType === OrderType.STOP_LIMIT) &&
+      (!order.price || order.price <= 0)
+    ) {
       errors.push('Price must be specified and greater than 0 for limit orders');
+    }
+
+    // Check stop price for stop orders
+    if (
+      (order.orderType === OrderType.STOP_LOSS || order.orderType === OrderType.STOP_LIMIT) &&
+      (!order.stopPrice || order.stopPrice <= 0)
+    ) {
+      errors.push('Stop price must be specified for stop orders');
+    }
+
+    // Check trailing parameters for trailing stop
+    if (order.orderType === OrderType.TRAILING_STOP) {
+      if (!order.trailingAmount || order.trailingAmount <= 0) {
+        errors.push('Trailing amount must be specified for trailing stop orders');
+      }
+      if (!order.trailingType) {
+        errors.push('Trailing type must be specified for trailing stop orders');
+      }
+    }
+
+    // Check OCO parameters
+    if (order.orderType === OrderType.OCO) {
+      if (!order.takeProfitPrice || order.takeProfitPrice <= 0) {
+        errors.push('Take profit price must be specified for OCO orders');
+      }
+      if (!order.stopLossPrice || order.stopLossPrice <= 0) {
+        errors.push('Stop loss price must be specified for OCO orders');
+      }
+    }
+
+    // Check balance for buy orders (rough estimate - server will do precise check)
+    if (order.side === OrderSide.BUY && balance) {
+      const estimatedCost = order.quantity * (order.price || 0);
+      if (estimatedCost > 0 && balance.available < estimatedCost) {
+        errors.push('Insufficient balance for buy order');
+      }
+    }
+
+    // Check balance for sell orders
+    if (order.side === OrderSide.SELL && balance) {
+      if (balance.available < order.quantity) {
+        errors.push('Insufficient balance for sell order');
+      }
     }
 
     return {
       valid: errors.length === 0,
       errors
     };
+  }
+
+  /**
+   * Build a PlaceOrderRequest from form data
+   */
+  buildOrderRequest(
+    exchangeKeyId: string,
+    symbol: string,
+    side: OrderSide,
+    orderType: OrderType,
+    quantity: number,
+    options?: {
+      price?: number;
+      stopPrice?: number;
+      trailingAmount?: number;
+      trailingType?: TrailingType;
+      takeProfitPrice?: number;
+      stopLossPrice?: number;
+      timeInForce?: 'GTC' | 'IOC' | 'FOK';
+    }
+  ): PlaceOrderRequest {
+    const request: PlaceOrderRequest = {
+      exchangeKeyId,
+      symbol,
+      side,
+      orderType,
+      quantity
+    };
+
+    // Add conditional fields based on order type
+    if (options?.price !== undefined) {
+      request.price = options.price;
+    }
+    if (options?.stopPrice !== undefined) {
+      request.stopPrice = options.stopPrice;
+    }
+    if (options?.trailingAmount !== undefined) {
+      request.trailingAmount = options.trailingAmount;
+    }
+    if (options?.trailingType !== undefined) {
+      request.trailingType = options.trailingType;
+    }
+    if (options?.takeProfitPrice !== undefined) {
+      request.takeProfitPrice = options.takeProfitPrice;
+    }
+    if (options?.stopLossPrice !== undefined) {
+      request.stopLossPrice = options.stopLossPrice;
+    }
+    if (options?.timeInForce !== undefined) {
+      request.timeInForce = options.timeInForce as any;
+    }
+
+    return request;
   }
 }

--- a/libs/api-interfaces/src/lib/order/exchange-order-support.ts
+++ b/libs/api-interfaces/src/lib/order/exchange-order-support.ts
@@ -1,0 +1,131 @@
+import { ExchangeOrderTypeSupport, OrderType, TimeInForce } from './order.interface';
+
+/**
+ * Exchange-specific order type support configuration
+ * This is the single source of truth for what order types each exchange supports
+ */
+export const EXCHANGE_ORDER_TYPE_SUPPORT: Record<string, ExchangeOrderTypeSupport> = {
+  binanceus: {
+    exchangeSlug: 'binanceus',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TAKE_PROFIT,
+      OrderType.OCO
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: true,
+    hasTrailingStopSupport: false
+  },
+  binance: {
+    exchangeSlug: 'binance',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TRAILING_STOP,
+      OrderType.TAKE_PROFIT,
+      OrderType.OCO
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: true,
+    hasTrailingStopSupport: true
+  },
+  coinbase: {
+    exchangeSlug: 'coinbase',
+    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  coinbasepro: {
+    exchangeSlug: 'coinbasepro',
+    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  coinbaseexchange: {
+    exchangeSlug: 'coinbaseexchange',
+    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  kraken: {
+    exchangeSlug: 'kraken',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TAKE_PROFIT
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  kucoin: {
+    exchangeSlug: 'kucoin',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TRAILING_STOP
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: true
+  },
+  okx: {
+    exchangeSlug: 'okx',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TRAILING_STOP,
+      OrderType.TAKE_PROFIT
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: true
+  }
+};
+
+/**
+ * Default order type support for unknown exchanges
+ */
+export const DEFAULT_ORDER_TYPE_SUPPORT: ExchangeOrderTypeSupport = {
+  exchangeSlug: 'default',
+  supportedTypes: [OrderType.MARKET, OrderType.LIMIT],
+  supportedTimeInForce: [TimeInForce.GTC],
+  hasOcoSupport: false,
+  hasTrailingStopSupport: false
+};
+
+/**
+ * Get the order type support for a specific exchange
+ */
+export function getExchangeOrderTypeSupport(exchangeSlug: string): ExchangeOrderTypeSupport {
+  return EXCHANGE_ORDER_TYPE_SUPPORT[exchangeSlug] || DEFAULT_ORDER_TYPE_SUPPORT;
+}
+
+/**
+ * Check if an exchange supports a specific order type
+ */
+export function isOrderTypeSupported(exchangeSlug: string, orderType: OrderType): boolean {
+  const support = getExchangeOrderTypeSupport(exchangeSlug);
+  return support.supportedTypes.includes(orderType);
+}
+
+/**
+ * Get the supported order types for a specific exchange
+ */
+export function getSupportedOrderTypes(exchangeSlug: string): OrderType[] {
+  return getExchangeOrderTypeSupport(exchangeSlug).supportedTypes;
+}

--- a/libs/api-interfaces/src/lib/order/index.ts
+++ b/libs/api-interfaces/src/lib/order/index.ts
@@ -1,1 +1,2 @@
 export * from './order.interface';
+export * from './exchange-order-support';

--- a/libs/api-interfaces/src/lib/order/order.interface.ts
+++ b/libs/api-interfaces/src/lib/order/order.interface.ts
@@ -32,6 +32,12 @@ export enum TrailingType {
   PERCENTAGE = 'percentage'
 }
 
+export enum TimeInForce {
+  GTC = 'GTC', // Good Till Canceled
+  IOC = 'IOC', // Immediate Or Cancel
+  FOK = 'FOK' // Fill Or Kill
+}
+
 export interface Order {
   id: string;
   symbol: string;
@@ -96,6 +102,34 @@ export interface TradeExecution {
   takerOrMaker?: string;
 }
 
+/**
+ * Unified order request interface for placing orders
+ * This is the single source of truth for order creation
+ */
+export interface PlaceOrderRequest {
+  // Required fields
+  exchangeKeyId: string;
+  symbol: string;
+  side: OrderSide;
+  orderType: OrderType;
+  quantity: number;
+
+  // Conditional fields based on order type
+  price?: number; // Required for LIMIT, STOP_LIMIT
+  stopPrice?: number; // Required for STOP_LOSS, STOP_LIMIT
+  trailingAmount?: number; // Required for TRAILING_STOP
+  trailingType?: TrailingType; // Required for TRAILING_STOP
+  takeProfitPrice?: number; // Required for OCO
+  stopLossPrice?: number; // Required for OCO
+
+  // Optional fields
+  timeInForce?: TimeInForce;
+}
+
+/**
+ * @deprecated Use PlaceOrderRequest instead
+ * Kept for backward compatibility during migration
+ */
 export interface CreateOrderRequest {
   baseCoinId: string;
   quoteCoinId?: string;
@@ -112,6 +146,10 @@ export interface CreateOrderRequest {
   reduceOnly?: boolean;
 }
 
+/**
+ * @deprecated Use PlaceOrderRequest instead
+ * Kept for backward compatibility during migration
+ */
 export interface PlaceManualOrderRequest {
   exchangeKeyId: string;
   symbol: string;
@@ -128,6 +166,9 @@ export interface PlaceManualOrderRequest {
   timeInForce?: string;
 }
 
+/**
+ * Unified order preview request
+ */
 export interface OrderPreviewRequest {
   exchangeKeyId: string;
   symbol: string;
@@ -158,6 +199,7 @@ export interface OrderPreview {
   trailingType?: TrailingType;
   estimatedCost: number;
   estimatedFee: number;
+  feeRate: number;
   feeCurrency: string;
   totalRequired: number;
   marketPrice?: number;
@@ -165,6 +207,19 @@ export interface OrderPreview {
   balanceCurrency: string;
   hasSufficientBalance: boolean;
   priceDeviation?: number;
-  warnings?: string[];
+  estimatedSlippage?: number;
+  warnings: string[];
   exchange: string;
+  supportedOrderTypes?: OrderType[];
+}
+
+/**
+ * Supported order types per exchange
+ */
+export interface ExchangeOrderTypeSupport {
+  exchangeSlug: string;
+  supportedTypes: OrderType[];
+  supportedTimeInForce: TimeInForce[];
+  hasOcoSupport: boolean;
+  hasTrailingStopSupport: boolean;
 }


### PR DESCRIPTION
## Summary
- **Fix OCO order validation**: Changed `takeProfitPrice` and `stopLossPrice` from `@IsOptional` to required fields with proper `@ValidateIf` conditions and validation messages
- **Add debounce to order preview**: Added 300ms debounce to preview API calls in crypto-trading component to reduce server load
- **Create shared exchange order support config**: Consolidated duplicate exchange order type configuration into single source of truth in `libs/api-interfaces/src/lib/order/exchange-order-support.ts`
- **Batch coin queries**: Reduced N+1 queries in OCO order creation by using `getMultipleCoinsBySymbol()` for batch lookup
- **Update tests**: Added `DataSource` mock for QueryRunner transaction support

## Test plan
- [x] All unit tests pass (142 tests)
- [x] Build succeeds
- [ ] Verify OCO order validation rejects missing `takeProfitPrice`/`stopLossPrice`
- [ ] Verify order preview debounces rapid changes
- [ ] Verify exchange order type support works across frontend/backend