### PR TITLE
fix(backtest): add missing completedAt column to Backtest entity

### DIFF
--- a/apps/api/src/migrations/1736600000000-add-backtest-completed-at.ts
+++ b/apps/api/src/migrations/1736600000000-add-backtest-completed-at.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddBacktestCompletedAt1736600000000 implements MigrationInterface {
+  name = 'AddBacktestCompletedAt1736600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "backtests"
+      ADD COLUMN IF NOT EXISTS "completedAt" TIMESTAMP WITH TIME ZONE
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "backtests"
+      DROP COLUMN IF EXISTS "completedAt"
+    `);
+  }
+}

--- a/apps/api/src/order/backtest/backtest.entity.ts
+++ b/apps/api/src/order/backtest/backtest.entity.ts
@@ -171,6 +171,10 @@ export class Backtest {
   @ApiProperty({ description: 'When the backtest was last updated' })
   updatedAt: Date;
 
+  @Column({ type: 'timestamptz', nullable: true })
+  @ApiProperty({ description: 'When the backtest completed', required: false })
+  completedAt?: Date;
+
   @Index('backtest_userId_index')
   @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn()

--- a/apps/api/src/order/backtest/backtest.service.ts
+++ b/apps/api/src/order/backtest/backtest.service.ts
@@ -466,7 +466,7 @@ export class BacktestService {
                 }
               : undefined,
             initiatedAt: backtest.createdAt,
-            completedAt: backtest.updatedAt
+            completedAt: backtest.completedAt
           },
           metrics: {
             totalReturn: backtest.totalReturn ?? 0,
@@ -767,9 +767,7 @@ export class BacktestService {
   }
 
   private mapRunSummary(backtest: Backtest): BacktestRunSummary {
-    const completedAt =
-      (backtest as { completedAt?: Date }).completedAt ??
-      (backtest.status === BacktestStatus.COMPLETED ? backtest.updatedAt : undefined);
+    const completedAt = backtest.completedAt;
 
     return {
       id: backtest.id,


### PR DESCRIPTION
## Summary

- Add missing `completedAt` column to the Backtest entity that `BacktestResultService.persistSuccess()` was attempting to set
- Add migration to add the column to existing database tables
- Remove workaround code that fell back to `updatedAt` when `completedAt` was unavailable

## Changes

- `apps/api/src/order/backtest/backtest.entity.ts` - Add `completedAt` column to Backtest entity
- `apps/api/src/migrations/1736600000000-add-backtest-completed-at.ts` - Migration to add column to database
- `apps/api/src/order/backtest/backtest.service.ts` - Remove workaround logic that used `updatedAt` as fallback

## Test Plan

- [ ] Run migration: `nx run api:typeorm migration:run`
- [ ] Execute a backtest and verify `completedAt` is populated correctly
- [ ] Verify existing backtests continue to display properly (null `completedAt` for old records)

## Related Issues

Closes #88