### PR TITLE
feat(api): add strategy heartbeat tracking for health monitoring

### DIFF
--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -197,6 +197,31 @@ import { MetricsService } from './metrics.service';
       labelNames: ['strategy', 'signal_type']
     }),
 
+    // Strategy Heartbeat Metrics
+    makeGaugeProvider({
+      name: 'chansey_strategy_heartbeat_age_seconds',
+      help: 'Age of the last heartbeat in seconds (time since last heartbeat)',
+      labelNames: ['strategy', 'shadow_status']
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_strategy_heartbeat_total',
+      help: 'Total number of heartbeats received',
+      labelNames: ['strategy', 'status']
+    }),
+
+    makeGaugeProvider({
+      name: 'chansey_strategy_heartbeat_failures',
+      help: 'Number of consecutive heartbeat failures',
+      labelNames: ['strategy']
+    }),
+
+    makeGaugeProvider({
+      name: 'chansey_strategy_health_score',
+      help: 'Health score of strategy (0-100)',
+      labelNames: ['strategy', 'shadow_status']
+    }),
+
     MetricsService
   ],
   exports: [PrometheusModule, MetricsService]

--- a/apps/api/src/metrics/metrics.service.spec.ts
+++ b/apps/api/src/metrics/metrics.service.spec.ts
@@ -1,0 +1,205 @@
+import { MetricsService } from './metrics.service';
+
+const createCounterMock = () => ({ inc: jest.fn() }) as any;
+const createGaugeMock = () => ({ set: jest.fn() }) as any;
+const createHistogramMock = () =>
+  ({
+    observe: jest.fn(),
+    startTimer: jest.fn()
+  }) as any;
+
+const buildService = () => {
+  const mocks = {
+    httpRequestDuration: createHistogramMock(),
+    httpRequestsTotal: createCounterMock(),
+    httpConnectionsActive: createGaugeMock(),
+
+    ordersSyncedTotal: createCounterMock(),
+    ordersSyncErrorsTotal: createCounterMock(),
+    orderSyncDuration: createHistogramMock(),
+
+    tradesExecutedTotal: createCounterMock(),
+    tradeExecutionDuration: createHistogramMock(),
+
+    exchangeConnections: createGaugeMock(),
+    exchangeApiCallsTotal: createCounterMock(),
+    exchangeApiLatency: createHistogramMock(),
+
+    priceUpdatesTotal: createCounterMock(),
+    priceUpdateLag: createGaugeMock(),
+
+    backtestsCompletedTotal: createCounterMock(),
+    backtestDuration: createHistogramMock(),
+
+    queueJobsWaiting: createGaugeMock(),
+    queueJobsActive: createGaugeMock(),
+    queueJobsCompletedTotal: createCounterMock(),
+    queueJobsFailedTotal: createCounterMock(),
+
+    portfolioTotalValue: createGaugeMock(),
+    portfolioAssetsCount: createGaugeMock(),
+
+    strategyDeploymentsActive: createGaugeMock(),
+    strategySignalsTotal: createCounterMock(),
+
+    strategyHeartbeatAge: createGaugeMock(),
+    strategyHeartbeatTotal: createCounterMock(),
+    strategyHeartbeatFailures: createGaugeMock(),
+    strategyHealthScore: createGaugeMock()
+  };
+
+  const service = new MetricsService(
+    mocks.httpRequestDuration,
+    mocks.httpRequestsTotal,
+    mocks.httpConnectionsActive,
+    mocks.ordersSyncedTotal,
+    mocks.ordersSyncErrorsTotal,
+    mocks.orderSyncDuration,
+    mocks.tradesExecutedTotal,
+    mocks.tradeExecutionDuration,
+    mocks.exchangeConnections,
+    mocks.exchangeApiCallsTotal,
+    mocks.exchangeApiLatency,
+    mocks.priceUpdatesTotal,
+    mocks.priceUpdateLag,
+    mocks.backtestsCompletedTotal,
+    mocks.backtestDuration,
+    mocks.queueJobsWaiting,
+    mocks.queueJobsActive,
+    mocks.queueJobsCompletedTotal,
+    mocks.queueJobsFailedTotal,
+    mocks.portfolioTotalValue,
+    mocks.portfolioAssetsCount,
+    mocks.strategyDeploymentsActive,
+    mocks.strategySignalsTotal,
+    mocks.strategyHeartbeatAge,
+    mocks.strategyHeartbeatTotal,
+    mocks.strategyHeartbeatFailures,
+    mocks.strategyHealthScore
+  );
+
+  return { service, mocks };
+};
+
+describe('MetricsService', () => {
+  it('records HTTP requests and durations', () => {
+    const { service, mocks } = buildService();
+
+    service.recordHttpRequest('GET', '/test', 200, 250);
+
+    expect(mocks.httpRequestDuration.observe).toHaveBeenCalledWith(
+      { method: 'GET', route: '/test', status_code: '200' },
+      0.25
+    );
+    expect(mocks.httpRequestsTotal.inc).toHaveBeenCalledWith({ method: 'GET', route: '/test', status_code: '200' });
+  });
+
+  it('handles order sync timers and counters', () => {
+    const { service, mocks } = buildService();
+    const end = jest.fn();
+    mocks.orderSyncDuration.startTimer.mockReturnValue(end);
+
+    const timer = service.startOrderSyncTimer('binance');
+    timer();
+
+    expect(mocks.orderSyncDuration.startTimer).toHaveBeenCalledWith({ exchange: 'binance' });
+    expect(end).toHaveBeenCalled();
+
+    service.recordOrdersSynced('binance', 'success', 3);
+    expect(mocks.ordersSyncedTotal.inc).toHaveBeenCalledWith({ exchange: 'binance', status: 'success' }, 3);
+
+    service.recordOrderSyncError('binance', 'network');
+    expect(mocks.ordersSyncErrorsTotal.inc).toHaveBeenCalledWith({ exchange: 'binance', error_type: 'network' });
+  });
+
+  it('records trades and exchanges metrics', () => {
+    const { service, mocks } = buildService();
+    const tradeEnd = jest.fn();
+    const apiEnd = jest.fn();
+    mocks.tradeExecutionDuration.startTimer.mockReturnValue(tradeEnd);
+    mocks.exchangeApiLatency.startTimer.mockReturnValue(apiEnd);
+
+    service.recordTradeExecuted('coinbase', 'buy', 'BTC/USD');
+    service.recordExchangeApiCall('coinbase', '/orders', true);
+    service.setExchangeConnections('coinbase', 4);
+    service.startTradeExecutionTimer('coinbase')();
+    service.startExchangeApiTimer('coinbase', '/orders')();
+
+    expect(mocks.tradesExecutedTotal.inc).toHaveBeenCalledWith({
+      exchange: 'coinbase',
+      side: 'buy',
+      symbol: 'BTC/USD'
+    });
+    expect(mocks.exchangeApiCallsTotal.inc).toHaveBeenCalledWith({
+      exchange: 'coinbase',
+      endpoint: '/orders',
+      success: 'true'
+    });
+    expect(mocks.exchangeConnections.set).toHaveBeenCalledWith({ exchange: 'coinbase' }, 4);
+    expect(tradeEnd).toHaveBeenCalled();
+    expect(apiEnd).toHaveBeenCalled();
+  });
+
+  it('records price, backtest, and queue metrics', () => {
+    const { service, mocks } = buildService();
+    const backtestEnd = jest.fn();
+    mocks.backtestDuration.startTimer.mockReturnValue(backtestEnd);
+
+    service.recordPriceUpdate('coingecko', 2);
+    service.setPriceUpdateLag('coingecko', 5);
+    service.recordBacktestCompleted('mean-reversion', 'success');
+    service.startBacktestTimer('mean-reversion')();
+    service.setQueueJobsWaiting('orders', 7);
+    service.setQueueJobsActive('orders', 3);
+    service.recordQueueJobCompleted('orders');
+    service.recordQueueJobFailed('orders', 'timeout');
+
+    expect(mocks.priceUpdatesTotal.inc).toHaveBeenCalledWith({ source: 'coingecko' }, 2);
+    expect(mocks.priceUpdateLag.set).toHaveBeenCalledWith({ source: 'coingecko' }, 5);
+    expect(mocks.backtestsCompletedTotal.inc).toHaveBeenCalledWith({ strategy: 'mean-reversion', status: 'success' });
+    expect(backtestEnd).toHaveBeenCalled();
+    expect(mocks.queueJobsWaiting.set).toHaveBeenCalledWith({ queue: 'orders' }, 7);
+    expect(mocks.queueJobsActive.set).toHaveBeenCalledWith({ queue: 'orders' }, 3);
+    expect(mocks.queueJobsCompletedTotal.inc).toHaveBeenCalledWith({ queue: 'orders' });
+    expect(mocks.queueJobsFailedTotal.inc).toHaveBeenCalledWith({ queue: 'orders', error_type: 'timeout' });
+  });
+
+  it('records portfolio and strategy deployment metrics', () => {
+    const { service, mocks } = buildService();
+
+    service.setPortfolioTotalValue('user-1', 12000);
+    service.setPortfolioAssetsCount('user-1', 'binance', 5);
+    service.setStrategyDeploymentsActive('trend', 'live', 2);
+    service.recordStrategySignal('trend', 'buy');
+
+    expect(mocks.portfolioTotalValue.set).toHaveBeenCalledWith({ user_id: 'user-1' }, 12000);
+    expect(mocks.portfolioAssetsCount.set).toHaveBeenCalledWith({ user_id: 'user-1', exchange: 'binance' }, 5);
+    expect(mocks.strategyDeploymentsActive.set).toHaveBeenCalledWith({ strategy: 'trend', status: 'live' }, 2);
+    expect(mocks.strategySignalsTotal.inc).toHaveBeenCalledWith({ strategy: 'trend', signal_type: 'buy' });
+  });
+
+  it('records strategy heartbeat metrics and clamps health score', () => {
+    const { service, mocks } = buildService();
+
+    service.recordStrategyHeartbeat('scalper', 'success');
+    service.setStrategyHeartbeatAge('scalper', 'shadow', 42);
+    service.setStrategyHeartbeatFailures('scalper', 3);
+    service.setStrategyHealthScore('scalper', 'shadow', 150);
+    service.setStrategyHealthScore('scalper', 'shadow', -10);
+
+    expect(mocks.strategyHeartbeatTotal.inc).toHaveBeenCalledWith({ strategy: 'scalper', status: 'success' });
+    expect(mocks.strategyHeartbeatAge.set).toHaveBeenCalledWith({ strategy: 'scalper', shadow_status: 'shadow' }, 42);
+    expect(mocks.strategyHeartbeatFailures.set).toHaveBeenCalledWith({ strategy: 'scalper' }, 3);
+    expect(mocks.strategyHealthScore.set).toHaveBeenCalledWith({ strategy: 'scalper', shadow_status: 'shadow' }, 100);
+    expect(mocks.strategyHealthScore.set).toHaveBeenCalledWith({ strategy: 'scalper', shadow_status: 'shadow' }, 0);
+  });
+
+  it('calculates health score from heartbeat metrics', () => {
+    const { service } = buildService();
+    const clampSpy = jest.spyOn(service, 'setStrategyHealthScore').mockImplementation(jest.fn());
+
+    service.calculateAndSetHealthScore('scalper', 'shadow', 900, 3, 300);
+
+    expect(clampSpy).toHaveBeenCalledWith('scalper', 'shadow', 15);
+  });
+});

