### PR TITLE
feat(risk): add tiered thresholds for risk checks with auto-demote

### DIFF
--- a/apps/api/src/strategy/risk/consecutive-losses.check.spec.ts
+++ b/apps/api/src/strategy/risk/consecutive-losses.check.spec.ts
@@ -1,0 +1,205 @@
+import { DeploymentStatus } from '@chansey/api-interfaces';
+
+import { ConsecutiveLossesCheck } from './consecutive-losses.check';
+
+import { Deployment } from '../entities/deployment.entity';
+import { PerformanceMetric } from '../entities/performance-metric.entity';
+
+const createDeployment = (overrides: Partial<Deployment> = {}): Deployment =>
+  ({
+    id: 'deployment-1',
+    status: DeploymentStatus.ACTIVE,
+    metadata: {},
+    ...overrides
+  }) as Deployment;
+
+const createMetric = (overrides: Partial<PerformanceMetric> = {}): PerformanceMetric =>
+  ({
+    id: 'metric-1',
+    deploymentId: 'deployment-1',
+    dailyPnl: 100,
+    dailyReturn: 0.01,
+    ...overrides
+  }) as PerformanceMetric;
+
+const createHistoricalMetrics = (losingDays: number, winningDays = 0): PerformanceMetric[] => {
+  const metrics: PerformanceMetric[] = [];
+
+  // Add winning days first (older)
+  for (let i = 0; i < winningDays; i++) {
+    metrics.push(createMetric({ dailyPnl: 100, dailyReturn: 0.01 }));
+  }
+
+  // Add losing days (most recent)
+  for (let i = 0; i < losingDays; i++) {
+    metrics.push(createMetric({ dailyPnl: -50, dailyReturn: -0.005 }));
+  }
+
+  return metrics;
+};
+
+describe('ConsecutiveLossesCheck', () => {
+  let check: ConsecutiveLossesCheck;
+
+  beforeEach(() => {
+    check = new ConsecutiveLossesCheck();
+  });
+
+  describe('static properties', () => {
+    it('has correct name', () => {
+      expect(check.name).toBe('consecutive-losses');
+    });
+
+    it('has correct priority', () => {
+      expect(check.priority).toBe(3);
+    });
+
+    it('has autoDemote enabled', () => {
+      expect(check.autoDemote).toBe(true);
+    });
+
+    it('has description mentioning both thresholds', () => {
+      expect(check.description).toContain('10');
+      expect(check.description).toContain('15');
+    });
+  });
+
+  describe('evaluate', () => {
+    const deployment = createDeployment();
+    const latestMetric = createMetric();
+
+    describe('insufficient data', () => {
+      it('returns passed with low severity when no historical metrics', async () => {
+        const result = await check.evaluate(deployment, latestMetric, undefined);
+
+        expect(result.passed).toBe(true);
+        expect(result.severity).toBe('low');
+        expect(result.message).toContain('Insufficient');
+      });
+
+      it('returns passed with low severity when less than 10 days of data', async () => {
+        const metrics = createHistoricalMetrics(5);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.passed).toBe(true);
+        expect(result.severity).toBe('low');
+      });
+    });
+
+    describe('severity: low (0-6 consecutive losses)', () => {
+      it.each([
+        [0, 'low', true],
+        [5, 'low', true],
+        [6, 'low', true]
+      ])('returns %s severity for %p consecutive losses', async (losses, severity, passed) => {
+        const metrics = createHistoricalMetrics(losses, 10);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.passed).toBe(passed);
+        expect(result.severity).toBe(severity);
+        expect(result.actualValue).toBe(`${losses} days`);
+      });
+    });
+
+    describe('severity: medium (7-9 consecutive losses)', () => {
+      it.each([
+        [7, 'medium', true],
+        [9, 'medium', true]
+      ])('returns %s severity for %p consecutive losses', async (losses, severity, passed) => {
+        const metrics = createHistoricalMetrics(losses, 10);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.passed).toBe(passed);
+        expect(result.severity).toBe(severity);
+        expect(result.actualValue).toBe(`${losses} days`);
+      });
+    });
+
+    describe('severity: high (10-14 consecutive losses) - WARNING threshold', () => {
+      it.each([
+        [10, 'high'],
+        [14, 'high']
+      ])('flags %p losses as %s severity', async (losses, severity) => {
+        const metrics = createHistoricalMetrics(losses, 10);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.passed).toBe(false);
+        expect(result.severity).toBe(severity);
+        expect(result.actualValue).toBe(`${losses} days`);
+        expect(result.recommendedAction).toBeDefined();
+      });
+    });
+
+    describe('severity: critical (15+ consecutive losses) - AUTO-DEMOTE threshold', () => {
+      it.each([
+        [15, 'critical'],
+        [20, 'critical'],
+        [30, 'critical']
+      ])('flags %p losses as %s severity', async (losses, severity) => {
+        const metrics = createHistoricalMetrics(losses, 10);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.passed).toBe(false);
+        expect(result.severity).toBe(severity);
+        expect(result.actualValue).toBe(`${losses} days`);
+        expect(result.recommendedAction).toBeDefined();
+      });
+    });
+
+    describe('metadata', () => {
+      it('includes warningThreshold and criticalThreshold in metadata', async () => {
+        const metrics = createHistoricalMetrics(10, 10);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.metadata).toBeDefined();
+        expect(result.metadata?.warningThreshold).toBe(10);
+        expect(result.metadata?.criticalThreshold).toBe(15);
+        expect(result.metadata?.consecutiveLosses).toBe(10);
+        expect(result.metadata?.totalDaysReviewed).toBe(20);
+      });
+    });
+
+    describe('threshold message', () => {
+      it('includes both warning and critical thresholds in threshold field', async () => {
+        const metrics = createHistoricalMetrics(12, 10);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.threshold).toContain('10');
+        expect(result.threshold).toContain('15');
+        expect(result.threshold).toContain('critical');
+      });
+    });
+
+    describe('streak counting', () => {
+      it('correctly counts streak that breaks in the middle', async () => {
+        // Need at least 10 metrics for valid evaluation
+        const metrics: PerformanceMetric[] = [
+          createMetric({ dailyPnl: 100 }), // Older days - winning
+          createMetric({ dailyPnl: 100 }),
+          createMetric({ dailyPnl: 100 }),
+          createMetric({ dailyPnl: 100 }),
+          createMetric({ dailyPnl: -50 }), // Old losing streak
+          createMetric({ dailyPnl: -50 }),
+          createMetric({ dailyPnl: -50 }),
+          createMetric({ dailyPnl: 100 }), // Breaks the streak
+          createMetric({ dailyPnl: -50 }), // Current losing streak (2 days)
+          createMetric({ dailyPnl: -50 })
+        ];
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        // Should only count the 2 most recent losses
+        expect(result.actualValue).toBe('2 days');
+        expect(result.passed).toBe(true);
+      });
+
+      it('counts zero consecutive losses when all days are profitable', async () => {
+        const metrics = createHistoricalMetrics(0, 15);
+        const result = await check.evaluate(deployment, latestMetric, metrics);
+
+        expect(result.actualValue).toBe('0 days');
+        expect(result.passed).toBe(true);
+        expect(result.severity).toBe('low');
+      });
+    });
+  });
+});

