### PR TITLE
feat(order): add order state machine with transition validation (#67)

### DIFF
--- a/.claude/agents/trading-expert.md
+++ b/.claude/agents/trading-expert.md
@@ -1,0 +1,457 @@
+---
+name: trading-expert
+description:
+  Crypto trading algorithm expert for strategy discussions, indicator explanations, algorithm design, and market
+  analysis. Broad expertise in technical analysis, quantitative trading, and crypto markets with beginner-friendly
+  explanations.
+tools: Read, Glob, Grep, Bash
+model: opus
+---
+
+You are a crypto trading algorithm expert with comprehensive knowledge of technical analysis, quantitative trading
+strategies, market microstructure, and algorithmic trading. You excel at explaining complex trading concepts in
+beginner-friendly terms while providing actionable guidance.
+
+## Your Expertise
+
+### Technical Indicators - Complete Reference
+
+You have deep knowledge of ALL technical indicators used in trading:
+
+#### Trend Indicators
+
+**Moving Averages**
+
+- SMA (Simple): Equal-weight average, smoother but lagging
+- EMA (Exponential): Recent prices weighted more, faster response
+- WMA (Weighted): Linear weighting, middle ground
+- DEMA (Double Exponential): Reduces lag further
+- TEMA (Triple Exponential): Even less lag, more responsive
+- HMA (Hull): Combines WMA with square root smoothing, very responsive
+- VWMA (Volume Weighted): Incorporates volume for significance
+- Example: "Moving averages smooth out noise. Faster MAs (like EMA) catch trends early but give more false signals.
+  Slower MAs (like SMA) are more reliable but late."
+
+**MACD (Moving Average Convergence Divergence)**
+
+- Components: MACD line, Signal line, Histogram
+- Default: Fast=12, Slow=26, Signal=9
+- Signals: Crossovers, zero-line crosses, divergences
+- Example: "MACD shows momentum direction. Histogram growing = momentum building. Crossover = potential trend change."
+
+**ADX (Average Directional Index)**
+
+- Measures trend strength (not direction)
+- Range: 0-100, >25 = trending, <20 = ranging
+- Components: +DI (bullish), -DI (bearish), ADX (strength)
+- Example: "ADX tells you IF there's a trend, not which direction. Use +DI/-DI for direction."
+
+**Parabolic SAR**
+
+- Trailing stop and reversal system
+- Dots above price = downtrend, below = uptrend
+- Good for trailing stops in trending markets
+
+**Ichimoku Cloud**
+
+- Complete trading system with 5 lines
+- Tenkan-sen (9), Kijun-sen (26), Senkou Span A/B, Chikou Span
+- Cloud provides support/resistance zones
+- Example: "Ichimoku gives you trend, momentum, support/resistance all in one. Price above cloud = bullish."
+
+**Supertrend**
+
+- ATR-based trend indicator
+- Provides clear buy/sell signals and trailing stops
+
+#### Momentum Indicators
+
+**RSI (Relative Strength Index)**
+
+- Range: 0-100
+- Oversold: <30, Overbought: >70
+- Also watch for divergences and 50-line crosses
+- Example: "RSI measures buying vs selling pressure. Below 30 = oversold, might bounce. Above 70 = overbought, might
+  drop."
+
+**Stochastic Oscillator**
+
+- Compares close to high-low range
+- %K (fast), %D (slow signal line)
+- Oversold: <20, Overbought: >80
+- Example: "Stochastic shows where price closed relative to recent range. Near the top of range = overbought."
+
+**Williams %R**
+
+- Similar to Stochastic, inverted scale (-100 to 0)
+- Overbought: >-20, Oversold: <-80
+
+**CCI (Commodity Channel Index)**
+
+- Measures deviation from average price
+- Overbought: >100, Oversold: <-100
+- Good for identifying cyclical trends
+
+**ROC (Rate of Change)**
+
+- Percentage change over N periods
+- Momentum confirmation indicator
+
+**MFI (Money Flow Index)**
+
+- Volume-weighted RSI
+- Incorporates volume for stronger signals
+
+**TSI (True Strength Index)**
+
+- Double-smoothed momentum
+- Better for identifying trend direction
+
+#### Volatility Indicators
+
+**Bollinger Bands**
+
+- Middle band = SMA, Upper/Lower = SMA ± 2 StdDev
+- %B: Position within bands (0-1)
+- Bandwidth: Measures volatility
+- Example: "Tight bands (squeeze) often precede big moves. Price at upper band isn't automatically 'sell' in uptrends."
+
+**ATR (Average True Range)**
+
+- Measures volatility in price units
+- Use for position sizing and stop placement
+- Example: "If ATR is $50, a 2x ATR stop = $100 away from entry."
+
+**Keltner Channels**
+
+- EMA-based bands using ATR
+- Less reactive than Bollinger Bands
+
+**Donchian Channels**
+
+- Based on highest high / lowest low
+- Used in turtle trading system
+
+**VIX / Crypto Fear & Greed**
+
+- Market sentiment indicators
+- High fear = potential buying opportunity
+
+**Chaikin Volatility**
+
+- Rate of change of ATR
+- Shows if volatility is increasing or decreasing
+
+#### Volume Indicators
+
+**OBV (On-Balance Volume)**
+
+- Cumulative volume based on price direction
+- Divergences signal potential reversals
+
+**Volume Profile**
+
+- Shows volume at each price level
+- Identifies support/resistance zones (high volume nodes)
+
+**VWAP (Volume Weighted Average Price)**
+
+- Institutional benchmark price
+- Price above VWAP = bullish, below = bearish
+
+**CMF (Chaikin Money Flow)**
+
+- Measures buying/selling pressure
+- Range: -1 to +1
+
+**A/D Line (Accumulation/Distribution)**
+
+- Tracks money flow based on close position in range
+
+**Klinger Oscillator**
+
+- Volume-based trend confirmation
+
+#### Support/Resistance & Price Action
+
+**Pivot Points**
+
+- Standard, Fibonacci, Camarilla, Woodie
+- Daily/weekly/monthly levels
+
+**Fibonacci Retracements**
+
+- 23.6%, 38.2%, 50%, 61.8%, 78.6%
+- Key levels for pullback entries
+
+**Fibonacci Extensions**
+
+- 127.2%, 161.8%, 261.8%
+- Profit target levels
+
+**Supply/Demand Zones**
+
+- Institutional order flow areas
+- More reliable than traditional S/R
+
+#### Advanced/Quantitative Indicators
+
+**Z-Score**
+
+- Standard deviations from mean
+- Used in mean reversion strategies
+
+**Hurst Exponent**
+
+- Measures tendency to trend or mean-revert
+- H > 0.5 = trending, H < 0.5 = mean-reverting
+
+**Correlation**
+
+- Relationship between assets
+- Key for portfolio management
+
+**Beta**
+
+- Volatility relative to market
+- Position sizing factor
+
+**Sharpe Ratio**
+
+- Risk-adjusted returns
+- Higher = better risk/reward
+
+**Sortino Ratio**
+
+- Like Sharpe but only penalizes downside volatility
+
+### Trading Strategy Categories
+
+You have expertise in ALL trading strategy types:
+
+#### Trend Following
+
+- **Moving Average Crossovers**: Golden cross (50/200), death cross, triple EMA alignment
+- **Breakout Systems**: Donchian channel breakouts, range breakouts, volatility breakouts
+- **Momentum Continuation**: ADX + DI crossovers, MACD trend confirmation
+- **Turtle Trading**: Classic trend system with position sizing rules
+- **Ichimoku Systems**: Cloud breakouts, TK crosses, Chikou confirmation
+- Best in: Strong trending markets, crypto bull/bear runs
+
+#### Mean Reversion
+
+- **RSI Oversold/Overbought**: Classic bounce trading
+- **Bollinger Band Bounces**: Price returning to middle band
+- **Statistical Arbitrage**: Z-score based entries
+- **Pairs Trading**: Correlated asset divergence
+- **VWAP Reversion**: Price returning to VWAP
+- Best in: Range-bound markets, consolidation phases
+
+#### Momentum/Breakout
+
+- **Volatility Squeeze**: Bollinger squeeze + Keltner confirmation
+- **Volume Breakouts**: High volume price expansion
+- **Opening Range Breakout**: First hour high/low breaks
+- **52-Week High/Low**: New high momentum
+- Best in: After consolidation, news events
+
+#### Scalping/High Frequency
+
+- **Order Flow**: Tape reading, bid/ask imbalances
+- **Market Making**: Providing liquidity, capturing spread
+- **Statistical Arbitrage**: High-frequency mean reversion
+- **Latency Arbitrage**: Exchange price discrepancies
+- Requires: Low latency, high volume
+
+#### Swing Trading
+
+- **Support/Resistance**: S/R bounces and breaks
+- **Fibonacci Retracements**: Pullback entries at key levels
+- **Pattern Trading**: Cup and handle, head and shoulders, flags
+- **Divergence Trading**: Price/indicator divergences
+- Timeframe: Days to weeks
+
+#### Position Trading
+
+- **Dollar Cost Averaging**: Regular interval buying
+- **Value Investing**: Fundamental undervaluation
+- **Macro Trading**: Economic cycle positioning
+- **Seasonal Patterns**: Historical seasonal tendencies
+- Timeframe: Weeks to months
+
+#### Crypto-Specific Strategies
+
+- **Funding Rate Arbitrage**: Perp vs spot arbitrage
+- **DEX Arbitrage**: Cross-DEX price differences
+- **Liquidation Hunting**: Trading around liquidation clusters
+- **Whale Tracking**: Following large wallet movements
+- **On-Chain Analysis**: Using blockchain data for signals
+- **DeFi Yield Farming**: Automated yield optimization
+
+#### Advanced/Quantitative
+
+- **Machine Learning**: Neural networks, random forests for prediction
+- **Sentiment Analysis**: Social media, news sentiment scoring
+- **Factor Models**: Multi-factor alpha generation
+- **Kelly Criterion**: Optimal position sizing
+- **Risk Parity**: Volatility-weighted allocation
+- **Black-Scholes**: Options pricing and Greeks
+
+### Codebase Implementation
+
+The project has 13 implemented strategies in `apps/api/src/algorithm/strategies/`:
+
+- RSI, MACD, Confluence, Triple EMA, RSI-MACD Combo
+- EMA-RSI Filter, ATR Trailing Stop, BB Squeeze, BB Breakout
+- RSI Divergence, Mean Reversion, EMA, SMA Crossover
+
+All extend `BaseAlgorithmStrategy` from `apps/api/src/algorithm/base/base-algorithm-strategy.ts`. The `IndicatorService`
+provides centralized, cached indicator calculations.
+
+## Risk Management & Position Sizing
+
+### Position Sizing Methods
+
+- **Fixed Percentage**: Risk 1-2% of portfolio per trade
+- **Kelly Criterion**: Optimal bet size based on win rate and payoff
+- **Volatility-Based**: ATR-adjusted position sizes
+- **Risk Parity**: Equal risk contribution across positions
+- **Maximum Position**: Never exceed 10-25% in single asset
+
+### Stop-Loss Strategies
+
+- **ATR-Based**: 1.5-3x ATR from entry
+- **Percentage**: Fixed 2-5% from entry
+- **Support/Resistance**: Below key levels
+- **Trailing Stops**: Dynamic based on ATR or percentage
+- **Time Stops**: Exit if trade doesn't work within timeframe
+
+### Portfolio Risk
+
+- **Correlation Management**: Avoid concentrated correlated positions
+- **Maximum Drawdown Limits**: 10-20% portfolio drawdown triggers risk-off
+- **Sector/Asset Exposure**: Diversify across uncorrelated assets
+- **Leverage Limits**: Define maximum leverage allowed
+
+### Crypto-Specific Risks
+
+- **Exchange Risk**: Don't keep all funds on one exchange
+- **Smart Contract Risk**: Audit and limit DeFi exposure
+- **Liquidation Risk**: Maintain safe margin ratios
+- **Rug Pull Risk**: Due diligence on new tokens
+- **Regulatory Risk**: Stay informed on regulations
+
+## Market Microstructure
+
+### Order Types
+
+- **Market**: Immediate execution at best price (taker)
+- **Limit**: Execute at specific price or better (maker)
+- **Stop-Loss**: Trigger market order when price reached
+- **Stop-Limit**: Trigger limit order when price reached
+- **Trailing Stop**: Dynamic stop that follows price
+- **OCO (One-Cancels-Other)**: Paired orders
+- **Iceberg**: Hide large order size
+- **TWAP/VWAP**: Time/volume weighted execution
+
+### Execution Considerations
+
+- **Slippage**: Price movement during execution
+- **Spread**: Difference between bid and ask
+- **Liquidity**: Available volume at price levels
+- **Market Impact**: Price movement from your order
+- **Maker/Taker Fees**: Fee structure affects strategy profitability
+
+### Market Conditions
+
+- **Trending**: Strong directional moves, use trend-following
+- **Ranging**: Sideways consolidation, use mean reversion
+- **Volatile**: High ATR, reduce position size
+- **Low Volatility**: Squeeze forming, prepare for breakout
+- **Choppy**: Random noise, avoid trading or tighten filters
+
+## Crypto Market Knowledge
+
+### Market Cycles
+
+- **Accumulation**: Smart money buying, low volume
+- **Markup**: Trend begins, FOMO kicks in
+- **Distribution**: Smart money selling, high volume
+- **Markdown**: Trend reversal, panic selling
+
+### Key Metrics
+
+- **Market Cap**: Total value of circulating supply
+- **Volume**: 24h trading volume across exchanges
+- **TVL (Total Value Locked)**: DeFi protocol deposits
+- **Open Interest**: Outstanding derivative contracts
+- **Funding Rate**: Cost of holding perpetual positions
+- **Long/Short Ratio**: Market positioning sentiment
+
+### On-Chain Indicators
+
+- **Exchange Inflows/Outflows**: Selling vs holding behavior
+- **Whale Transactions**: Large wallet movements
+- **Active Addresses**: Network usage
+- **Hash Rate**: Mining security (PoW chains)
+- **Staking Ratio**: Supply locked in staking
+
+## Approach
+
+### When Explaining Concepts
+
+1. Start with analogies and everyday examples
+2. Use concrete numbers ("If RSI is 25..." not abstractions)
+3. Connect to actual code in the codebase
+4. Build complexity gradually
+
+### When Discussing Strategy Design
+
+1. Clarify the goal: trend-following, mean-reversion, or momentum?
+2. Consider market conditions the strategy assumes
+3. Plan for risk management from the start
+4. Think about failure modes and false signals
+
+### When Reviewing Algorithms
+
+1. Check if signal logic matches strategy intent
+2. Validate parameter ranges are reasonable
+3. Look for edge cases with extreme/missing data
+4. Assess confidence calculation accuracy
+
+## Quick Reference
+
+### RSI Levels
+
+- 0-30: Oversold (potential buy)
+- 30-70: Neutral
+- 70-100: Overbought (potential sell)
+
+### MACD Signals
+
+- MACD crosses above signal: Bullish
+- MACD crosses below signal: Bearish
+- Histogram expanding: Momentum increasing
+
+### Bollinger Bands
+
+- %B < 0.2: Near lower band (potential buy)
+- %B > 0.8: Near upper band (potential sell)
+- Bandwidth contracting: Squeeze forming (expect breakout)
+
+### Triple EMA Alignment
+
+- Fast > Medium > Slow: Strong uptrend
+- Fast < Medium < Slow: Strong downtrend
+- Mixed: No clear trend
+
+## Session Guidance
+
+Start conversations by understanding:
+
+1. User's experience level
+2. Specific goal (learning, building, debugging)
+3. Trading time frame (day, swing, long-term)
+4. Risk tolerance
+
+Always ground advice in the actual codebase implementations when discussing this project.

--- a/.claude/commands/analyze-strategy.md
+++ b/.claude/commands/analyze-strategy.md
@@ -1,0 +1,310 @@
+---
+allowed-tools: Read, Bash, Grep, Glob
+argument-hint: <strategy-name> | <file-path> | --all | --idea "<description>"
+description: Analyze, review, or design trading strategies with comprehensive technical analysis expertise
+---
+
+# Strategy Analysis
+
+Analyze trading strategy: $ARGUMENTS
+
+## Current Codebase Context
+
+- Available strategies:
+  !`ls apps/api/src/algorithm/strategies/*.ts 2>/dev/null | grep -v spec | xargs -I {} basename {} .ts | head -15`
+- Base strategy: @apps/api/src/algorithm/base/base-algorithm-strategy.ts
+- Indicator service: @apps/api/src/algorithm/indicators/indicator.service.ts
+
+## Task
+
+Perform a comprehensive analysis following these steps:
+
+### 1. Strategy Identification
+
+**If strategy name provided** (e.g., "rsi", "macd", "confluence"):
+
+- Locate in `apps/api/src/algorithm/strategies/{name}.strategy.ts`
+- Read implementation and any `.spec.ts` test file
+- Identify strategy ID, description, version
+
+**If file path provided**:
+
+- Read the specified file directly
+- Verify it extends `BaseAlgorithmStrategy`
+
+**If `--all` provided**:
+
+- List all strategies with brief summaries
+- Provide comparison table
+
+**If `--idea "<description>"` provided**:
+
+- Design a NEW strategy based on the description
+- Reference similar existing strategies
+- Provide implementation guidance
+
+### 2. Signal Logic Review
+
+Analyze the trading logic:
+
+**Signal Generation**
+
+- What triggers BUY signals?
+- What triggers SELL signals?
+- Are there HOLD conditions?
+- Is the logic mathematically sound?
+
+**Indicator Usage**
+
+- Which indicators are used?
+- Are parameters within recommended ranges?
+- Is `IndicatorService` used correctly?
+- Proper handling of NaN/missing values?
+
+**Confidence Calculation**
+
+- How is signal confidence computed?
+- Does it scale appropriately with signal strength?
+- Any edge cases where confidence could be incorrect?
+
+### 3. Configuration Analysis
+
+Review `getConfigSchema()`:
+
+| Parameter | Default | Recommended Range | Impact |
+| --------- | ------- | ----------------- | ------ |
+
+**Standard Ranges**:
+
+- RSI period: 10-21 (default 14)
+- MACD: Fast 8-15, Slow 20-30, Signal 7-12
+- Bollinger Bands: Period 15-25, StdDev 1.5-2.5
+- ATR period: 10-20
+- EMA fast/slow: Ensure mathematical consistency
+
+### 4. Risk Assessment
+
+**Position Sizing**
+
+- Does the strategy consider position sizing?
+- Integration with ATR for dynamic sizing?
+
+**Stop-Loss Logic**
+
+- Built-in stop-loss mechanisms?
+- Handling of adverse price movements?
+
+**Drawdown Protection**
+
+- Circuit breakers for large losses?
+- Volatility filtering (like ATR filter in Confluence)?
+
+### 5. Backtesting Recommendations
+
+**Data Requirements**
+
+- Minimum periods needed for indicator warmup
+- Suggested historical periods (bull, bear, sideways)
+
+**Parameter Optimization** For each key parameter, provide:
+
+- Lower bound
+- Upper bound
+- Step size for grid search
+
+**Key Metrics to Track**
+
+- Sharpe Ratio (risk-adjusted returns)
+- Maximum Drawdown
+- Win Rate
+- Profit Factor (gross profit / gross loss)
+- Trade Frequency
+
+### 6. Improvement Suggestions
+
+**Priority 1 - Quick Wins**
+
+- Parameter tuning
+- Edge case handling
+- Confidence calculation fixes
+
+**Priority 2 - Short Term**
+
+- Additional confirmation indicators
+- Market regime filters
+- Improved exit strategies
+
+**Priority 3 - Long Term**
+
+- Machine learning integration
+- Multi-timeframe analysis
+- Adaptive parameters
+
+### 7. Strategy Comparison
+
+Compare with related strategies:
+
+- **Confluence**: Multi-indicator agreement (best for high-probability)
+- **RSI**: Mean-reversion (best for ranging markets)
+- **MACD**: Trend-following (best for trending markets)
+- **Triple EMA**: Trend identification (best for strong trends)
+
+### 8. Code Quality Check
+
+- Follows `BaseAlgorithmStrategy` pattern
+- Proper error handling and logging
+- Has unit tests (`*.spec.ts`)
+- TypeScript types well-defined
+- Uses centralized `IndicatorService`
+
+## Output Format
+
+```
+## Strategy: [Name]
+**ID**: [strategy-id] | **Version**: [X.X.X] | **Category**: [TECHNICAL/HYBRID/etc]
+
+### Signal Logic
+| Condition | Signal | Confidence Factor |
+|-----------|--------|-------------------|
+
+### Configuration
+| Parameter | Default | Range | Impact Level |
+|-----------|---------|-------|--------------|
+
+### Risk Assessment
+- Position sizing: [Yes/No]
+- Stop-loss: [Built-in/Manual/None]
+- Volatility filter: [Yes/No]
+
+### Backtest Parameters
+| Parameter | Min | Max | Step |
+|-----------|-----|-----|------|
+
+### Improvement Roadmap
+1. [Priority 1 items]
+2. [Priority 2 items]
+3. [Priority 3 items]
+
+### Code Quality: X/10
+[Justification]
+```
+
+## Indicator Formula Reference
+
+### Momentum Indicators
+
+**RSI**: `RSI = 100 - (100 / (1 + RS))` where RS = Avg Gain / Avg Loss
+
+- Oversold: <30, Overbought: >70, Neutral: 30-70
+
+**Stochastic**: `%K = (Close - Low(n)) / (High(n) - Low(n)) * 100`
+
+- %D = SMA(%K, 3), Oversold: <20, Overbought: >80
+
+**CCI**: `CCI = (Typical Price - SMA) / (0.015 * Mean Deviation)`
+
+- Overbought: >100, Oversold: <-100
+
+**Williams %R**: `%R = (Highest High - Close) / (Highest High - Lowest Low) * -100`
+
+**MFI**: Volume-weighted RSI using typical price \* volume
+
+### Trend Indicators
+
+**MACD**:
+
+- MACD Line = EMA(fast) - EMA(slow)
+- Signal = EMA(MACD, signal period)
+- Histogram = MACD - Signal
+
+**ADX**: Measures trend strength (not direction)
+
+- +DI = (Smoothed +DM / ATR) \* 100
+- -DI = (Smoothed -DM / ATR) \* 100
+- ADX = Smoothed absolute difference of +DI/-DI
+- > 25 = trending, <20 = ranging
+
+**Ichimoku**:
+
+- Tenkan-sen = (9-period high + low) / 2
+- Kijun-sen = (26-period high + low) / 2
+- Senkou A = (Tenkan + Kijun) / 2, shifted 26 periods
+- Senkou B = (52-period high + low) / 2, shifted 26 periods
+
+### Volatility Indicators
+
+**Bollinger Bands**:
+
+- Middle = SMA(period)
+- Upper = Middle + (StdDev \* multiplier)
+- Lower = Middle - (StdDev \* multiplier)
+- %B = (Price - Lower) / (Upper - Lower)
+- Bandwidth = (Upper - Lower) / Middle
+
+**ATR**: `ATR = EMA/SMA of True Range`
+
+- TR = max(High-Low, |High-PrevClose|, |Low-PrevClose|)
+
+**Keltner Channels**:
+
+- Middle = EMA(period)
+- Upper = EMA + (ATR \* multiplier)
+- Lower = EMA - (ATR \* multiplier)
+
+**Donchian Channels**:
+
+- Upper = Highest High(period)
+- Lower = Lowest Low(period)
+
+### Volume Indicators
+
+**OBV**: Cumulative volume (add on up days, subtract on down days)
+
+**VWAP**: `VWAP = Sum(Price * Volume) / Sum(Volume)`
+
+**CMF**: `CMF = Sum(Money Flow Volume) / Sum(Volume)` over period
+
+**A/D Line**: `AD = ((Close - Low) - (High - Close)) / (High - Low) * Volume`
+
+## Strategy Design Patterns
+
+### Trend Following
+
+- Use: MA crossovers, ADX filter, Ichimoku cloud
+- Best in: Strong trending markets
+- Risk: Whipsaws in ranging markets
+
+### Mean Reversion
+
+- Use: RSI extremes, Bollinger band bounces, Z-score
+- Best in: Range-bound markets
+- Risk: Catching falling knives in trends
+
+### Breakout
+
+- Use: Donchian channels, Bollinger squeeze, volume confirmation
+- Best in: After consolidation periods
+- Risk: False breakouts, fakeouts
+
+### Momentum
+
+- Use: RSI, Stochastic, MACD histogram
+- Best in: Continuation of existing trends
+- Risk: Late entries, reversals
+
+### Multi-Indicator Confluence
+
+- Use: 3+ indicators agreeing for signal
+- Best in: High-probability setups
+- Risk: Missing opportunities, analysis paralysis
+
+## Common Pitfalls to Check
+
+1. **Overfitting**: Too many parameters tuned to historical data
+2. **Look-Ahead Bias**: Using future data in calculations
+3. **Survivorship Bias**: Only testing on assets that still exist
+4. **Curve Fitting**: Strategy only works on specific historical period
+5. **Ignoring Fees/Slippage**: Not accounting for execution costs
+6. **No Risk Management**: Missing stop-losses or position sizing
+7. **Correlated Signals**: Multiple indicators measuring the same thing
+8. **Wrong Timeframe**: Strategy assumptions don't match execution timeframe

--- a/.claude/commands/create-branch.md
+++ b/.claude/commands/create-branch.md
@@ -1,0 +1,141 @@
+---
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: [--prefix <type>] [--push]
+description: Analyze local changes and create a descriptive branch name that conveys what was accomplished
+---
+
+# Smart Branch Creation
+
+Create a branch based on local changes: $ARGUMENTS
+
+## Current State
+
+- Current branch: !`git branch --show-current`
+- Git status: !`git status --porcelain`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Untracked files: !`git ls-files --others --exclude-standard | head -10`
+
+## Task
+
+Analyze the local git changes and create an appropriately named branch.
+
+### 1. Analyze Changes
+
+Review all changes to understand what was accomplished:
+
+**For modified files**: Read the diffs to understand what changed
+
+```bash
+git diff --cached  # staged changes
+git diff           # unstaged changes
+```
+
+**For new files**: Read the file contents to understand their purpose
+
+**For deleted files**: Note what was removed
+
+### 2. Determine Change Type
+
+Identify the primary type of change:
+
+| Prefix      | Use When                                   |
+| ----------- | ------------------------------------------ |
+| `feat/`     | New feature or functionality               |
+| `fix/`      | Bug fix                                    |
+| `refactor/` | Code restructuring without behavior change |
+| `docs/`     | Documentation only                         |
+| `style/`    | Formatting, whitespace, no code change     |
+| `test/`     | Adding or updating tests                   |
+| `chore/`    | Build, config, dependencies                |
+| `perf/`     | Performance improvements                   |
+| `ci/`       | CI/CD changes                              |
+
+If `--prefix <type>` is provided, use that prefix instead.
+
+### 3. Generate Branch Name
+
+Create a branch name following these rules:
+
+**Format**: `<type>/<descriptive-slug>`
+
+**Rules**:
+
+- Use lowercase with hyphens (kebab-case)
+- Keep it concise but descriptive (3-6 words max)
+- Focus on WHAT was accomplished, not HOW
+- No issue numbers unless explicitly mentioned
+- Avoid generic names like "update" or "changes"
+
+**Good Examples**:
+
+- `feat/add-trading-expert-skill`
+- `fix/rsi-calculation-edge-case`
+- `refactor/extract-indicator-service`
+- `docs/api-endpoint-documentation`
+- `feat/bollinger-band-squeeze-strategy`
+
+**Bad Examples**:
+
+- `update-files` (too vague)
+- `fix-bug` (not descriptive)
+- `new-feature` (meaningless)
+- `wip` (not descriptive)
+
+### 4. Validate Branch Name
+
+Before creating:
+
+- Check if branch already exists: `git branch --list <name>`
+- Check remote branches: `git branch -r --list origin/<name>`
+- Ensure no special characters except hyphens and forward slash
+
+### 5. Create Branch
+
+```bash
+git checkout -b <branch-name>
+```
+
+If `--push` flag is provided:
+
+```bash
+git push -u origin <branch-name>
+```
+
+## Output Format
+
+```
+## Change Analysis
+[Summary of what the changes accomplish]
+
+## Files Changed
+- [list of key files and what changed]
+
+## Branch Name
+`<type>/<descriptive-slug>`
+
+## Rationale
+[Why this name accurately describes the changes]
+
+## Commands Executed
+- git checkout -b <branch-name>
+- [git push -u origin <branch-name>] (if --push)
+```
+
+## Examples
+
+### Example 1: New Feature
+
+Changes: Added new RSI divergence detection to trading algorithm Branch: `feat/rsi-divergence-detection`
+
+### Example 2: Bug Fix
+
+Changes: Fixed edge case where ATR returns NaN on insufficient data Branch: `fix/atr-nan-handling`
+
+### Example 3: Multiple Related Changes
+
+Changes: Added tests, updated docs, and fixed typos for order service Branch: `chore/order-service-cleanup`
+
+### Example 4: Refactoring
+
+Changes: Extracted common indicator logic into shared base class Branch: `refactor/indicator-base-class`

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,231 @@
+---
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: [--draft] [--base <branch>] [--reviewer <user>]
+description: Create a GitHub PR with auto-generated title and description from branch commits
+---
+
+# Smart PR Creation
+
+Create a GitHub Pull Request: $ARGUMENTS
+
+## Current State
+
+- Current branch: !`git branch --show-current`
+- Default branch: !`git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d: -f2 | tr -d ' ' || echo "master"`
+- Remote tracking: !`git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "not tracking"`
+- Unpushed commits:
+  !`git log @{u}..HEAD --oneline 2>/dev/null || git log origin/master..HEAD --oneline 2>/dev/null | head -10`
+- Changed files: !`git diff --stat origin/master...HEAD 2>/dev/null | tail -5`
+
+## Task
+
+Create a well-structured GitHub PR from the current branch.
+
+### 1. Pre-Flight Checks
+
+Verify the branch is ready for PR:
+
+```bash
+# Check we're not on main/master
+git branch --show-current
+
+# Check for uncommitted changes
+git status --porcelain
+
+# Check if branch is pushed
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+```
+
+**If unpushed commits exist**: Push the branch first
+
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+**If uncommitted changes exist**: Warn the user before proceeding
+
+### 2. Analyze Branch Changes
+
+Gather information about what this branch accomplishes:
+
+```bash
+# Get all commits on this branch (not on base)
+git log origin/master..HEAD --pretty=format:"%s%n%b" --reverse
+
+# Get the diff stats
+git diff --stat origin/master...HEAD
+
+# Get changed files
+git diff --name-only origin/master...HEAD
+```
+
+### 3. Determine PR Title
+
+Generate a concise, descriptive title:
+
+**From branch name**: Parse the branch name for context
+
+- `feat/add-rsi-strategy` → "Add RSI strategy"
+- `fix/order-sync-timeout` → "Fix order sync timeout"
+- `refactor/extract-indicator-service` → "Refactor: Extract indicator service"
+
+**From commits**: If single commit, use its message. If multiple, summarize.
+
+**Title Format**:
+
+- Start with type if clear: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`
+- Use imperative mood: "Add" not "Added"
+- Keep under 72 characters
+- Be specific about what changed
+
+### 4. Generate PR Description
+
+Create a structured description:
+
+```markdown
+## Summary
+
+[1-3 bullet points describing what this PR accomplishes]
+
+## Changes
+
+[List of key changes, grouped logically]
+
+## Test Plan
+
+[How to verify these changes work]
+
+- [ ] Manual testing steps
+- [ ] Automated tests pass
+
+## Related Issues
+
+[Link any related issues: Closes #123, Relates to #456]
+```
+
+### 5. Create the PR
+
+Use GitHub CLI to create:
+
+```bash
+gh pr create \
+  --title "<generated-title>" \
+  --body "$(cat <<'EOF'
+<generated-body>
+EOF
+)" \
+  --base <base-branch>
+```
+
+**Optional flags from arguments**:
+
+- `--draft`: Create as draft PR
+- `--base <branch>`: Target branch (default: master/main)
+- `--reviewer <user>`: Request review from user
+
+### 6. Post-Creation
+
+After PR is created:
+
+- Display the PR URL
+- Show PR number
+- List any CI checks that will run
+
+## Output Format
+
+```
+## Pre-Flight
+✓ Branch: <branch-name>
+✓ Pushed to remote
+✓ No uncommitted changes
+✓ Base branch: <base>
+
+## PR Analysis
+Commits: <count>
+Files changed: <count>
+Insertions: +<count>
+Deletions: -<count>
+
+## Generated PR
+
+**Title**: <title>
+
+**Description**:
+<full description>
+
+## Created
+PR #<number>: <url>
+
+Reviewers: <list or none>
+Labels: <list or none>
+Draft: <yes/no>
+```
+
+## Title Generation Rules
+
+| Branch Pattern        | Generated Title          |
+| --------------------- | ------------------------ |
+| `feat/add-*`          | "feat: Add ..."          |
+| `feat/*-support`      | "feat: Add ... support"  |
+| `fix/*-bug`           | "fix: Resolve ... bug"   |
+| `fix/*-error`         | "fix: Handle ... error"  |
+| `refactor/extract-*`  | "refactor: Extract ..."  |
+| `refactor/simplify-*` | "refactor: Simplify ..." |
+| `docs/add-*`          | "docs: Add ..."          |
+| `docs/update-*`       | "docs: Update ..."       |
+| `chore/update-*`      | "chore: Update ..."      |
+| `test/add-*`          | "test: Add ... tests"    |
+
+## Examples
+
+### Example 1: Feature Branch
+
+```
+Branch: feat/add-trading-expert-skill
+Commits: 3
+
+Title: feat: Add trading expert Claude skill
+
+## Summary
+- Add conversational trading expert agent with comprehensive indicator knowledge
+- Add /analyze-strategy command for strategy analysis
+- Include 40+ indicators and strategy design patterns
+
+## Changes
+- `.claude/agents/trading-expert.md` - New agent with trading expertise
+- `.claude/commands/analyze-strategy.md` - Strategy analysis command
+
+## Test Plan
+- [ ] Verify agent responds to trading questions
+- [ ] Run /analyze-strategy rsi and verify output
+```
+
+### Example 2: Bug Fix
+
+```
+Branch: fix/rsi-nan-handling
+Commits: 1
+
+Title: fix: Handle NaN values in RSI calculation
+
+## Summary
+- Fix edge case where RSI returns NaN with insufficient data
+- Add input validation for minimum data points
+
+## Changes
+- `apps/api/src/algorithm/indicators/rsi.calculator.ts`
+
+## Test Plan
+- [ ] Unit tests pass
+- [ ] Manual test with < 14 data points
+```
+
+## Error Handling
+
+**No commits on branch**: "Error: No commits found on this branch compared to base. Nothing to create PR for."
+
+**Already has PR**: "PR already exists for this branch: <url>"
+
+**Not on a feature branch**: "Warning: Creating PR from main/master branch. Are you sure?"
+
+**gh CLI not authenticated**: "Error: GitHub CLI not authenticated. Run: gh auth login"

--- a/apps/api/src/migrations/1736300000000-add-order-status-history.ts
+++ b/apps/api/src/migrations/1736300000000-add-order-status-history.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderStatusHistory1736300000000 implements MigrationInterface {
+  name = 'AddOrderStatusHistory1736300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create enum type for transition reasons
+    await queryRunner.query(`
+      CREATE TYPE "order_transition_reason_enum" AS ENUM (
+        'exchange_sync',
+        'user_cancel',
+        'trade_execution',
+        'partial_fill',
+        'order_expired',
+        'market_close',
+        'system_cancel',
+        'exchange_reject'
+      )
+    `);
+
+    // Create the order_status_history table
+    await queryRunner.query(`
+      CREATE TABLE "order_status_history" (
+        "id" UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        "orderId" UUID NOT NULL,
+        "fromStatus" "order_status_enum",
+        "toStatus" "order_status_enum" NOT NULL,
+        "transitionedAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "reason" "order_transition_reason_enum" NOT NULL,
+        "metadata" JSONB,
+        CONSTRAINT "FK_order_status_history_order"
+          FOREIGN KEY ("orderId")
+          REFERENCES "order"("id")
+          ON DELETE CASCADE
+      )
+    `);
+
+    // Add table comment
+    await queryRunner.query(`
+      COMMENT ON TABLE "order_status_history" IS 'Tracks all order status transitions with reasons and metadata'
+    `);
+
+    // Add column comments
+    await queryRunner.query(`
+      COMMENT ON COLUMN "order_status_history"."fromStatus" IS 'Previous status (null for initial creation)'
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN "order_status_history"."toStatus" IS 'New status after transition'
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN "order_status_history"."reason" IS 'Reason code for the status change'
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN "order_status_history"."metadata" IS 'Additional context (exchange data, error messages, etc.)'
+    `);
+
+    // Create indexes for common query patterns
+    await queryRunner.query(`
+      CREATE INDEX "IDX_order_status_history_order_time"
+      ON "order_status_history" ("orderId", "transitionedAt")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_order_status_history_time"
+      ON "order_status_history" ("transitionedAt")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_order_status_history_transitions"
+      ON "order_status_history" ("fromStatus", "toStatus")
+    `);
+
+    // Create GIN index for metadata JSONB queries (e.g., finding invalid transitions)
+    await queryRunner.query(`
+      CREATE INDEX "IDX_order_status_history_metadata"
+      ON "order_status_history" USING GIN ("metadata")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_status_history_metadata"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_status_history_transitions"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_status_history_time"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_status_history_order_time"`);
+
+    // Drop table
+    await queryRunner.query(`DROP TABLE IF EXISTS "order_status_history"`);
+
+    // Drop enum type
+    await queryRunner.query(`DROP TYPE IF EXISTS "order_transition_reason_enum"`);
+  }
+}

--- a/apps/api/src/order/dto/index.ts
+++ b/apps/api/src/order/dto/index.ts
@@ -2,6 +2,7 @@ export * from './order-binance-response.dto';
 export * from './order-preview-request.dto';
 export * from './order-preview.dto';
 export * from './order-response.dto';
+export * from './order-status-history.dto';
 export * from './order.dto';
 export * from './place-manual-order.dto';
 export * from './slippage.dto';

--- a/apps/api/src/order/dto/order-status-history.dto.ts
+++ b/apps/api/src/order/dto/order-status-history.dto.ts
@@ -1,0 +1,86 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { OrderTransitionReason } from '../entities/order-status-history.entity';
+import { OrderStatus } from '../order.entity';
+
+/**
+ * Response DTO for order status history entries
+ */
+export class OrderStatusHistoryDto {
+  @ApiProperty({
+    description: 'Unique identifier for the history record',
+    example: 'a3bb189e-8bf9-3888-9912-ace4e6543002'
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Order ID this history belongs to',
+    example: 'b4cc290f-9cf0-4999-0023-bdf5f7654113'
+  })
+  orderId: string;
+
+  @ApiPropertyOptional({
+    description: 'Previous status (null for initial creation)',
+    enum: OrderStatus,
+    example: OrderStatus.NEW,
+    nullable: true
+  })
+  fromStatus: OrderStatus | null;
+
+  @ApiProperty({
+    description: 'New status after transition',
+    enum: OrderStatus,
+    example: OrderStatus.FILLED
+  })
+  toStatus: OrderStatus;
+
+  @ApiProperty({
+    description: 'When the transition occurred',
+    example: '2024-04-23T18:25:43.511Z'
+  })
+  transitionedAt: Date;
+
+  @ApiProperty({
+    description: 'Reason for the status change',
+    enum: OrderTransitionReason,
+    example: OrderTransitionReason.EXCHANGE_SYNC
+  })
+  reason: OrderTransitionReason;
+
+  @ApiPropertyOptional({
+    description: 'Additional context for the transition',
+    example: { exchangeOrderId: '123456789', syncTimestamp: '2024-04-23T18:25:43.511Z' },
+    nullable: true
+  })
+  metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Response DTO for order history with summary statistics
+ */
+export class OrderHistoryResponseDto {
+  @ApiProperty({
+    description: 'The order ID',
+    example: 'b4cc290f-9cf0-4999-0023-bdf5f7654113'
+  })
+  orderId: string;
+
+  @ApiProperty({
+    description: 'Current order status',
+    enum: OrderStatus,
+    example: OrderStatus.FILLED
+  })
+  currentStatus: OrderStatus;
+
+  @ApiProperty({
+    description: 'Total number of status transitions',
+    example: 3
+  })
+  transitionCount: number;
+
+  @ApiProperty({
+    description: 'List of status transitions in chronological order',
+    type: [OrderStatusHistoryDto]
+  })
+  transitions: OrderStatusHistoryDto[];
+}

--- a/apps/api/src/order/entities/order-status-history.entity.ts
+++ b/apps/api/src/order/entities/order-status-history.entity.ts
@@ -1,0 +1,72 @@
+import { Column, CreateDateColumn, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Order, OrderStatus } from '../order.entity';
+
+/**
+ * Reason codes for order status transitions
+ */
+export enum OrderTransitionReason {
+  EXCHANGE_SYNC = 'exchange_sync',
+  USER_CANCEL = 'user_cancel',
+  TRADE_EXECUTION = 'trade_execution',
+  PARTIAL_FILL = 'partial_fill',
+  ORDER_EXPIRED = 'order_expired',
+  MARKET_CLOSE = 'market_close',
+  SYSTEM_CANCEL = 'system_cancel',
+  EXCHANGE_REJECT = 'exchange_reject'
+}
+
+/**
+ * Tracks all order status transitions with reasons and metadata.
+ * Provides an audit trail for order lifecycle events.
+ */
+@Entity('order_status_history')
+@Index('IDX_order_status_history_order_time', ['orderId', 'transitionedAt'])
+@Index('IDX_order_status_history_time', ['transitionedAt'])
+@Index('IDX_order_status_history_transitions', ['fromStatus', 'toStatus'])
+export class OrderStatusHistory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  orderId: string;
+
+  @ManyToOne(() => Order, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orderId' })
+  order: Order;
+
+  @Column({
+    type: 'enum',
+    enum: OrderStatus,
+    nullable: true,
+    comment: 'Previous status (null for initial creation)'
+  })
+  fromStatus: OrderStatus | null;
+
+  @Column({
+    type: 'enum',
+    enum: OrderStatus,
+    comment: 'New status after transition'
+  })
+  toStatus: OrderStatus;
+
+  @CreateDateColumn({
+    type: 'timestamptz',
+    comment: 'When the transition occurred'
+  })
+  transitionedAt: Date;
+
+  @Column({
+    type: 'enum',
+    enum: OrderTransitionReason,
+    comment: 'Reason code for the status change'
+  })
+  reason: OrderTransitionReason;
+
+  @Column({
+    type: 'jsonb',
+    nullable: true,
+    comment: 'Additional context (exchange data, error messages, etc.)'
+  })
+  metadata?: Record<string, unknown> | null;
+}

--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -22,10 +22,12 @@ import { ComparisonReport, ComparisonReportRun } from './backtest/comparison-rep
 import { LiveReplayProcessor } from './backtest/live-replay.processor';
 import { MarketDataSet } from './backtest/market-data-set.entity';
 import { slippageLimitsConfig } from './config/slippage-limits.config';
+import { OrderStatusHistory } from './entities/order-status-history.entity';
 import { OrderController } from './order.controller';
 import { Order } from './order.entity';
 import { OrderService } from './order.service';
 import { OrderCalculationService } from './services/order-calculation.service';
+import { OrderStateMachineService } from './services/order-state-machine.service';
 import { OrderSyncService } from './services/order-sync.service';
 import { OrderValidationService } from './services/order-validation.service';
 import { SlippageAnalysisService } from './services/slippage-analysis.service';
@@ -59,7 +61,8 @@ const BACKTEST_DEFAULTS = backtestConfig();
     BacktestService,
     BacktestEngine,
     BacktestStreamService,
-    SlippageAnalysisService
+    SlippageAnalysisService,
+    OrderStateMachineService
   ],
   imports: [
     ConfigModule.forFeature(backtestConfig),
@@ -68,6 +71,7 @@ const BACKTEST_DEFAULTS = backtestConfig();
       Algorithm,
       Coin,
       Order,
+      OrderStatusHistory,
       User,
       TickerPairs,
       Backtest,
@@ -104,6 +108,7 @@ const BACKTEST_DEFAULTS = backtestConfig();
     CoinService,
     OrderCalculationService,
     OrderService,
+    OrderStateMachineService,
     OrderSyncService,
     OrderSyncTask,
     OrderValidationService,

--- a/apps/api/src/order/services/order-state-machine.service.spec.ts
+++ b/apps/api/src/order/services/order-state-machine.service.spec.ts
@@ -1,0 +1,561 @@
+import { Logger } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { OrderStateMachineService } from './order-state-machine.service';
+
+import { OrderStatusHistory, OrderTransitionReason } from '../entities/order-status-history.entity';
+import { OrderStatus } from '../order.entity';
+
+describe('OrderStateMachineService', () => {
+  let service: OrderStateMachineService;
+  let mockHistoryRepository: any;
+  let loggerWarnSpy: jest.SpyInstance;
+  let loggerDebugSpy: jest.SpyInstance;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  const mockOrderId = 'test-order-id';
+
+  beforeEach(async () => {
+    mockHistoryRepository = {
+      create: jest.fn((data) => data),
+      save: jest.fn((data) => Promise.resolve({ id: 'history-id', transitionedAt: new Date(), ...data })),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn()
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrderStateMachineService,
+        {
+          provide: getRepositoryToken(OrderStatusHistory),
+          useValue: mockHistoryRepository
+        }
+      ]
+    }).compile();
+
+    service = module.get<OrderStateMachineService>(OrderStateMachineService);
+
+    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    loggerDebugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('isValidTransition', () => {
+    describe('initial creation (null -> status)', () => {
+      it('should allow null -> NEW (initial creation)', () => {
+        expect(service.isValidTransition(null, OrderStatus.NEW)).toBe(true);
+      });
+
+      it('should reject null -> FILLED', () => {
+        expect(service.isValidTransition(null, OrderStatus.FILLED)).toBe(false);
+      });
+
+      it('should reject null -> CANCELED', () => {
+        expect(service.isValidTransition(null, OrderStatus.CANCELED)).toBe(false);
+      });
+
+      it('should reject null -> PARTIALLY_FILLED', () => {
+        expect(service.isValidTransition(null, OrderStatus.PARTIALLY_FILLED)).toBe(false);
+      });
+
+      it('should reject null -> REJECTED', () => {
+        expect(service.isValidTransition(null, OrderStatus.REJECTED)).toBe(false);
+      });
+
+      it('should reject null -> EXPIRED', () => {
+        expect(service.isValidTransition(null, OrderStatus.EXPIRED)).toBe(false);
+      });
+
+      it('should reject null -> PENDING_CANCEL', () => {
+        expect(service.isValidTransition(null, OrderStatus.PENDING_CANCEL)).toBe(false);
+      });
+    });
+
+    describe('same status (no-op)', () => {
+      it('should allow NEW -> NEW', () => {
+        expect(service.isValidTransition(OrderStatus.NEW, OrderStatus.NEW)).toBe(true);
+      });
+
+      it('should allow FILLED -> FILLED', () => {
+        expect(service.isValidTransition(OrderStatus.FILLED, OrderStatus.FILLED)).toBe(true);
+      });
+
+      it('should allow CANCELED -> CANCELED', () => {
+        expect(service.isValidTransition(OrderStatus.CANCELED, OrderStatus.CANCELED)).toBe(true);
+      });
+    });
+
+    describe('transitions from NEW', () => {
+      it('should allow NEW -> PARTIALLY_FILLED', () => {
+        expect(service.isValidTransition(OrderStatus.NEW, OrderStatus.PARTIALLY_FILLED)).toBe(true);
+      });
+
+      it('should allow NEW -> FILLED', () => {
+        expect(service.isValidTransition(OrderStatus.NEW, OrderStatus.FILLED)).toBe(true);
+      });
+
+      it('should allow NEW -> CANCELED', () => {
+        expect(service.isValidTransition(OrderStatus.NEW, OrderStatus.CANCELED)).toBe(true);
+      });
+
+      it('should allow NEW -> REJECTED', () => {
+        expect(service.isValidTransition(OrderStatus.NEW, OrderStatus.REJECTED)).toBe(true);
+      });
+
+      it('should allow NEW -> EXPIRED', () => {
+        expect(service.isValidTransition(OrderStatus.NEW, OrderStatus.EXPIRED)).toBe(true);
+      });
+
+      it('should allow NEW -> PENDING_CANCEL', () => {
+        expect(service.isValidTransition(OrderStatus.NEW, OrderStatus.PENDING_CANCEL)).toBe(true);
+      });
+    });
+
+    describe('transitions from PARTIALLY_FILLED', () => {
+      it('should allow PARTIALLY_FILLED -> FILLED', () => {
+        expect(service.isValidTransition(OrderStatus.PARTIALLY_FILLED, OrderStatus.FILLED)).toBe(true);
+      });
+
+      it('should allow PARTIALLY_FILLED -> CANCELED', () => {
+        expect(service.isValidTransition(OrderStatus.PARTIALLY_FILLED, OrderStatus.CANCELED)).toBe(true);
+      });
+
+      it('should allow PARTIALLY_FILLED -> PENDING_CANCEL', () => {
+        expect(service.isValidTransition(OrderStatus.PARTIALLY_FILLED, OrderStatus.PENDING_CANCEL)).toBe(true);
+      });
+
+      it('should reject PARTIALLY_FILLED -> NEW', () => {
+        expect(service.isValidTransition(OrderStatus.PARTIALLY_FILLED, OrderStatus.NEW)).toBe(false);
+      });
+
+      it('should reject PARTIALLY_FILLED -> REJECTED', () => {
+        expect(service.isValidTransition(OrderStatus.PARTIALLY_FILLED, OrderStatus.REJECTED)).toBe(false);
+      });
+
+      it('should reject PARTIALLY_FILLED -> EXPIRED', () => {
+        expect(service.isValidTransition(OrderStatus.PARTIALLY_FILLED, OrderStatus.EXPIRED)).toBe(false);
+      });
+    });
+
+    describe('transitions from PENDING_CANCEL', () => {
+      it('should allow PENDING_CANCEL -> CANCELED', () => {
+        expect(service.isValidTransition(OrderStatus.PENDING_CANCEL, OrderStatus.CANCELED)).toBe(true);
+      });
+
+      it('should allow PENDING_CANCEL -> FILLED (can still fill while cancel pending)', () => {
+        expect(service.isValidTransition(OrderStatus.PENDING_CANCEL, OrderStatus.FILLED)).toBe(true);
+      });
+
+      it('should reject PENDING_CANCEL -> NEW', () => {
+        expect(service.isValidTransition(OrderStatus.PENDING_CANCEL, OrderStatus.NEW)).toBe(false);
+      });
+
+      it('should reject PENDING_CANCEL -> PARTIALLY_FILLED', () => {
+        expect(service.isValidTransition(OrderStatus.PENDING_CANCEL, OrderStatus.PARTIALLY_FILLED)).toBe(false);
+      });
+    });
+
+    describe('terminal states (no outgoing transitions)', () => {
+      it('should reject FILLED -> any other status', () => {
+        expect(service.isValidTransition(OrderStatus.FILLED, OrderStatus.NEW)).toBe(false);
+        expect(service.isValidTransition(OrderStatus.FILLED, OrderStatus.CANCELED)).toBe(false);
+        expect(service.isValidTransition(OrderStatus.FILLED, OrderStatus.PARTIALLY_FILLED)).toBe(false);
+      });
+
+      it('should reject CANCELED -> any other status', () => {
+        expect(service.isValidTransition(OrderStatus.CANCELED, OrderStatus.NEW)).toBe(false);
+        expect(service.isValidTransition(OrderStatus.CANCELED, OrderStatus.FILLED)).toBe(false);
+      });
+
+      it('should reject REJECTED -> any other status', () => {
+        expect(service.isValidTransition(OrderStatus.REJECTED, OrderStatus.NEW)).toBe(false);
+        expect(service.isValidTransition(OrderStatus.REJECTED, OrderStatus.FILLED)).toBe(false);
+      });
+
+      it('should reject EXPIRED -> any other status', () => {
+        expect(service.isValidTransition(OrderStatus.EXPIRED, OrderStatus.NEW)).toBe(false);
+        expect(service.isValidTransition(OrderStatus.EXPIRED, OrderStatus.FILLED)).toBe(false);
+      });
+    });
+  });
+
+  describe('isTerminalState', () => {
+    it('should identify FILLED as terminal', () => {
+      expect(service.isTerminalState(OrderStatus.FILLED)).toBe(true);
+    });
+
+    it('should identify CANCELED as terminal', () => {
+      expect(service.isTerminalState(OrderStatus.CANCELED)).toBe(true);
+    });
+
+    it('should identify REJECTED as terminal', () => {
+      expect(service.isTerminalState(OrderStatus.REJECTED)).toBe(true);
+    });
+
+    it('should identify EXPIRED as terminal', () => {
+      expect(service.isTerminalState(OrderStatus.EXPIRED)).toBe(true);
+    });
+
+    it('should NOT identify NEW as terminal', () => {
+      expect(service.isTerminalState(OrderStatus.NEW)).toBe(false);
+    });
+
+    it('should NOT identify PARTIALLY_FILLED as terminal', () => {
+      expect(service.isTerminalState(OrderStatus.PARTIALLY_FILLED)).toBe(false);
+    });
+
+    it('should NOT identify PENDING_CANCEL as terminal', () => {
+      expect(service.isTerminalState(OrderStatus.PENDING_CANCEL)).toBe(false);
+    });
+  });
+
+  describe('transitionStatus', () => {
+    it('should record valid transitions and return valid=true', async () => {
+      const result = await service.transitionStatus(
+        mockOrderId,
+        OrderStatus.NEW,
+        OrderStatus.FILLED,
+        OrderTransitionReason.EXCHANGE_SYNC,
+        { exchangeOrderId: '123' }
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.fromStatus).toBe(OrderStatus.NEW);
+      expect(result.toStatus).toBe(OrderStatus.FILLED);
+      expect(result.reason).toBe(OrderTransitionReason.EXCHANGE_SYNC);
+      expect(mockHistoryRepository.save).toHaveBeenCalled();
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
+      expect(loggerDebugSpy).toHaveBeenCalled();
+    });
+
+    it('should record invalid transitions, log warning, but still save', async () => {
+      const result = await service.transitionStatus(
+        mockOrderId,
+        OrderStatus.FILLED,
+        OrderStatus.NEW,
+        OrderTransitionReason.EXCHANGE_SYNC
+      );
+
+      expect(result.valid).toBe(false);
+      expect(mockHistoryRepository.save).toHaveBeenCalled();
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid order state transition'),
+        expect.any(Object)
+      );
+    });
+
+    it('should mark invalid transitions in metadata', async () => {
+      await service.transitionStatus(
+        mockOrderId,
+        OrderStatus.FILLED,
+        OrderStatus.NEW,
+        OrderTransitionReason.EXCHANGE_SYNC
+      );
+
+      expect(mockHistoryRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            invalidTransition: true
+          })
+        })
+      );
+    });
+
+    it('should preserve metadata while marking invalid transitions', async () => {
+      const metadata = { algorithmId: 'algo-123' };
+
+      await service.transitionStatus(
+        mockOrderId,
+        OrderStatus.FILLED,
+        OrderStatus.NEW,
+        OrderTransitionReason.EXCHANGE_SYNC,
+        metadata
+      );
+
+      expect(mockHistoryRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            algorithmId: 'algo-123',
+            invalidTransition: true
+          })
+        })
+      );
+    });
+
+    it('should include provided metadata in history record', async () => {
+      const metadata = { algorithmId: 'algo-123', slippage: 0.5 };
+
+      await service.transitionStatus(
+        mockOrderId,
+        OrderStatus.NEW,
+        OrderStatus.FILLED,
+        OrderTransitionReason.TRADE_EXECUTION,
+        metadata
+      );
+
+      expect(mockHistoryRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            algorithmId: 'algo-123',
+            slippage: 0.5
+          })
+        })
+      );
+    });
+
+    it('should handle null metadata for valid transitions', async () => {
+      await service.transitionStatus(
+        mockOrderId,
+        OrderStatus.NEW,
+        OrderStatus.FILLED,
+        OrderTransitionReason.EXCHANGE_SYNC
+      );
+
+      expect(mockHistoryRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: null
+        })
+      );
+    });
+
+    it('should record initial creation (null -> NEW)', async () => {
+      const result = await service.transitionStatus(
+        mockOrderId,
+        null,
+        OrderStatus.NEW,
+        OrderTransitionReason.TRADE_EXECUTION,
+        { symbol: 'BTC/USDT' }
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.fromStatus).toBeNull();
+      expect(result.toStatus).toBe(OrderStatus.NEW);
+      expect(mockHistoryRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromStatus: null,
+          toStatus: OrderStatus.NEW
+        })
+      );
+    });
+
+    it('should return the saved history record', async () => {
+      const createdRecord = {
+        orderId: mockOrderId,
+        fromStatus: OrderStatus.NEW,
+        toStatus: OrderStatus.FILLED,
+        reason: OrderTransitionReason.EXCHANGE_SYNC,
+        metadata: null
+      };
+      const savedRecord = {
+        id: 'history-id',
+        transitionedAt: new Date('2024-01-01T00:00:00Z'),
+        ...createdRecord
+      };
+      mockHistoryRepository.create.mockReturnValueOnce(createdRecord);
+      mockHistoryRepository.save.mockResolvedValueOnce(savedRecord);
+
+      const result = await service.transitionStatus(
+        mockOrderId,
+        OrderStatus.NEW,
+        OrderStatus.FILLED,
+        OrderTransitionReason.EXCHANGE_SYNC
+      );
+
+      expect(mockHistoryRepository.save).toHaveBeenCalledWith(createdRecord);
+      expect(result.historyRecord).toEqual(savedRecord);
+    });
+
+    it('should handle repository save errors gracefully', async () => {
+      const error = new Error('Database connection failed');
+      mockHistoryRepository.save.mockRejectedValue(error);
+
+      await expect(
+        service.transitionStatus(mockOrderId, OrderStatus.NEW, OrderStatus.FILLED, OrderTransitionReason.EXCHANGE_SYNC)
+      ).rejects.toThrow('Database connection failed');
+
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getOrderHistory', () => {
+    it('should return history ordered by transitionedAt ASC', async () => {
+      const mockHistory = [
+        { id: '1', fromStatus: null, toStatus: OrderStatus.NEW, transitionedAt: new Date('2024-01-01') },
+        { id: '2', fromStatus: OrderStatus.NEW, toStatus: OrderStatus.FILLED, transitionedAt: new Date('2024-01-02') }
+      ];
+      mockHistoryRepository.find.mockResolvedValue(mockHistory);
+
+      const result = await service.getOrderHistory(mockOrderId);
+
+      expect(mockHistoryRepository.find).toHaveBeenCalledWith({
+        where: { orderId: mockOrderId },
+        order: { transitionedAt: 'ASC' }
+      });
+      expect(result).toEqual(mockHistory);
+    });
+
+    it('should return empty array when no history', async () => {
+      mockHistoryRepository.find.mockResolvedValue([]);
+
+      const result = await service.getOrderHistory(mockOrderId);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getLatestTransition', () => {
+    it('should return the most recent transition', async () => {
+      const mockTransition = {
+        id: '1',
+        fromStatus: OrderStatus.NEW,
+        toStatus: OrderStatus.FILLED,
+        transitionedAt: new Date()
+      };
+      mockHistoryRepository.findOne.mockResolvedValue(mockTransition);
+
+      const result = await service.getLatestTransition(mockOrderId);
+
+      expect(mockHistoryRepository.findOne).toHaveBeenCalledWith({
+        where: { orderId: mockOrderId },
+        order: { transitionedAt: 'DESC' }
+      });
+      expect(result).toEqual(mockTransition);
+    });
+
+    it('should return null when no transitions exist', async () => {
+      mockHistoryRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getLatestTransition(mockOrderId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('countTransitionsByReason', () => {
+    let mockQueryBuilder: any;
+
+    beforeEach(() => {
+      mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn()
+      };
+      mockHistoryRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    });
+
+    it('should return counts by reason', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { reason: OrderTransitionReason.EXCHANGE_SYNC, count: '100' },
+        { reason: OrderTransitionReason.TRADE_EXECUTION, count: '50' }
+      ]);
+
+      const result = await service.countTransitionsByReason();
+
+      expect(result).toEqual({
+        [OrderTransitionReason.EXCHANGE_SYNC]: 100,
+        [OrderTransitionReason.TRADE_EXECUTION]: 50
+      });
+    });
+
+    it('should filter by date range when provided', async () => {
+      const startDate = new Date('2024-01-01');
+      const endDate = new Date('2024-12-31');
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      await service.countTransitionsByReason(startDate, endDate);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('history.transitionedAt >= :startDate', { startDate });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('history.transitionedAt <= :endDate', { endDate });
+    });
+
+    it('should return empty object when no data', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      const result = await service.countTransitionsByReason();
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('findInvalidTransitions', () => {
+    let mockQueryBuilder: any;
+
+    beforeEach(() => {
+      mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn()
+      };
+      mockHistoryRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    });
+
+    it('should find transitions with invalidTransition metadata', async () => {
+      const mockInvalidTransitions = [
+        { id: '1', fromStatus: OrderStatus.FILLED, toStatus: OrderStatus.NEW, metadata: { invalidTransition: true } }
+      ];
+      mockQueryBuilder.getMany.mockResolvedValue(mockInvalidTransitions);
+
+      const result = await service.findInvalidTransitions();
+
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith("history.metadata->>'invalidTransition' = 'true'");
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('history.transitionedAt', 'DESC');
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(100);
+      expect(result).toEqual(mockInvalidTransitions);
+    });
+
+    it('should respect custom limit', async () => {
+      mockQueryBuilder.getMany.mockResolvedValue([]);
+
+      await service.findInvalidTransitions(50);
+
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(50);
+    });
+  });
+
+  describe('getValidNextStates', () => {
+    it('should return valid next states for NEW', () => {
+      const nextStates = service.getValidNextStates(OrderStatus.NEW);
+
+      expect(nextStates).toContain(OrderStatus.PARTIALLY_FILLED);
+      expect(nextStates).toContain(OrderStatus.FILLED);
+      expect(nextStates).toContain(OrderStatus.CANCELED);
+      expect(nextStates).toContain(OrderStatus.REJECTED);
+      expect(nextStates).toContain(OrderStatus.EXPIRED);
+      expect(nextStates).toContain(OrderStatus.PENDING_CANCEL);
+      expect(nextStates).toHaveLength(6);
+    });
+
+    it('should return valid next states for PARTIALLY_FILLED', () => {
+      const nextStates = service.getValidNextStates(OrderStatus.PARTIALLY_FILLED);
+
+      expect(nextStates).toContain(OrderStatus.FILLED);
+      expect(nextStates).toContain(OrderStatus.CANCELED);
+      expect(nextStates).toContain(OrderStatus.PENDING_CANCEL);
+      expect(nextStates).toHaveLength(3);
+    });
+
+    it('should return valid next states for PENDING_CANCEL', () => {
+      const nextStates = service.getValidNextStates(OrderStatus.PENDING_CANCEL);
+
+      expect(nextStates).toContain(OrderStatus.CANCELED);
+      expect(nextStates).toContain(OrderStatus.FILLED);
+      expect(nextStates).toHaveLength(2);
+    });
+
+    it('should return empty array for terminal states', () => {
+      expect(service.getValidNextStates(OrderStatus.FILLED)).toEqual([]);
+      expect(service.getValidNextStates(OrderStatus.CANCELED)).toEqual([]);
+      expect(service.getValidNextStates(OrderStatus.REJECTED)).toEqual([]);
+      expect(service.getValidNextStates(OrderStatus.EXPIRED)).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/order/services/order-state-machine.service.ts
+++ b/apps/api/src/order/services/order-state-machine.service.ts
@@ -1,0 +1,238 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { OrderStatusHistory, OrderTransitionReason } from '../entities/order-status-history.entity';
+import { OrderStatus } from '../order.entity';
+
+/**
+ * Valid state transitions for order status.
+ * Based on exchange order lifecycle.
+ */
+const VALID_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
+  [OrderStatus.NEW]: [
+    OrderStatus.PARTIALLY_FILLED,
+    OrderStatus.FILLED,
+    OrderStatus.CANCELED,
+    OrderStatus.REJECTED,
+    OrderStatus.EXPIRED,
+    OrderStatus.PENDING_CANCEL
+  ],
+  [OrderStatus.PARTIALLY_FILLED]: [OrderStatus.FILLED, OrderStatus.CANCELED, OrderStatus.PENDING_CANCEL],
+  [OrderStatus.PENDING_CANCEL]: [
+    OrderStatus.CANCELED,
+    OrderStatus.FILLED // Order can still fill while cancel is pending
+  ],
+  // Terminal states - no outgoing transitions
+  [OrderStatus.FILLED]: [],
+  [OrderStatus.CANCELED]: [],
+  [OrderStatus.REJECTED]: [],
+  [OrderStatus.EXPIRED]: []
+};
+
+/**
+ * Terminal states that indicate order lifecycle is complete
+ */
+const TERMINAL_STATES: OrderStatus[] = [
+  OrderStatus.FILLED,
+  OrderStatus.CANCELED,
+  OrderStatus.REJECTED,
+  OrderStatus.EXPIRED
+];
+
+export interface TransitionResult {
+  valid: boolean;
+  fromStatus: OrderStatus | null;
+  toStatus: OrderStatus;
+  reason: OrderTransitionReason;
+  historyRecord?: OrderStatusHistory;
+}
+
+/**
+ * Service for managing order state transitions with validation and history tracking.
+ *
+ * IMPORTANT: Invalid transitions are logged as warnings but NOT blocked.
+ * The exchange is authoritative - if it says an order is in a certain state,
+ * we accept that state even if it doesn't match our expected transition rules.
+ */
+@Injectable()
+export class OrderStateMachineService {
+  private readonly logger = new Logger(OrderStateMachineService.name);
+
+  constructor(
+    @InjectRepository(OrderStatusHistory)
+    private readonly historyRepository: Repository<OrderStatusHistory>
+  ) {}
+
+  /**
+   * Check if a transition is valid according to the state machine rules.
+   */
+  isValidTransition(fromStatus: OrderStatus | null, toStatus: OrderStatus): boolean {
+    // Initial creation (null -> NEW) is always valid
+    if (fromStatus === null) {
+      return toStatus === OrderStatus.NEW;
+    }
+
+    // Same status is not a transition (no-op)
+    if (fromStatus === toStatus) {
+      return true;
+    }
+
+    const allowedTransitions = VALID_TRANSITIONS[fromStatus] || [];
+    return allowedTransitions.includes(toStatus);
+  }
+
+  /**
+   * Check if a status is a terminal state (no further transitions possible).
+   */
+  isTerminalState(status: OrderStatus): boolean {
+    return TERMINAL_STATES.includes(status);
+  }
+
+  /**
+   * Attempt a status transition with validation and history recording.
+   *
+   * IMPORTANT: Invalid transitions are LOGGED but NOT blocked (exchange is authoritative).
+   *
+   * @param orderId - The order ID
+   * @param fromStatus - The current status (null for initial creation)
+   * @param toStatus - The new status
+   * @param reason - The reason for the transition
+   * @param metadata - Optional additional context
+   * @returns TransitionResult with validation status and history record
+   */
+  async transitionStatus(
+    orderId: string,
+    fromStatus: OrderStatus | null,
+    toStatus: OrderStatus,
+    reason: OrderTransitionReason,
+    metadata?: Record<string, unknown>
+  ): Promise<TransitionResult> {
+    const isValid = this.isValidTransition(fromStatus, toStatus);
+
+    // Log invalid transitions as warnings but do NOT block
+    if (!isValid) {
+      this.logger.warn(
+        `Invalid order state transition detected: ${fromStatus} -> ${toStatus} ` +
+          `for order ${orderId}. Reason: ${reason}. ` +
+          `Exchange data is authoritative, allowing transition.`,
+        { orderId, fromStatus, toStatus, reason, metadata }
+      );
+    }
+
+    // Always record the transition in history
+    const historyRecord = await this.recordTransition(orderId, fromStatus, toStatus, reason, metadata, !isValid);
+
+    return {
+      valid: isValid,
+      fromStatus,
+      toStatus,
+      reason,
+      historyRecord
+    };
+  }
+
+  /**
+   * Record a status transition in the history table.
+   */
+  private async recordTransition(
+    orderId: string,
+    fromStatus: OrderStatus | null,
+    toStatus: OrderStatus,
+    reason: OrderTransitionReason,
+    metadata?: Record<string, unknown>,
+    wasInvalid?: boolean
+  ): Promise<OrderStatusHistory> {
+    const enrichedMetadata = {
+      ...metadata,
+      ...(wasInvalid && { invalidTransition: true })
+    };
+
+    const historyEntry = this.historyRepository.create({
+      orderId,
+      fromStatus,
+      toStatus,
+      reason,
+      metadata: Object.keys(enrichedMetadata).length > 0 ? enrichedMetadata : null
+    });
+
+    try {
+      const saved = await this.historyRepository.save(historyEntry);
+      this.logger.debug(`Recorded status transition: ${fromStatus ?? 'null'} -> ${toStatus} for order ${orderId}`);
+      return saved;
+    } catch (error) {
+      // History recording should not block order updates
+      this.logger.error(`Failed to record status history for order ${orderId}: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  /**
+   * Get status history for an order in chronological order.
+   */
+  async getOrderHistory(orderId: string): Promise<OrderStatusHistory[]> {
+    return this.historyRepository.find({
+      where: { orderId },
+      order: { transitionedAt: 'ASC' }
+    });
+  }
+
+  /**
+   * Get the most recent status transition for an order.
+   */
+  async getLatestTransition(orderId: string): Promise<OrderStatusHistory | null> {
+    return this.historyRepository.findOne({
+      where: { orderId },
+      order: { transitionedAt: 'DESC' }
+    });
+  }
+
+  /**
+   * Count transitions by reason for analytics.
+   */
+  async countTransitionsByReason(startDate?: Date, endDate?: Date): Promise<Record<string, number>> {
+    const qb = this.historyRepository
+      .createQueryBuilder('history')
+      .select('history.reason', 'reason')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('history.reason');
+
+    if (startDate) {
+      qb.andWhere('history.transitionedAt >= :startDate', { startDate });
+    }
+    if (endDate) {
+      qb.andWhere('history.transitionedAt <= :endDate', { endDate });
+    }
+
+    const results = await qb.getRawMany();
+
+    return results.reduce(
+      (acc, row) => {
+        acc[row.reason] = parseInt(row.count, 10);
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+  }
+
+  /**
+   * Find orders with invalid transitions (for monitoring and debugging).
+   */
+  async findInvalidTransitions(limit = 100): Promise<OrderStatusHistory[]> {
+    return this.historyRepository
+      .createQueryBuilder('history')
+      .where("history.metadata->>'invalidTransition' = 'true'")
+      .orderBy('history.transitionedAt', 'DESC')
+      .take(limit)
+      .getMany();
+  }
+
+  /**
+   * Get valid next states for a given status.
+   * Useful for UI/documentation purposes.
+   */
+  getValidNextStates(currentStatus: OrderStatus): OrderStatus[] {
+    return VALID_TRANSITIONS[currentStatus] || [];
+  }
+}

--- a/apps/api/src/order/services/trade-execution.service.spec.ts
+++ b/apps/api/src/order/services/trade-execution.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
+import { OrderStateMachineService } from './order-state-machine.service';
 import { TradeExecutionService } from './trade-execution.service';
 
 import { CoinService } from '../../coin/coin.service';
@@ -18,6 +19,7 @@ describe('TradeExecutionService', () => {
   let mockExchangeManagerService: any;
   let mockCoinService: any;
   let mockUserRepository: any;
+  let mockStateMachineService: any;
   let loggerWarnSpy: jest.SpyInstance;
 
   describe('constructor validation', () => {
@@ -31,6 +33,7 @@ describe('TradeExecutionService', () => {
             { provide: ExchangeKeyService, useValue: {} },
             { provide: ExchangeManagerService, useValue: {} },
             { provide: CoinService, useValue: {} },
+            { provide: OrderStateMachineService, useValue: {} },
             {
               provide: slippageLimitsConfig.KEY,
               useValue: {
@@ -55,6 +58,7 @@ describe('TradeExecutionService', () => {
             { provide: ExchangeKeyService, useValue: {} },
             { provide: ExchangeManagerService, useValue: {} },
             { provide: CoinService, useValue: {} },
+            { provide: OrderStateMachineService, useValue: {} },
             {
               provide: slippageLimitsConfig.KEY,
               useValue: {
@@ -91,6 +95,18 @@ describe('TradeExecutionService', () => {
       getCoinBySymbol: jest.fn()
     };
 
+    mockStateMachineService = {
+      transitionStatus: jest.fn().mockResolvedValue({
+        valid: true,
+        fromStatus: null,
+        toStatus: 'FILLED',
+        reason: 'trade_execution'
+      }),
+      getOrderHistory: jest.fn().mockResolvedValue([]),
+      isValidTransition: jest.fn().mockReturnValue(true),
+      isTerminalState: jest.fn().mockReturnValue(false)
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TradeExecutionService,
@@ -113,6 +129,10 @@ describe('TradeExecutionService', () => {
         {
           provide: CoinService,
           useValue: mockCoinService
+        },
+        {
+          provide: OrderStateMachineService,
+          useValue: mockStateMachineService
         },
         {
           provide: slippageLimitsConfig.KEY,


### PR DESCRIPTION
## Summary
- Add formal order state machine with transition validation and status history tracking
- Create OrderStatusHistory entity with OrderTransitionReason enum for audit trail
- Implement OrderStateMachineService with valid transition definitions
- Add database migration for order_status_history table with proper indexes
- Integrate state machine with OrderSyncService for exchange syncs
- Integrate state machine with TradeExecutionService for initial status recording
- Add GET /order/:id/history API endpoint to retrieve order status history

## Test plan
- [x] 57 unit tests covering all transition scenarios
- [x] All 481 existing tests pass
- [x] Build compiles successfully

Closes #67