--- a/apps/api/src/migrations/1734400000000-add-strategy-heartbeat-columns.ts
+++ b/apps/api/src/migrations/1734400000000-add-strategy-heartbeat-columns.ts
@@ -1,0 +1,85 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStrategyHeartbeatColumns1734400000000 implements MigrationInterface {
+  name = 'AddStrategyHeartbeatColumns1734400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add lastHeartbeat column - tracks when strategy last sent a heartbeat
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      ADD COLUMN IF NOT EXISTS "lastHeartbeat" TIMESTAMPTZ NULL
+    `);
+
+    // Add heartbeatFailures column - tracks consecutive heartbeat failures
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      ADD COLUMN IF NOT EXISTS "heartbeatFailures" INTEGER NOT NULL DEFAULT 0
+    `);
+
+    // Add lastError column - stores last error message
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      ADD COLUMN IF NOT EXISTS "lastError" VARCHAR(500) NULL
+    `);
+
+    // Add lastErrorAt column - tracks when last error occurred
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      ADD COLUMN IF NOT EXISTS "lastErrorAt" TIMESTAMPTZ NULL
+    `);
+
+    // Add comments for documentation
+    await queryRunner.query(`
+      COMMENT ON COLUMN "strategy_configs"."lastHeartbeat" IS 'Last time this strategy sent a heartbeat signal (for health monitoring)'
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN "strategy_configs"."heartbeatFailures" IS 'Number of consecutive heartbeat failures (resets on success)'
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN "strategy_configs"."lastError" IS 'Last error message from strategy execution'
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN "strategy_configs"."lastErrorAt" IS 'Timestamp of last error occurrence'
+    `);
+
+    // Add indexes for heartbeat queries
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_strategy_configs_status_lastHeartbeat"
+      ON "strategy_configs" ("status", "lastHeartbeat")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_strategy_configs_heartbeatFailures"
+      ON "strategy_configs" ("heartbeatFailures")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes first
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_strategy_configs_heartbeatFailures"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_strategy_configs_status_lastHeartbeat"`);
+
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      DROP COLUMN IF EXISTS "lastErrorAt"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      DROP COLUMN IF EXISTS "lastError"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      DROP COLUMN IF EXISTS "heartbeatFailures"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "strategy_configs"
+      DROP COLUMN IF EXISTS "lastHeartbeat"
+    `);
+  }
+}