--- a/apps/api/src/strategy/risk/risk-management.service.spec.ts
+++ b/apps/api/src/strategy/risk/risk-management.service.spec.ts
@@ -1,0 +1,369 @@
+import { Repository } from 'typeorm';
+
+import { DeploymentStatus } from '@chansey/api-interfaces';
+
+import { ConsecutiveLossesCheck } from './consecutive-losses.check';
+import { DailyLossLimitCheck } from './daily-loss-limit.check';
+import { DrawdownBreachCheck } from './drawdown-breach.check';
+import { RiskManagementService } from './risk-management.service';
+import { SharpeDegradationCheck } from './sharpe-degradation.check';
+import { VolatilitySpikeCheck } from './volatility-spike.check';
+
+import { AuditService } from '../../audit/audit.service';
+import { DeploymentService } from '../deployment.service';
+import { Deployment } from '../entities/deployment.entity';
+import { PerformanceMetric } from '../entities/performance-metric.entity';
+
+// Mock factories
+const createDeployment = (overrides: Partial<Deployment> = {}): Deployment =>
+  ({
+    id: 'deployment-1',
+    strategyConfigId: 'strategy-1',
+    status: DeploymentStatus.ACTIVE,
+    isActive: true,
+    daysLive: 30,
+    maxDrawdownLimit: 0.4, // 40% max drawdown limit (breach threshold = 60%)
+    dailyLossLimit: 0.05, // 5% daily loss limit
+    metadata: {
+      backtestVolatility: 0.2, // 20% expected volatility
+      backtestSharpe: 1.5
+    },
+    ...overrides
+  }) as Deployment;
+
+const createMetric = (overrides: Partial<PerformanceMetric> = {}): PerformanceMetric =>
+  ({
+    id: 'metric-1',
+    deploymentId: 'deployment-1',
+    dailyPnl: 100,
+    dailyReturn: 0.01,
+    drawdown: 0.05, // 5% drawdown (well under 60% breach threshold)
+    volatility: 0.25,
+    sharpeRatio: 1.5,
+    ...overrides
+  }) as PerformanceMetric;
+
+// Creates historical metrics with specified winning/losing days
+const createHistoricalMetrics = (losingDays: number, winningDays = 10): PerformanceMetric[] => {
+  const metrics: PerformanceMetric[] = [];
+  for (let i = 0; i < winningDays; i++) {
+    metrics.push(createMetric({ dailyPnl: 100, dailyReturn: 0.01 }));
+  }
+  for (let i = 0; i < losingDays; i++) {
+    metrics.push(createMetric({ dailyPnl: -50, dailyReturn: -0.005 }));
+  }
+  return metrics;
+};
+
+describe('RiskManagementService', () => {
+  let service: RiskManagementService;
+  let deploymentRepo: jest.Mocked<Repository<Deployment>>;
+  let performanceMetricRepo: jest.Mocked<Repository<PerformanceMetric>>;
+  let deploymentService: jest.Mocked<DeploymentService>;
+  let auditService: jest.Mocked<AuditService>;
+
+  // Risk checks
+  let drawdownBreachCheck: DrawdownBreachCheck;
+  let dailyLossLimitCheck: DailyLossLimitCheck;
+  let consecutiveLossesCheck: ConsecutiveLossesCheck;
+  let volatilitySpikeCheck: VolatilitySpikeCheck;
+  let sharpeDegradationCheck: SharpeDegradationCheck;
+  let mockHistoricalMetrics: (metrics: PerformanceMetric[]) => void;
+
+  beforeEach(() => {
+    deploymentRepo = {
+      findOne: jest.fn()
+    } as unknown as jest.Mocked<Repository<Deployment>>;
+
+    const makeQueryBuilder = () => ({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([])
+    });
+    performanceMetricRepo = {
+      createQueryBuilder: jest.fn().mockImplementation(() => makeQueryBuilder())
+    } as unknown as jest.Mocked<Repository<PerformanceMetric>>;
+
+    mockHistoricalMetrics = (metrics: PerformanceMetric[]) => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(metrics)
+      };
+      (performanceMetricRepo.createQueryBuilder as jest.Mock).mockReturnValueOnce(qb as any);
+    };
+
+    deploymentService = {
+      findOne: jest.fn(),
+      getLatestPerformanceMetric: jest.fn(),
+      getActiveDeployments: jest.fn(),
+      demoteDeployment: jest.fn()
+    } as unknown as jest.Mocked<DeploymentService>;
+
+    auditService = {
+      createAuditLog: jest.fn()
+    } as unknown as jest.Mocked<AuditService>;
+
+    // Create real check instances
+    drawdownBreachCheck = new DrawdownBreachCheck();
+    dailyLossLimitCheck = new DailyLossLimitCheck();
+    consecutiveLossesCheck = new ConsecutiveLossesCheck();
+    volatilitySpikeCheck = new VolatilitySpikeCheck();
+    sharpeDegradationCheck = new SharpeDegradationCheck();
+
+    service = new RiskManagementService(
+      deploymentRepo,
+      performanceMetricRepo,
+      deploymentService,
+      auditService,
+      drawdownBreachCheck,
+      dailyLossLimitCheck,
+      consecutiveLossesCheck,
+      volatilitySpikeCheck,
+      sharpeDegradationCheck
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  describe('auto-demotion flow', () => {
+    describe('ConsecutiveLossesCheck auto-demotion', () => {
+      it('triggers auto-demotion when 15+ consecutive losses (critical severity)', async () => {
+        const deployment = createDeployment();
+        const latestMetric = createMetric();
+        const historicalMetrics = createHistoricalMetrics(15, 10); // 15 consecutive losses
+
+        deploymentService.findOne.mockResolvedValue(deployment);
+        deploymentService.getLatestPerformanceMetric.mockResolvedValue(latestMetric);
+        mockHistoricalMetrics(historicalMetrics);
+
+        const evaluation = await service.evaluateRisks(deployment.id);
+
+        expect(evaluation.shouldDemote).toBe(true);
+        expect(evaluation.hasCriticalRisk).toBe(true);
+        expect(evaluation.failedChecks).toContain('consecutive-losses');
+        expect(deploymentService.demoteDeployment).toHaveBeenCalledWith(
+          deployment.id,
+          expect.stringContaining('consecutive-losses'),
+          expect.objectContaining({ autoDemotion: true })
+        );
+      });
+
+      it('does NOT trigger auto-demotion for 10-14 consecutive losses (high severity warning)', async () => {
+        const deployment = createDeployment();
+        const latestMetric = createMetric();
+        const historicalMetrics = createHistoricalMetrics(12, 10); // 12 consecutive losses (warning)
+
+        deploymentService.findOne.mockResolvedValue(deployment);
+        deploymentService.getLatestPerformanceMetric.mockResolvedValue(latestMetric);
+        mockHistoricalMetrics(historicalMetrics);
+
+        const evaluation = await service.evaluateRisks(deployment.id);
+
+        // Check failed but not critical
+        const consecutiveLossResult = evaluation.checkResults.find((r) => r.checkName === 'consecutive-losses');
+        expect(consecutiveLossResult?.passed).toBe(false);
+        expect(consecutiveLossResult?.severity).toBe('high');
+
+        // Should NOT trigger auto-demotion for warning-level failures
+        expect(evaluation.shouldDemote).toBe(false);
+        expect(deploymentService.demoteDeployment).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('VolatilitySpikeCheck auto-demotion', () => {
+      it('triggers auto-demotion when volatility >= 3x expected (critical severity)', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.2 } });
+        // 65% volatility = 3.25x of 20% expected = critical
+        const latestMetric = createMetric({ volatility: 0.65, drawdown: 0.05 });
+        const historicalMetrics = createHistoricalMetrics(0, 15);
+
+        deploymentService.findOne.mockResolvedValue(deployment);
+        deploymentService.getLatestPerformanceMetric.mockResolvedValue(latestMetric);
+        mockHistoricalMetrics(historicalMetrics);
+
+        const evaluation = await service.evaluateRisks(deployment.id);
+
+        expect(evaluation.shouldDemote).toBe(true);
+        expect(evaluation.hasCriticalRisk).toBe(true);
+        expect(evaluation.failedChecks).toContain('volatility-spike');
+        expect(deploymentService.demoteDeployment).toHaveBeenCalledWith(
+          deployment.id,
+          expect.stringContaining('volatility-spike'),
+          expect.objectContaining({ autoDemotion: true })
+        );
+      });
+
+      it('does NOT trigger auto-demotion for 2x-3x volatility (high severity warning)', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.2 } });
+        // 50% volatility = 2.5x of 20% expected = high (warning)
+        const latestMetric = createMetric({ volatility: 0.5, drawdown: 0.05 });
+        const historicalMetrics = createHistoricalMetrics(0, 15);
+
+        deploymentService.findOne.mockResolvedValue(deployment);
+        deploymentService.getLatestPerformanceMetric.mockResolvedValue(latestMetric);
+        mockHistoricalMetrics(historicalMetrics);
+
+        const evaluation = await service.evaluateRisks(deployment.id);
+
+        const volatilityResult = evaluation.checkResults.find((r) => r.checkName === 'volatility-spike');
+        expect(volatilityResult?.passed).toBe(false);
+        expect(volatilityResult?.severity).toBe('high');
+
+        // Should NOT trigger auto-demotion for warning-level failures
+        expect(evaluation.shouldDemote).toBe(false);
+        expect(deploymentService.demoteDeployment).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('SharpeDegradationCheck (autoDemote=false)', () => {
+      it('does NOT trigger auto-demotion even with critical-level Sharpe degradation', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.2, backtestSharpe: 2.0 } });
+        // Sharpe dropped from 2.0 to -0.5 = severe degradation
+        const latestMetric = createMetric({ sharpeRatio: -0.5, volatility: 0.25, drawdown: 0.05 });
+        const historicalMetrics = createHistoricalMetrics(0, 15);
+
+        deploymentService.findOne.mockResolvedValue(deployment);
+        deploymentService.getLatestPerformanceMetric.mockResolvedValue(latestMetric);
+        mockHistoricalMetrics(historicalMetrics);
+
+        const evaluation = await service.evaluateRisks(deployment.id);
+
+        // Sharpe check should fail
+        const sharpeResult = evaluation.checkResults.find((r) => r.checkName === 'sharpe-degradation');
+        expect(sharpeResult?.passed).toBe(false);
+
+        // But since autoDemote=false, should NOT auto-demote
+        // (unless other checks trigger it)
+        const autoDemoteFromSharpe = evaluation.checkResults.some(
+          (r) => r.checkName === 'sharpe-degradation' && r.severity === 'critical'
+        );
+        const sharpeDegradationCheck = service.getCheck('sharpe-degradation');
+        expect(sharpeDegradationCheck?.autoDemote).toBe(false);
+
+        // If only Sharpe failed critically, should not demote
+        if (autoDemoteFromSharpe && evaluation.failedChecks.length === 1) {
+          expect(evaluation.shouldDemote).toBe(false);
+        }
+      });
+    });
+
+    describe('multiple critical failures', () => {
+      it('triggers auto-demotion when multiple checks fail critically', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.2 } });
+        // 65% volatility (3.25x) AND 15 consecutive losses
+        const latestMetric = createMetric({ volatility: 0.65, drawdown: 0.05 });
+        const historicalMetrics = createHistoricalMetrics(15, 5);
+
+        deploymentService.findOne.mockResolvedValue(deployment);
+        deploymentService.getLatestPerformanceMetric.mockResolvedValue(latestMetric);
+        mockHistoricalMetrics(historicalMetrics);
+
+        const evaluation = await service.evaluateRisks(deployment.id);
+
+        expect(evaluation.shouldDemote).toBe(true);
+        expect(evaluation.hasCriticalRisk).toBe(true);
+        expect(evaluation.failedChecks).toContain('consecutive-losses');
+        expect(evaluation.failedChecks).toContain('volatility-spike');
+
+        // demoteDeployment should mention both checks
+        expect(deploymentService.demoteDeployment).toHaveBeenCalledWith(
+          deployment.id,
+          expect.stringMatching(/consecutive-losses.*volatility-spike|volatility-spike.*consecutive-losses/),
+          expect.objectContaining({ autoDemotion: true })
+        );
+      });
+    });
+  });
+
+  describe('getChecks', () => {
+    it('returns all registered risk checks', () => {
+      const checks = service.getChecks();
+      expect(checks.length).toBe(5);
+      expect(checks.map((c) => c.name)).toEqual(
+        expect.arrayContaining([
+          'drawdown-breach',
+          'daily-loss-limit',
+          'consecutive-losses',
+          'volatility-spike',
+          'sharpe-degradation'
+        ])
+      );
+    });
+
+    it('returns checks sorted by priority', () => {
+      const checks = service.getChecks();
+      for (let i = 0; i < checks.length - 1; i++) {
+        expect(checks[i].priority).toBeLessThanOrEqual(checks[i + 1].priority);
+      }
+    });
+  });
+
+  describe('getCriticalChecks', () => {
+    it('returns only checks with autoDemote=true', () => {
+      const criticalChecks = service.getCriticalChecks();
+
+      // Verify all returned checks have autoDemote=true
+      criticalChecks.forEach((check) => {
+        expect(check.autoDemote).toBe(true);
+      });
+
+      // Verify expected checks are included
+      const names = criticalChecks.map((c) => c.name);
+      expect(names).toContain('drawdown-breach');
+      expect(names).toContain('consecutive-losses');
+      expect(names).toContain('volatility-spike');
+
+      // SharpeDegradationCheck should NOT be in critical checks
+      expect(names).not.toContain('sharpe-degradation');
+    });
+  });
+
+  describe('inactive deployment handling', () => {
+    it('returns empty evaluation for inactive deployments', async () => {
+      const deployment = createDeployment({ isActive: false });
+
+      deploymentService.findOne.mockResolvedValue(deployment);
+
+      const evaluation = await service.evaluateRisks(deployment.id);
+
+      expect(evaluation.hasCriticalRisk).toBe(false);
+      expect(evaluation.shouldDemote).toBe(false);
+      expect(evaluation.checkResults).toHaveLength(0);
+      expect(evaluation.summary).toContain('not active');
+      expect(deploymentService.demoteDeployment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('audit logging', () => {
+    it('logs risk evaluation to audit trail', async () => {
+      const deployment = createDeployment();
+      const latestMetric = createMetric();
+      const historicalMetrics = createHistoricalMetrics(0, 15);
+
+      deploymentService.findOne.mockResolvedValue(deployment);
+      deploymentService.getLatestPerformanceMetric.mockResolvedValue(latestMetric);
+      mockHistoricalMetrics(historicalMetrics);
+
+      await service.evaluateRisks(deployment.id, 'user-123');
+
+      expect(auditService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'RISK_EVALUATION',
+          entityType: 'Deployment',
+          entityId: deployment.id,
+          userId: 'user-123',
+          afterState: expect.objectContaining({
+            hasCriticalRisk: expect.any(Boolean),
+            shouldDemote: expect.any(Boolean)
+          })
+        })
+      );
+    });
+  });
+});

--- a/apps/api/src/strategy/risk/volatility-spike.check.spec.ts
+++ b/apps/api/src/strategy/risk/volatility-spike.check.spec.ts
@@ -1,0 +1,193 @@
+import { DeploymentStatus } from '@chansey/api-interfaces';
+
+import { VolatilitySpikeCheck } from './volatility-spike.check';
+
+import { Deployment } from '../entities/deployment.entity';
+import { PerformanceMetric } from '../entities/performance-metric.entity';
+
+const createDeployment = (overrides: Partial<Deployment> = {}): Deployment =>
+  ({
+    id: 'deployment-1',
+    status: DeploymentStatus.ACTIVE,
+    metadata: {
+      backtestVolatility: 0.2 // 20% expected volatility
+    },
+    ...overrides
+  }) as Deployment;
+
+const createMetric = (overrides: Partial<PerformanceMetric> = {}): PerformanceMetric =>
+  ({
+    id: 'metric-1',
+    deploymentId: 'deployment-1',
+    volatility: 0.25,
+    sharpeRatio: 1.5,
+    ...overrides
+  }) as PerformanceMetric;
+
+describe('VolatilitySpikeCheck', () => {
+  let check: VolatilitySpikeCheck;
+
+  beforeEach(() => {
+    check = new VolatilitySpikeCheck();
+  });
+
+  describe('static properties', () => {
+    it('has correct name', () => {
+      expect(check.name).toBe('volatility-spike');
+    });
+
+    it('has correct priority', () => {
+      expect(check.priority).toBe(4);
+    });
+
+    it('has autoDemote enabled', () => {
+      expect(check.autoDemote).toBe(true);
+    });
+
+    it('has description mentioning both thresholds', () => {
+      expect(check.description).toContain('2x');
+      expect(check.description).toContain('3x');
+    });
+  });
+
+  describe('evaluate', () => {
+    describe('no data available', () => {
+      it('returns passed with low severity when latestMetric is null', async () => {
+        const deployment = createDeployment();
+        const result = await check.evaluate(deployment, null);
+
+        expect(result.passed).toBe(true);
+        expect(result.severity).toBe('low');
+        expect(result.message).toContain('not available');
+      });
+
+      it('returns passed with low severity when volatility is null', async () => {
+        const deployment = createDeployment();
+        const metric = createMetric({ volatility: null });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.passed).toBe(true);
+        expect(result.severity).toBe('low');
+        expect(result.message).toContain('not available');
+      });
+    });
+
+    describe('with 20% expected volatility (backtestVolatility: 0.20)', () => {
+      // Warning threshold: 2x = 40%
+      // Critical threshold: 3x = 60%
+      const deployment = createDeployment({ metadata: { backtestVolatility: 0.2 } });
+
+      it.each([
+        [0.2, 'low', true, '20.00%'],
+        [0.3, 'low', true, '30.00%'],
+        [0.35, 'medium', true, '35.00%'],
+        [0.39, 'medium', true, '39.00%'],
+        [0.4, 'high', false, '40.00%'],
+        [0.5, 'high', false, '50.00%'],
+        [0.59, 'high', false, '59.00%'],
+        [0.61, 'critical', false, '61.00%'],
+        [0.8, 'critical', false, '80.00%'],
+        [1.0, 'critical', false, '100.00%']
+      ])('returns %s severity at %p volatility', async (volatility, severity, passed, expectedValue) => {
+        const metric = createMetric({ volatility });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.severity).toBe(severity);
+        expect(result.passed).toBe(passed);
+        expect(result.actualValue).toBe(expectedValue);
+        if (!passed) {
+          expect(result.recommendedAction).toBeDefined();
+        }
+      });
+    });
+
+    describe('default expected volatility (50% when not set)', () => {
+      // Warning threshold: 2x = 100%
+      // Critical threshold: 3x = 150%
+      const deployment = createDeployment({ metadata: {} });
+
+      it('uses 50% default when backtestVolatility is not set', async () => {
+        const metric = createMetric({ volatility: 0.8 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.passed).toBe(true);
+        expect(result.metadata?.expectedVolatility).toBe('50.00%');
+      });
+
+      it('returns passed=false, severity=high at 100% volatility (2x default)', async () => {
+        const metric = createMetric({ volatility: 1.0 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.passed).toBe(false);
+        expect(result.severity).toBe('high');
+      });
+
+      it('returns passed=false, severity=critical at 150% volatility (3x default)', async () => {
+        const metric = createMetric({ volatility: 1.5 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.passed).toBe(false);
+        expect(result.severity).toBe('critical');
+      });
+    });
+
+    describe('metadata', () => {
+      it('includes warningMultiplier and criticalMultiplier in metadata', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.2 } });
+        const metric = createMetric({ volatility: 0.4 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.metadata).toBeDefined();
+        expect(result.metadata?.warningMultiplier).toBe(2.0);
+        expect(result.metadata?.criticalMultiplier).toBe(3.0);
+        expect(result.metadata?.expectedVolatility).toBe('20.00%');
+        expect(result.metadata?.sharpeRatio).toBe(1.5);
+      });
+    });
+
+    describe('threshold message', () => {
+      it('includes both warning and critical thresholds in threshold field', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.2 } });
+        const metric = createMetric({ volatility: 0.4 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.threshold).toContain('40.00%'); // Warning threshold
+        expect(result.threshold).toContain('60.00%'); // Critical threshold
+        expect(result.threshold).toContain('critical');
+      });
+    });
+
+    describe('edge cases', () => {
+      it('handles very low expected volatility (5%)', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.05 } });
+        // Warning: 10%, Critical: 15%
+        const metric = createMetric({ volatility: 0.16 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.passed).toBe(false);
+        expect(result.severity).toBe('critical');
+      });
+
+      it('handles very high expected volatility (80%)', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.8 } });
+        // Warning: 160%, Critical: 240%
+        const metric = createMetric({ volatility: 1.6 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.passed).toBe(false);
+        expect(result.severity).toBe('high');
+        expect(result.message).toContain('WARNING');
+      });
+
+      it('handles zero volatility gracefully', async () => {
+        const deployment = createDeployment({ metadata: { backtestVolatility: 0.2 } });
+        const metric = createMetric({ volatility: 0 });
+        const result = await check.evaluate(deployment, metric);
+
+        expect(result.passed).toBe(true);
+        expect(result.severity).toBe('low');
+        expect(result.actualValue).toBe('0.00%');
+      });
+    });
+  });
+});

