### PR TITLE
feat(order): overhaul order system with manual trading support

### DIFF
--- a/apps/api/src/order/dto/order-preview.dto.ts
+++ b/apps/api/src/order/dto/order-preview.dto.ts
@@ -70,13 +70,19 @@ export class OrderPreviewDto {
   estimatedFee: number;
 
   @ApiProperty({
+    description: 'Fee rate as decimal (e.g., 0.001 for 0.1%)',
+    example: 0.001
+  })
+  feeRate: number;
+
+  @ApiProperty({
     description: 'Fee currency symbol',
     example: 'USDT'
   })
   feeCurrency: string;
 
   @ApiProperty({
-    description: 'Total required (cost + fees)',
+    description: 'Total required (cost + fees for BUY, cost for SELL)',
     example: 5005.0
   })
   totalRequired: number;
@@ -114,16 +120,32 @@ export class OrderPreviewDto {
   priceDeviation?: number;
 
   @ApiProperty({
+    description: 'Estimated slippage for market orders (percentage)',
+    example: 0.05,
+    required: false
+  })
+  estimatedSlippage?: number;
+
+  @ApiProperty({
     description: 'Warning messages about the order',
     type: [String],
     example: ['Price is 5% above market price'],
-    required: false
+    default: []
   })
-  warnings?: string[];
+  warnings: string[];
 
   @ApiProperty({
     description: 'Exchange where the order will be executed',
     example: 'binance_us'
   })
   exchange: string;
+
+  @ApiProperty({
+    description: 'Order types supported by this exchange',
+    type: [String],
+    enum: OrderType,
+    example: [OrderType.MARKET, OrderType.LIMIT],
+    required: false
+  })
+  supportedOrderTypes?: OrderType[];
 }

--- a/apps/api/src/order/dto/place-manual-order.dto.ts
+++ b/apps/api/src/order/dto/place-manual-order.dto.ts
@@ -1,15 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import {
-  IsEnum,
-  IsNotEmpty,
-  IsNumber,
-  IsOptional,
-  IsString,
-  IsUUID,
-  Min,
-  ValidateIf
-} from 'class-validator';
+import { IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, Matches, Min, ValidateIf } from 'class-validator';
 
 import { OrderSide, OrderType, TrailingType } from '../order.entity';
 
@@ -24,6 +15,9 @@ export class PlaceManualOrderDto {
 
   @IsNotEmpty()
   @IsString()
+  @Matches(/^[A-Z0-9]+\/[A-Z0-9]+$/i, {
+    message: 'Symbol must be in trading pair format (e.g., BTC/USDT)'
+  })
   @ApiProperty({
     description: 'Trading pair symbol (e.g., BTC/USDT)',
     example: 'BTC/USDT'
@@ -103,22 +97,22 @@ export class PlaceManualOrderDto {
   trailingType?: TrailingType;
 
   @ValidateIf((o) => o.orderType === OrderType.TAKE_PROFIT || o.orderType === OrderType.OCO)
-  @IsOptional()
+  @IsNotEmpty({ message: 'Take profit price is required for TAKE_PROFIT and OCO orders' })
   @IsNumber()
   @Min(0)
   @ApiProperty({
-    description: 'Take profit price (optional for TAKE_PROFIT, required for OCO orders)',
+    description: 'Take profit price (required for TAKE_PROFIT and OCO orders)',
     example: 55000.0,
     required: false
   })
   takeProfitPrice?: number;
 
   @ValidateIf((o) => o.orderType === OrderType.OCO)
-  @IsOptional()
+  @IsNotEmpty({ message: 'Stop loss price is required for OCO orders' })
   @IsNumber()
   @Min(0)
   @ApiProperty({
-    description: 'Stop loss price (optional for OCO orders)',
+    description: 'Stop loss price (required for OCO orders)',
     example: 45000.0,
     required: false
   })

--- a/apps/api/src/order/order.service.ts
+++ b/apps/api/src/order/order.service.ts
@@ -2,9 +2,14 @@ import { BadRequestException, Injectable, Logger, NotFoundException } from '@nes
 import { InjectRepository } from '@nestjs/typeorm';
 
 import * as ccxt from 'ccxt';
-import { FindManyOptions, In, Repository } from 'typeorm';
+import { DataSource, FindManyOptions, In, Repository } from 'typeorm';
 
-import { UserHoldingsDto } from '@chansey/api-interfaces';
+import {
+  getExchangeOrderTypeSupport,
+  getSupportedOrderTypes,
+  isOrderTypeSupported,
+  UserHoldingsDto
+} from '@chansey/api-interfaces';
 
 import { ExchangeService } from '@chansey-api/exchange/exchange.service';
 
@@ -18,9 +23,18 @@ import { OrderValidationService } from './services/order-validation.service';
 
 import { Coin } from '../coin/coin.entity';
 import { CoinService } from '../coin/coin.service';
+import { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
 import { ExchangeKeyService } from '../exchange/exchange-key/exchange-key.service';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
 import { User } from '../users/users.entity';
+
+/** CCXT order creation parameters */
+interface CcxtOrderParams {
+  stopPrice?: number;
+  trailingDelta?: number;
+  timeInForce?: string;
+  [key: string]: unknown;
+}
 
 export interface OrderFilters {
   status?: OrderStatus | string;
@@ -36,6 +50,7 @@ export class OrderService {
 
   constructor(
     @InjectRepository(Order) private readonly orderRepository: Repository<Order>,
+    private readonly dataSource: DataSource,
     private readonly exchangeService: ExchangeService,
     private readonly exchangeManager: ExchangeManagerService,
     private readonly exchangeKeyService: ExchangeKeyService,
@@ -45,7 +60,8 @@ export class OrderService {
   ) {}
 
   /**
-   * Create a new order (buy or sell)
+   * Create a new order (buy or sell) - Legacy method for coin-id based orders
+   * @deprecated Use placeManualOrder instead for better exchange integration
    */
   async createOrder(orderDto: OrderDto, user: User): Promise<Order> {
     this.logger.log(`Creating ${orderDto.side} order for user: ${user.id} on exchange: ${orderDto.exchangeId}`);
@@ -55,7 +71,6 @@ export class OrderService {
       const { baseCoin, quoteCoin } = await this.validateAndGetCoins(orderDto);
 
       // 2. Get exchange client
-
       const { slug: exchangeSlug } = await this.exchangeService.getExchangeById(orderDto.exchangeId);
       const exchange = await this.exchangeManager.getExchangeClient(exchangeSlug, user);
 
@@ -71,8 +86,16 @@ export class OrderService {
       // 5. Create order on exchange
       const exchangeOrder = await this.executeOrderOnExchange(exchange, symbol, orderDto);
 
-      // 6. Save order to database
-      const savedOrder = await this.saveOrderToDatabase(exchangeOrder, orderDto, baseCoin, quoteCoin, user);
+      // 6. Save order to database with exchange reference
+      const exchangeEntity = await this.exchangeService.getExchangeById(orderDto.exchangeId);
+      const savedOrder = await this.saveOrderToDatabase(
+        exchangeOrder,
+        orderDto,
+        baseCoin,
+        quoteCoin,
+        user,
+        exchangeEntity
+      );
 
       this.logger.log(`Order created successfully: ${savedOrder.id}`);
       return savedOrder;
@@ -100,7 +123,7 @@ export class OrderService {
       const rawSymbol = `${baseCoin.symbol.toUpperCase()}${quoteCoin.symbol.toUpperCase()}`;
       const symbol = this.exchangeManager.formatSymbol(exchangeSlug, rawSymbol);
 
-      // 5. Get current market data
+      // 4. Get current market data
       const ticker = await exchange.fetchTicker(symbol);
       const marketPrice = ticker.last || ticker.close || 0;
 
@@ -114,13 +137,8 @@ export class OrderService {
 
       const orderValue = quantity * price;
 
-      // 6. Get trading fees from exchange with fallback
-      const { feeRate, feeAmount, feePercentage } = await this.getTradingFees(
-        exchange,
-        exchangeSlug,
-        orderDto.side,
-        orderValue
-      );
+      // 6. Get trading fees with proper maker/taker determination
+      const { feeRate, feeAmount } = await this.getTradingFees(exchange, exchangeSlug, orderDto.type, orderValue);
 
       // 7. Get user balance
       const balances = await exchange.fetchBalance();
@@ -128,15 +146,14 @@ export class OrderService {
       const availableBalance = balances[balanceCurrency]?.free || 0;
 
       // 8. Calculate total cost or net amount
-      let totalCost: number | undefined;
-      let netAmount: number | undefined;
+      let totalRequired: number;
       let hasSufficientBalance = false;
 
       if (orderDto.side === OrderSide.BUY) {
-        totalCost = orderValue + feeAmount;
-        hasSufficientBalance = availableBalance >= totalCost;
+        totalRequired = orderValue + feeAmount;
+        hasSufficientBalance = availableBalance >= totalRequired;
       } else {
-        netAmount = orderValue - feeAmount;
+        totalRequired = orderValue;
         hasSufficientBalance = availableBalance >= quantity;
       }
 
@@ -147,6 +164,17 @@ export class OrderService {
         estimatedSlippage = this.calculateSlippage(orderBook, quantity, orderDto.side);
       }
 
+      // 10. Get supported order types
+      const supportedOrderTypes = this.getSupportedOrderTypesForExchange(exchangeSlug);
+
+      // 11. Build warnings
+      const warnings: string[] = [];
+      if (!hasSufficientBalance) {
+        warnings.push(
+          `Insufficient ${balanceCurrency} balance. Available: ${availableBalance.toFixed(8)}, Required: ${totalRequired.toFixed(8)}`
+        );
+      }
+
       const preview: OrderPreviewDto = {
         symbol,
         side: orderDto.side,
@@ -155,13 +183,17 @@ export class OrderService {
         price,
         estimatedCost: orderValue,
         estimatedFee: feeAmount,
+        feeRate,
         feeCurrency: balanceCurrency,
-        totalRequired: totalCost || orderValue,
+        totalRequired,
         marketPrice,
         availableBalance,
         balanceCurrency,
         hasSufficientBalance,
-        exchange: 'binance_us'
+        estimatedSlippage,
+        warnings,
+        exchange: exchangeSlug,
+        supportedOrderTypes
       };
 
       this.logger.log(`Order preview calculated for user: ${user.id}`);
@@ -281,14 +313,15 @@ export class OrderService {
   }
 
   /**
-   * Save order to database
+   * Save order to database with exchange reference
    */
   private async saveOrderToDatabase(
     exchangeOrder: any,
     orderDto: OrderDto,
-    baseCoin: any,
-    quoteCoin: any,
-    user: User
+    baseCoin: Coin,
+    quoteCoin: Coin,
+    user: User,
+    exchangeEntity?: any
   ): Promise<Order> {
     const order = this.orderRepository.create({
       orderId: exchangeOrder.id?.toString(),
@@ -307,6 +340,7 @@ export class OrderService {
       baseCoin,
       quoteCoin,
       user,
+      exchange: exchangeEntity,
       trades: exchangeOrder.trades,
       info: exchangeOrder.info
     });
@@ -333,24 +367,31 @@ export class OrderService {
   }
 
   /**
-   * Get trading fees with fallback mechanisms
+   * Get trading fees with proper maker/taker determination
+   * Maker/Taker is determined by order type, NOT by side (buy/sell)
+   * - LIMIT orders that add liquidity (not immediately matched) are maker orders
+   * - MARKET orders always take liquidity, so they're taker orders
+   * - STOP and other advanced orders typically execute as market orders (taker)
    */
   private async getTradingFees(
     exchange: ccxt.Exchange,
     exchangeSlug: string,
-    side: OrderSide,
+    orderType: OrderType,
     orderValue: number
-  ): Promise<{ feeRate: number; feeAmount: number; feePercentage: number }> {
+  ): Promise<{ feeRate: number; feeAmount: number }> {
+    // Determine if this is a maker or taker order
+    // LIMIT orders add liquidity (maker), all others typically take liquidity (taker)
+    const isMaker = orderType === OrderType.LIMIT;
+
     try {
       // Try to get trading fees from exchange API
       const tradingFees = await exchange.fetchTradingFees();
       this.logger.debug(`Trading fees from API for ${exchangeSlug}:`, tradingFees);
 
-      const feeRate = side === OrderSide.BUY ? tradingFees.taker || 0.001 : tradingFees.maker || 0.001;
+      const feeRate = isMaker ? tradingFees.maker || 0.001 : tradingFees.taker || 0.001;
       const feeAmount = orderValue * (feeRate as number);
-      const feePercentage = (feeRate as number) * 100;
 
-      return { feeRate: feeRate as number, feeAmount, feePercentage };
+      return { feeRate: feeRate as number, feeAmount };
     } catch (error) {
       this.logger.warn(`Failed to fetch trading fees from API for ${exchangeSlug}: ${error.message}`);
 
@@ -359,12 +400,11 @@ export class OrderService {
         if (exchange.markets && Object.keys(exchange.markets).length > 0) {
           // Get fee from any market as they're usually consistent across the exchange
           const firstMarket = Object.values(exchange.markets)[0];
-          const feeRate = side === OrderSide.BUY ? firstMarket.taker || 0.001 : firstMarket.maker || 0.001;
+          const feeRate = isMaker ? firstMarket.maker || 0.001 : firstMarket.taker || 0.001;
           const feeAmount = orderValue * feeRate;
-          const feePercentage = feeRate * 100;
 
-          this.logger.debug(`Using market fees for ${exchangeSlug}: ${feeRate}`);
-          return { feeRate, feeAmount, feePercentage };
+          this.logger.debug(`Using market fees for ${exchangeSlug}: ${feeRate} (${isMaker ? 'maker' : 'taker'})`);
+          return { feeRate, feeAmount };
         }
       } catch (marketError) {
         this.logger.warn(`Failed to get fees from markets for ${exchangeSlug}: ${marketError.message}`);
@@ -372,12 +412,11 @@ export class OrderService {
 
       // Fallback 2: Use exchange-specific default fees
       const defaultFees = this.getDefaultFees(exchangeSlug);
-      const feeRate = side === OrderSide.BUY ? defaultFees.taker : defaultFees.maker;
+      const feeRate = isMaker ? defaultFees.maker : defaultFees.taker;
       const feeAmount = orderValue * feeRate;
-      const feePercentage = feeRate * 100;
 
-      this.logger.debug(`Using default fees for ${exchangeSlug}: ${feeRate}`);
-      return { feeRate, feeAmount, feePercentage };
+      this.logger.debug(`Using default fees for ${exchangeSlug}: ${feeRate} (${isMaker ? 'maker' : 'taker'})`);
+      return { feeRate, feeAmount };
     }
   }
 
@@ -388,9 +427,9 @@ export class OrderService {
     const defaultFees: Record<string, { maker: number; taker: number }> = {
       binanceus: { maker: 0.001, taker: 0.001 }, // 0.1%
       binance: { maker: 0.001, taker: 0.001 }, // 0.1%
-      coinbase: { maker: 0.005, taker: 0.005 }, // 0.5%
-      coinbasepro: { maker: 0.005, taker: 0.005 }, // 0.5%
-      coinbaseexchange: { maker: 0.005, taker: 0.005 }, // 0.5%
+      coinbase: { maker: 0.004, taker: 0.006 }, // 0.4%/0.6%
+      coinbasepro: { maker: 0.004, taker: 0.006 }, // 0.4%/0.6%
+      coinbaseexchange: { maker: 0.004, taker: 0.006 }, // 0.4%/0.6%
       kraken: { maker: 0.0016, taker: 0.0026 }, // 0.16%/0.26%
       kucoin: { maker: 0.001, taker: 0.001 }, // 0.1%
       okx: { maker: 0.0008, taker: 0.001 } // 0.08%/0.1%
@@ -409,7 +448,6 @@ export class OrderService {
 
       let remainingQuantity = quantity;
       let totalCost = 0;
-      let weightedAveragePrice = 0;
 
       // Calculate weighted average price by consuming order book
       for (const [price, availableQuantity] of orders) {
@@ -421,7 +459,7 @@ export class OrderService {
       }
 
       if (quantity > 0) {
-        weightedAveragePrice = totalCost / quantity;
+        const weightedAveragePrice = totalCost / quantity;
         const marketPrice = orders[0][0]; // Best bid/ask price
         const slippage = Math.abs((weightedAveragePrice - marketPrice) / marketPrice) * 100;
         return Math.round(slippage * 100) / 100; // Round to 2 decimal places
@@ -432,6 +470,22 @@ export class OrderService {
       this.logger.warn(`Failed to calculate slippage: ${error.message}`);
       return 0;
     }
+  }
+
+  /**
+   * Get supported order types for an exchange
+   * Delegates to shared utility from api-interfaces
+   */
+  getSupportedOrderTypesForExchange(exchangeSlug: string): OrderType[] {
+    return getSupportedOrderTypes(exchangeSlug);
+  }
+
+  /**
+   * Check if an exchange supports a specific order type
+   * Delegates to shared utility from api-interfaces
+   */
+  isOrderTypeSupportedByExchange(exchangeSlug: string, orderType: OrderType): boolean {
+    return isOrderTypeSupported(exchangeSlug, orderType);
   }
 
   /**
@@ -450,8 +504,17 @@ export class OrderService {
         throw new NotFoundException('Exchange key not found');
       }
 
-      const exchange = await this.exchangeManager.getExchangeClient(exchangeKey.exchange.slug, user);
+      const exchangeSlug = exchangeKey.exchange.slug;
+      const exchange = await this.exchangeManager.getExchangeClient(exchangeSlug, user);
       await exchange.loadMarkets();
+
+      // Validate order type is supported
+      if (!this.isOrderTypeSupportedByExchange(exchangeSlug, dto.orderType)) {
+        throw new BadRequestException(
+          `Order type "${dto.orderType}" is not supported on ${exchangeKey.exchange.name}. ` +
+            `Supported types: ${this.getSupportedOrderTypesForExchange(exchangeSlug).join(', ')}`
+        );
+      }
 
       // Get market data
       const ticker = await exchange.fetchTicker(dto.symbol);
@@ -468,11 +531,12 @@ export class OrderService {
       // Calculate estimated cost
       const estimatedCost = dto.quantity * executionPrice;
 
-      // Get trading fees
+      // Get trading fees with proper maker/taker determination
       const market = exchange.markets[dto.symbol];
-      const feeRate = dto.side === OrderSide.BUY ? market?.taker || 0.001 : market?.maker || 0.001;
+      const isMaker = dto.orderType === OrderType.LIMIT;
+      const feeRate = isMaker ? market?.maker || 0.001 : market?.taker || 0.001;
       const estimatedFee = estimatedCost * feeRate;
-      const totalRequired = estimatedCost + estimatedFee;
+      const totalRequired = dto.side === OrderSide.BUY ? estimatedCost + estimatedFee : estimatedCost;
 
       // Get user balance
       const balances = await exchange.fetchBalance();
@@ -504,6 +568,23 @@ export class OrderService {
         );
       }
 
+      // Calculate slippage for market orders
+      let estimatedSlippage: number | undefined;
+      if (dto.orderType === OrderType.MARKET) {
+        try {
+          const orderBook = await exchange.fetchOrderBook(dto.symbol, 20);
+          estimatedSlippage = this.calculateSlippage(orderBook, dto.quantity, dto.side);
+          if (estimatedSlippage > 1) {
+            warnings.push(`High estimated slippage: ${estimatedSlippage.toFixed(2)}%`);
+          }
+        } catch (error) {
+          this.logger.warn(`Failed to calculate slippage: ${error.message}`);
+        }
+      }
+
+      // Get supported order types for this exchange
+      const supportedOrderTypes = this.getSupportedOrderTypesForExchange(exchangeSlug);
+
       const preview: OrderPreviewDto = {
         symbol: dto.symbol,
         side: dto.side,
@@ -515,14 +596,17 @@ export class OrderService {
         trailingType: dto.trailingType,
         estimatedCost,
         estimatedFee,
+        feeRate,
         feeCurrency: quoteCurrency,
         totalRequired,
         marketPrice,
         availableBalance,
         balanceCurrency,
         hasSufficientBalance,
+        estimatedSlippage,
         warnings,
-        exchange: exchange.name || 'Unknown'
+        exchange: exchangeKey.exchange.name,
+        supportedOrderTypes
       };
 
       return preview;
@@ -537,9 +621,23 @@ export class OrderService {
    * @param dto Order placement data
    * @param user Authenticated user
    * @param exchange CCXT exchange instance
+   * @param exchangeSlug Exchange slug for order type validation
    * @throws BadRequestException for validation failures
    */
-  private async validateManualOrder(dto: PlaceManualOrderDto, user: User, exchange: ccxt.Exchange): Promise<void> {
+  private async validateManualOrder(
+    dto: PlaceManualOrderDto,
+    user: User,
+    exchange: ccxt.Exchange,
+    exchangeSlug: string
+  ): Promise<void> {
+    // Validate order type is supported by this exchange
+    if (!this.isOrderTypeSupportedByExchange(exchangeSlug, dto.orderType)) {
+      const supportedTypes = this.getSupportedOrderTypesForExchange(exchangeSlug);
+      throw new BadRequestException(
+        `Order type "${dto.orderType}" is not supported on this exchange. Supported types: ${supportedTypes.join(', ')}`
+      );
+    }
+
     // Validate trading pair exists on exchange
     if (!exchange.markets || !exchange.markets[dto.symbol]) {
       throw new BadRequestException(`Trading pair ${dto.symbol} is not available on this exchange`);
@@ -573,6 +671,10 @@ export class OrderService {
 
     // Validate trailing stop parameters
     if (dto.orderType === OrderType.TRAILING_STOP) {
+      const support = getExchangeOrderTypeSupport(exchangeSlug);
+      if (!support.hasTrailingStopSupport) {
+        throw new BadRequestException(`Trailing stop orders are not supported on this exchange`);
+      }
       if (!dto.trailingAmount) {
         throw new BadRequestException('Trailing amount is required for trailing stop orders');
       }
@@ -583,6 +685,10 @@ export class OrderService {
 
     // Validate OCO parameters
     if (dto.orderType === OrderType.OCO) {
+      const support = getExchangeOrderTypeSupport(exchangeSlug);
+      if (!support.hasOcoSupport) {
+        throw new BadRequestException(`OCO orders are not supported on this exchange`);
+      }
       if (!dto.takeProfitPrice) {
         throw new BadRequestException('Take profit price is required for OCO orders');
       }
@@ -591,7 +697,7 @@ export class OrderService {
       }
     }
 
-    // Check user balance
+    // Check user balance (including fees for buy orders)
     const balances = await exchange.fetchBalance();
     const [baseCurrency, quoteCurrency] = dto.symbol.split('/');
 
@@ -600,12 +706,15 @@ export class OrderService {
       const ticker = await exchange.fetchTicker(dto.symbol);
       const price = dto.price || ticker.last || ticker.close || 0;
       const cost = dto.quantity * price;
-      const feeRate = market?.taker || 0.001;
+
+      // Use proper fee determination (taker for market, maker for limit)
+      const isMaker = dto.orderType === OrderType.LIMIT;
+      const feeRate = isMaker ? market?.maker || 0.001 : market?.taker || 0.001;
       const totalRequired = cost * (1 + feeRate);
 
       if (availableQuote < totalRequired) {
         throw new BadRequestException(
-          `Insufficient ${quoteCurrency} balance. Available: ${availableQuote.toFixed(8)}, Required: ${totalRequired.toFixed(8)}`
+          `Insufficient ${quoteCurrency} balance. Available: ${availableQuote.toFixed(8)}, Required: ${totalRequired.toFixed(8)} (including ${(feeRate * 100).toFixed(2)}% fee)`
         );
       }
     } else {
@@ -619,7 +728,7 @@ export class OrderService {
   }
 
   /**
-   * Place a manual order on the exchange
+   * Place a manual order on the exchange with transaction safety
    * @param dto Order placement data
    * @param user Authenticated user
    * @returns Created order entity
@@ -627,22 +736,35 @@ export class OrderService {
   async placeManualOrder(dto: PlaceManualOrderDto, user: User): Promise<Order> {
     this.logger.log(`Placing manual ${dto.side} ${dto.orderType} order for user: ${user.id}`);
 
+    // Get exchange key and client first (outside transaction)
+    const exchangeKey = await this.exchangeKeyService.findOne(dto.exchangeKeyId, user.id);
+    if (!exchangeKey || !exchangeKey.exchange) {
+      throw new NotFoundException('Exchange key not found');
+    }
+
+    const exchangeSlug = exchangeKey.exchange.slug;
+    const exchange = await this.exchangeManager.getExchangeClient(exchangeSlug, user);
+    await exchange.loadMarkets();
+
+    // Validate order before starting transaction
+    await this.validateManualOrder(dto, user, exchange, exchangeSlug);
+
+    // Handle OCO orders separately (they need special transaction handling)
+    if (dto.orderType === OrderType.OCO) {
+      return await this.createOcoOrderWithTransaction(dto, user, exchange, exchangeKey);
+    }
+
+    // Start database transaction for order creation
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    let ccxtOrder: ccxt.Order | null = null;
+
     try {
-      // Get exchange key and client
-      const exchangeKey = await this.exchangeKeyService.findOne(dto.exchangeKeyId, user.id);
-      if (!exchangeKey || !exchangeKey.exchange) {
-        throw new NotFoundException('Exchange key not found');
-      }
-
-      const exchange = await this.exchangeManager.getExchangeClient(exchangeKey.exchange.slug, user);
-      await exchange.loadMarkets();
-
-      // Validate order
-      await this.validateManualOrder(dto, user, exchange);
-
       // Map order type to CCXT params
       const ccxtOrderType = this.mapOrderTypeToCcxt(dto.orderType);
-      const params: any = {};
+      const params: CcxtOrderParams = {};
 
       // Add order-type-specific parameters
       if (dto.stopPrice) {
@@ -655,13 +777,8 @@ export class OrderService {
         params.timeInForce = dto.timeInForce;
       }
 
-      // Handle OCO orders (create two linked orders)
-      if (dto.orderType === OrderType.OCO) {
-        return await this.createOcoOrder(dto, user, exchange, exchangeKey);
-      }
-
       // Create order on exchange
-      const ccxtOrder = await exchange.createOrder(
+      ccxtOrder = await exchange.createOrder(
         dto.symbol,
         ccxtOrderType,
         dto.side.toLowerCase(),
@@ -670,25 +787,23 @@ export class OrderService {
         params
       );
 
-      // Parse symbol to get base and quote
+      // Parse symbol to get base and quote - batch fetch in single query
       const [baseSymbol, quoteSymbol] = dto.symbol.split('/');
-      let baseCoin = null;
-      let quoteCoin = null;
+      let baseCoin: Coin | null = null;
+      let quoteCoin: Coin | null = null;
 
       try {
-        baseCoin = await this.coinService.getCoinBySymbol(baseSymbol, [], false);
+        const coins = await this.coinService.getMultipleCoinsBySymbol([baseSymbol, quoteSymbol]);
+        baseCoin = coins.find((c) => c.symbol.toLowerCase() === baseSymbol.toLowerCase()) || null;
+        quoteCoin = coins.find((c) => c.symbol.toLowerCase() === quoteSymbol.toLowerCase()) || null;
+        if (!baseCoin) this.logger.warn(`Base coin ${baseSymbol} not found`);
+        if (!quoteCoin) this.logger.warn(`Quote coin ${quoteSymbol} not found`);
       } catch (error) {
-        this.logger.warn(`Base coin ${baseSymbol} not found`);
-      }
-
-      try {
-        quoteCoin = await this.coinService.getCoinBySymbol(quoteSymbol, [], false);
-      } catch (error) {
-        this.logger.warn(`Quote coin ${quoteSymbol} not found`);
+        this.logger.warn(`Could not find coins for order: ${error.message}`);
       }
 
       // Create order entity
-      const order = this.orderRepository.create({
+      const order = queryRunner.manager.create(Order, {
         orderId: ccxtOrder.id?.toString() || '',
         clientOrderId: ccxtOrder.clientOrderId || ccxtOrder.id?.toString() || '',
         symbol: dto.symbol,
@@ -718,115 +833,177 @@ export class OrderService {
         info: ccxtOrder.info
       });
 
-      const savedOrder = await this.orderRepository.save(order);
+      const savedOrder = await queryRunner.manager.save(order);
+
+      // Commit transaction
+      await queryRunner.commitTransaction();
+
       this.logger.log(`Manual order created successfully: ${savedOrder.id}`);
       return savedOrder;
     } catch (error) {
+      // Rollback transaction
+      await queryRunner.rollbackTransaction();
+
+      // If we created an order on the exchange but failed to save to DB, log it for manual reconciliation
+      if (ccxtOrder) {
+        this.logger.error(
+          `CRITICAL: Order created on exchange but failed to save to database. ` +
+            `Exchange order ID: ${ccxtOrder.id}, Symbol: ${dto.symbol}, Quantity: ${dto.quantity}. ` +
+            `Manual reconciliation required.`,
+          error.stack
+        );
+      }
+
       this.logger.error(`Manual order placement failed: ${error.message}`, error.stack);
-      throw error;
+      throw new BadRequestException(`Failed to place order: ${error.message}`);
+    } finally {
+      await queryRunner.release();
     }
   }
 
   /**
-   * Create OCO (One-Cancels-Other) order pair
+   * Create OCO (One-Cancels-Other) order pair with transaction safety
    * @param dto Order placement data
    * @param user Authenticated user
    * @param exchange CCXT exchange instance
    * @param exchangeKey Exchange key entity
    * @returns Created take-profit order (linked to stop-loss)
    */
-  private async createOcoOrder(
+  private async createOcoOrderWithTransaction(
     dto: PlaceManualOrderDto,
     user: User,
     exchange: ccxt.Exchange,
-    exchangeKey: any
+    exchangeKey: ExchangeKey
   ): Promise<Order> {
-    // Create take-profit order
-    const takeProfitOrder = await exchange.createOrder(
-      dto.symbol,
-      'limit',
-      dto.side.toLowerCase(),
-      dto.quantity,
-      dto.takeProfitPrice
-    );
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-    // Create stop-loss order
-    const stopLossOrder = await exchange.createOrder(
-      dto.symbol,
-      'stop_loss',
-      dto.side.toLowerCase(),
-      dto.quantity,
-      undefined,
-      { stopPrice: dto.stopLossPrice }
-    );
-
-    // Save both orders to database
-    const [baseSymbol, quoteSymbol] = dto.symbol.split('/');
-    let baseCoin = null;
-    let quoteCoin = null;
+    let takeProfitExchangeOrder: ccxt.Order | null = null;
+    let stopLossExchangeOrder: ccxt.Order | null = null;
 
     try {
-      baseCoin = await this.coinService.getCoinBySymbol(baseSymbol, [], false);
-      quoteCoin = await this.coinService.getCoinBySymbol(quoteSymbol, [], false);
+      // Create take-profit order on exchange
+      takeProfitExchangeOrder = await exchange.createOrder(
+        dto.symbol,
+        'limit',
+        dto.side.toLowerCase(),
+        dto.quantity,
+        dto.takeProfitPrice
+      );
+
+      // Create stop-loss order on exchange
+      try {
+        stopLossExchangeOrder = await exchange.createOrder(
+          dto.symbol,
+          'stop_loss',
+          dto.side.toLowerCase(),
+          dto.quantity,
+          undefined,
+          { stopPrice: dto.stopLossPrice }
+        );
+      } catch (stopLossError) {
+        // If stop-loss fails, cancel the take-profit order
+        this.logger.warn(`Stop-loss order failed, canceling take-profit order: ${stopLossError.message}`);
+        try {
+          await exchange.cancelOrder(takeProfitExchangeOrder.id, dto.symbol);
+        } catch (cancelError) {
+          this.logger.error(`Failed to cancel take-profit order after stop-loss failure: ${cancelError.message}`);
+        }
+        throw stopLossError;
+      }
+
+      // Save both orders to database - batch fetch coins in single query
+      const [baseSymbol, quoteSymbol] = dto.symbol.split('/');
+      let baseCoin: Coin | null = null;
+      let quoteCoin: Coin | null = null;
+
+      try {
+        const coins = await this.coinService.getMultipleCoinsBySymbol([baseSymbol, quoteSymbol]);
+        baseCoin = coins.find((c) => c.symbol.toLowerCase() === baseSymbol.toLowerCase()) || null;
+        quoteCoin = coins.find((c) => c.symbol.toLowerCase() === quoteSymbol.toLowerCase()) || null;
+      } catch (error) {
+        this.logger.warn('Could not find coins for OCO order');
+      }
+
+      // Create take-profit order entity
+      const tpOrder = queryRunner.manager.create(Order, {
+        orderId: takeProfitExchangeOrder.id?.toString() || '',
+        clientOrderId: takeProfitExchangeOrder.clientOrderId || takeProfitExchangeOrder.id?.toString() || '',
+        symbol: dto.symbol,
+        side: dto.side,
+        type: OrderType.TAKE_PROFIT,
+        quantity: dto.quantity,
+        price: dto.takeProfitPrice || 0,
+        executedQuantity: 0,
+        status: OrderStatus.NEW,
+        transactTime: new Date(),
+        isManual: true,
+        exchangeKeyId: dto.exchangeKeyId,
+        takeProfitPrice: dto.takeProfitPrice,
+        user,
+        baseCoin: baseCoin || undefined,
+        quoteCoin: quoteCoin || undefined,
+        exchange: exchangeKey.exchange,
+        info: takeProfitExchangeOrder.info
+      });
+
+      const savedTpOrder = await queryRunner.manager.save(tpOrder);
+
+      // Create stop-loss order entity linked to take-profit
+      const slOrder = queryRunner.manager.create(Order, {
+        orderId: stopLossExchangeOrder.id?.toString() || '',
+        clientOrderId: stopLossExchangeOrder.clientOrderId || stopLossExchangeOrder.id?.toString() || '',
+        symbol: dto.symbol,
+        side: dto.side,
+        type: OrderType.STOP_LOSS,
+        quantity: dto.quantity,
+        price: 0,
+        executedQuantity: 0,
+        status: OrderStatus.NEW,
+        transactTime: new Date(),
+        isManual: true,
+        exchangeKeyId: dto.exchangeKeyId,
+        stopPrice: dto.stopLossPrice,
+        stopLossPrice: dto.stopLossPrice,
+        ocoLinkedOrderId: savedTpOrder.id,
+        user,
+        baseCoin: baseCoin || undefined,
+        quoteCoin: quoteCoin || undefined,
+        exchange: exchangeKey.exchange,
+        info: stopLossExchangeOrder.info
+      });
+
+      const savedSlOrder = await queryRunner.manager.save(slOrder);
+
+      // Update take-profit order with link to stop-loss
+      savedTpOrder.ocoLinkedOrderId = savedSlOrder.id;
+      await queryRunner.manager.save(savedTpOrder);
+
+      // Commit transaction
+      await queryRunner.commitTransaction();
+
+      this.logger.log(`OCO order pair created: TP=${savedTpOrder.id}, SL=${savedSlOrder.id}`);
+      return savedTpOrder;
     } catch (error) {
-      this.logger.warn('Could not find coins for OCO order');
+      // Rollback transaction
+      await queryRunner.rollbackTransaction();
+
+      // Log orphaned exchange orders for manual reconciliation
+      if (takeProfitExchangeOrder || stopLossExchangeOrder) {
+        this.logger.error(
+          `CRITICAL: OCO orders may exist on exchange but failed to save to database. ` +
+            `TP Order ID: ${takeProfitExchangeOrder?.id || 'N/A'}, SL Order ID: ${stopLossExchangeOrder?.id || 'N/A'}. ` +
+            `Manual reconciliation required.`,
+          error.stack
+        );
+      }
+
+      this.logger.error(`OCO order creation failed: ${error.message}`, error.stack);
+      throw new BadRequestException(`Failed to create OCO order: ${error.message}`);
+    } finally {
+      await queryRunner.release();
     }
-
-    // Create take-profit order entity
-    const tpOrder = this.orderRepository.create({
-      orderId: takeProfitOrder.id?.toString() || '',
-      clientOrderId: takeProfitOrder.clientOrderId || takeProfitOrder.id?.toString() || '',
-      symbol: dto.symbol,
-      side: dto.side,
-      type: OrderType.TAKE_PROFIT,
-      quantity: dto.quantity,
-      price: dto.takeProfitPrice || 0,
-      executedQuantity: 0,
-      status: OrderStatus.NEW,
-      transactTime: new Date(),
-      isManual: true,
-      exchangeKeyId: dto.exchangeKeyId,
-      takeProfitPrice: dto.takeProfitPrice,
-      user,
-      baseCoin: baseCoin || undefined,
-      quoteCoin: quoteCoin || undefined,
-      exchange: exchangeKey.exchange,
-      info: takeProfitOrder.info
-    });
-
-    const savedTpOrder = await this.orderRepository.save(tpOrder);
-
-    // Create stop-loss order entity linked to take-profit
-    const slOrder = this.orderRepository.create({
-      orderId: stopLossOrder.id?.toString() || '',
-      clientOrderId: stopLossOrder.clientOrderId || stopLossOrder.id?.toString() || '',
-      symbol: dto.symbol,
-      side: dto.side,
-      type: OrderType.STOP_LOSS,
-      quantity: dto.quantity,
-      price: 0,
-      executedQuantity: 0,
-      status: OrderStatus.NEW,
-      transactTime: new Date(),
-      isManual: true,
-      exchangeKeyId: dto.exchangeKeyId,
-      stopPrice: dto.stopLossPrice,
-      stopLossPrice: dto.stopLossPrice,
-      ocoLinkedOrderId: savedTpOrder.id,
-      user,
-      baseCoin: baseCoin || undefined,
-      quoteCoin: quoteCoin || undefined,
-      exchange: exchangeKey.exchange,
-      info: stopLossOrder.info
-    });
-
-    await this.orderRepository.save(slOrder);
-
-    // Update take-profit order with link to stop-loss
-    savedTpOrder.ocoLinkedOrderId = slOrder.id;
-    await this.orderRepository.save(savedTpOrder);
-
-    return savedTpOrder;
   }
 
   /**

--- a/apps/chansey/project.json
+++ b/apps/chansey/project.json
@@ -28,10 +28,7 @@
             "output": "/assets/fonts/primeicons"
           }
         ],
-        "styles": [
-          "node_modules/primeicons/primeicons.css",
-          "apps/chansey/src/styles.scss"
-        ],
+        "styles": ["node_modules/primeicons/primeicons.css", "apps/chansey/src/styles.scss"],
         "scripts": [],
         "serviceWorker": true,
         "ngswConfigPath": "apps/chansey/ngsw-config.json"
@@ -47,7 +44,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "2kb",
-              "maximumError": "4kb"
+              "maximumError": "5kb"
             }
           ],
           "fileReplacements": [
@@ -89,7 +86,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "2kb",
-              "maximumError": "4kb"
+              "maximumError": "5kb"
             }
           ],
           "outputHashing": "all",

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.html
@@ -1,48 +1,42 @@
 <div class="h-full overflow-y-auto">
-  <!-- Trading Header with Status Bar -->
-  <div class="relative mb-4">
-    <!-- Active Trading Status Bar -->
-    <div
-      class="from-primary-50 dark:from-primary-950 border-primary-100 dark:border-primary-800 flex items-center justify-between rounded-lg border bg-gradient-to-r to-blue-50 p-3 dark:to-blue-950"
-    >
-      <div class="flex items-center gap-3">
-        <div class="flex items-center gap-2">
-          <div class="h-2 w-2 animate-pulse rounded-full bg-green-500"></div>
-          <span class="text-primary-700 dark:text-primary-300 text-sm font-medium">Live Trading</span>
-        </div>
-        <div class="bg-primary-200 dark:bg-primary-700 h-4 w-px"></div>
+  <!-- Compact Status Bar -->
+  <div
+    class="border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800 mb-4 flex items-center justify-between rounded-lg border px-3 py-2"
+  >
+    <div class="flex items-center gap-2">
+      <div
+        class="h-2 w-2 animate-pulse rounded-full"
+        [class]="selectedExchangeId() ? 'bg-green-500' : 'bg-orange-500'"
+      ></div>
+      <span class="text-surface-700 dark:text-surface-300 text-sm font-medium">
         @if (selectedExchangeId()) {
-          <span class="text-primary-600 dark:text-primary-400 text-xs">
-            Connected to {{ getSelectedExchangeName() }}
-          </span>
+          {{ getSelectedExchangeName() }}
         } @else {
-          <span class="text-xs text-orange-600 dark:text-orange-400">No exchange selected</span>
+          Select Exchange
         }
-      </div>
-      <div class="flex items-center gap-2">
-        <i class="pi pi-chart-line text-primary-600 dark:text-primary-400 text-sm"></i>
-        <span class="text-primary-600 dark:text-primary-400 text-xs">Real-time</span>
-      </div>
+      </span>
     </div>
-
-    <!-- Decorative separator line -->
-    <div
-      class="via-primary-300 dark:via-primary-600 absolute -bottom-2 left-1/2 h-0.5 w-16 -translate-x-1/2 transform bg-gradient-to-r from-transparent to-transparent"
-    ></div>
+    @if (selectedPair()) {
+      <div class="flex items-center gap-2 text-sm">
+        <span class="font-semibold">{{ selectedPair()?.currentPrice | currency: 'USD' : 'symbol' : '1.2-6' }}</span>
+        <span [class]="priceChangeClass()" class="text-xs font-medium">
+          {{ (selectedPair()?.spreadPercentage || 0) >= 0 ? '+' : ''
+          }}{{ selectedPair()?.spreadPercentage | number: '1.2-2' }}%
+        </span>
+      </div>
+    }
   </div>
 
   <!-- Exchange Selection -->
-  <div class="mb-3">
-    <div class="mb-3 flex items-center gap-2">
-      <i class="pi pi-building text-primary-600 dark:text-primary-400"></i>
-      <label class="text-surface-700 dark:text-surface-300 text-sm font-medium">Exchange Platform</label>
-      <div
-        class="from-surface-200 to-surface-200 dark:from-surface-700 dark:to-surface-700 h-px flex-1 bg-gradient-to-r via-transparent"
-      ></div>
-    </div>
+  <div class="mb-4">
+    <label for="exchangeSelect" class="text-surface-700 dark:text-surface-300 mb-1.5 block text-sm font-medium"
+      >Exchange</label
+    >
     <p-select
+      inputId="exchangeSelect"
       [options]="exchangeOptions()"
-      [(ngModel)]="selectedExchangeId"
+      [ngModel]="selectedExchangeId()"
+      (ngModelChange)="selectedExchangeId.set($event)"
       (onChange)="onExchangeChange($event)"
       placeholder="Choose an exchange..."
       optionLabel="label"
@@ -52,43 +46,30 @@
     >
       <ng-template pTemplate="selectedItem" let-option>
         @if (option) {
-          <div class="flex items-center gap-3">
-            <div class="flex items-center gap-3">
-              <p-avatar [image]="option.image" shape="circle" />
-              <div class="flex items-center gap-2">
-                <div class="h-2 w-2 rounded-full" [class]="getExchangeStatusClass(option.status)"></div>
-                <span class="font-medium">{{ option.label }}</span>
-              </div>
-            </div>
-            <span
-              class="bg-surface-100 dark:bg-surface-700 text-surface-600 dark:text-surface-400 rounded-full px-2 py-1 text-xs"
-            >
-              {{ option.pairCount }} pairs
-            </span>
+          <div class="flex items-center gap-2">
+            <p-avatar [image]="option.image" shape="circle" size="normal" />
+            <div class="h-2 w-2 rounded-full" [class]="getExchangeStatusClass(option.status)"></div>
+            <span class="font-medium">{{ option.label }}</span>
           </div>
         }
       </ng-template>
       <ng-template pTemplate="item" let-option>
-        <div class="py- flex w-full items-center justify-between">
-          <div class="flex items-center gap-3">
+        <div class="flex w-full items-center justify-between py-1">
+          <div class="flex items-center gap-2">
             <p-avatar [image]="option.image" shape="circle" size="normal" />
-            <div class="flex items-center gap-2">
-              <div>
-                <div class="text-surface-900 dark:text-surface-100 font-semibold">{{ option.label }}</div>
-                <div class="text-xs capitalize" [class]="getExchangeStatusTextClass(option.status)">
-                  <div class="inline-block h-2 w-2 rounded-full" [class]="getExchangeStatusClass(option.status)"></div>
-                  {{ option.status }}
-                </div>
+            <div>
+              <div class="text-surface-900 dark:text-surface-100 font-medium">{{ option.label }}</div>
+              <div class="flex items-center gap-1 text-xs" [class]="getExchangeStatusTextClass(option.status)">
+                <div class="h-1.5 w-1.5 rounded-full" [class]="getExchangeStatusClass(option.status)"></div>
+                {{ option.status }}
               </div>
             </div>
           </div>
-          <div class="text-right">
-            <div
-              class="bg-surface-100 dark:bg-surface-700 text-surface-600 dark:text-surface-400 rounded-full px-3 py-1 text-xs font-medium"
-            >
-              {{ option.pairCount }} pairs
-            </div>
-          </div>
+          <span
+            class="bg-surface-100 text-surface-600 dark:bg-surface-700 dark:text-surface-400 rounded-full px-2 py-0.5 text-xs"
+          >
+            {{ option.pairCount }} pairs
+          </span>
         </div>
       </ng-template>
     </p-select>
@@ -96,126 +77,86 @@
 
   <!-- Exchange Selection Notice -->
   @if (!selectedExchangeId()) {
-    <div class="mb-4 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950">
+    <div class="mb-4 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950">
       <div class="flex items-center gap-2 text-blue-700 dark:text-blue-300">
-        <i class="pi pi-info-circle"></i>
-        <span class="text-sm font-medium">Please select an exchange above to start trading</span>
+        <i class="pi pi-info-circle text-sm"></i>
+        <span class="text-sm">Select an exchange to start trading</span>
       </div>
     </div>
   }
 
-  <!-- Trading Pair Section Header -->
-  <div class="mb-3 flex items-center gap-2" [class.opacity-50]="!selectedExchangeId()">
-    <i class="pi pi-chart-bar text-primary-600 dark:text-primary-400"></i>
-    <h3 class="text-surface-800 dark:text-surface-200 text-lg font-semibold">Market Selection</h3>
-    <div
-      class="from-surface-200 to-surface-200 dark:from-surface-700 dark:to-surface-700 h-px flex-1 bg-gradient-to-r via-transparent"
-    ></div>
-  </div>
-
-  <!-- Enhanced Trading Pair Selection -->
-  <p-card class="mb-6 block" [class.opacity-50]="!selectedExchangeId()">
-    <ng-template pTemplate="header">
-      <div class="mb-3 flex items-center justify-between">
-        <div class="flex items-center gap-2">
-          <span class="text-lg font-semibold">Trading Pair</span>
-          @if (selectedPair()) {
-            <div class="bg-primary-500 h-1 w-1 rounded-full"></div>
-          }
-        </div>
-        @if (selectedPair()) {
-          <div class="text-right">
-            <div class="text-lg font-bold">
-              {{ selectedPair()?.currentPrice | currency: 'USD' : 'symbol' : '1.2-8' }}
-            </div>
-            <div [class]="priceChangeClass()" class="flex items-center gap-1 text-sm font-medium">
-              <i
-                class="pi text-xs"
-                [class.pi-arrow-up]="(selectedPair()?.spreadPercentage || 0) >= 0"
-                [class.pi-arrow-down]="(selectedPair()?.spreadPercentage || 0) < 0"
-              ></i>
-              {{ selectedPair()?.spreadPercentage | number: '1.2-2' }}%
-            </div>
+  <!-- Trading Pair Selection -->
+  <div class="mb-4" [class.opacity-50]="!selectedExchangeId()">
+    <label for="tradingPairSelect" class="text-surface-700 dark:text-surface-300 mb-1.5 block text-sm font-medium"
+      >Trading Pair</label
+    >
+    <p-select
+      inputId="tradingPairSelect"
+      [options]="tradingPairOptions()"
+      [ngModel]="selectedPairValue()"
+      (ngModelChange)="selectedPairValue.set($event)"
+      (onChange)="onPairChange($event)"
+      placeholder="Search trading pairs..."
+      optionLabel="label"
+      optionValue="value"
+      class="w-full"
+      [loading]="tradingPairsQuery.isPending()"
+      [filter]="true"
+      filterBy="label"
+      [showClear]="true"
+      [disabled]="!selectedExchangeId()"
+    >
+      <ng-template pTemplate="selectedItem" let-option>
+        @if (option) {
+          <div class="flex items-center gap-2">
+            <span class="font-medium uppercase">{{ option.label }}</span>
           </div>
         }
-      </div>
-
-      <!-- Trading Pair Search -->
-      <p-select
-        [options]="tradingPairOptions()"
-        [(ngModel)]="selectedPairValue"
-        (onChange)="onPairChange($event)"
-        placeholder="Search trading pairs..."
-        optionLabel="label"
-        optionValue="value"
-        class="w-full"
-        [loading]="tradingPairsQuery.isPending()"
-        [filter]="true"
-        filterBy="label"
-        [showClear]="true"
-        [disabled]="!selectedExchangeId()"
-      >
-        <ng-template pTemplate="selectedItem" let-option>
-          @if (option) {
-            <div class="flex items-center gap-2">
-              <span class="font-medium uppercase">{{ option.label }}</span>
-              <span class="rounded px-2 py-1 text-xs">
-                {{ getSelectedExchangeName() }}
-              </span>
-            </div>
-          }
-        </ng-template>
-        <ng-template pTemplate="item" let-option>
-          <div class="flex w-full items-center justify-between">
-            <span class="font-medium uppercase">{{ option.label }}</span>
-            <div class="text-right text-sm">
-              <div class="font-medium">{{ option.price | currency: 'USD' : 'symbol' : '1.2-6' }}</div>
-              <div [class]="option.change24h >= 0 ? 'text-green-600' : 'text-red-600'" class="text-xs">
-                {{ option.change24h | number: '1.2-2' }}%
-              </div>
+      </ng-template>
+      <ng-template pTemplate="item" let-option>
+        <div class="flex w-full items-center justify-between">
+          <span class="font-medium uppercase">{{ option.label }}</span>
+          <div class="text-right text-sm">
+            <div class="font-medium">{{ option.price | currency: 'USD' : 'symbol' : '1.2-6' }}</div>
+            <div [class]="option.change24h >= 0 ? 'text-green-600' : 'text-red-600'" class="text-xs">
+              {{ option.change24h | number: '1.2-2' }}%
             </div>
           </div>
-        </ng-template>
-      </p-select>
-    </ng-template>
-  </p-card>
+        </div>
+      </ng-template>
+    </p-select>
+  </div>
 
   <!-- Order Form -->
-  <div [class.opacity-50]="!selectedExchangeId()">
-    <p-tabs [(value)]="activeOrderTab">
-      <p-tablist class="bg-surface-50 dark:bg-surface-800 flex w-full rounded-t-2xl">
-        <p-tab value="buy" [disabled]="!selectedPairValue() || !selectedExchangeId()" class="flex-1">
-          <div
-            class="flex w-full items-center justify-center font-semibold transition-all duration-200 hover:bg-green-50 dark:hover:bg-green-900/20"
-          >
-            <span class="text-green-700 dark:text-green-300">Buy</span>
-          </div>
-        </p-tab>
-        <p-tab value="sell" [disabled]="!selectedPairValue() || !selectedExchangeId()" class="flex-1">
-          <div
-            class="flex w-full items-center justify-center font-semibold transition-all duration-200 hover:bg-red-50 dark:hover:bg-red-900/20"
-          >
-            <span class="text-red-700 dark:text-red-300">Sell</span>
-          </div>
-        </p-tab>
+  <div [class.opacity-50]="!selectedExchangeId()" class="mt-4">
+    <p-tabs
+      [value]="activeOrderTab()"
+      (valueChange)="activeOrderTab.set($any($event))"
+      class="trading-tabs"
+      [class.buy-active]="activeOrderTab() === 'buy'"
+      [class.sell-active]="activeOrderTab() === 'sell'"
+    >
+      <p-tablist>
+        <p-tab value="buy" [disabled]="!selectedPairValue() || !selectedExchangeId()"> Buy </p-tab>
+        <p-tab value="sell" [disabled]="!selectedPairValue() || !selectedExchangeId()"> Sell </p-tab>
       </p-tablist>
 
-      <p-tabpanels class="!p-0">
+      <p-tabpanels class="mt-4 !p-0">
         <p-tabpanel value="buy">
-          <div class="p-6">
-            <form [formGroup]="buyOrderForm" (ngSubmit)="onSubmitOrder('BUY')" class="space-y-6">
+          <div class="space-y-4">
+            <form [formGroup]="buyOrderForm" (ngSubmit)="onSubmitOrder('BUY')" class="space-y-4">
               <!-- Buy Order Form -->
-              <div class="space-y-3">
+              <div class="space-y-2">
                 <p-floatlabel variant="on">
                   <p-select
-                    inputId="orderType"
+                    inputId="buyOrderType"
                     formControlName="type"
                     [options]="enhancedOrderTypeOptions"
                     placeholder="Select order type"
                     class="w-full"
                     optionLabel="label"
                     optionValue="value"
-                    size="large"
+                    appendTo="body"
                   >
                     <ng-template pTemplate="selectedItem" let-option>
                       <div class="flex items-center gap-2">
@@ -224,7 +165,7 @@
                       </div>
                     </ng-template>
                     <ng-template pTemplate="item" let-option>
-                      <div class="flex items-center gap-4">
+                      <div class="flex items-center gap-2">
                         <i [class]="option.icon" class="text-sm"></i>
                         <div>
                           <div class="font-medium">{{ option.label }}</div>
@@ -233,26 +174,26 @@
                       </div>
                     </ng-template>
                   </p-select>
-                  <label for="orderType">Order Type</label>
+                  <label for="buyOrderType">Order Type</label>
                 </p-floatlabel>
               </div>
 
-              <div class="space-y-3">
+              <div class="space-y-2">
                 <p-floatlabel variant="on">
                   <p-inputnumber
+                    inputId="buyQuantity"
                     formControlName="quantity"
                     mode="decimal"
                     [minFractionDigits]="2"
                     [maxFractionDigits]="8"
-                    size="large"
                     class="w-full"
                     [class.ng-invalid]="isFieldInvalid(buyOrderForm, 'quantity')"
                     [class.ng-dirty]="isFieldInvalid(buyOrderForm, 'quantity')"
                   />
-                  <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
+                  <label for="buyQuantity">
                     Quantity
                     @if (selectedPair()?.baseAsset?.symbol) {
-                      <span> ({{ selectedPair()?.baseAsset?.symbol }})</span>
+                      <span>({{ selectedPair()?.baseAsset?.symbol | uppercase }})</span>
                     }
                   </label>
                 </p-floatlabel>
@@ -262,38 +203,38 @@
                   </small>
                 }
                 <!-- Percentage Buttons -->
-                <div class="space-y-3">
+                <div class="mt-2">
                   <p-selectbutton
                     [options]="quickAmountOptions"
-                    [(ngModel)]="selectedBuyPercentage"
+                    [ngModel]="selectedBuyPercentage()"
+                    (ngModelChange)="selectedBuyPercentage.set($event)"
                     (onChange)="onBuyPercentageChange($event.value)"
                     optionLabel="label"
                     optionValue="value"
-                    size="large"
                     [disabled]="!selectedPairValue()"
-                    class="quickAmount flex w-full justify-between"
+                    styleClass="w-full flex [&_.p-togglebutton]:flex-1"
                   />
                 </div>
               </div>
 
               <!-- Price Input (for Limit/Stop orders) -->
               @if (shouldShowPriceField(buyOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="buyPrice"
                       formControlName="price"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(buyOrderForm, 'price')"
                       [class.ng-dirty]="isFieldInvalid(buyOrderForm, 'price')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
+                    <label for="buyPrice">
                       Price
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
@@ -307,22 +248,22 @@
 
               <!-- Stop Price (for Stop orders) -->
               @if (shouldShowStopPriceField(buyOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="buyStopPrice"
                       formControlName="stopPrice"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(buyOrderForm, 'stopPrice')"
                       [class.ng-dirty]="isFieldInvalid(buyOrderForm, 'stopPrice')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
+                    <label for="buyStopPrice">
                       Stop Price
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
@@ -332,242 +273,192 @@
                     </small>
                   }
                   <div
-                    class="flex items-start gap-2 rounded-lg border border-orange-200 bg-orange-50 p-3 dark:border-orange-800 dark:bg-orange-900/20"
+                    class="flex items-start gap-2 rounded-lg border border-orange-200 bg-orange-50 p-2 text-xs dark:border-orange-800 dark:bg-orange-900/20"
                   >
-                    <i class="pi pi-info-circle mt-0.5 text-sm text-orange-600 dark:text-orange-400"></i>
-                    <div class="text-sm text-orange-700 dark:text-orange-300">
-                      <span class="font-medium">Trigger Condition:</span> Order will execute when price
+                    <i class="pi pi-info-circle text-orange-600 dark:text-orange-400"></i>
+                    <span class="text-orange-700 dark:text-orange-300">
+                      Order executes when price
                       {{ buyOrderForm.get('type')?.value === 'STOP_LOSS' ? 'drops to' : 'reaches' }} this level
-                    </div>
+                    </span>
                   </div>
                 </div>
               }
 
               <!-- Trailing Stop Fields -->
               @if (shouldShowTrailingFields(buyOrderForm)) {
-                <div class="space-y-3">
-                  <div class="grid grid-cols-2 gap-3">
+                <div class="space-y-2">
+                  <div class="grid grid-cols-2 gap-2">
                     <div>
                       <p-floatlabel variant="on">
                         <p-inputnumber
+                          inputId="buyTrailingAmount"
                           formControlName="trailingAmount"
                           mode="decimal"
                           [minFractionDigits]="2"
                           [maxFractionDigits]="8"
-                          size="large"
                           class="w-full"
                           [class.ng-invalid]="isFieldInvalid(buyOrderForm, 'trailingAmount')"
                           [class.ng-dirty]="isFieldInvalid(buyOrderForm, 'trailingAmount')"
                         />
-                        <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
-                          Trailing Amount
-                        </label>
+                        <label for="buyTrailingAmount">Trailing Amount</label>
                       </p-floatlabel>
                       @if (isFieldInvalid(buyOrderForm, 'trailingAmount')) {
-                        <small class="p-error">
-                          {{ getFieldError(buyOrderForm, 'trailingAmount') }}
-                        </small>
+                        <small class="p-error">{{ getFieldError(buyOrderForm, 'trailingAmount') }}</small>
                       }
                     </div>
                     <p-floatlabel variant="on">
                       <p-select
+                        inputId="buyTrailingType"
                         formControlName="trailingType"
                         [options]="trailingTypeOptions"
                         placeholder="Select type"
                         class="w-full"
                         optionLabel="label"
                         optionValue="value"
-                        size="large"
+                        appendTo="body"
                       />
-                      <label>Type</label>
+                      <label for="buyTrailingType">Type</label>
                     </p-floatlabel>
                   </div>
                   <div
-                    class="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-900/20"
+                    class="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-2 text-xs dark:border-blue-800 dark:bg-blue-900/20"
                   >
-                    <i class="pi pi-info-circle mt-0.5 text-sm text-blue-600 dark:text-blue-400"></i>
-                    <div class="text-sm text-blue-700 dark:text-blue-300">
-                      <span class="font-medium">Dynamic Stop:</span> Stop price automatically adjusts by the trailing
-                      amount as market price moves in your favor
-                    </div>
+                    <i class="pi pi-info-circle text-blue-600 dark:text-blue-400"></i>
+                    <span class="text-blue-700 dark:text-blue-300"
+                      >Stop price adjusts as market moves in your favor</span
+                    >
                   </div>
                 </div>
               }
 
               <!-- Take Profit Price -->
               @if (shouldShowTakeProfitField(buyOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="buyTakeProfitPrice"
                       formControlName="takeProfitPrice"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(buyOrderForm, 'takeProfitPrice')"
                       [class.ng-dirty]="isFieldInvalid(buyOrderForm, 'takeProfitPrice')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
-                      Take Profit Price
+                    <label for="buyTakeProfitPrice">
+                      Take Profit
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
                   @if (isFieldInvalid(buyOrderForm, 'takeProfitPrice')) {
-                    <small class="p-error">
-                      {{ getFieldError(buyOrderForm, 'takeProfitPrice') }}
-                    </small>
+                    <small class="p-error">{{ getFieldError(buyOrderForm, 'takeProfitPrice') }}</small>
                   }
                 </div>
               }
 
               <!-- Stop Loss Price (for OCO) -->
               @if (shouldShowStopLossField(buyOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="buyStopLossPrice"
                       formControlName="stopLossPrice"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(buyOrderForm, 'stopLossPrice')"
                       [class.ng-dirty]="isFieldInvalid(buyOrderForm, 'stopLossPrice')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
-                      Stop Loss Price
+                    <label for="buyStopLossPrice">
+                      Stop Loss
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
                   @if (isFieldInvalid(buyOrderForm, 'stopLossPrice')) {
-                    <small class="p-error">
-                      {{ getFieldError(buyOrderForm, 'stopLossPrice') }}
-                    </small>
+                    <small class="p-error">{{ getFieldError(buyOrderForm, 'stopLossPrice') }}</small>
                   }
                   <div
-                    class="flex items-start gap-2 rounded-lg border border-purple-200 bg-purple-50 p-3 dark:border-purple-800 dark:bg-purple-900/20"
+                    class="flex items-start gap-2 rounded-lg border border-purple-200 bg-purple-50 p-2 text-xs dark:border-purple-800 dark:bg-purple-900/20"
                   >
-                    <i class="pi pi-info-circle mt-0.5 text-sm text-purple-600 dark:text-purple-400"></i>
-                    <div class="text-sm text-purple-700 dark:text-purple-300">
-                      <span class="font-medium">OCO Order:</span> Creates two linked orders - when one executes, the
-                      other is automatically canceled
-                    </div>
+                    <i class="pi pi-info-circle text-purple-600 dark:text-purple-400"></i>
+                    <span class="text-purple-700 dark:text-purple-300"
+                      >OCO: When one order executes, the other cancels</span
+                    >
                   </div>
                 </div>
               }
 
+              <!-- Order Summary -->
               <div
-                class="rounded-2xl border-2 border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 p-5 dark:border-green-800 dark:from-green-900/20 dark:to-emerald-900/20"
+                class="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/20"
               >
-                <div class="mb-4 flex items-center gap-2">
-                  <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-green-100 dark:bg-green-900">
-                    <i class="pi pi-calculator text-green-600 dark:text-green-400"></i>
-                  </div>
-                  <h4 class="font-bold text-green-800 dark:text-green-200">Order Summary</h4>
-                </div>
-
-                <!-- Show preview data if available, otherwise show fallback -->
+                <div class="mb-2 text-xs font-semibold text-green-800 dark:text-green-200">Order Summary</div>
                 @if (buyOrderPreview()) {
-                  <div class="space-y-3">
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-green-700 dark:text-green-300">Market Price</span>
-                      <span class="text-sm font-bold text-green-900 dark:text-green-100">
-                        {{ buyOrderPreview()?.marketPrice | number: '1.2-8' }}
+                  <div class="space-y-1.5 text-sm">
+                    <div class="flex justify-between">
+                      <span class="text-green-700 dark:text-green-300">Value</span>
+                      <span class="font-medium text-green-900 dark:text-green-100">
+                        {{ buyOrderPreview()?.estimatedCost | number: '1.2-6' }}
                         {{ buyOrderPreview()?.balanceCurrency?.toUpperCase() }}
                       </span>
                     </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-green-700 dark:text-green-300">Order Value</span>
-                      <span class="text-lg font-bold text-green-900 dark:text-green-100">
-                        {{ buyOrderPreview()?.estimatedCost | number: '1.2-8' }}
-                        {{ buyOrderPreview()?.balanceCurrency?.toUpperCase() }}
-                      </span>
-                    </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-green-700 dark:text-green-300"> Trading Fees </span>
-                      <span class="text-sm font-semibold text-green-800 dark:text-green-200">
-                        {{ buyOrderPreview()?.estimatedFee | number: '1.2-8' }}
+                    <div class="flex justify-between">
+                      <span class="text-green-700 dark:text-green-300">Fee</span>
+                      <span class="text-green-800 dark:text-green-200">
+                        {{ buyOrderPreview()?.estimatedFee | number: '1.2-6' }}
                         {{ buyOrderPreview()?.feeCurrency?.toUpperCase() }}
                       </span>
                     </div>
-                    <div class="h-px bg-green-200 dark:bg-green-800"></div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-bold text-green-700 dark:text-green-300">Total Cost</span>
-                      <span class="text-xl font-bold text-green-900 dark:text-green-100">
-                        {{ buyOrderPreview()?.totalRequired | number: '1.2-8' }}
-                        {{ buyOrderPreview()?.balanceCurrency?.toUpperCase() }}
-                      </span>
+                    <div class="border-t border-green-200 pt-1.5 dark:border-green-700">
+                      <div class="flex justify-between font-semibold">
+                        <span class="text-green-700 dark:text-green-300">Total</span>
+                        <span class="text-green-900 dark:text-green-100">
+                          {{ buyOrderPreview()?.totalRequired | number: '1.2-6' }}
+                          {{ buyOrderPreview()?.balanceCurrency?.toUpperCase() }}
+                        </span>
+                      </div>
                     </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-green-700 dark:text-green-300">Available Balance</span>
+                    <div class="flex justify-between text-xs">
+                      <span class="text-green-600 dark:text-green-400">Balance</span>
                       <span
-                        class="text-sm font-semibold"
                         [class.text-green-600]="buyOrderPreview()?.hasSufficientBalance"
                         [class.text-red-600]="!buyOrderPreview()?.hasSufficientBalance"
                       >
-                        {{ buyOrderPreview()?.availableBalance | number: '1.2-8' }}
+                        {{ buyOrderPreview()?.availableBalance | number: '1.2-6' }}
                         {{ buyOrderPreview()?.balanceCurrency?.toUpperCase() }}
                       </span>
                     </div>
-                    <!-- Balance warning -->
                     @if (!buyOrderPreview()?.hasSufficientBalance) {
-                      <div
-                        class="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20"
-                      >
-                        <div class="flex items-center gap-2 text-red-700 dark:text-red-300">
-                          <i class="pi pi-exclamation-triangle text-sm"></i>
-                          <span class="text-sm font-medium">Insufficient Balance</span>
-                        </div>
+                      <div class="mt-1 flex items-center gap-1 text-xs text-red-600">
+                        <i class="pi pi-exclamation-triangle"></i>
+                        <span>Insufficient balance</span>
                       </div>
                     }
                   </div>
                 } @else {
-                  <div class="space-y-3">
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-green-700 dark:text-green-300">Order Amount</span>
-                      <span class="text-lg font-bold text-green-900 dark:text-green-100">{{
-                        calculateOrderTotal('BUY') | currency: 'USD' : 'symbol' : '1.2-8'
-                      }}</span>
-                    </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-green-700 dark:text-green-300">Trading Fees</span>
-                      <span class="text-sm font-semibold text-green-800 dark:text-green-200">{{
-                        calculateOrderFees('BUY') | currency: 'USD' : 'symbol' : '1.2-8'
-                      }}</span>
-                    </div>
-                    <div class="h-px bg-green-200 dark:bg-green-800"></div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-bold text-green-700 dark:text-green-300">Total Cost</span>
-                      <span class="text-xl font-bold text-green-900 dark:text-green-100">{{
-                        calculateBuyOrderTotalWithFees() | currency: 'USD' : 'symbol' : '1.2-8'
-                      }}</span>
+                  <div class="space-y-1.5 text-sm">
+                    <div class="flex justify-between">
+                      <span class="text-green-700 dark:text-green-300">Est. Total</span>
+                      <span class="font-medium text-green-900 dark:text-green-100">
+                        {{ calculateBuyOrderTotalWithFees() | currency: 'USD' : 'symbol' : '1.2-6' }}
+                      </span>
                     </div>
                   </div>
                 }
-
-                <!-- Fallback for when no preview data is available -->
               </div>
 
-              <div class="mt-6">
+              <div class="mt-4">
                 <p-button
                   type="submit"
-                  [label]="
-                    selectedPair()
-                      ? 'Buy ' +
-                        selectedPair()?.baseAsset?.symbol?.toUpperCase() +
-                        ' with ' +
-                        selectedPair()?.quoteAsset?.symbol?.toUpperCase()
-                      : 'Buy'
-                  "
+                  [label]="selectedPair() ? 'Buy ' + selectedPair()?.baseAsset?.symbol?.toUpperCase() : 'Buy'"
                   icon="pi pi-arrow-up"
                   severity="success"
-                  size="large"
-                  class="!h-14 w-full !rounded-xl !text-lg !font-bold !text-white !shadow-lg !transition-all !duration-200 hover:!shadow-xl"
+                  styleClass="w-full"
                   [disabled]="
                     buyOrderForm.invalid ||
                     createOrderMutation.isPending() ||
@@ -582,10 +473,10 @@
         </p-tabpanel>
 
         <p-tabpanel value="sell">
-          <div class="p-6">
-            <form [formGroup]="sellOrderForm" (ngSubmit)="onSubmitOrder('SELL')" class="space-y-6">
+          <div class="space-y-4">
+            <form [formGroup]="sellOrderForm" (ngSubmit)="onSubmitOrder('SELL')" class="space-y-4">
               <!-- Sell Order Form -->
-              <div class="space-y-3">
+              <div class="space-y-2">
                 <p-floatlabel variant="on">
                   <p-select
                     inputId="sellOrderType"
@@ -595,7 +486,7 @@
                     class="w-full"
                     optionLabel="label"
                     optionValue="value"
-                    size="large"
+                    appendTo="body"
                   >
                     <ng-template pTemplate="selectedItem" let-option>
                       <div class="flex items-center gap-2">
@@ -617,354 +508,293 @@
                 </p-floatlabel>
               </div>
 
-              <div class="space-y-3">
+              <div class="space-y-2">
                 <p-floatlabel variant="on">
                   <p-inputnumber
+                    inputId="sellQuantity"
                     formControlName="quantity"
                     mode="decimal"
                     [minFractionDigits]="2"
                     [maxFractionDigits]="8"
-                    size="large"
                     class="w-full"
                     [class.ng-invalid]="isFieldInvalid(sellOrderForm, 'quantity')"
                     [class.ng-dirty]="isFieldInvalid(sellOrderForm, 'quantity')"
                   />
-                  <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
+                  <label for="sellQuantity">
                     Quantity
                     @if (selectedPair()?.baseAsset?.symbol) {
-                      <span> ({{ selectedPair()?.baseAsset?.symbol }})</span>
+                      <span>({{ selectedPair()?.baseAsset?.symbol | uppercase }})</span>
                     }
                   </label>
                 </p-floatlabel>
                 @if (isFieldInvalid(sellOrderForm, 'quantity')) {
-                  <small class="p-error">
-                    {{ getFieldError(sellOrderForm, 'quantity') }}
-                  </small>
+                  <small class="p-error">{{ getFieldError(sellOrderForm, 'quantity') }}</small>
                 }
                 <!-- Percentage Buttons -->
-                <div class="space-y-3">
+                <div class="mt-2">
                   <p-selectbutton
                     [options]="quickAmountOptions"
-                    [(ngModel)]="selectedSellPercentage"
+                    [ngModel]="selectedSellPercentage()"
+                    (ngModelChange)="selectedSellPercentage.set($event)"
                     (onChange)="onSellPercentageChange($event.value)"
                     optionLabel="label"
                     optionValue="value"
-                    size="large"
                     [disabled]="!selectedPairValue()"
-                    class="quickAmount flex w-full justify-between"
+                    styleClass="w-full flex [&_.p-togglebutton]:flex-1"
                   />
                 </div>
                 <div
-                  class="bg-surface-50 dark:bg-surface-800 border-surface-200 dark:border-surface-700 mt-4 rounded-xl border p-3"
+                  class="border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800 mt-2 rounded-lg border p-2 text-xs"
                 >
-                  <div class="flex items-center justify-between text-sm">
-                    <span class="text-surface-600 dark:text-surface-400 font-medium">Available Balance</span>
-                    <span class="text-surface-900 dark:text-surface-100 font-semibold">
-                      {{ getSellBalance()?.available | number: '1.2-8' }} {{ selectedPair()?.baseAsset?.symbol }}
+                  <div class="flex justify-between">
+                    <span class="text-surface-600 dark:text-surface-400">Available</span>
+                    <span class="text-surface-900 dark:text-surface-100 font-medium">
+                      {{ getSellBalance()?.available | number: '1.2-6' }}
+                      {{ selectedPair()?.baseAsset?.symbol | uppercase }}
                     </span>
-                  </div>
-                  <div class="mt-2 flex items-center justify-between text-sm">
-                    <span class="text-surface-600 dark:text-surface-400 font-medium">Trading Fee</span>
-                    <span class="font-semibold text-orange-600 dark:text-orange-400"> {{ getTradingFeeRate() }}% </span>
                   </div>
                 </div>
               </div>
 
               <!-- Price Input (for Limit/Stop orders) -->
               @if (shouldShowPriceField(sellOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="sellPrice"
                       formControlName="price"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(sellOrderForm, 'price')"
                       [class.ng-dirty]="isFieldInvalid(sellOrderForm, 'price')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
+                    <label for="sellPrice">
                       Price
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
                   @if (isFieldInvalid(sellOrderForm, 'price')) {
-                    <small class="p-error">
-                      {{ getFieldError(sellOrderForm, 'price') }}
-                    </small>
+                    <small class="p-error">{{ getFieldError(sellOrderForm, 'price') }}</small>
                   }
                 </div>
               }
 
               <!-- Stop Price (for Stop orders) -->
               @if (shouldShowStopPriceField(sellOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="sellStopPrice"
                       formControlName="stopPrice"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(sellOrderForm, 'stopPrice')"
                       [class.ng-dirty]="isFieldInvalid(sellOrderForm, 'stopPrice')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
+                    <label for="sellStopPrice">
                       Stop Price
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
                   @if (isFieldInvalid(sellOrderForm, 'stopPrice')) {
-                    <small class="p-error">
-                      {{ getFieldError(sellOrderForm, 'stopPrice') }}
-                    </small>
+                    <small class="p-error">{{ getFieldError(sellOrderForm, 'stopPrice') }}</small>
                   }
                   <div
-                    class="flex items-start gap-2 rounded-lg border border-orange-200 bg-orange-50 p-3 dark:border-orange-800 dark:bg-orange-900/20"
+                    class="flex items-start gap-2 rounded-lg border border-orange-200 bg-orange-50 p-2 text-xs dark:border-orange-800 dark:bg-orange-900/20"
                   >
-                    <i class="pi pi-info-circle mt-0.5 text-sm text-orange-600 dark:text-orange-400"></i>
-                    <div class="text-sm text-orange-700 dark:text-orange-300">
-                      <span class="font-medium">Trigger Condition:</span> Order will execute when price
+                    <i class="pi pi-info-circle text-orange-600 dark:text-orange-400"></i>
+                    <span class="text-orange-700 dark:text-orange-300">
+                      Order executes when price
                       {{ sellOrderForm.get('type')?.value === 'STOP_LOSS' ? 'drops to' : 'reaches' }} this level
-                    </div>
+                    </span>
                   </div>
                 </div>
               }
 
               <!-- Trailing Stop Fields -->
               @if (shouldShowTrailingFields(sellOrderForm)) {
-                <div class="space-y-3">
-                  <div class="grid grid-cols-2 gap-3">
+                <div class="space-y-2">
+                  <div class="grid grid-cols-2 gap-2">
                     <div>
                       <p-floatlabel variant="on">
                         <p-inputnumber
+                          inputId="sellTrailingAmount"
                           formControlName="trailingAmount"
                           mode="decimal"
                           [minFractionDigits]="2"
                           [maxFractionDigits]="8"
-                          size="large"
                           class="w-full"
                           [class.ng-invalid]="isFieldInvalid(sellOrderForm, 'trailingAmount')"
                           [class.ng-dirty]="isFieldInvalid(sellOrderForm, 'trailingAmount')"
                         />
-                        <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
-                          Trailing Amount
-                        </label>
+                        <label for="sellTrailingAmount">Trailing Amount</label>
                       </p-floatlabel>
                       @if (isFieldInvalid(sellOrderForm, 'trailingAmount')) {
-                        <small class="p-error">
-                          {{ getFieldError(sellOrderForm, 'trailingAmount') }}
-                        </small>
+                        <small class="p-error">{{ getFieldError(sellOrderForm, 'trailingAmount') }}</small>
                       }
                     </div>
                     <p-floatlabel variant="on">
                       <p-select
+                        inputId="sellTrailingType"
                         formControlName="trailingType"
                         [options]="trailingTypeOptions"
                         placeholder="Select type"
                         class="w-full"
                         optionLabel="label"
                         optionValue="value"
-                        size="large"
+                        appendTo="body"
                       />
-                      <label>Type</label>
+                      <label for="sellTrailingType">Type</label>
                     </p-floatlabel>
                   </div>
                   <div
-                    class="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-900/20"
+                    class="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-2 text-xs dark:border-blue-800 dark:bg-blue-900/20"
                   >
-                    <i class="pi pi-info-circle mt-0.5 text-sm text-blue-600 dark:text-blue-400"></i>
-                    <div class="text-sm text-blue-700 dark:text-blue-300">
-                      <span class="font-medium">Dynamic Stop:</span> Stop price automatically adjusts by the trailing
-                      amount as market price moves in your favor
-                    </div>
+                    <i class="pi pi-info-circle text-blue-600 dark:text-blue-400"></i>
+                    <span class="text-blue-700 dark:text-blue-300"
+                      >Stop price adjusts as market moves in your favor</span
+                    >
                   </div>
                 </div>
               }
 
               <!-- Take Profit Price -->
               @if (shouldShowTakeProfitField(sellOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="sellTakeProfitPrice"
                       formControlName="takeProfitPrice"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(sellOrderForm, 'takeProfitPrice')"
                       [class.ng-dirty]="isFieldInvalid(sellOrderForm, 'takeProfitPrice')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
-                      Take Profit Price
+                    <label for="sellTakeProfitPrice">
+                      Take Profit
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
                   @if (isFieldInvalid(sellOrderForm, 'takeProfitPrice')) {
-                    <small class="p-error">
-                      {{ getFieldError(sellOrderForm, 'takeProfitPrice') }}
-                    </small>
+                    <small class="p-error">{{ getFieldError(sellOrderForm, 'takeProfitPrice') }}</small>
                   }
                 </div>
               }
 
               <!-- Stop Loss Price (for OCO) -->
               @if (shouldShowStopLossField(sellOrderForm)) {
-                <div class="space-y-3">
+                <div class="space-y-2">
                   <p-floatlabel variant="on">
                     <p-inputnumber
+                      inputId="sellStopLossPrice"
                       formControlName="stopLossPrice"
                       mode="decimal"
                       [minFractionDigits]="2"
                       [maxFractionDigits]="8"
-                      size="large"
                       class="w-full"
                       [class.ng-invalid]="isFieldInvalid(sellOrderForm, 'stopLossPrice')"
                       [class.ng-dirty]="isFieldInvalid(sellOrderForm, 'stopLossPrice')"
                     />
-                    <label class="text-surface-900 dark:text-surface-100 text-sm font-semibold">
-                      Stop Loss Price
+                    <label for="sellStopLossPrice">
+                      Stop Loss
                       @if (selectedPair()?.quoteAsset?.symbol) {
-                        <span> ({{ selectedPair()?.quoteAsset?.symbol }})</span>
+                        <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
                       }
                     </label>
                   </p-floatlabel>
                   @if (isFieldInvalid(sellOrderForm, 'stopLossPrice')) {
-                    <small class="p-error">
-                      {{ getFieldError(sellOrderForm, 'stopLossPrice') }}
-                    </small>
+                    <small class="p-error">{{ getFieldError(sellOrderForm, 'stopLossPrice') }}</small>
                   }
                   <div
-                    class="flex items-start gap-2 rounded-lg border border-purple-200 bg-purple-50 p-3 dark:border-purple-800 dark:bg-purple-900/20"
+                    class="flex items-start gap-2 rounded-lg border border-purple-200 bg-purple-50 p-2 text-xs dark:border-purple-800 dark:bg-purple-900/20"
                   >
-                    <i class="pi pi-info-circle mt-0.5 text-sm text-purple-600 dark:text-purple-400"></i>
-                    <div class="text-sm text-purple-700 dark:text-purple-300">
-                      <span class="font-medium">OCO Order:</span> Creates two linked orders - when one executes, the
-                      other is automatically canceled
-                    </div>
+                    <i class="pi pi-info-circle text-purple-600 dark:text-purple-400"></i>
+                    <span class="text-purple-700 dark:text-purple-300"
+                      >OCO: When one order executes, the other cancels</span
+                    >
                   </div>
                 </div>
               }
 
-              <div
-                class="rounded-2xl border-2 border-red-200 bg-gradient-to-br from-red-50 to-rose-50 p-5 dark:border-red-800 dark:from-red-900/20 dark:to-rose-900/20"
-              >
-                <div class="mb-4 flex items-center gap-2">
-                  <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-red-100 dark:bg-red-900">
-                    <i class="pi pi-calculator text-red-600 dark:text-red-400"></i>
-                  </div>
-                  <h4 class="font-bold text-red-800 dark:text-red-200">Order Summary</h4>
-                </div>
-
-                <!-- Show preview data if available, otherwise show fallback -->
+              <!-- Order Summary -->
+              <div class="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                <div class="mb-2 text-xs font-semibold text-red-800 dark:text-red-200">Order Summary</div>
                 @if (sellOrderPreview()) {
-                  <div class="space-y-3">
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-red-700 dark:text-red-300">Market Price</span>
-                      <span class="text-sm font-bold text-red-900 dark:text-red-100">
-                        {{ sellOrderPreview()?.marketPrice | number: '1.2-8' }}
+                  <div class="space-y-1.5 text-sm">
+                    <div class="flex justify-between">
+                      <span class="text-red-700 dark:text-red-300">Value</span>
+                      <span class="font-medium text-red-900 dark:text-red-100">
+                        {{ sellOrderPreview()?.estimatedCost | number: '1.2-6' }}
                         {{ sellOrderPreview()?.balanceCurrency?.toUpperCase() }}
                       </span>
                     </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-red-700 dark:text-red-300">Order Value</span>
-                      <span class="text-lg font-bold text-red-900 dark:text-red-100">
-                        {{ sellOrderPreview()?.estimatedCost | number: '1.2-8' }}
-                        {{ sellOrderPreview()?.balanceCurrency?.toUpperCase() }}
-                      </span>
-                    </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-red-700 dark:text-red-300"> Trading Fees </span>
-                      <span class="text-sm font-semibold text-red-800 dark:text-red-200">
-                        {{ sellOrderPreview()?.estimatedFee | number: '1.2-8' }}
+                    <div class="flex justify-between">
+                      <span class="text-red-700 dark:text-red-300">Fee</span>
+                      <span class="text-red-800 dark:text-red-200">
+                        {{ sellOrderPreview()?.estimatedFee | number: '1.2-6' }}
                         {{ sellOrderPreview()?.feeCurrency?.toUpperCase() }}
                       </span>
                     </div>
-                    <div class="h-px bg-red-200 dark:bg-red-800"></div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-bold text-red-700 dark:text-red-300">Net Amount</span>
-                      <span class="text-xl font-bold text-red-900 dark:text-red-100">
-                        {{
-                          (sellOrderPreview()?.estimatedCost || 0) - (sellOrderPreview()?.estimatedFee || 0)
-                            | number: '1.2-8'
-                        }}
-                        {{ sellOrderPreview()?.balanceCurrency?.toUpperCase() }}
-                      </span>
+                    <div class="border-t border-red-200 pt-1.5 dark:border-red-700">
+                      <div class="flex justify-between font-semibold">
+                        <span class="text-red-700 dark:text-red-300">Net</span>
+                        <span class="text-red-900 dark:text-red-100">
+                          {{
+                            (sellOrderPreview()?.estimatedCost || 0) - (sellOrderPreview()?.estimatedFee || 0)
+                              | number: '1.2-6'
+                          }}
+                          {{ sellOrderPreview()?.balanceCurrency?.toUpperCase() }}
+                        </span>
+                      </div>
                     </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-red-700 dark:text-red-300">Available Balance</span>
+                    <div class="flex justify-between text-xs">
+                      <span class="text-red-600 dark:text-red-400">Balance</span>
                       <span
-                        class="text-sm font-semibold"
                         [class.text-green-600]="sellOrderPreview()?.hasSufficientBalance"
                         [class.text-red-600]="!sellOrderPreview()?.hasSufficientBalance"
                       >
-                        {{ sellOrderPreview()?.availableBalance | number: '1.2-8' }}
+                        {{ sellOrderPreview()?.availableBalance | number: '1.2-6' }}
                         {{ sellOrderPreview()?.balanceCurrency?.toUpperCase() }}
                       </span>
                     </div>
-                    <!-- Balance warning -->
                     @if (!sellOrderPreview()?.hasSufficientBalance) {
-                      <div
-                        class="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20"
-                      >
-                        <div class="flex items-center gap-2 text-red-700 dark:text-red-300">
-                          <i class="pi pi-exclamation-triangle text-sm"></i>
-                          <span class="text-sm font-medium">Insufficient Balance</span>
-                        </div>
+                      <div class="mt-1 flex items-center gap-1 text-xs text-red-600">
+                        <i class="pi pi-exclamation-triangle"></i>
+                        <span>Insufficient balance</span>
                       </div>
                     }
                   </div>
                 } @else {
-                  <div class="space-y-3">
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-red-700 dark:text-red-300">Order Value</span>
-                      <span class="text-lg font-bold text-red-900 dark:text-red-100">{{
-                        calculateOrderTotal('SELL') | currency: 'USD' : 'symbol' : '1.2-8'
-                      }}</span>
-                    </div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium text-red-700 dark:text-red-300">Trading Fees</span>
-                      <span class="text-sm font-semibold text-red-800 dark:text-red-200">{{
-                        calculateOrderFees('SELL') | currency: 'USD' : 'symbol' : '1.2-8'
-                      }}</span>
-                    </div>
-                    <div class="h-px bg-red-200 dark:bg-red-800"></div>
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-bold text-red-700 dark:text-red-300">Net Amount</span>
-                      <span class="text-xl font-bold text-red-900 dark:text-red-100">{{
-                        calculateSellOrderNetAmount() | currency: 'USD' : 'symbol' : '1.2-8'
-                      }}</span>
+                  <div class="space-y-1.5 text-sm">
+                    <div class="flex justify-between">
+                      <span class="text-red-700 dark:text-red-300">Est. Net</span>
+                      <span class="font-medium text-red-900 dark:text-red-100">
+                        {{ calculateSellOrderNetAmount() | currency: 'USD' : 'symbol' : '1.2-6' }}
+                      </span>
                     </div>
                   </div>
                 }
-
-                <!-- Fallback for when no preview data is available -->
               </div>
 
-              <div class="mt-6">
+              <div class="mt-4">
                 <p-button
                   type="submit"
-                  [label]="
-                    selectedPair()
-                      ? 'Sell ' +
-                        selectedPair()?.baseAsset?.symbol?.toUpperCase() +
-                        ' for ' +
-                        selectedPair()?.quoteAsset?.symbol?.toUpperCase()
-                      : 'Sell'
-                  "
+                  [label]="selectedPair() ? 'Sell ' + selectedPair()?.baseAsset?.symbol?.toUpperCase() : 'Sell'"
                   icon="pi pi-arrow-down"
                   severity="danger"
-                  size="large"
-                  class="!h-14 w-full !rounded-xl !text-lg !font-bold !text-white !shadow-lg !transition-all !duration-200 hover:!shadow-xl"
+                  styleClass="w-full"
                   [disabled]="
                     sellOrderForm.invalid ||
                     createOrderMutation.isPending() ||
@@ -980,191 +810,112 @@
     </p-tabs>
   </div>
 
-  <!-- Order Book & Market Data -->
-  @if (selectedPair()) {
-    <div class="space-y-4 lg:col-span-2">
-      <!-- Order Book -->
-      <p-card>
-        <ng-template pTemplate="header">
-          <div class="p-4">
-            <h3 class="text-lg font-semibold">Order Book</h3>
-          </div>
-        </ng-template>
-        @if (orderBookQuery.data()) {
-          <div class="grid grid-cols-2 gap-4">
-            <!-- Asks (Sell Orders) -->
-            <div>
-              <h4 class="mb-2 text-sm font-semibold text-red-600">Asks (Sell)</h4>
-              <div class="space-y-1">
-                @for (ask of getTopAsks(); track trackByPrice($index, ask)) {
-                  <div class="flex justify-between rounded bg-red-50 p-2 text-sm dark:bg-red-950">
-                    <span class="text-red-600">{{ ask.price | number: '1.2-8' }}</span>
-                    <span>{{ ask.quantity | number: '1.2-8' }}</span>
-                  </div>
-                }
-              </div>
+  <!-- Compact Order Book (collapsible for drawer) -->
+  @if (selectedPair() && orderBookQuery.data()) {
+    <div
+      class="border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800 mt-4 rounded-lg border p-3"
+    >
+      <button
+        type="button"
+        (click)="showOrderBook.set(!showOrderBook())"
+        class="text-surface-700 dark:text-surface-300 flex w-full items-center justify-between text-sm font-medium"
+      >
+        <span>Order Book</span>
+        <i class="pi text-xs" [class.pi-chevron-down]="showOrderBook()" [class.pi-chevron-right]="!showOrderBook()"></i>
+      </button>
+      @if (showOrderBook()) {
+        <div class="mt-3 grid grid-cols-2 gap-3">
+          <div>
+            <div class="mb-1.5 flex justify-between text-xs font-medium text-red-600">
+              <span>Price</span>
+              <span>Amount</span>
             </div>
-            <!-- Bids (Buy Orders) -->
-            <div>
-              <h4 class="mb-2 text-sm font-semibold text-green-600">Bids (Buy)</h4>
-              <div class="space-y-1">
-                @for (bid of getTopBids(); track trackByPrice($index, bid)) {
-                  <div class="flex justify-between rounded bg-green-50 p-2 text-sm dark:bg-green-950">
-                    <span class="text-green-600">{{ bid.price | number: '1.2-8' }}</span>
-                    <span>{{ bid.quantity | number: '1.2-8' }}</span>
-                  </div>
-                }
-              </div>
-            </div>
-          </div>
-        } @else {
-          <div class="flex items-center justify-center p-8">
-            <i class="pi pi-spinner pi-spin mr-2"></i>
-            Loading order book...
-          </div>
-        }
-      </p-card>
-    </div>
-  }
-
-  <!-- Collapsible Active Orders -->
-  @if (activeOrdersQuery.data() && (activeOrdersQuery.data() || []).length > 0) {
-    <p-card class="mt-4">
-      <!-- <ng-template pTemplate="header">
-      <div class="flex items-center justify-between p-3">
-        <button
-          (click)="showActiveOrders.set(!showActiveOrders())"
-          class="flex items-center gap-2 text-lg font-semibold transition-colors hover:text-primary-600"
-          >
-          <i class="pi" [class.pi-chevron-down]="showActiveOrders()" [class.pi-chevron-right]="!showActiveOrders()"></i>
-          Active Orders
-          <span class="px-2 py-1 ml-2 text-xs rounded-full bg-primary-100 text-primary-800">
-            {{ (activeOrdersQuery.data() || []).length }}
-          </span>
-        </button>
-        <p-button
-          icon="pi pi-refresh"
-          severity="secondary"
-          size="small"
-          text
-          (click)="refreshActiveOrders()"
-          [loading]="activeOrdersQuery.isPending()"
-          pTooltip="Refresh"
-          />
-      </div>
-    </ng-template>-->
-      <!-- Collapsible Content -->
-      @if (showActiveOrders()) {
-        <div class="px-3 pb-3">
-          <!-- Mobile-Friendly Order Cards -->
-          <div class="space-y-2 md:hidden">
-            @for (order of activeOrdersQuery.data() || []; track trackByOrderId($index, order)) {
-              <div class="bg-surface-50 dark:bg-surface-800 rounded-lg border p-3">
-                <div class="mb-2 flex items-center justify-between">
-                  <div class="flex items-center gap-2">
-                    <span class="font-semibold">{{ order.symbol }}</span>
-                    <span
-                      [class]="order.side === 'BUY' ? 'text-green-600' : 'text-red-600'"
-                      class="text-sm font-medium"
-                    >
-                      {{ order.side }}
-                    </span>
-                  </div>
-                  <span class="rounded-full px-2 py-1 text-xs font-semibold" [class]="getStatusClass(order.status)">
-                    {{ order.status }}
-                  </span>
-                </div>
-                <div class="text-surface-600 dark:text-surface-400 mb-2 grid grid-cols-2 gap-2 text-sm">
-                  <div><span class="font-medium">Type:</span> {{ order.type }}</div>
-                  <div><span class="font-medium">Quantity:</span> {{ order.quantity | number: '1.2-6' }}</div>
-                  <div><span class="font-medium">Price:</span> {{ order.price | number: '1.2-6' }}</div>
-                  <div><span class="font-medium">Filled:</span> {{ order.executedQuantity | number: '1.2-6' }}</div>
-                </div>
-                <p-button
-                  icon="pi pi-times"
-                  label="Cancel"
-                  severity="danger"
-                  size="small"
-                  outlined
-                  (click)="cancelOrder(order.id)"
-                  [disabled]="cancelOrderMutation.isPending()"
-                  class="w-full"
-                />
+            @for (ask of getTopAsks(); track trackByPrice($index, ask)) {
+              <div class="flex justify-between rounded px-1.5 py-0.5 text-xs odd:bg-red-50 dark:odd:bg-red-950/50">
+                <span class="text-red-600">{{ ask.price | number: '1.2-6' }}</span>
+                <span class="text-surface-600 dark:text-surface-400">{{ ask.quantity | number: '1.2-4' }}</span>
               </div>
             }
           </div>
-          <!-- Desktop Table -->
-          <div class="hidden md:block">
-            <p-table
-              [value]="activeOrdersQuery.data() || []"
-              [loading]="activeOrdersQuery.isPending()"
-              class="p-datatable-sm"
-            >
-              <ng-template pTemplate="header">
-                <tr>
-                  <th class="text-xs">Symbol</th>
-                  <th class="text-xs">Side</th>
-                  <th class="text-xs">Type</th>
-                  <th class="text-xs">Quantity</th>
-                  <th class="text-xs">Price</th>
-                  <th class="text-xs">Filled</th>
-                  <th class="text-xs">Status</th>
-                  <th class="text-xs">Actions</th>
-                </tr>
-              </ng-template>
-              <ng-template pTemplate="body" let-order>
-                <tr>
-                  <td class="text-sm font-medium">{{ order.symbol }}</td>
-                  <td>
-                    <span
-                      [class]="order.side === 'BUY' ? 'text-green-600' : 'text-red-600'"
-                      class="text-sm font-medium"
-                    >
-                      {{ order.side }}
-                    </span>
-                  </td>
-                  <td class="text-sm">{{ order.type }}</td>
-                  <td class="text-sm">{{ order.quantity | number: '1.2-6' }}</td>
-                  <td class="text-sm">{{ order.price | number: '1.2-6' }}</td>
-                  <td class="text-sm">{{ order.executedQuantity | number: '1.2-6' }}</td>
-                  <td>
-                    <span class="rounded-full px-2 py-1 text-xs font-semibold" [class]="getStatusClass(order.status)">
-                      {{ order.status }}
-                    </span>
-                  </td>
-                  <td>
-                    <p-button
-                      icon="pi pi-times"
-                      severity="danger"
-                      size="small"
-                      text
-                      (click)="cancelOrder(order.id)"
-                      [disabled]="cancelOrderMutation.isPending()"
-                      pTooltip="Cancel Order"
-                    />
-                  </td>
-                </tr>
-              </ng-template>
-              <ng-template pTemplate="emptymessage">
-                <tr>
-                  <td colspan="8" class="text-surface-600 dark:text-surface-400 py-4 text-center">
-                    <i class="pi pi-inbox mb-2 block text-2xl"></i>
-                    No active orders
-                  </td>
-                </tr>
-              </ng-template>
-            </p-table>
+          <div>
+            <div class="mb-1.5 flex justify-between text-xs font-medium text-green-600">
+              <span>Price</span>
+              <span>Amount</span>
+            </div>
+            @for (bid of getTopBids(); track trackByPrice($index, bid)) {
+              <div class="flex justify-between rounded px-1.5 py-0.5 text-xs odd:bg-green-50 dark:odd:bg-green-950/50">
+                <span class="text-green-600">{{ bid.price | number: '1.2-6' }}</span>
+                <span class="text-surface-600 dark:text-surface-400">{{ bid.quantity | number: '1.2-4' }}</span>
+              </div>
+            }
           </div>
         </div>
       }
-    </p-card>
+    </div>
+  }
+
+  <!-- Active Orders (compact for drawer) -->
+  @if (activeOrdersQuery.data() && (activeOrdersQuery.data() || []).length > 0) {
+    <div
+      class="border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800 mt-4 rounded-lg border p-3"
+    >
+      <button
+        type="button"
+        (click)="showActiveOrders.set(!showActiveOrders())"
+        class="text-surface-700 dark:text-surface-300 flex w-full items-center justify-between text-sm font-medium"
+      >
+        <span>Active Orders</span>
+        <div class="flex items-center gap-2">
+          <span
+            class="bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300 rounded-full px-2 py-0.5 text-xs font-semibold"
+          >
+            {{ (activeOrdersQuery.data() || []).length }}
+          </span>
+          <i
+            class="pi text-xs"
+            [class.pi-chevron-down]="showActiveOrders()"
+            [class.pi-chevron-right]="!showActiveOrders()"
+          ></i>
+        </div>
+      </button>
+      @if (showActiveOrders()) {
+        <div class="mt-3 space-y-2">
+          @for (order of activeOrdersQuery.data() || []; track trackByOrderId($index, order)) {
+            <div class="border-surface-200 dark:border-surface-600 dark:bg-surface-700 rounded-lg border bg-white p-2">
+              <div class="mb-1.5 flex items-center justify-between">
+                <div class="flex items-center gap-2">
+                  <span class="text-sm font-semibold">{{ order.symbol }}</span>
+                  <span
+                    class="text-xs font-medium"
+                    [class.text-green-600]="order.side === 'BUY'"
+                    [class.text-red-600]="order.side === 'SELL'"
+                  >
+                    {{ order.side }}
+                  </span>
+                </div>
+                <span class="rounded-full px-1.5 py-0.5 text-xs font-medium" [class]="getStatusClass(order.status)">
+                  {{ order.status }}
+                </span>
+              </div>
+              <div class="text-surface-600 dark:text-surface-400 mb-2 grid grid-cols-2 gap-x-3 text-xs">
+                <div>Qty: {{ order.quantity | number: '1.2-4' }}</div>
+                <div>Price: {{ order.price | number: '1.2-4' }}</div>
+              </div>
+              <p-button
+                icon="pi pi-times"
+                label="Cancel"
+                severity="danger"
+                outlined
+                (click)="cancelOrder(order.id)"
+                [disabled]="cancelOrderMutation.isPending()"
+                styleClass="w-full text-sm"
+              />
+            </div>
+          }
+        </div>
+      }
+    </div>
   }
 
   <p-toast />
 </div>
-
-<style>
-  :host ::ng-deep .quickAmount .p-togglebutton {
-    flex: 1;
-  }
-</style>

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.scss
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.scss
@@ -1,0 +1,157 @@
+:host {
+  display: block;
+
+  // Trading tabs - Buy/Sell toggle style
+  ::ng-deep {
+    .trading-tabs {
+      .p-tablist {
+        background: transparent;
+        border: 1px solid var(--p-surface-200);
+        border-radius: 0.5rem;
+        padding: 0.25rem;
+        overflow: hidden;
+
+        .p-tablist-tab-list {
+          background: transparent;
+          border: none;
+          gap: 0.25rem;
+          width: 100%;
+          display: flex;
+        }
+
+        .p-tab {
+          flex: 1;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          padding: 0.625rem 1rem;
+          border: none;
+          background: transparent;
+          margin: 0;
+          border-radius: 0.375rem;
+          font-weight: 600;
+          font-size: 0.875rem;
+          transition: all 0.15s ease;
+          color: var(--p-surface-500);
+
+          &:hover:not(.p-disabled):not(.p-tab-active) {
+            background: var(--p-surface-100);
+            color: var(--p-surface-700);
+          }
+
+          &.p-disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+          }
+
+          &:focus,
+          &:focus-visible {
+            outline: none;
+            box-shadow: none;
+          }
+        }
+
+        // Hide the default active bar
+        .p-tablist-active-bar {
+          display: none;
+        }
+      }
+
+      // Buy active state - green theme
+      &.buy-active {
+        .p-tablist .p-tab {
+          &[data-p-active='true'],
+          &.p-tab-active {
+            background: #22c55e;
+            color: white;
+
+            &:hover {
+              background: #16a34a;
+            }
+          }
+        }
+      }
+
+      // Sell active state - red theme
+      &.sell-active {
+        .p-tablist .p-tab {
+          &[data-p-active='true'],
+          &.p-tab-active {
+            background: #ef4444;
+            color: white;
+
+            &:hover {
+              background: #dc2626;
+            }
+          }
+        }
+      }
+
+      // Tab panels
+      .p-tabpanels {
+        padding: 0;
+        background: transparent;
+      }
+    }
+
+    // Quick amount buttons
+    .p-selectbutton {
+      display: flex;
+      width: 100%;
+
+      .p-togglebutton {
+        flex: 1;
+        justify-content: center;
+      }
+    }
+  }
+}
+
+// Dark mode adjustments
+.dark :host,
+:host-context(.dark) {
+  ::ng-deep {
+    .trading-tabs {
+      .p-tablist {
+        border-color: var(--p-surface-700);
+
+        .p-tab {
+          color: var(--p-surface-400);
+
+          &:hover:not(.p-disabled):not(.p-tab-active) {
+            background: var(--p-surface-800);
+            color: var(--p-surface-200);
+          }
+        }
+      }
+
+      &.buy-active {
+        .p-tablist .p-tab {
+          &[data-p-active='true'],
+          &.p-tab-active {
+            background: #22c55e;
+            color: white;
+
+            &:hover {
+              background: #16a34a;
+            }
+          }
+        }
+      }
+
+      &.sell-active {
+        .p-tablist .p-tab {
+          &[data-p-active='true'],
+          &.p-tab-active {
+            background: #ef4444;
+            color: white;
+
+            &:hover {
+              background: #dc2626;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
@@ -14,9 +14,18 @@ import { TableModule } from 'primeng/table';
 import { TabsModule } from 'primeng/tabs';
 import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
-import { Subject, takeUntil } from 'rxjs';
+import { debounceTime, Subject, takeUntil } from 'rxjs';
 
-import { Exchange, OrderPreview, OrderSide, OrderStatus, OrderType, TickerPair } from '@chansey/api-interfaces';
+import {
+  Exchange,
+  OrderPreview,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  PlaceOrderRequest,
+  TickerPair,
+  TrailingType
+} from '@chansey/api-interfaces';
 
 import { AuthService } from '../../services';
 import { Balance, CryptoTradingService } from '../../services/crypto-trading.service';
@@ -41,7 +50,8 @@ import { ExchangeService } from '../../services/exchange.service';
     ToastModule,
     TooltipModule
   ],
-  templateUrl: './crypto-trading.component.html'
+  templateUrl: './crypto-trading.component.html',
+  styleUrls: ['./crypto-trading.component.scss']
 })
 export class CryptoTradingComponent implements OnInit, OnDestroy {
   private readonly authService = inject(AuthService);
@@ -50,18 +60,20 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   private readonly fb = inject(FormBuilder);
   private readonly messageService = inject(MessageService);
   private readonly destroy$ = new Subject<void>();
+  private readonly previewSubject$ = new Subject<'BUY' | 'SELL'>();
 
   // Reactive state
   selectedPairValue = signal<string | null>(null);
   selectedExchangeId = signal<string | null>(null);
   activeOrderTab = signal<string>('buy');
-  showActiveOrders = signal<boolean>(true);
+  showActiveOrders = signal<boolean>(false);
+  showOrderBook = signal<boolean>(false);
   selectedBuyPercentage = signal<number | null>(null);
   selectedSellPercentage = signal<number | null>(null);
   buyOrderPreview = signal<OrderPreview | null>(null);
   sellOrderPreview = signal<OrderPreview | null>(null);
 
-  // Computed symbol for order book query
+  // Computed symbol for order book query (uppercase for CCXT compatibility)
   selectedSymbol = computed(() => {
     const pairSymbol = this.selectedPairValue();
     const pairs = this.tradingPairsQuery.data();
@@ -71,7 +83,7 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
     }
 
     const foundPair = pairs.find((pair) => pair.symbol.toUpperCase() === pairSymbol.toUpperCase());
-    return foundPair?.symbol || null;
+    return foundPair?.symbol.toUpperCase() || null;
   });
 
   // Forms
@@ -97,21 +109,23 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
     const pairs = this.tradingPairsQuery.data();
 
     if (!pairSymbol || !pairs) {
-      console.log('No pair symbol or no pairs data:', { pairSymbol, pairs });
       return null;
     }
 
-    console.log('Looking for pair:', pairSymbol);
-    console.log(
-      'Available pairs:',
-      pairs.map((p) => ({ symbol: p.symbol, upperSymbol: p.symbol.toUpperCase() }))
-    );
-
     // Find pair by comparing uppercase symbols since tradingPairOptions uses toUpperCase()
     const foundPair = pairs.find((pair) => pair.symbol.toUpperCase() === pairSymbol.toUpperCase());
-    console.log('Found pair:', foundPair);
-
     return foundPair || null;
+  });
+
+  // Get the exchange key ID for the selected exchange
+  selectedExchangeKeyId = computed(() => {
+    const exchangeId = this.selectedExchangeId();
+    const userExchanges = this.userQuery.data()?.exchanges;
+
+    if (!exchangeId || !userExchanges) return null;
+
+    const userExchange = userExchanges.find((ue: any) => ue.exchangeId === exchangeId);
+    return userExchange?.id || null;
   });
 
   exchangeOptions = computed(() => {
@@ -146,10 +160,13 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
     }));
   });
 
-  orderTypeOptions = [
-    { label: 'Market', value: OrderType.MARKET },
-    { label: 'Limit', value: OrderType.LIMIT }
-  ];
+  // Supported order types (will be updated from preview response)
+  supportedOrderTypes = signal<OrderType[]>([OrderType.MARKET, OrderType.LIMIT]);
+
+  orderTypeOptions = computed(() => {
+    const supported = this.supportedOrderTypes();
+    return this.enhancedOrderTypeOptions.filter((opt) => supported.includes(opt.value));
+  });
 
   enhancedOrderTypeOptions = [
     {
@@ -192,7 +209,7 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
       label: 'OCO',
       value: OrderType.OCO,
       icon: 'pi pi-arrows-h',
-      description: 'One-Cancels-Other: Take profit and stop loss pair, cancels one when the other executes'
+      description: 'One-Cancels-Other: Take profit and stop loss pair'
     }
   ];
 
@@ -204,8 +221,8 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   ];
 
   trailingTypeOptions = [
-    { label: 'Amount', value: 'amount' },
-    { label: 'Percentage', value: 'percentage' }
+    { label: 'Amount', value: TrailingType.AMOUNT },
+    { label: 'Percentage', value: TrailingType.PERCENTAGE }
   ];
 
   // Auto-select the first connected exchange when available
@@ -234,6 +251,13 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.initializeForms();
     this.setupFormSubscriptions();
+    this.setupPreviewDebounce();
+  }
+
+  private setupPreviewDebounce() {
+    this.previewSubject$
+      .pipe(debounceTime(300), takeUntil(this.destroy$))
+      .subscribe((side) => this.executePreview(side));
   }
 
   ngOnDestroy() {
@@ -244,220 +268,182 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   private initializeForms() {
     this.buyOrderForm = this.fb.group({
       type: [OrderType.MARKET, Validators.required],
-      quantity: [null, [Validators.required, Validators.min(0.001)]],
+      quantity: [null, [Validators.required, Validators.min(0.00000001)]],
       price: [null],
       stopPrice: [null],
       trailingAmount: [null],
-      trailingType: ['amount'],
+      trailingType: [TrailingType.AMOUNT],
       takeProfitPrice: [null],
       stopLossPrice: [null]
     });
 
     this.sellOrderForm = this.fb.group({
       type: [OrderType.MARKET, Validators.required],
-      quantity: [null, [Validators.required, Validators.min(0.001)]],
+      quantity: [null, [Validators.required, Validators.min(0.00000001)]],
       price: [null],
       stopPrice: [null],
       trailingAmount: [null],
-      trailingType: ['amount'],
+      trailingType: [TrailingType.AMOUNT],
       takeProfitPrice: [null],
       stopLossPrice: [null]
     });
   }
 
   private setupFormSubscriptions() {
-    // Update validators when order type changes
+    // Update validators when order type changes for buy form
     this.buyOrderForm
       .get('type')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((type) => {
-        const priceControl = this.buyOrderForm.get('price');
-        const stopPriceControl = this.buyOrderForm.get('stopPrice');
-        const trailingAmountControl = this.buyOrderForm.get('trailingAmount');
-        const takeProfitPriceControl = this.buyOrderForm.get('takeProfitPrice');
-        const stopLossPriceControl = this.buyOrderForm.get('stopLossPrice');
-
-        // Reset validators
-        priceControl?.clearValidators();
-        stopPriceControl?.clearValidators();
-        trailingAmountControl?.clearValidators();
-        takeProfitPriceControl?.clearValidators();
-        stopLossPriceControl?.clearValidators();
-
-        // Set validators based on order type
-        if (type === OrderType.LIMIT || type === OrderType.STOP_LIMIT) {
-          priceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.STOP_LOSS || type === OrderType.STOP_LIMIT) {
-          stopPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.TRAILING_STOP) {
-          trailingAmountControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.TAKE_PROFIT) {
-          takeProfitPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.OCO) {
-          takeProfitPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-          stopLossPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-
-        priceControl?.updateValueAndValidity();
-        stopPriceControl?.updateValueAndValidity();
-        trailingAmountControl?.updateValueAndValidity();
-        takeProfitPriceControl?.updateValueAndValidity();
-        stopLossPriceControl?.updateValueAndValidity();
-
-        // Preview order when type changes
-        this.calculateOrderTotalWithPreview('BUY');
+        this.updateFormValidators(this.buyOrderForm, type);
+        this.triggerPreview('BUY');
       });
 
+    // Update validators when order type changes for sell form
     this.sellOrderForm
       .get('type')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((type) => {
-        const priceControl = this.sellOrderForm.get('price');
-        const stopPriceControl = this.sellOrderForm.get('stopPrice');
-        const trailingAmountControl = this.sellOrderForm.get('trailingAmount');
-        const takeProfitPriceControl = this.sellOrderForm.get('takeProfitPrice');
-        const stopLossPriceControl = this.sellOrderForm.get('stopLossPrice');
-
-        // Reset validators
-        priceControl?.clearValidators();
-        stopPriceControl?.clearValidators();
-        trailingAmountControl?.clearValidators();
-        takeProfitPriceControl?.clearValidators();
-        stopLossPriceControl?.clearValidators();
-
-        // Set validators based on order type
-        if (type === OrderType.LIMIT || type === OrderType.STOP_LIMIT) {
-          priceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.STOP_LOSS || type === OrderType.STOP_LIMIT) {
-          stopPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.TRAILING_STOP) {
-          trailingAmountControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.TAKE_PROFIT) {
-          takeProfitPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-        if (type === OrderType.OCO) {
-          takeProfitPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-          stopLossPriceControl?.setValidators([Validators.required, Validators.min(0.001)]);
-        }
-
-        priceControl?.updateValueAndValidity();
-        stopPriceControl?.updateValueAndValidity();
-        trailingAmountControl?.updateValueAndValidity();
-        takeProfitPriceControl?.updateValueAndValidity();
-        stopLossPriceControl?.updateValueAndValidity();
-
-        // Preview order when type changes
-        this.calculateOrderTotalWithPreview('SELL');
+        this.updateFormValidators(this.sellOrderForm, type);
+        this.triggerPreview('SELL');
       });
 
     // Preview order when quantity changes
     this.buyOrderForm
       .get('quantity')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.calculateOrderTotalWithPreview('BUY');
-      });
+      .subscribe(() => this.triggerPreview('BUY'));
 
     this.sellOrderForm
       .get('quantity')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.calculateOrderTotalWithPreview('SELL');
-      });
+      .subscribe(() => this.triggerPreview('SELL'));
 
     // Preview order when price changes (for limit orders)
     this.buyOrderForm
       .get('price')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.calculateOrderTotalWithPreview('BUY');
-      });
+      .subscribe(() => this.triggerPreview('BUY'));
 
     this.sellOrderForm
       .get('price')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.calculateOrderTotalWithPreview('SELL');
-      });
+      .subscribe(() => this.triggerPreview('SELL'));
+  }
+
+  private updateFormValidators(form: FormGroup, type: OrderType) {
+    const controls = ['price', 'stopPrice', 'trailingAmount', 'takeProfitPrice', 'stopLossPrice'];
+    controls.forEach((ctrl) => {
+      form.get(ctrl)?.clearValidators();
+    });
+
+    if (type === OrderType.LIMIT || type === OrderType.STOP_LIMIT) {
+      form.get('price')?.setValidators([Validators.required, Validators.min(0.00000001)]);
+    }
+    if (type === OrderType.STOP_LOSS || type === OrderType.STOP_LIMIT) {
+      form.get('stopPrice')?.setValidators([Validators.required, Validators.min(0.00000001)]);
+    }
+    if (type === OrderType.TRAILING_STOP) {
+      form.get('trailingAmount')?.setValidators([Validators.required, Validators.min(0.00000001)]);
+    }
+    if (type === OrderType.TAKE_PROFIT) {
+      form.get('takeProfitPrice')?.setValidators([Validators.required, Validators.min(0.00000001)]);
+    }
+    if (type === OrderType.OCO) {
+      form.get('takeProfitPrice')?.setValidators([Validators.required, Validators.min(0.00000001)]);
+      form.get('stopLossPrice')?.setValidators([Validators.required, Validators.min(0.00000001)]);
+    }
+
+    controls.forEach((ctrl) => form.get(ctrl)?.updateValueAndValidity());
   }
 
   onPairChange(event: { value: string }) {
     const symbol = event.value;
     this.selectedPairValue.set(symbol);
 
-    // Use case-insensitive matching to find the pair
     const pair = this.tradingPairsQuery.data()?.find((p) => p.symbol.toUpperCase() === symbol.toUpperCase());
     if (pair) {
       this.tradingService.setSelectedPair(pair);
+      // Trigger preview to get supported order types
+      this.triggerPreview('BUY');
     }
+  }
+
+  /**
+   * Build a PlaceOrderRequest from form data
+   */
+  private buildOrderRequest(side: 'BUY' | 'SELL'): PlaceOrderRequest | null {
+    const form = side === 'BUY' ? this.buyOrderForm : this.sellOrderForm;
+    const pair = this.selectedPair();
+    const exchangeKeyId = this.selectedExchangeKeyId();
+
+    if (!pair || !exchangeKeyId) return null;
+
+    const formValue = form.value;
+
+    const request: PlaceOrderRequest = {
+      exchangeKeyId,
+      symbol: pair.symbol.toUpperCase(),
+      side: side === 'BUY' ? OrderSide.BUY : OrderSide.SELL,
+      orderType: formValue.type,
+      quantity: formValue.quantity || 0
+    };
+
+    // Add conditional fields based on order type
+    if (formValue.price) request.price = formValue.price;
+    if (formValue.stopPrice) request.stopPrice = formValue.stopPrice;
+    if (formValue.trailingAmount) {
+      request.trailingAmount = formValue.trailingAmount;
+      request.trailingType = formValue.trailingType;
+    }
+    if (formValue.takeProfitPrice) request.takeProfitPrice = formValue.takeProfitPrice;
+    if (formValue.stopLossPrice) request.stopLossPrice = formValue.stopLossPrice;
+
+    return request;
   }
 
   onSubmitOrder(side: 'BUY' | 'SELL') {
     const form = side === 'BUY' ? this.buyOrderForm : this.sellOrderForm;
-    const pair = this.selectedPair();
-    const exchangeId = this.selectedExchangeId();
 
-    if (!form.valid || !pair || !exchangeId) return;
-
-    const formValue = form.value;
-    const userExchanges = this.userQuery.data()?.exchanges;
-    const userExchange = userExchanges?.find((ue: any) => ue.exchangeId === exchangeId);
-
-    if (!userExchange?.id) {
+    if (!form.valid) {
       this.messageService.add({
-        severity: 'error',
-        summary: 'Error',
-        detail: 'No exchange key found for selected exchange'
+        severity: 'warn',
+        summary: 'Validation Error',
+        detail: 'Please fill in all required fields'
       });
       return;
     }
 
-    const orderData: any = {
-      exchangeKeyId: userExchange.id,
-      symbol: pair.symbol,
-      orderType: formValue.type,
-      side: side === 'BUY' ? OrderSide.BUY : OrderSide.SELL,
-      quantity: formValue.quantity
-    };
-
-    // Add conditional fields based on order type
-    if (formValue.price) {
-      orderData.price = formValue.price;
-    }
-    if (formValue.stopPrice) {
-      orderData.stopPrice = formValue.stopPrice;
-    }
-    if (formValue.trailingAmount) {
-      orderData.trailingAmount = formValue.trailingAmount;
-      orderData.trailingType = formValue.trailingType;
-    }
-    if (formValue.takeProfitPrice) {
-      orderData.takeProfitPrice = formValue.takeProfitPrice;
-    }
-    if (formValue.stopLossPrice) {
-      orderData.stopLossPrice = formValue.stopLossPrice;
+    const orderRequest = this.buildOrderRequest(side);
+    if (!orderRequest) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Please select an exchange and trading pair'
+      });
+      return;
     }
 
-    this.createOrderMutation.mutate(orderData, {
+    this.createOrderMutation.mutate(orderRequest, {
       onSuccess: () => {
         this.messageService.add({
           severity: 'success',
-          summary: 'Success',
+          summary: 'Order Placed',
           detail: `${side} order placed successfully`
         });
-        form.reset({ type: OrderType.MARKET, trailingType: 'amount' });
+        form.reset({ type: OrderType.MARKET, trailingType: TrailingType.AMOUNT });
+        if (side === 'BUY') {
+          this.buyOrderPreview.set(null);
+          this.selectedBuyPercentage.set(null);
+        } else {
+          this.sellOrderPreview.set(null);
+          this.selectedSellPercentage.set(null);
+        }
       },
       onError: (error: Error) => {
         this.messageService.add({
           severity: 'error',
-          summary: 'Error',
+          summary: 'Order Failed',
           detail: error.message || 'Failed to place order'
         });
       }
@@ -469,14 +455,14 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
       onSuccess: () => {
         this.messageService.add({
           severity: 'success',
-          summary: 'Success',
+          summary: 'Order Cancelled',
           detail: 'Order cancelled successfully'
         });
       },
       onError: (error: any) => {
         this.messageService.add({
           severity: 'error',
-          summary: 'Error',
+          summary: 'Cancellation Failed',
           detail: error.message || 'Failed to cancel order'
         });
       }
@@ -484,47 +470,44 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   }
 
   refreshActiveOrders() {
-    // this.activeOrdersQuery.refetch();
+    // Trigger refetch of active orders
   }
 
   /**
-   * Calculate order total and fees using real-time exchange data
+   * Trigger order preview with debouncing (300ms)
    */
-  calculateOrderTotalWithPreview(side: 'BUY' | 'SELL'): void {
+  private triggerPreview(side: 'BUY' | 'SELL'): void {
+    this.previewSubject$.next(side);
+  }
+
+  /**
+   * Execute the actual preview API call (called after debounce)
+   */
+  private executePreview(side: 'BUY' | 'SELL'): void {
     const form = side === 'BUY' ? this.buyOrderForm : this.sellOrderForm;
-    const pair = this.selectedPair();
-    console.log(pair);
+    const quantity = form.get('quantity')?.value;
 
-    if (!pair || !form.valid || !pair.baseAsset?.id) return;
+    // Only preview if we have a valid quantity
+    if (!quantity || quantity <= 0) return;
 
-    const quantity = form.get('quantity')?.value || 0;
-    const orderType = form.get('type')?.value;
-    const price = form.get('price')?.value;
+    const orderRequest = this.buildOrderRequest(side);
+    if (!orderRequest) return;
 
-    if (quantity <= 0) return;
-
-    const orderData = {
-      baseCoinId: pair.baseAsset.id,
-      quoteCoinId: pair.quoteAsset?.id,
-      quantity: quantity.toString(),
-      price: price?.toString(),
-      type: orderType,
-      exchangeId: this.selectedExchangeId() || pair.exchange?.id,
-      side: side === 'BUY' ? OrderSide.BUY : OrderSide.SELL
-    };
-
-    // Preview the order to get real-time fees and calculations
-    this.previewOrderMutation.mutate(orderData, {
+    this.previewOrderMutation.mutate(orderRequest, {
       onSuccess: (preview) => {
-        // Store the preview data for display in the UI
         if (side === 'BUY') {
           this.buyOrderPreview.set(preview);
         } else {
           this.sellOrderPreview.set(preview);
         }
+
+        // Update supported order types if provided
+        if (preview.supportedOrderTypes) {
+          this.supportedOrderTypes.set(preview.supportedOrderTypes);
+        }
       },
       onError: (error: any) => {
-        console.error('Order preview failed:', error);
+        console.warn('Order preview failed:', error.message);
       }
     });
   }
@@ -533,157 +516,99 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
    * Get order total from preview or calculate fallback
    */
   calculateOrderTotal(side: 'BUY' | 'SELL'): number {
-    const preview = side === 'BUY' ? this.buyOrderPreview() : this.sellOrderPreview();
-    if (preview) {
-      return preview.estimatedCost;
-    }
-
-    // Fallback calculation
     const form = side === 'BUY' ? this.buyOrderForm : this.sellOrderForm;
     const pair = this.selectedPair();
+    const preview = side === 'BUY' ? this.buyOrderPreview() : this.sellOrderPreview();
 
-    if (!pair || !form.valid) return 0;
+    // Prefer preview's estimatedCost when available
+    if (preview?.estimatedCost !== undefined) return preview.estimatedCost;
+
+    if (!pair) return 0;
 
     const quantity = form.get('quantity')?.value || 0;
     const orderType = form.get('type')?.value;
-
-    let price: number;
-    if (orderType === OrderType.MARKET) {
-      price = pair.currentPrice || 0;
-    } else {
-      price = form.get('price')?.value || pair.currentPrice || 0;
-    }
+    // Use preview's marketPrice as fallback when pair.currentPrice is null
+    const marketPrice = pair.currentPrice || preview?.marketPrice || 0;
+    const price = orderType === OrderType.MARKET ? marketPrice : form.get('price')?.value || marketPrice;
 
     return quantity * price;
   }
+
   calculateOrderFees(side: 'BUY' | 'SELL'): number {
     const preview = side === 'BUY' ? this.buyOrderPreview() : this.sellOrderPreview();
-    if (preview) {
-      return preview.estimatedFee;
-    }
+    if (preview) return preview.estimatedFee;
 
-    // Fallback calculation
-    const total = this.calculateOrderTotal(side);
-    const feeRate = this.getTradingFeeRate() / 100; // Convert percentage to decimal
-    return total * feeRate;
+    // Fallback: estimate 0.1% fee
+    return this.calculateOrderTotal(side) * 0.001;
   }
 
   /**
-   * Calculate the total cost including fees for a buy order
+   * Get fee rate from preview or default
    */
+  getFeeRate(side: 'BUY' | 'SELL'): number {
+    const preview = side === 'BUY' ? this.buyOrderPreview() : this.sellOrderPreview();
+    return preview?.feeRate || 0.001;
+  }
+
   calculateBuyOrderTotalWithFees(): number {
     const preview = this.buyOrderPreview();
-    if (preview) {
-      return preview.totalRequired;
-    }
-
-    // Fallback calculation
-    const orderTotal = this.calculateOrderTotal('BUY');
-    const fees = this.calculateOrderFees('BUY');
-    return orderTotal + fees;
+    if (preview) return preview.totalRequired;
+    return this.calculateOrderTotal('BUY') + this.calculateOrderFees('BUY');
   }
 
-  /**
-   * Calculate the net amount received after fees for a sell order
-   */
   calculateSellOrderNetAmount(): number {
     const preview = this.sellOrderPreview();
-    if (preview) {
-      // For sell orders, it's total - fees
-      return preview.estimatedCost - preview.estimatedFee;
-    }
-
-    // Fallback calculation
-    const orderTotal = this.calculateOrderTotal('SELL');
-    const fees = this.calculateOrderFees('SELL');
-    return orderTotal - fees;
+    if (preview) return preview.estimatedCost - preview.estimatedFee;
+    return this.calculateOrderTotal('SELL') - this.calculateOrderFees('SELL');
   }
 
   getBuyBalance(): Balance | undefined {
     const pair = this.selectedPair();
-    console.log('Selected pair for buy balance:', pair);
     const balances = this.balancesQuery.data();
-    console.log('Available balances:', balances);
-
     if (!pair || !balances) return undefined;
-
     return balances.find((b) => b.coin.id === pair.quoteAsset?.id);
   }
 
   getSellBalance(): Balance | undefined {
     const pair = this.selectedPair();
     const balances = this.balancesQuery.data();
-
     if (!pair || !balances) return undefined;
-
     return balances.find((b) => b.coin.id === pair.baseAsset?.id);
   }
 
-  /**
-   * Get available balance for buying, accounting for trading fees
-   */
   getAvailableBuyBalance(): number {
     const balance = this.getBuyBalance();
-    const pair = this.selectedPair();
-
-    if (!balance || !pair) return 0;
-
-    const feeRate = this.getTradingFeeRate() / 100; // Convert percentage to decimal
-    const totalCost = balance.available;
-
-    // Account for fees when calculating how much we can actually spend
-    // If we have $100 and fee is 0.1%, we can only spend ~$99.90 worth
-    return totalCost * (1 - feeRate);
-  }
-
-  /**
-   * Get available balance for selling, accounting for trading fees
-   */
-  getAvailableSellBalance(): number {
-    const balance = this.getSellBalance();
-
     if (!balance) return 0;
 
-    // For selling, we can sell the full amount but need to account for fees in the received amount
-    return balance.available;
+    const feeRate = this.getFeeRate('BUY');
+    return balance.available * (1 - feeRate);
   }
 
-  /**
-   * Calculate the actual quantity that can be bought with available balance including fees
-   */
-  calculateMaxBuyQuantityWithFees(): number {
+  getAvailableSellBalance(): number {
+    const balance = this.getSellBalance();
+    return balance?.available || 0;
+  }
+
+  calculateMaxBuyQuantity(): number {
     const availableBalance = this.getAvailableBuyBalance();
     const pair = this.selectedPair();
+    const preview = this.buyOrderPreview();
 
-    if (!pair || !pair.currentPrice || availableBalance <= 0) return 0;
+    if (!pair || availableBalance <= 0) return 0;
 
-    // Calculate max quantity we can buy with available balance after fees
-    return availableBalance / pair.currentPrice;
-  }
+    // Use preview's marketPrice as fallback when pair.currentPrice is null
+    const price = pair.currentPrice || preview?.marketPrice || 0;
+    if (price <= 0) return 0;
 
-  /**
-   * Calculate the net amount received after selling, accounting for fees
-   */
-  calculateNetSellAmount(quantity: number): number {
-    const pair = this.selectedPair();
-
-    if (!pair || !pair.currentPrice) return 0;
-
-    const grossAmount = quantity * pair.currentPrice;
-    const feeRate = this.getTradingFeeRate() / 100;
-    const fees = grossAmount * feeRate;
-
-    return grossAmount - fees;
+    return availableBalance / price;
   }
 
   getTopBids() {
-    const orderBook = this.orderBookQuery.data();
-    return orderBook?.bids.slice(0, 5) || [];
+    return this.orderBookQuery.data()?.bids.slice(0, 5) || [];
   }
 
   getTopAsks() {
-    const orderBook = this.orderBookQuery.data();
-    return orderBook?.asks.slice(0, 5) || [];
+    return this.orderBookQuery.data()?.asks.slice(0, 5) || [];
   }
 
   priceChangeClass(): string {
@@ -692,18 +617,16 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   }
 
   getStatusClass(status: OrderStatus): string {
-    switch (status) {
-      case OrderStatus.NEW:
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
-      case OrderStatus.PARTIALLY_FILLED:
-        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
-      case OrderStatus.FILLED:
-        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
-      case OrderStatus.CANCELED:
-        return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
-      default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
-    }
+    const classes: Record<OrderStatus, string> = {
+      [OrderStatus.NEW]: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+      [OrderStatus.PARTIALLY_FILLED]: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+      [OrderStatus.FILLED]: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      [OrderStatus.CANCELED]: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+      [OrderStatus.PENDING_CANCEL]: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+      [OrderStatus.REJECTED]: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+      [OrderStatus.EXPIRED]: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200'
+    };
+    return classes[status] || 'bg-gray-100 text-gray-800';
   }
 
   trackByPrice(_index: number, item: any) {
@@ -714,67 +637,47 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
     return order.id;
   }
 
-  // Enhanced functionality methods
   setQuantityPercentage(side: 'BUY' | 'SELL', percentage: number) {
     const form = side === 'BUY' ? this.buyOrderForm : this.sellOrderForm;
     const pair = this.selectedPair();
 
     if (!pair) return;
 
-    // Update the selected percentage signal
+    // Get price from pair or fallback to preview's market price
+    const preview = side === 'BUY' ? this.buyOrderPreview() : this.sellOrderPreview();
+    const price = pair.currentPrice || preview?.marketPrice || 0;
+
     if (side === 'BUY') {
       this.selectedBuyPercentage.set(percentage);
-    } else {
-      this.selectedSellPercentage.set(percentage);
-    }
-
-    let quantity: number;
-    if (side === 'BUY') {
-      // For buying, use available balance after fees
       const availableBalance = this.getAvailableBuyBalance();
       const amountToSpend = availableBalance * (percentage / 100);
-      const currentPrice = pair.currentPrice || 0;
-      quantity = currentPrice > 0 ? amountToSpend / currentPrice : 0;
+      const quantity = price > 0 ? amountToSpend / price : 0;
+      form.get('quantity')?.setValue(quantity);
     } else {
-      // For selling, use available sell balance
-      const availableBalance = this.getAvailableSellBalance();
-      quantity = availableBalance * (percentage / 100);
+      this.selectedSellPercentage.set(percentage);
+      const quantity = this.getAvailableSellBalance() * (percentage / 100);
+      form.get('quantity')?.setValue(quantity);
     }
-
-    form.get('quantity')?.setValue(quantity);
   }
 
   onBuyPercentageChange(percentage: number | null) {
-    if (percentage !== null) {
-      this.setQuantityPercentage('BUY', percentage);
-    }
+    if (percentage !== null) this.setQuantityPercentage('BUY', percentage);
   }
 
   onSellPercentageChange(percentage: number | null) {
-    if (percentage !== null) {
-      this.setQuantityPercentage('SELL', percentage);
-    }
-  }
-
-  calculateMaxBuyQuantity(): number {
-    // Use the new fee-aware calculation
-    return this.calculateMaxBuyQuantityWithFees();
+    if (percentage !== null) this.setQuantityPercentage('SELL', percentage);
   }
 
   getTradingFeeRate(): number {
-    // This should come from exchange configuration or user settings
-    return 0.1; // 0.1% default trading fee
+    return (this.getFeeRate('BUY') || 0.001) * 100; // Return as percentage
   }
 
   onExchangeChange(event: { value: string }) {
     const exchangeId = event.value;
     this.selectedExchangeId.set(exchangeId);
-
-    // Clear selected pair when exchange changes
     this.selectedPairValue.set(null);
-
-    // Set the active exchange for trading operations
-    // this.tradingService.setActiveExchange(exchangeId); // Uncomment when method is available
+    this.buyOrderPreview.set(null);
+    this.sellOrderPreview.set(null);
 
     this.messageService.add({
       severity: 'info',
@@ -785,8 +688,7 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
 
   getSelectedExchangeName(): string {
     const exchangeId = this.selectedExchangeId();
-    const exchanges = this.exchangeOptions();
-    const exchange = exchanges?.find((ex: any) => ex.value === exchangeId);
+    const exchange = this.exchangeOptions()?.find((ex: any) => ex.value === exchangeId);
     return exchange?.label || 'No Exchange';
   }
 
@@ -810,8 +712,7 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   }
 
   shouldShowTrailingFields(form: FormGroup): boolean {
-    const type = form.get('type')?.value;
-    return type === OrderType.TRAILING_STOP;
+    return form.get('type')?.value === OrderType.TRAILING_STOP;
   }
 
   shouldShowTakeProfitField(form: FormGroup): boolean {
@@ -820,11 +721,9 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   }
 
   shouldShowStopLossField(form: FormGroup): boolean {
-    const type = form.get('type')?.value;
-    return type === OrderType.OCO;
+    return form.get('type')?.value === OrderType.OCO;
   }
 
-  // Validation helper methods
   isFieldInvalid(form: FormGroup, fieldName: string): boolean {
     const field = form.get(fieldName);
     return !!field && field.invalid && (field.dirty || field.touched);
@@ -832,14 +731,31 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
 
   getFieldError(form: FormGroup, fieldName: string): string {
     const field = form.get(fieldName);
-    if (!field || !field.errors) return '';
+    if (!field?.errors) return '';
 
-    if (field.errors['required']) {
-      return 'This field is required';
-    }
+    if (field.errors['required']) return 'This field is required';
     if (field.errors['min']) {
-      return `Minimum value is ${field.errors['min'].min}`;
+      const minValue = field.errors['min'].min;
+      // Format small numbers to avoid scientific notation
+      const formatted = minValue < 0.0001 ? minValue.toFixed(8) : minValue;
+      return `Minimum value is ${formatted}`;
     }
     return 'Invalid value';
+  }
+
+  /**
+   * Get preview warnings if any
+   */
+  getPreviewWarnings(side: 'BUY' | 'SELL'): string[] {
+    const preview = side === 'BUY' ? this.buyOrderPreview() : this.sellOrderPreview();
+    return preview?.warnings || [];
+  }
+
+  /**
+   * Check if order has sufficient balance
+   */
+  hasSufficientBalance(side: 'BUY' | 'SELL'): boolean {
+    const preview = side === 'BUY' ? this.buyOrderPreview() : this.sellOrderPreview();
+    return preview?.hasSufficientBalance ?? true;
   }
 }

--- a/libs/api-interfaces/src/lib/order/exchange-order-support.ts
+++ b/libs/api-interfaces/src/lib/order/exchange-order-support.ts
@@ -1,0 +1,131 @@
+import { ExchangeOrderTypeSupport, OrderType, TimeInForce } from './order.interface';
+
+/**
+ * Exchange-specific order type support configuration
+ * This is the single source of truth for what order types each exchange supports
+ */
+export const EXCHANGE_ORDER_TYPE_SUPPORT: Record<string, ExchangeOrderTypeSupport> = {
+  binanceus: {
+    exchangeSlug: 'binanceus',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TAKE_PROFIT,
+      OrderType.OCO
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: true,
+    hasTrailingStopSupport: false
+  },
+  binance: {
+    exchangeSlug: 'binance',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TRAILING_STOP,
+      OrderType.TAKE_PROFIT,
+      OrderType.OCO
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: true,
+    hasTrailingStopSupport: true
+  },
+  coinbase: {
+    exchangeSlug: 'coinbase',
+    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  coinbasepro: {
+    exchangeSlug: 'coinbasepro',
+    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  coinbaseexchange: {
+    exchangeSlug: 'coinbaseexchange',
+    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  kraken: {
+    exchangeSlug: 'kraken',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TAKE_PROFIT
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: false
+  },
+  kucoin: {
+    exchangeSlug: 'kucoin',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TRAILING_STOP
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: true
+  },
+  okx: {
+    exchangeSlug: 'okx',
+    supportedTypes: [
+      OrderType.MARKET,
+      OrderType.LIMIT,
+      OrderType.STOP_LOSS,
+      OrderType.STOP_LIMIT,
+      OrderType.TRAILING_STOP,
+      OrderType.TAKE_PROFIT
+    ],
+    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+    hasOcoSupport: false,
+    hasTrailingStopSupport: true
+  }
+};
+
+/**
+ * Default order type support for unknown exchanges
+ */
+export const DEFAULT_ORDER_TYPE_SUPPORT: ExchangeOrderTypeSupport = {
+  exchangeSlug: 'default',
+  supportedTypes: [OrderType.MARKET, OrderType.LIMIT],
+  supportedTimeInForce: [TimeInForce.GTC],
+  hasOcoSupport: false,
+  hasTrailingStopSupport: false
+};
+
+/**
+ * Get the order type support for a specific exchange
+ */
+export function getExchangeOrderTypeSupport(exchangeSlug: string): ExchangeOrderTypeSupport {
+  return EXCHANGE_ORDER_TYPE_SUPPORT[exchangeSlug] || DEFAULT_ORDER_TYPE_SUPPORT;
+}
+
+/**
+ * Check if an exchange supports a specific order type
+ */
+export function isOrderTypeSupported(exchangeSlug: string, orderType: OrderType): boolean {
+  const support = getExchangeOrderTypeSupport(exchangeSlug);
+  return support.supportedTypes.includes(orderType);
+}
+
+/**
+ * Get the supported order types for a specific exchange
+ */
+export function getSupportedOrderTypes(exchangeSlug: string): OrderType[] {
+  return getExchangeOrderTypeSupport(exchangeSlug).supportedTypes;
+}

--- a/libs/api-interfaces/src/lib/order/index.ts
+++ b/libs/api-interfaces/src/lib/order/index.ts
@@ -1,1 +1,2 @@
 export * from './order.interface';
+export * from './exchange-order-support';

--- a/libs/api-interfaces/src/lib/order/order.interface.ts
+++ b/libs/api-interfaces/src/lib/order/order.interface.ts
@@ -32,6 +32,12 @@ export enum TrailingType {
   PERCENTAGE = 'percentage'
 }
 
+export enum TimeInForce {
+  GTC = 'GTC', // Good Till Canceled
+  IOC = 'IOC', // Immediate Or Cancel
+  FOK = 'FOK' // Fill Or Kill
+}
+
 export interface Order {
   id: string;
   symbol: string;
@@ -96,6 +102,34 @@ export interface TradeExecution {
   takerOrMaker?: string;
 }
 
+/**
+ * Unified order request interface for placing orders
+ * This is the single source of truth for order creation
+ */
+export interface PlaceOrderRequest {
+  // Required fields
+  exchangeKeyId: string;
+  symbol: string;
+  side: OrderSide;
+  orderType: OrderType;
+  quantity: number;
+
+  // Conditional fields based on order type
+  price?: number; // Required for LIMIT, STOP_LIMIT
+  stopPrice?: number; // Required for STOP_LOSS, STOP_LIMIT
+  trailingAmount?: number; // Required for TRAILING_STOP
+  trailingType?: TrailingType; // Required for TRAILING_STOP
+  takeProfitPrice?: number; // Required for OCO
+  stopLossPrice?: number; // Required for OCO
+
+  // Optional fields
+  timeInForce?: TimeInForce;
+}
+
+/**
+ * @deprecated Use PlaceOrderRequest instead
+ * Kept for backward compatibility during migration
+ */
 export interface CreateOrderRequest {
   baseCoinId: string;
   quoteCoinId?: string;
@@ -112,6 +146,10 @@ export interface CreateOrderRequest {
   reduceOnly?: boolean;
 }
 
+/**
+ * @deprecated Use PlaceOrderRequest instead
+ * Kept for backward compatibility during migration
+ */
 export interface PlaceManualOrderRequest {
   exchangeKeyId: string;
   symbol: string;
@@ -128,6 +166,9 @@ export interface PlaceManualOrderRequest {
   timeInForce?: string;
 }
 
+/**
+ * Unified order preview request
+ */
 export interface OrderPreviewRequest {
   exchangeKeyId: string;
   symbol: string;
@@ -158,6 +199,7 @@ export interface OrderPreview {
   trailingType?: TrailingType;
   estimatedCost: number;
   estimatedFee: number;
+  feeRate: number;
   feeCurrency: string;
   totalRequired: number;
   marketPrice?: number;
@@ -165,6 +207,19 @@ export interface OrderPreview {
   balanceCurrency: string;
   hasSufficientBalance: boolean;
   priceDeviation?: number;
-  warnings?: string[];
+  estimatedSlippage?: number;
+  warnings: string[];
   exchange: string;
+  supportedOrderTypes?: OrderType[];
+}
+
+/**
+ * Supported order types per exchange
+ */
+export interface ExchangeOrderTypeSupport {
+  exchangeSlug: string;
+  supportedTypes: OrderType[];
+  supportedTimeInForce: TimeInForce[];
+  hasOcoSupport: boolean;
+  hasTrailingStopSupport: boolean;
 }


### PR DESCRIPTION
## Summary

### Order Service Improvements
- Add manual order placement endpoint with real-time preview
- Implement comprehensive order validation and fee calculation
- Add exchange-specific order type support configuration
- Improve error handling with detailed validation messages
- Add order preview with balance checks and fee estimates
- Refactor service for better performance and code organization

### Crypto Trading Component
- Redesign Buy/Sell tabs with pill-style toggle and color themes
- Fix CCXT compatibility by normalizing symbols to uppercase
- Add price fallback logic using preview marketPrice
- Fix dropdown overflow with appendTo="body" on select components
- Add uppercase pipe to all symbol displays
- Improve error message formatting (avoid scientific notation)

### Shared Libraries
- Add exchange order type support configuration to api-interfaces
- Update PlaceOrderRequest with all order type parameters
- Enhance OrderPreview DTO with balance and fee information

## Test plan
- [x] All API tests pass (147 tests)
- [x] All frontend tests pass (79 tests)
- [x] Lint passes
- [x] Build succeeds

Supersedes #45 (closed due to history rewrite)