--- a/apps/api/src/strategy/entities/strategy-config.entity.ts
+++ b/apps/api/src/strategy/entities/strategy-config.entity.ts
@@ -1,12 +1,12 @@
 import {
   Column,
   CreateDateColumn,
-  UpdateDateColumn,
   Entity,
-  PrimaryGeneratedColumn,
-  ManyToOne,
+  Index,
   JoinColumn,
-  Index
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
 } from 'typeorm';
 
 import { StrategyStatus } from '@chansey/api-interfaces';
@@ -23,6 +23,8 @@ import { User } from '../../users/users.entity';
 @Entity('strategy_configs')
 @Index(['status'])
 @Index(['algorithmId'])
+@Index(['status', 'lastHeartbeat'])
+@Index(['heartbeatFailures'])
 export class StrategyConfig {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -104,6 +106,36 @@ export class StrategyConfig {
   @ManyToOne(() => User, { nullable: true })
   @JoinColumn({ name: 'createdBy' })
   creator?: User | null;
+
+  // Heartbeat tracking for health monitoring
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+    comment: 'Last time this strategy sent a heartbeat signal (for health monitoring)'
+  })
+  lastHeartbeat?: Date | null;
+
+  @Column({
+    type: 'int',
+    default: 0,
+    comment: 'Number of consecutive heartbeat failures (resets on success)'
+  })
+  heartbeatFailures: number;
+
+  @Column({
+    type: 'varchar',
+    length: 500,
+    nullable: true,
+    comment: 'Last error message from strategy execution'
+  })
+  lastError?: string | null;
+
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+    comment: 'Timestamp of last error occurrence'
+  })
+  lastErrorAt?: Date | null;
 
   @CreateDateColumn({
     type: 'timestamptz'

--- a/apps/api/src/strategy/strategy.module.ts
+++ b/apps/api/src/strategy/strategy.module.ts
@@ -40,6 +40,7 @@ import { AlgorithmModule } from '../algorithm/algorithm.module';
 import { AuditModule } from '../audit/audit.module';
 import { BalanceModule } from '../balance/balance.module';
 import { MarketRegimeModule } from '../market-regime/market-regime.module';
+import { MetricsModule } from '../metrics/metrics.module';
 import { Order } from '../order/order.entity';
 import { OrderModule } from '../order/order.module';
 import { Risk } from '../risk/risk.entity';
@@ -64,6 +65,7 @@ import { User } from '../users/users.entity';
     AuditModule,
     forwardRef(() => BalanceModule),
     forwardRef(() => MarketRegimeModule),
+    MetricsModule,
     forwardRef(() => OrderModule),
     forwardRef(() => TasksModule)
   ],

--- a/apps/api/src/strategy/strategy.service.spec.ts
+++ b/apps/api/src/strategy/strategy.service.spec.ts
@@ -1,0 +1,373 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+
+import { Repository } from 'typeorm';
+
+import {
+  AuditEventType,
+  CreateStrategyConfigDto,
+  StrategyConfigListFilters,
+  StrategyStatus,
+  UpdateStrategyConfigDto
+} from '@chansey/api-interfaces';
+
+import { BacktestRun } from './entities/backtest-run.entity';
+import { StrategyConfig } from './entities/strategy-config.entity';
+import { StrategyScore } from './entities/strategy-score.entity';
+import { StrategyService } from './strategy.service';
+
+import { AlgorithmService } from '../algorithm/algorithm.service';
+import { AlgorithmRegistry } from '../algorithm/registry/algorithm-registry.service';
+import { AuditService } from '../audit/audit.service';
+import { MetricsService } from '../metrics/metrics.service';
+
+type MockRepo<T> = jest.Mocked<Repository<T>>;
+
+const createStrategy = (overrides: Partial<StrategyConfig> = {}): StrategyConfig =>
+  ({
+    id: overrides.id ?? 'strategy-1',
+    name: overrides.name ?? 'Momentum',
+    algorithmId: overrides.algorithmId ?? 'algo-1',
+    parameters: overrides.parameters ?? { window: 14 },
+    version: overrides.version ?? '1.0.0',
+    status: overrides.status ?? StrategyStatus.LIVE,
+    shadowStatus: overrides.shadowStatus ?? 'shadow',
+    heartbeatFailures: overrides.heartbeatFailures ?? 0,
+    lastHeartbeat: overrides.lastHeartbeat === undefined ? new Date() : overrides.lastHeartbeat,
+    lastError: overrides.lastError ?? null,
+    lastErrorAt: overrides.lastErrorAt ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date()
+  }) as StrategyConfig;
+
+const createQueryBuilderMock = () => {
+  const qb: any = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getCount: jest.fn(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+    where: jest.fn().mockReturnThis()
+  };
+  return qb;
+};
+
+describe('StrategyService', () => {
+  let service: StrategyService;
+  let strategyRepo: MockRepo<StrategyConfig>;
+  let backtestRunRepo: MockRepo<BacktestRun>;
+  let strategyScoreRepo: MockRepo<StrategyScore>;
+  let algorithmService: jest.Mocked<AlgorithmService>;
+  let algorithmRegistry: jest.Mocked<AlgorithmRegistry>;
+  let auditService: jest.Mocked<AuditService>;
+  let metricsService: jest.Mocked<MetricsService>;
+
+  beforeEach(() => {
+    strategyRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      create: jest.fn(),
+      remove: jest.fn(),
+      find: jest.fn(),
+      createQueryBuilder: jest.fn()
+    } as unknown as MockRepo<StrategyConfig>;
+
+    backtestRunRepo = { findOne: jest.fn() } as unknown as MockRepo<BacktestRun>;
+    strategyScoreRepo = { findOne: jest.fn() } as unknown as MockRepo<StrategyScore>;
+
+    algorithmService = { getAlgorithmById: jest.fn() } as unknown as jest.Mocked<AlgorithmService>;
+    algorithmRegistry = { getStrategyForAlgorithm: jest.fn() } as unknown as jest.Mocked<AlgorithmRegistry>;
+    auditService = { createAuditLog: jest.fn() } as unknown as jest.Mocked<AuditService>;
+    metricsService = {
+      recordStrategyHeartbeat: jest.fn(),
+      setStrategyHeartbeatFailures: jest.fn(),
+      setStrategyHeartbeatAge: jest.fn(),
+      calculateAndSetHealthScore: jest.fn()
+    } as unknown as jest.Mocked<MetricsService>;
+
+    service = new StrategyService(
+      strategyRepo,
+      backtestRunRepo,
+      strategyScoreRepo,
+      algorithmService,
+      algorithmRegistry,
+      auditService,
+      metricsService
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const dto: CreateStrategyConfigDto = {
+      name: 'Momentum',
+      algorithmId: 'algo-1',
+      parameters: { window: 10 }
+    };
+
+    it('creates a strategy when algorithm exists and is registered', async () => {
+      algorithmService.getAlgorithmById.mockResolvedValue({ id: 'algo-1', name: 'Algo', config: {} } as any);
+      algorithmRegistry.getStrategyForAlgorithm.mockReturnValue({} as any);
+      strategyRepo.create.mockReturnValue(createStrategy({ id: 'created-id', name: dto.name }));
+      strategyRepo.save.mockResolvedValue(createStrategy({ id: 'created-id', name: dto.name }));
+
+      const result = await service.create(dto, 'user-1');
+
+      expect(result.id).toBe('created-id');
+      expect(strategyRepo.save).toHaveBeenCalled();
+      expect(auditService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: AuditEventType.STRATEGY_CREATED,
+          entityId: 'created-id'
+        })
+      );
+    });
+
+    it('throws when algorithm is missing', async () => {
+      algorithmService.getAlgorithmById.mockResolvedValue(null as any);
+
+      await expect(service.create(dto)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws when algorithm is not registered', async () => {
+      algorithmService.getAlgorithmById.mockResolvedValue({ id: 'algo-1', name: 'Algo', config: {} } as any);
+      algorithmRegistry.getStrategyForAlgorithm.mockImplementation(() => {
+        throw new Error('not registered');
+      });
+
+      await expect(service.create(dto)).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns strategy if found', async () => {
+      const strategy = createStrategy();
+      strategyRepo.findOne.mockResolvedValue(strategy);
+
+      await expect(service.findOne('strategy-1')).resolves.toEqual(strategy);
+    });
+
+    it('throws when not found', async () => {
+      strategyRepo.findOne.mockResolvedValue(null as any);
+
+      await expect(service.findOne('missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('applies filters, sorting, and pagination', async () => {
+      const qb = createQueryBuilderMock();
+      const strategies = [createStrategy({ id: '1' }), createStrategy({ id: '2' })];
+      qb.getCount.mockResolvedValue(2);
+      qb.getMany.mockResolvedValue(strategies);
+      strategyRepo.createQueryBuilder.mockReturnValue(qb as any);
+
+      const filters: StrategyConfigListFilters = {
+        status: [StrategyStatus.LIVE],
+        algorithmId: 'algo-1',
+        search: 'momentum',
+        sortBy: 'name',
+        sortOrder: 'ASC',
+        limit: 10,
+        offset: 5
+      };
+
+      const result = await service.findAll(filters);
+
+      expect(qb.andWhere).toHaveBeenCalledTimes(3);
+      expect(qb.orderBy).toHaveBeenCalledWith('strategy.name', 'ASC');
+      expect(qb.skip).toHaveBeenCalledWith(5);
+      expect(qb.take).toHaveBeenCalledWith(10);
+      expect(result).toEqual({ strategies, total: 2 });
+    });
+  });
+
+  describe('update and delete', () => {
+    it('updates a strategy and logs audit', async () => {
+      const existing = createStrategy({ name: 'Old Name', parameters: { window: 5 }, status: StrategyStatus.DRAFT });
+      strategyRepo.findOne.mockResolvedValue(existing);
+      strategyRepo.save.mockImplementation(async (value) => value as any);
+
+      const dto: UpdateStrategyConfigDto = {
+        name: 'New Name',
+        parameters: { window: 10 },
+        status: StrategyStatus.LIVE
+      };
+      const updated = await service.update('strategy-1', dto, 'user-1');
+
+      expect(updated.name).toBe('New Name');
+      expect(strategyRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'New Name', parameters: { window: 10 } })
+      );
+      expect(auditService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: AuditEventType.STRATEGY_UPDATED,
+          beforeState: expect.objectContaining({ name: 'Old Name' }),
+          afterState: expect.objectContaining({ name: 'New Name' })
+        })
+      );
+    });
+
+    it('removes a strategy and logs audit', async () => {
+      const strategy = createStrategy();
+      strategyRepo.findOne.mockResolvedValue(strategy);
+      strategyRepo.remove.mockResolvedValue(strategy as any);
+
+      await service.delete(strategy.id, 'user-1');
+
+      expect(strategyRepo.remove).toHaveBeenCalledWith(strategy);
+      expect(auditService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: AuditEventType.STRATEGY_DELETED,
+          entityId: strategy.id
+        })
+      );
+    });
+  });
+
+  describe('getStrategyInstance', () => {
+    it('merges algorithm defaults with strategy parameters', async () => {
+      const strategy = createStrategy({ parameters: { risk: 0.5 } });
+      strategyRepo.findOne.mockResolvedValue(strategy);
+      algorithmService.getAlgorithmById.mockResolvedValue({
+        id: strategy.algorithmId,
+        name: 'Algo',
+        config: { parameters: { base: true, risk: 0.1 } }
+      } as any);
+      algorithmRegistry.getStrategyForAlgorithm.mockReturnValue({ execute: jest.fn() } as any);
+
+      const result = await service.getStrategyInstance(strategy.id);
+
+      expect(result.config).toEqual({ base: true, risk: 0.5 });
+      expect(result.strategy).toBeDefined();
+    });
+  });
+
+  describe('latest run/score', () => {
+    it('returns latest backtest run and score', async () => {
+      const run = { id: 'run-1' } as BacktestRun;
+      const score = { id: 'score-1' } as StrategyScore;
+      backtestRunRepo.findOne.mockResolvedValue(run);
+      strategyScoreRepo.findOne.mockResolvedValue(score);
+
+      await expect(service.getLatestBacktestRun('id')).resolves.toBe(run);
+      await expect(service.getLatestScore('id')).resolves.toBe(score);
+    });
+  });
+
+  describe('heartbeats', () => {
+    it('records successful heartbeat and resets failures', async () => {
+      const strategy = createStrategy({ heartbeatFailures: 2, lastError: 'err' });
+      strategyRepo.findOne.mockResolvedValue(strategy);
+      strategyRepo.save.mockImplementation(async (value) => value as any);
+
+      await service.recordHeartbeat(strategy.id);
+
+      expect(strategyRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ heartbeatFailures: 0, lastError: null })
+      );
+      expect(metricsService.recordStrategyHeartbeat).toHaveBeenCalledWith(strategy.name, 'success');
+      expect(metricsService.setStrategyHeartbeatFailures).toHaveBeenCalledWith(strategy.name, 0);
+    });
+
+    it('records failed heartbeat and increments failures', async () => {
+      const strategy = createStrategy({ heartbeatFailures: 1 });
+      strategyRepo.findOne.mockResolvedValue(strategy);
+      strategyRepo.save.mockImplementation(async (value) => value as any);
+
+      await service.recordHeartbeatFailure(strategy.id, 'boom');
+
+      expect(strategyRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ heartbeatFailures: 2, lastError: 'boom', lastErrorAt: expect.any(Date) })
+      );
+      expect(metricsService.recordStrategyHeartbeat).toHaveBeenCalledWith(strategy.name, 'failed');
+      expect(metricsService.setStrategyHeartbeatFailures).toHaveBeenCalledWith(strategy.name, 2);
+    });
+
+    it('updates heartbeat metrics for active strategies', async () => {
+      const now = new Date('2024-01-01T00:00:00Z').getTime();
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      const withHeartbeat = createStrategy({
+        name: 'WithHeartbeat',
+        status: StrategyStatus.LIVE,
+        lastHeartbeat: new Date(now - 300 * 1000),
+        heartbeatFailures: 1
+      });
+      const withoutHeartbeat = createStrategy({
+        name: 'NoHeartbeat',
+        status: StrategyStatus.TESTING,
+        lastHeartbeat: null,
+        heartbeatFailures: 0
+      });
+      strategyRepo.find.mockResolvedValue([withHeartbeat, withoutHeartbeat]);
+
+      await service.updateHeartbeatMetrics();
+
+      expect(metricsService.setStrategyHeartbeatAge).toHaveBeenCalledWith(
+        'WithHeartbeat',
+        withHeartbeat.shadowStatus,
+        300
+      );
+      expect(metricsService.calculateAndSetHealthScore).toHaveBeenCalledWith(
+        'NoHeartbeat',
+        withoutHeartbeat.shadowStatus,
+        99999,
+        0,
+        300
+      );
+      expect(metricsService.setStrategyHeartbeatFailures).toHaveBeenCalledWith('WithHeartbeat', 1);
+      expect(metricsService.setStrategyHeartbeatFailures).toHaveBeenCalledWith('NoHeartbeat', 0);
+    });
+  });
+
+  describe('status queries', () => {
+    it('returns strategies by status', async () => {
+      const strategies = [createStrategy()];
+      strategyRepo.find.mockResolvedValue(strategies);
+
+      await expect(service.findByStatus(StrategyStatus.LIVE)).resolves.toEqual(strategies);
+    });
+
+    it('updates status via update()', async () => {
+      const updated = createStrategy({ status: StrategyStatus.TESTING });
+      jest.spyOn(service, 'update').mockResolvedValue(updated);
+
+      const result = await service.updateStatus('id', StrategyStatus.TESTING, 'user');
+
+      expect(result).toBe(updated);
+      expect(service.update).toHaveBeenCalledWith('id', { status: StrategyStatus.TESTING }, 'user');
+    });
+  });
+
+  describe('stale heartbeat queries', () => {
+    it('finds stale heartbeats', async () => {
+      const qb = createQueryBuilderMock();
+      const stale = [createStrategy()];
+      qb.getMany.mockResolvedValue(stale);
+      strategyRepo.createQueryBuilder.mockReturnValue(qb as any);
+
+      const result = await service.getStrategiesWithStaleHeartbeats(15);
+
+      expect(qb.where).toHaveBeenCalled();
+      expect(qb.andWhere).toHaveBeenCalled();
+      expect(result).toEqual(stale);
+    });
+
+    it('filters strategies with heartbeat failures', async () => {
+      const strategies = [
+        createStrategy({ heartbeatFailures: 1, status: StrategyStatus.LIVE }),
+        createStrategy({ heartbeatFailures: 4, status: StrategyStatus.TESTING })
+      ];
+      strategyRepo.find.mockResolvedValue(strategies);
+
+      const result = await service.getStrategiesWithHeartbeatFailures(3);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].heartbeatFailures).toBe(4);
+    });
+  });
+});