--- a/apps/api/src/strategy/risk/volatility-spike.check.ts
+++ b/apps/api/src/strategy/risk/volatility-spike.check.ts
@@ -9,25 +9,25 @@ import { PerformanceMetric } from '../entities/performance-metric.entity';
  * VolatilitySpikeCheck
  *
  * Risk Check 4: Volatility Spike Detection
- * Triggers if realized volatility exceeds 2x expected volatility from backtest.
+ * - Warning: Volatility exceeds 2x expected
+ * - Critical + Auto-Demote: Volatility exceeds 3x expected
  *
- * Rationale: Unexpected volatility spikes indicate the strategy is experiencing
- * higher risk than anticipated, which may lead to outsized losses.
+ * Rationale: 2x volatility is uncomfortable but manageable. 3x+ is dangerous
+ * territory where position sizing assumptions break down and a single bad day
+ * could wipe out months of gains.
  */
 @Injectable()
 export class VolatilitySpikeCheck implements IRiskCheck {
   readonly name = 'volatility-spike';
-  readonly description = 'Detect if volatility exceeds 2x expected levels';
+  readonly description = 'Detect volatility spikes (warns at 2x, auto-demotes at 3x expected)';
   readonly priority = 4;
-  readonly autoDemote = false; // Warning only
+  readonly autoDemote = true; // Auto-demotes at critical threshold (3x expected)
 
-  private readonly VOLATILITY_MULTIPLIER = 2.0;
+  private readonly WARNING_MULTIPLIER = 2.0;
+  private readonly CRITICAL_MULTIPLIER = 3.0;
+  private readonly EPSILON = 1e-10; // For floating point comparison precision
 
-  async evaluate(
-    deployment: Deployment,
-    latestMetric: PerformanceMetric | null,
-    historicalMetrics?: PerformanceMetric[]
-  ): Promise<RiskCheckResult> {
+  async evaluate(deployment: Deployment, latestMetric: PerformanceMetric | null): Promise<RiskCheckResult> {
     if (!latestMetric || latestMetric.volatility === null) {
       return {
         checkName: this.name,
@@ -42,28 +42,38 @@ export class VolatilitySpikeCheck implements IRiskCheck {
     // Get expected volatility from backtest metadata
     const expectedVolatility = deployment.metadata?.backtestVolatility || 0.5; // Default 50% if not set
     const currentVolatility = Number(latestMetric.volatility);
-    const spikeThreshold = expectedVolatility * this.VOLATILITY_MULTIPLIER;
+    const warningThreshold = expectedVolatility * this.WARNING_MULTIPLIER;
+    const criticalThreshold = expectedVolatility * this.CRITICAL_MULTIPLIER;
 
-    const passed = currentVolatility < spikeThreshold;
+    // Use epsilon for floating point precision at exact threshold boundaries
+    const passed = currentVolatility < warningThreshold;
+    const isCritical = currentVolatility >= criticalThreshold - this.EPSILON;
 
     let severity: 'low' | 'medium' | 'high' | 'critical' = 'low';
-    if (currentVolatility >= spikeThreshold * 1.5) severity = 'critical';
-    else if (currentVolatility >= spikeThreshold) severity = 'high';
-    else if (currentVolatility >= spikeThreshold * 0.8) severity = 'medium';
+    if (isCritical) severity = 'critical';
+    else if (currentVolatility >= warningThreshold) severity = 'high';
+    else if (currentVolatility >= warningThreshold * 0.8) severity = 'medium';
 
     return {
       checkName: this.name,
       passed,
       actualValue: `${(currentVolatility * 100).toFixed(2)}%`,
-      threshold: `< ${(spikeThreshold * 100).toFixed(2)}%`,
+      threshold: `< ${(warningThreshold * 100).toFixed(2)}% (critical at ${(criticalThreshold * 100).toFixed(2)}%+)`,
       severity,
-      message: passed
-        ? `Volatility of ${(currentVolatility * 100).toFixed(2)}% within expected range`
-        : `WARNING: Volatility of ${(currentVolatility * 100).toFixed(2)}% exceeds ${this.VOLATILITY_MULTIPLIER}x expected`,
-      recommendedAction: passed ? undefined : 'Consider reducing position sizes or pausing strategy',
+      message: isCritical
+        ? `CRITICAL: Volatility ${(currentVolatility * 100).toFixed(2)}% exceeds ${this.CRITICAL_MULTIPLIER}x expected - automatic demotion triggered`
+        : passed
+          ? `Volatility of ${(currentVolatility * 100).toFixed(2)}% within expected range`
+          : `WARNING: Volatility of ${(currentVolatility * 100).toFixed(2)}% exceeds ${this.WARNING_MULTIPLIER}x expected`,
+      recommendedAction: isCritical
+        ? 'Strategy auto-demoted due to extreme volatility'
+        : passed
+          ? undefined
+          : 'Consider reducing position sizes or pausing strategy',
       metadata: {
         expectedVolatility: `${(expectedVolatility * 100).toFixed(2)}%`,
-        spikeMultiplier: this.VOLATILITY_MULTIPLIER,
+        warningMultiplier: this.WARNING_MULTIPLIER,
+        criticalMultiplier: this.CRITICAL_MULTIPLIER,
         sharpeRatio: latestMetric.sharpeRatio
       }
     };


### PR DESCRIPTION
## Summary
- Enable tiered severity escalation for ConsecutiveLossesCheck and VolatilitySpikeCheck with automatic demotion at critical thresholds
- ConsecutiveLossesCheck: warn at 10+ days, auto-demote at 15+ consecutive losing days
- VolatilitySpikeCheck: warn at 2x expected volatility, auto-demote at 3x expected
- Add EPSILON constant for floating point boundary precision in volatility comparisons
- Remove unused `historicalMetrics` parameter from VolatilitySpikeCheck

## Test plan
- [x] 20 unit tests for ConsecutiveLossesCheck covering all severity tiers
- [x] 24 unit tests for VolatilitySpikeCheck covering all severity tiers
- [x] 11 integration tests for RiskManagementService verifying full auto-demotion flow
- [x] All 231 tests pass

Closes #63