--- a/apps/api/src/strategy/strategy.service.ts
+++ b/apps/api/src/strategy/strategy.service.ts
@@ -1,14 +1,14 @@
-import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 
 import {
+  AuditEventType,
   CreateStrategyConfigDto,
-  UpdateStrategyConfigDto,
   StrategyConfigListFilters,
   StrategyStatus,
-  AuditEventType
+  UpdateStrategyConfigDto
 } from '@chansey/api-interfaces';
 
 import { BacktestRun } from './entities/backtest-run.entity';
@@ -18,6 +18,7 @@ import { StrategyScore } from './entities/strategy-score.entity';
 import { AlgorithmService } from '../algorithm/algorithm.service';
 import { AlgorithmRegistry } from '../algorithm/registry/algorithm-registry.service';
 import { AuditService } from '../audit/audit.service';
+import { MetricsService } from '../metrics/metrics.service';
 
 /**
  * Strategy Service
@@ -37,7 +38,8 @@ export class StrategyService {
     private readonly strategyScoreRepo: Repository<StrategyScore>,
     private readonly algorithmService: AlgorithmService,
     private readonly algorithmRegistry: AlgorithmRegistry,
-    private readonly auditService: AuditService
+    private readonly auditService: AuditService,
+    private readonly metricsService: MetricsService
   ) {}
 
   /**
@@ -280,5 +282,137 @@ export class StrategyService {
    */
   async updateStatus(id: string, status: StrategyStatus, userId?: string): Promise<StrategyConfig> {
     return this.update(id, { status }, userId);
+  }
+
+  // ===================
+  // Heartbeat Methods
+  // ===================
+
+  /**
+   * Record a successful heartbeat for a strategy
+   * Call this when a strategy successfully executes a cycle
+   */
+  async recordHeartbeat(strategyId: string): Promise<void> {
+    const strategy = await this.strategyConfigRepo.findOne({ where: { id: strategyId } });
+    if (!strategy) {
+      this.logger.warn(`Cannot record heartbeat: Strategy ${strategyId} not found`);
+      return;
+    }
+
+    strategy.lastHeartbeat = new Date();
+    strategy.heartbeatFailures = 0;
+    strategy.lastError = null;
+    strategy.lastErrorAt = null;
+
+    await this.strategyConfigRepo.save(strategy);
+
+    // Record metric
+    this.metricsService.recordStrategyHeartbeat(strategy.name, 'success');
+    this.metricsService.setStrategyHeartbeatFailures(strategy.name, 0);
+
+    this.logger.debug(`Heartbeat recorded for strategy: ${strategy.name}`);
+  }
+
+  /**
+   * Record a failed heartbeat for a strategy
+   * Call this when a strategy fails to execute properly
+   */
+  async recordHeartbeatFailure(strategyId: string, error: string): Promise<void> {
+    const strategy = await this.strategyConfigRepo.findOne({ where: { id: strategyId } });
+    if (!strategy) {
+      this.logger.warn(`Cannot record heartbeat failure: Strategy ${strategyId} not found`);
+      return;
+    }
+
+    strategy.heartbeatFailures = (strategy.heartbeatFailures || 0) + 1;
+    strategy.lastError = error.substring(0, 500); // Truncate to 500 chars
+    strategy.lastErrorAt = new Date();
+
+    await this.strategyConfigRepo.save(strategy);
+
+    // Record metric
+    this.metricsService.recordStrategyHeartbeat(strategy.name, 'failed');
+    this.metricsService.setStrategyHeartbeatFailures(strategy.name, strategy.heartbeatFailures);
+
+    this.logger.warn(
+      `Heartbeat failure recorded for strategy: ${strategy.name} (${strategy.heartbeatFailures} consecutive failures)`
+    );
+  }
+
+  /**
+   * Update all strategy heartbeat metrics for Prometheus
+   * Should be called periodically (e.g., every minute)
+   *
+   * Note on heartbeat age handling:
+   * - Strategies with no heartbeat (lastHeartbeat is null) get Infinity age internally
+   * - The heartbeat age metric is NOT emitted for strategies that have never sent a heartbeat
+   * - For health score calculation, Infinity is converted to 99999 seconds (~27.7 hours)
+   *   to ensure metric systems receive a finite value while still indicating unhealthy state
+   */
+  async updateHeartbeatMetrics(): Promise<void> {
+    const activeStatuses = [StrategyStatus.LIVE, StrategyStatus.TESTING];
+    const strategies = await this.strategyConfigRepo.find({
+      where: { status: In(activeStatuses) }
+    });
+
+    const now = Date.now();
+
+    for (const strategy of strategies) {
+      // Calculate heartbeat age in seconds
+      // Strategies that have never sent a heartbeat get Infinity (handled specially below)
+      const heartbeatAge = strategy.lastHeartbeat
+        ? Math.floor((now - strategy.lastHeartbeat.getTime()) / 1000)
+        : Infinity;
+
+      // Only emit heartbeat age metric if strategy has sent at least one heartbeat
+      // This avoids polluting metrics with strategies still in initial setup
+      if (heartbeatAge !== Infinity) {
+        this.metricsService.setStrategyHeartbeatAge(strategy.name, strategy.shadowStatus, heartbeatAge);
+      }
+
+      this.metricsService.setStrategyHeartbeatFailures(strategy.name, strategy.heartbeatFailures || 0);
+
+      // Calculate and set health score
+      // Use 99999 as sentinel value for "never received heartbeat" - large enough to
+      // indicate critical health but finite for Prometheus/Grafana compatibility
+      this.metricsService.calculateAndSetHealthScore(
+        strategy.name,
+        strategy.shadowStatus,
+        heartbeatAge === Infinity ? 99999 : heartbeatAge,
+        strategy.heartbeatFailures || 0,
+        300 // Expected heartbeat every 5 minutes
+      );
+    }
+
+    this.logger.debug(`Updated heartbeat metrics for ${strategies.length} strategies`);
+  }
+
+  /**
+   * Get strategies with stale heartbeats (no heartbeat for more than threshold)
+   * @param thresholdMinutes Number of minutes after which a heartbeat is considered stale
+   */
+  async getStrategiesWithStaleHeartbeats(thresholdMinutes = 10): Promise<StrategyConfig[]> {
+    const threshold = new Date(Date.now() - thresholdMinutes * 60 * 1000);
+    const activeStatuses = [StrategyStatus.LIVE, StrategyStatus.TESTING];
+
+    return this.strategyConfigRepo
+      .createQueryBuilder('strategy')
+      .where('strategy.status IN (:...statuses)', { statuses: activeStatuses })
+      .andWhere('(strategy.lastHeartbeat < :threshold OR strategy.lastHeartbeat IS NULL)', { threshold })
+      .getMany();
+  }
+
+  /**
+   * Get strategies with multiple consecutive heartbeat failures
+   * @param minFailures Minimum number of consecutive failures
+   */
+  async getStrategiesWithHeartbeatFailures(minFailures = 3): Promise<StrategyConfig[]> {
+    return this.strategyConfigRepo
+      .find({
+        where: {
+          status: In([StrategyStatus.LIVE, StrategyStatus.TESTING])
+        }
+      })
+      .then((strategies) => strategies.filter((s) => (s.heartbeatFailures || 0) >= minFailures));
   }
 }


### PR DESCRIPTION
## Summary
- Add heartbeat tracking columns to strategy_config table (lastHeartbeat, heartbeatStatus, consecutiveFailures, lastHealthCheck)
- Implement heartbeat recording and health status evaluation in StrategyService
- Add Prometheus metrics for strategy health monitoring (gauges, histograms, counters)
- Create scheduled task for periodic strategy health evaluation
- Add database migration for new heartbeat columns

## Test plan
- [ ] Run migration to add heartbeat columns
- [ ] Verify heartbeat recording works when strategies execute
- [ ] Check Prometheus metrics endpoint shows strategy health gauges
- [ ] Confirm health evaluation task runs on schedule and updates statuses
- [ ] Test consecutive failure tracking and status transitions