### PR TITLE
feat(tasks): add automatic backtest orchestration for algo-enabled users

### DIFF
--- a/apps/api/src/migrations/1736700000000-add-backtest-orchestration-indexes.ts
+++ b/apps/api/src/migrations/1736700000000-add-backtest-orchestration-indexes.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration to add indexes for backtest orchestration deduplication queries.
+ *
+ * - IDX_backtest_user_algo_created: Optimizes deduplication queries for
+ *   finding existing backtests by user/algorithm within a time window.
+ *
+ * - IDX_user_algo_trading_enabled: Optimizes the query for finding
+ *   eligible users with algo trading enabled.
+ */
+export class AddBacktestOrchestrationIndexes1736700000000 implements MigrationInterface {
+  name = 'AddBacktestOrchestrationIndexes1736700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Composite index for deduplication queries
+    // Used to efficiently find recent backtests for the same user/algorithm combination
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_backtest_user_algo_created"
+      ON "backtests" ("userId", "algorithmId", "createdAt" DESC)
+    `);
+
+    // Partial index for eligible users query
+    // Only indexes users with algo trading enabled for faster lookups
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_user_algo_trading_enabled"
+      ON "user" ("algoTradingEnabled")
+      WHERE "algoTradingEnabled" = true
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_backtest_user_algo_created"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_algo_trading_enabled"`);
+  }
+}

--- a/apps/api/src/tasks/backtest-orchestration.processor.spec.ts
+++ b/apps/api/src/tasks/backtest-orchestration.processor.spec.ts
@@ -1,0 +1,53 @@
+import { Job } from 'bullmq';
+
+import { BacktestOrchestrationProcessor } from './backtest-orchestration.processor';
+import { OrchestrationJobData, OrchestrationResult } from './dto/backtest-orchestration.dto';
+
+describe('BacktestOrchestrationProcessor', () => {
+  const mockService = {
+    orchestrateForUser: jest.fn()
+  };
+
+  const createJob = (data: OrchestrationJobData): Job<OrchestrationJobData> =>
+    ({ id: 'job-1', data }) as Job<OrchestrationJobData>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should orchestrate and return results for a job', async () => {
+    const processor = new BacktestOrchestrationProcessor(mockService as any);
+    const result: OrchestrationResult = {
+      userId: 'user-1',
+      backtestsCreated: 2,
+      backtestIds: ['bt-1', 'bt-2'],
+      skippedAlgorithms: [],
+      errors: []
+    };
+    mockService.orchestrateForUser.mockResolvedValue(result);
+
+    const job = createJob({
+      userId: 'user-1',
+      scheduledAt: new Date().toISOString(),
+      riskLevel: 3
+    });
+
+    const response = await processor.process(job);
+
+    expect(mockService.orchestrateForUser).toHaveBeenCalledWith('user-1');
+    expect(response).toBe(result);
+  });
+
+  it('should rethrow errors from orchestration', async () => {
+    const processor = new BacktestOrchestrationProcessor(mockService as any);
+    mockService.orchestrateForUser.mockRejectedValue(new Error('Boom'));
+
+    const job = createJob({
+      userId: 'user-2',
+      scheduledAt: new Date().toISOString(),
+      riskLevel: 4
+    });
+
+    await expect(processor.process(job)).rejects.toThrow('Boom');
+  });
+});

--- a/apps/api/src/tasks/backtest-orchestration.processor.ts
+++ b/apps/api/src/tasks/backtest-orchestration.processor.ts
@@ -1,0 +1,59 @@
+/**
+ * Backtest Orchestration Processor
+ *
+ * BullMQ processor that handles individual user orchestration jobs.
+ * Each job processes one user's algorithm activations and creates backtests.
+ */
+
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+
+import { Job } from 'bullmq';
+
+import { BacktestOrchestrationService } from './backtest-orchestration.service';
+import { OrchestrationJobData, OrchestrationResult } from './dto/backtest-orchestration.dto';
+
+@Injectable()
+@Processor('backtest-orchestration')
+export class BacktestOrchestrationProcessor extends WorkerHost {
+  private readonly logger = new Logger(BacktestOrchestrationProcessor.name);
+
+  constructor(private readonly orchestrationService: BacktestOrchestrationService) {
+    super();
+  }
+
+  /**
+   * Process a single user orchestration job.
+   */
+  async process(job: Job<OrchestrationJobData>): Promise<OrchestrationResult> {
+    const { userId, scheduledAt, riskLevel } = job.data;
+
+    this.logger.log(
+      `Processing orchestration job ${job.id} for user ${userId} ` +
+        `(risk level: ${riskLevel}, scheduled: ${scheduledAt})`
+    );
+
+    const startTime = Date.now();
+
+    try {
+      const result = await this.orchestrationService.orchestrateForUser(userId);
+
+      const duration = Date.now() - startTime;
+      this.logger.log(
+        `Orchestration job ${job.id} completed for user ${userId} in ${duration}ms: ` +
+          `${result.backtestsCreated} backtests created, ` +
+          `${result.skippedAlgorithms.length} skipped, ` +
+          `${result.errors.length} errors`
+      );
+
+      return result;
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      this.logger.error(
+        `Orchestration job ${job.id} failed for user ${userId} after ${duration}ms: ${error.message}`,
+        error.stack
+      );
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/tasks/backtest-orchestration.service.spec.ts
+++ b/apps/api/src/tasks/backtest-orchestration.service.spec.ts
@@ -1,0 +1,526 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { BacktestOrchestrationService } from './backtest-orchestration.service';
+import { getRiskConfig, MIN_ORCHESTRATION_CAPITAL, RISK_CONFIG_MATRIX } from './dto/backtest-orchestration.dto';
+
+import { AlgorithmActivation } from '../algorithm/algorithm-activation.entity';
+import { AlgorithmActivationService } from '../algorithm/services/algorithm-activation.service';
+import { BalanceService } from '../balance/balance.service';
+import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
+import { BacktestService } from '../order/backtest/backtest.service';
+import { MarketDataSet, MarketDataTimeframe } from '../order/backtest/market-data-set.entity';
+import { SlippageModelType } from '../order/backtest/slippage-model';
+import { Risk } from '../risk/risk.entity';
+import { User } from '../users/users.entity';
+import { UsersService } from '../users/users.service';
+
+describe('BacktestOrchestrationService', () => {
+  let service: BacktestOrchestrationService;
+  let userRepository: jest.Mocked<Repository<User>>;
+  let backtestRepository: jest.Mocked<Repository<Backtest>>;
+  let marketDataSetRepository: jest.Mocked<Repository<MarketDataSet>>;
+  let balanceService: jest.Mocked<BalanceService>;
+  let algorithmActivationService: jest.Mocked<AlgorithmActivationService>;
+  let backtestService: jest.Mocked<BacktestService>;
+
+  const mockUser: Partial<User> = {
+    id: 'user-123',
+    algoTradingEnabled: true,
+    algoCapitalAllocationPercentage: 25,
+    risk: { id: 'risk-1', level: 3, name: 'Moderate', description: '' } as Risk,
+    exchanges: []
+  };
+
+  const mockActivation: Partial<AlgorithmActivation> = {
+    id: 'activation-1',
+    userId: 'user-123',
+    algorithmId: 'algo-1',
+    isActive: true,
+    allocationPercentage: 10,
+    algorithm: { id: 'algo-1', name: 'Test Algorithm' } as any,
+    config: { parameters: { param1: 'value1' } }
+  };
+
+  const mockDataset: Partial<MarketDataSet> = {
+    id: 'dataset-1',
+    label: 'Test Dataset',
+    timeframe: MarketDataTimeframe.HOUR,
+    integrityScore: 85,
+    endAt: new Date()
+  };
+
+  beforeEach(async () => {
+    const mockQueryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+      getOne: jest.fn().mockResolvedValue(null)
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BacktestOrchestrationService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder)
+          }
+        },
+        {
+          provide: getRepositoryToken(Backtest),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+            update: jest.fn().mockResolvedValue({}),
+            findOne: jest.fn().mockResolvedValue(null)
+          }
+        },
+        {
+          provide: getRepositoryToken(MarketDataSet),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder)
+          }
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            getById: jest.fn().mockResolvedValue(mockUser)
+          }
+        },
+        {
+          provide: BalanceService,
+          useValue: {
+            getUserBalances: jest.fn().mockResolvedValue({ totalUsdValue: 10000 })
+          }
+        },
+        {
+          provide: AlgorithmActivationService,
+          useValue: {
+            findUserActiveAlgorithms: jest.fn().mockResolvedValue([])
+          }
+        },
+        {
+          provide: BacktestService,
+          useValue: {
+            createBacktest: jest.fn().mockResolvedValue({
+              id: 'backtest-1',
+              configSnapshot: {}
+            })
+          }
+        }
+      ]
+    }).compile();
+
+    service = module.get<BacktestOrchestrationService>(BacktestOrchestrationService);
+    userRepository = module.get(getRepositoryToken(User));
+    backtestRepository = module.get(getRepositoryToken(Backtest));
+    marketDataSetRepository = module.get(getRepositoryToken(MarketDataSet));
+    balanceService = module.get(BalanceService);
+    algorithmActivationService = module.get(AlgorithmActivationService);
+    backtestService = module.get(BacktestService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getRiskConfig', () => {
+    it('should return correct config for each risk level', () => {
+      expect(getRiskConfig(1).lookbackDays).toBe(180);
+      expect(getRiskConfig(1).slippageModel).toBe(SlippageModelType.VOLUME_BASED);
+      expect(getRiskConfig(1).slippageBps).toBe(10);
+      expect(getRiskConfig(1).tradingFee).toBe(0.0015);
+
+      expect(getRiskConfig(3).lookbackDays).toBe(90);
+      expect(getRiskConfig(3).slippageModel).toBe(SlippageModelType.FIXED);
+      expect(getRiskConfig(3).slippageBps).toBe(5);
+      expect(getRiskConfig(3).tradingFee).toBe(0.001);
+
+      expect(getRiskConfig(5).lookbackDays).toBe(30);
+      expect(getRiskConfig(5).slippageBps).toBe(3);
+      expect(getRiskConfig(5).tradingFee).toBe(0.0008);
+    });
+
+    it('should return default config for invalid risk levels', () => {
+      const defaultConfig = RISK_CONFIG_MATRIX[3];
+      expect(getRiskConfig(0)).toEqual(defaultConfig);
+      expect(getRiskConfig(6)).toEqual(defaultConfig);
+      expect(getRiskConfig(-1)).toEqual(defaultConfig);
+    });
+  });
+
+  describe('getEligibleUsers', () => {
+    it('should query users with algoTradingEnabled and valid risk', async () => {
+      const mockQueryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockUser])
+      };
+      (userRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getEligibleUsers();
+
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('user.algoTradingEnabled = :enabled', { enabled: true });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('risk.id IS NOT NULL');
+      expect(result).toHaveLength(1);
+    });
+
+    it('should return empty array on error', async () => {
+      const mockQueryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockRejectedValue(new Error('Database error'))
+      };
+      (userRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getEligibleUsers();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('calculateAllocatedCapital', () => {
+    it('should calculate capital based on portfolio and allocation percentages', async () => {
+      balanceService.getUserBalances.mockResolvedValue({ totalUsdValue: 100000 } as any);
+
+      const user = { ...mockUser, algoCapitalAllocationPercentage: 25 } as User;
+      const activation = { ...mockActivation, allocationPercentage: 10 } as AlgorithmActivation;
+
+      const result = await service.calculateAllocatedCapital(user, activation);
+
+      // 100000 * 0.25 * 0.10 = 2500
+      expect(result).toBe(2500);
+    });
+
+    it('should return minimum capital when calculated value is below minimum', async () => {
+      balanceService.getUserBalances.mockResolvedValue({ totalUsdValue: 5000 } as any);
+
+      const user = { ...mockUser, algoCapitalAllocationPercentage: 10 } as User;
+      const activation = { ...mockActivation, allocationPercentage: 5 } as AlgorithmActivation;
+
+      const result = await service.calculateAllocatedCapital(user, activation);
+
+      // 5000 * 0.10 * 0.05 = 25, but min is 1000
+      expect(result).toBe(MIN_ORCHESTRATION_CAPITAL);
+    });
+
+    it('should return minimum capital when portfolio value is zero', async () => {
+      balanceService.getUserBalances.mockResolvedValue({ totalUsdValue: 0 } as any);
+
+      const result = await service.calculateAllocatedCapital(mockUser as User, mockActivation as AlgorithmActivation);
+
+      expect(result).toBe(MIN_ORCHESTRATION_CAPITAL);
+    });
+
+    it('should return minimum capital on balance fetch error', async () => {
+      balanceService.getUserBalances.mockRejectedValue(new Error('Balance fetch failed'));
+
+      const result = await service.calculateAllocatedCapital(mockUser as User, mockActivation as AlgorithmActivation);
+
+      expect(result).toBe(MIN_ORCHESTRATION_CAPITAL);
+    });
+
+    it('should use default allocation percentages when values are missing', async () => {
+      balanceService.getUserBalances.mockResolvedValue({ totalUsdValue: 10000 } as any);
+
+      const user = { ...mockUser, algoCapitalAllocationPercentage: undefined } as User;
+      const activation = { ...mockActivation, allocationPercentage: undefined } as AlgorithmActivation;
+
+      const result = await service.calculateAllocatedCapital(user, activation);
+
+      // Defaults to 0% user allocation and 1% activation allocation, min capital applies.
+      expect(result).toBe(MIN_ORCHESTRATION_CAPITAL);
+    });
+  });
+
+  describe('isDuplicate', () => {
+    it('should return true if non-failed backtest exists within 24 hours', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({ id: 'existing-backtest' })
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const result = await service.isDuplicate('user-123', 'algo-1');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if no matching backtest exists', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null)
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const result = await service.isDuplicate('user-123', 'algo-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('should exclude failed and cancelled backtests from duplicate check', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null)
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      await service.isDuplicate('user-123', 'algo-1');
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('backtest.status NOT IN (:...failedStatuses)', {
+        failedStatuses: [BacktestStatus.FAILED, BacktestStatus.CANCELLED]
+      });
+    });
+
+    it('should constrain by user, algorithm, and recent time window', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null)
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      await service.isDuplicate('user-123', 'algo-1');
+
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('backtest.userId = :userId', { userId: 'user-123' });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('backtest.algorithmId = :algorithmId', {
+        algorithmId: 'algo-1'
+      });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('backtest.createdAt >= :since', {
+        since: expect.any(Date)
+      });
+    });
+  });
+
+  describe('selectDataset', () => {
+    it('should select dataset matching risk config timeframes', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockDataset])
+      };
+      (marketDataSetRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const riskConfig = getRiskConfig(3);
+      const result = await service.selectDataset(riskConfig);
+
+      expect(result).toEqual(mockDataset);
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('dataset.timeframe IN (:...timeframes)', {
+        timeframes: [MarketDataTimeframe.MINUTE, MarketDataTimeframe.HOUR]
+      });
+    });
+
+    it('should return null when no suitable dataset exists', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([])
+      };
+      (marketDataSetRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const riskConfig = getRiskConfig(3);
+      const result = await service.selectDataset(riskConfig);
+
+      expect(result).toBeNull();
+    });
+
+    it('should fall back when no dataset matches preferred timeframes', async () => {
+      const primaryQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([])
+      };
+      const fallbackQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockDataset])
+      };
+      (marketDataSetRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(primaryQueryBuilder)
+        .mockReturnValueOnce(fallbackQueryBuilder);
+
+      const riskConfig = getRiskConfig(3);
+      const result = await service.selectDataset(riskConfig);
+
+      expect(result).toEqual(mockDataset);
+      expect(fallbackQueryBuilder.take).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('orchestrateForUser', () => {
+    it('should return empty result when user has no active activations', async () => {
+      algorithmActivationService.findUserActiveAlgorithms.mockResolvedValue([]);
+
+      const result = await service.orchestrateForUser('user-123');
+
+      expect(result.backtestsCreated).toBe(0);
+      expect(result.backtestIds).toHaveLength(0);
+    });
+
+    it('should skip duplicate backtests', async () => {
+      algorithmActivationService.findUserActiveAlgorithms.mockResolvedValue([mockActivation as AlgorithmActivation]);
+
+      // Mock isDuplicate to return true
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({ id: 'existing' })
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const result = await service.orchestrateForUser('user-123');
+
+      expect(result.skippedAlgorithms).toHaveLength(1);
+      expect(result.skippedAlgorithms[0].reason).toContain('Duplicate');
+    });
+
+    it('should create backtest for valid activation', async () => {
+      algorithmActivationService.findUserActiveAlgorithms.mockResolvedValue([mockActivation as AlgorithmActivation]);
+      balanceService.getUserBalances.mockResolvedValue({ totalUsdValue: 10000 } as any);
+
+      // Mock no duplicates
+      const backtestQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null)
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(backtestQueryBuilder);
+
+      // Mock dataset selection
+      const datasetQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockDataset])
+      };
+      (marketDataSetRepository.createQueryBuilder as jest.Mock).mockReturnValue(datasetQueryBuilder);
+
+      // Mock backtest creation
+      backtestService.createBacktest.mockResolvedValue({
+        id: 'new-backtest',
+        configSnapshot: { algorithm: { id: 'algo-1' } }
+      } as any);
+      backtestRepository.findOne.mockResolvedValue({ id: 'new-backtest' } as any);
+
+      const result = await service.orchestrateForUser('user-123');
+
+      expect(result.backtestsCreated).toBe(1);
+      expect(result.backtestIds).toContain('new-backtest');
+      expect(backtestService.createBacktest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          type: BacktestType.HISTORICAL,
+          algorithmId: 'algo-1'
+        })
+      );
+    });
+
+    it('should skip when no dataset is available', async () => {
+      algorithmActivationService.findUserActiveAlgorithms.mockResolvedValue([mockActivation as AlgorithmActivation]);
+
+      const backtestQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null)
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(backtestQueryBuilder);
+
+      const datasetQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([])
+      };
+      (marketDataSetRepository.createQueryBuilder as jest.Mock).mockReturnValue(datasetQueryBuilder);
+
+      const result = await service.orchestrateForUser('user-123');
+
+      expect(result.skippedAlgorithms).toHaveLength(1);
+      expect(result.skippedAlgorithms[0].reason).toContain('No suitable dataset');
+      expect(result.backtestsCreated).toBe(0);
+    });
+
+    it('should capture errors when backtest creation fails', async () => {
+      algorithmActivationService.findUserActiveAlgorithms.mockResolvedValue([mockActivation as AlgorithmActivation]);
+
+      const backtestQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null)
+      };
+      (backtestRepository.createQueryBuilder as jest.Mock).mockReturnValue(backtestQueryBuilder);
+
+      const datasetQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockDataset])
+      };
+      (marketDataSetRepository.createQueryBuilder as jest.Mock).mockReturnValue(datasetQueryBuilder);
+
+      backtestService.createBacktest.mockRejectedValue(new Error('Create failed'));
+
+      const result = await service.orchestrateForUser('user-123');
+
+      expect(result.errors[0]).toContain('Failed to process activation');
+      expect(result.skippedAlgorithms[0].reason).toContain('Create failed');
+      expect(result.backtestsCreated).toBe(0);
+    });
+  });
+
+  describe('createOrchestratedBacktest', () => {
+    it('should update configSnapshot and return updated backtest', async () => {
+      backtestService.createBacktest.mockResolvedValue({
+        id: 'backtest-123',
+        configSnapshot: { existing: true }
+      } as any);
+      backtestRepository.update.mockResolvedValue({} as any);
+      backtestRepository.findOne.mockResolvedValue({ id: 'backtest-123' } as any);
+
+      const riskConfig = getRiskConfig(3);
+      const result = await service.createOrchestratedBacktest(
+        mockUser as User,
+        mockActivation as AlgorithmActivation,
+        riskConfig,
+        2500,
+        mockDataset as MarketDataSet
+      );
+
+      expect(backtestRepository.update).toHaveBeenCalledWith('backtest-123', {
+        configSnapshot: expect.objectContaining({
+          orchestrated: true,
+          riskLevel: 3
+        })
+      });
+      expect(result).toEqual({ id: 'backtest-123' });
+    });
+  });
+});

--- a/apps/api/src/tasks/backtest-orchestration.service.ts
+++ b/apps/api/src/tasks/backtest-orchestration.service.ts
@@ -1,0 +1,345 @@
+/**
+ * Backtest Orchestration Service
+ *
+ * Business logic for automatic backtest orchestration.
+ * Handles user selection, capital calculation, dataset selection,
+ * deduplication, and backtest creation.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { format } from 'date-fns';
+import { Repository } from 'typeorm';
+
+import {
+  DEFAULT_RISK_LEVEL,
+  getRiskConfig,
+  MIN_DATASET_INTEGRITY_SCORE,
+  MIN_ORCHESTRATION_CAPITAL,
+  OrchestratedConfigSnapshot,
+  OrchestrationResult,
+  RiskLevelConfig
+} from './dto/backtest-orchestration.dto';
+
+import { AlgorithmActivation } from '../algorithm/algorithm-activation.entity';
+import { AlgorithmActivationService } from '../algorithm/services/algorithm-activation.service';
+import { BalanceService } from '../balance/balance.service';
+import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
+import { BacktestService } from '../order/backtest/backtest.service';
+import { CreateBacktestDto } from '../order/backtest/dto/backtest.dto';
+import { MarketDataSet } from '../order/backtest/market-data-set.entity';
+import { User } from '../users/users.entity';
+import { UsersService } from '../users/users.service';
+
+@Injectable()
+export class BacktestOrchestrationService {
+  private readonly logger = new Logger(BacktestOrchestrationService.name);
+
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Backtest)
+    private readonly backtestRepository: Repository<Backtest>,
+    @InjectRepository(MarketDataSet)
+    private readonly marketDataSetRepository: Repository<MarketDataSet>,
+    private readonly usersService: UsersService,
+    private readonly balanceService: BalanceService,
+    private readonly algorithmActivationService: AlgorithmActivationService,
+    private readonly backtestService: BacktestService
+  ) {}
+
+  /**
+   * Get all users eligible for automatic backtest orchestration.
+   * Users must have algoTradingEnabled=true and a valid risk assignment.
+   */
+  async getEligibleUsers(): Promise<User[]> {
+    try {
+      const users = await this.userRepository
+        .createQueryBuilder('user')
+        .leftJoinAndSelect('user.risk', 'risk')
+        .where('user.algoTradingEnabled = :enabled', { enabled: true })
+        .andWhere('risk.id IS NOT NULL')
+        .getMany();
+
+      this.logger.log(`Found ${users.length} eligible users for orchestration`);
+      return users;
+    } catch (error) {
+      this.logger.error(`Failed to fetch eligible users: ${error.message}`, error.stack);
+      return [];
+    }
+  }
+
+  /**
+   * Main orchestration logic for a single user.
+   * Gets active algorithm activations and creates backtests for each.
+   */
+  async orchestrateForUser(userId: string): Promise<OrchestrationResult> {
+    const result: OrchestrationResult = {
+      userId,
+      backtestsCreated: 0,
+      backtestIds: [],
+      skippedAlgorithms: [],
+      errors: []
+    };
+
+    try {
+      // Get user with exchange keys for balance fetching
+      const user = await this.usersService.getById(userId, true);
+      const riskLevel = user.risk?.level ?? DEFAULT_RISK_LEVEL;
+      const riskConfig = getRiskConfig(riskLevel);
+
+      this.logger.log(`Orchestrating backtests for user ${userId} with risk level ${riskLevel}`);
+
+      // Get active algorithm activations
+      const activations = await this.algorithmActivationService.findUserActiveAlgorithms(userId);
+
+      if (activations.length === 0) {
+        this.logger.log(`No active algorithm activations found for user ${userId}`);
+        return result;
+      }
+
+      this.logger.log(`Found ${activations.length} active activations for user ${userId}`);
+
+      // Process each activation
+      for (const activation of activations) {
+        try {
+          await this.processActivation(user, activation, riskConfig, result);
+        } catch (error) {
+          const errorMsg = `Failed to process activation ${activation.id}: ${error.message}`;
+          this.logger.error(errorMsg, error.stack);
+          result.errors.push(errorMsg);
+          result.skippedAlgorithms.push({
+            algorithmId: activation.algorithmId,
+            algorithmName: activation.algorithm?.name ?? 'Unknown',
+            reason: error.message
+          });
+        }
+      }
+
+      this.logger.log(
+        `Orchestration completed for user ${userId}: ` +
+          `${result.backtestsCreated} created, ${result.skippedAlgorithms.length} skipped`
+      );
+
+      return result;
+    } catch (error) {
+      const errorMsg = `Failed to orchestrate for user ${userId}: ${error.message}`;
+      this.logger.error(errorMsg, error.stack);
+      result.errors.push(errorMsg);
+      return result;
+    }
+  }
+
+  /**
+   * Process a single algorithm activation - check for duplicates,
+   * calculate capital, select dataset, and create backtest.
+   */
+  private async processActivation(
+    user: User,
+    activation: AlgorithmActivation,
+    riskConfig: RiskLevelConfig,
+    result: OrchestrationResult
+  ): Promise<void> {
+    const algorithmId = activation.algorithmId;
+    const algorithmName = activation.algorithm?.name ?? 'Unknown';
+
+    // Check for duplicate backtest in the last 24 hours
+    if (await this.isDuplicate(user.id, algorithmId)) {
+      this.logger.debug(`Skipping duplicate backtest for user ${user.id}, algorithm ${algorithmId}`);
+      result.skippedAlgorithms.push({
+        algorithmId,
+        algorithmName,
+        reason: 'Duplicate backtest exists within 24 hours'
+      });
+      return;
+    }
+
+    // Select appropriate dataset
+    const dataset = await this.selectDataset(riskConfig);
+    if (!dataset) {
+      this.logger.warn(`No suitable dataset found for risk config (level ${user.risk?.level})`);
+      result.skippedAlgorithms.push({
+        algorithmId,
+        algorithmName,
+        reason: 'No suitable dataset found for risk configuration'
+      });
+      return;
+    }
+
+    // Calculate allocated capital
+    const allocatedCapital = await this.calculateAllocatedCapital(user, activation);
+
+    // Create the backtest
+    const backtest = await this.createOrchestratedBacktest(user, activation, riskConfig, allocatedCapital, dataset);
+
+    result.backtestsCreated++;
+    result.backtestIds.push(backtest.id);
+
+    this.logger.log(
+      `Created orchestrated backtest ${backtest.id} for user ${user.id}, ` +
+        `algorithm ${algorithmName}, capital $${allocatedCapital.toFixed(2)}`
+    );
+  }
+
+  /**
+   * Calculate the allocated capital for a backtest based on
+   * portfolio value and allocation percentages.
+   */
+  async calculateAllocatedCapital(user: User, activation: AlgorithmActivation): Promise<number> {
+    try {
+      // Get current portfolio value
+      const balanceResponse = await this.balanceService.getUserBalances(user, false);
+      const portfolioValue = balanceResponse.totalUsdValue;
+
+      if (!portfolioValue || portfolioValue <= 0) {
+        this.logger.warn(`No portfolio value for user ${user.id}, using minimum capital`);
+        return MIN_ORCHESTRATION_CAPITAL;
+      }
+
+      // Calculate: portfolioValue × userAllocation% × activationAllocation%
+      const userAllocationPct = user.algoCapitalAllocationPercentage ?? 0;
+      const activationAllocationPct = activation.allocationPercentage ?? 1;
+
+      const allocated = portfolioValue * (userAllocationPct / 100) * (activationAllocationPct / 100);
+
+      // Ensure minimum capital
+      const finalCapital = Math.max(allocated, MIN_ORCHESTRATION_CAPITAL);
+
+      this.logger.debug(
+        `Capital calculation for user ${user.id}: ` +
+          `portfolio=$${portfolioValue.toFixed(2)}, ` +
+          `userAlloc=${userAllocationPct}%, ` +
+          `activationAlloc=${activationAllocationPct}%, ` +
+          `final=$${finalCapital.toFixed(2)}`
+      );
+
+      return finalCapital;
+    } catch (error) {
+      this.logger.warn(`Failed to calculate capital for user ${user.id}, using minimum: ${error.message}`);
+      return MIN_ORCHESTRATION_CAPITAL;
+    }
+  }
+
+  /**
+   * Select the best matching dataset based on risk configuration.
+   * Priority: recency > timeframe match > integrity score.
+   */
+  async selectDataset(riskConfig: RiskLevelConfig): Promise<MarketDataSet | null> {
+    try {
+      const cutoffDate = new Date();
+      cutoffDate.setDate(cutoffDate.getDate() - riskConfig.lookbackDays);
+
+      const datasets = await this.marketDataSetRepository
+        .createQueryBuilder('dataset')
+        .where('dataset.integrityScore >= :minIntegrity', { minIntegrity: MIN_DATASET_INTEGRITY_SCORE })
+        .andWhere('dataset.endAt >= :cutoff', { cutoff: cutoffDate })
+        .andWhere('dataset.timeframe IN (:...timeframes)', { timeframes: riskConfig.preferredTimeframes })
+        .orderBy('dataset.endAt', 'DESC')
+        .addOrderBy('dataset.integrityScore', 'DESC')
+        .getMany();
+
+      if (datasets.length === 0) {
+        this.logger.warn('No datasets found matching risk configuration, trying fallback');
+        // Fallback: relax timeframe constraint
+        const fallbackDatasets = await this.marketDataSetRepository
+          .createQueryBuilder('dataset')
+          .where('dataset.integrityScore >= :minIntegrity', { minIntegrity: MIN_DATASET_INTEGRITY_SCORE })
+          .andWhere('dataset.endAt >= :cutoff', { cutoff: cutoffDate })
+          .orderBy('dataset.endAt', 'DESC')
+          .addOrderBy('dataset.integrityScore', 'DESC')
+          .take(1)
+          .getMany();
+
+        return fallbackDatasets[0] ?? null;
+      }
+
+      return datasets[0];
+    } catch (error) {
+      this.logger.error(`Failed to select dataset: ${error.message}`, error.stack);
+      return null;
+    }
+  }
+
+  /**
+   * Check if a duplicate backtest exists for this user/algorithm
+   * combination within the last 24 hours (excluding failed/cancelled).
+   */
+  async isDuplicate(userId: string, algorithmId: string): Promise<boolean> {
+    const twentyFourHoursAgo = new Date();
+    twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
+
+    const existing = await this.backtestRepository
+      .createQueryBuilder('backtest')
+      .where('backtest.userId = :userId', { userId })
+      .andWhere('backtest.algorithmId = :algorithmId', { algorithmId })
+      .andWhere('backtest.createdAt >= :since', { since: twentyFourHoursAgo })
+      .andWhere('backtest.status NOT IN (:...failedStatuses)', {
+        failedStatuses: [BacktestStatus.FAILED, BacktestStatus.CANCELLED]
+      })
+      .getOne();
+
+    return !!existing;
+  }
+
+  /**
+   * Create an orchestrated backtest with the appropriate configuration.
+   */
+  async createOrchestratedBacktest(
+    user: User,
+    activation: AlgorithmActivation,
+    riskConfig: RiskLevelConfig,
+    allocatedCapital: number,
+    dataset: MarketDataSet
+  ): Promise<Backtest> {
+    const algorithmName = activation.algorithm?.name ?? 'Unknown';
+    const dateStr = format(new Date(), 'yyyy-MM-dd');
+
+    // Calculate date range based on lookback days
+    const endDate = new Date();
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - riskConfig.lookbackDays);
+
+    const dto: CreateBacktestDto = {
+      name: `Auto-${algorithmName}-${dateStr}`,
+      description: `Orchestrated backtest for ${algorithmName}`,
+      type: BacktestType.HISTORICAL,
+      algorithmId: activation.algorithmId,
+      marketDataSetId: dataset.id,
+      initialCapital: allocatedCapital,
+      tradingFee: riskConfig.tradingFee,
+      slippageModel: riskConfig.slippageModel,
+      slippageFixedBps: riskConfig.slippageBps,
+      slippageBaseBps: riskConfig.slippageBps,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      strategyParams: activation.config?.parameters
+    };
+
+    // Create the backtest via BacktestService
+    const backtestResult = await this.backtestService.createBacktest(user, dto);
+
+    // Update configSnapshot to mark as orchestrated
+    const updatedConfigSnapshot: OrchestratedConfigSnapshot = {
+      ...backtestResult.configSnapshot,
+      orchestrated: true,
+      orchestratedAt: new Date().toISOString(),
+      riskLevel: user.risk?.level ?? DEFAULT_RISK_LEVEL
+    };
+
+    await this.backtestRepository.update(backtestResult.id, {
+      configSnapshot: updatedConfigSnapshot
+    });
+
+    // Fetch and return the updated backtest
+    const backtest = await this.backtestRepository.findOne({
+      where: { id: backtestResult.id }
+    });
+
+    if (!backtest) {
+      throw new Error(`Failed to fetch created backtest ${backtestResult.id}`);
+    }
+
+    return backtest;
+  }
+}

--- a/apps/api/src/tasks/backtest-orchestration.task.spec.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.spec.ts
@@ -1,0 +1,148 @@
+import { getQueueToken } from '@nestjs/bullmq';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { Queue } from 'bullmq';
+
+import { BacktestOrchestrationService } from './backtest-orchestration.service';
+import { BacktestOrchestrationTask } from './backtest-orchestration.task';
+import { STAGGER_INTERVAL_MS } from './dto/backtest-orchestration.dto';
+
+describe('BacktestOrchestrationTask', () => {
+  let task: BacktestOrchestrationTask;
+  let orchestrationQueue: jest.Mocked<Queue>;
+  let orchestrationService: jest.Mocked<BacktestOrchestrationService>;
+
+  const mockQueue = {
+    add: jest.fn(),
+    getWaitingCount: jest.fn(),
+    getActiveCount: jest.fn(),
+    getCompletedCount: jest.fn(),
+    getFailedCount: jest.fn(),
+    getDelayedCount: jest.fn()
+  };
+
+  const mockService = {
+    getEligibleUsers: jest.fn()
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BacktestOrchestrationTask,
+        { provide: getQueueToken('backtest-orchestration'), useValue: mockQueue },
+        { provide: BacktestOrchestrationService, useValue: mockService }
+      ]
+    }).compile();
+
+    task = module.get<BacktestOrchestrationTask>(BacktestOrchestrationTask);
+    orchestrationQueue = module.get(getQueueToken('backtest-orchestration'));
+    orchestrationService = module.get(BacktestOrchestrationService);
+
+    jest.clearAllMocks();
+  });
+
+  describe('scheduleOrchestration', () => {
+    it('should skip scheduling when no eligible users', async () => {
+      orchestrationService.getEligibleUsers.mockResolvedValue([]);
+
+      await task.scheduleOrchestration();
+
+      expect(orchestrationQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('should queue staggered orchestration jobs for eligible users', async () => {
+      orchestrationService.getEligibleUsers.mockResolvedValue([
+        { id: 'user-1', risk: { level: 4 } },
+        { id: 'user-2', risk: null }
+      ] as any);
+
+      await task.scheduleOrchestration();
+
+      expect(orchestrationQueue.add).toHaveBeenNthCalledWith(
+        1,
+        'orchestrate-user',
+        expect.objectContaining({
+          userId: 'user-1',
+          scheduledAt: expect.any(String),
+          riskLevel: 4
+        }),
+        expect.objectContaining({
+          delay: 0,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 60000 },
+          removeOnComplete: true,
+          removeOnFail: false
+        })
+      );
+
+      expect(orchestrationQueue.add).toHaveBeenNthCalledWith(
+        2,
+        'orchestrate-user',
+        expect.objectContaining({
+          userId: 'user-2',
+          scheduledAt: expect.any(String),
+          riskLevel: 3
+        }),
+        expect.objectContaining({
+          delay: STAGGER_INTERVAL_MS,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 60000 },
+          removeOnComplete: true,
+          removeOnFail: false
+        })
+      );
+    });
+  });
+
+  describe('triggerManualOrchestration', () => {
+    it('should queue a single user orchestration job', async () => {
+      const result = await task.triggerManualOrchestration('user-99');
+
+      expect(orchestrationQueue.add).toHaveBeenCalledWith(
+        'orchestrate-user',
+        expect.objectContaining({
+          userId: 'user-99',
+          scheduledAt: expect.any(String),
+          riskLevel: 3
+        }),
+        expect.objectContaining({
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 60000 },
+          removeOnComplete: true,
+          removeOnFail: false
+        })
+      );
+      expect(result).toEqual({ queued: 1 });
+    });
+
+    it('should trigger full orchestration when no userId is provided', async () => {
+      const scheduleSpy = jest.spyOn(task, 'scheduleOrchestration').mockResolvedValue();
+      orchestrationService.getEligibleUsers.mockResolvedValue([{ id: 'user-1' }, { id: 'user-2' }] as any);
+
+      const result = await task.triggerManualOrchestration();
+
+      expect(scheduleSpy).toHaveBeenCalled();
+      expect(result).toEqual({ queued: 2 });
+    });
+  });
+
+  describe('getQueueStats', () => {
+    it('should return queue counts', async () => {
+      orchestrationQueue.getWaitingCount.mockResolvedValue(2);
+      orchestrationQueue.getActiveCount.mockResolvedValue(1);
+      orchestrationQueue.getCompletedCount.mockResolvedValue(5);
+      orchestrationQueue.getFailedCount.mockResolvedValue(0);
+      orchestrationQueue.getDelayedCount.mockResolvedValue(3);
+
+      const stats = await task.getQueueStats();
+
+      expect(stats).toEqual({
+        waiting: 2,
+        active: 1,
+        completed: 5,
+        failed: 0,
+        delayed: 3
+      });
+    });
+  });
+});

--- a/apps/api/src/tasks/backtest-orchestration.task.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.ts
@@ -1,0 +1,129 @@
+/**
+ * Backtest Orchestration Task
+ *
+ * Scheduled task that runs daily at 3 AM UTC to orchestrate
+ * automatic backtests for users with algo trading enabled.
+ */
+
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+
+import { Queue } from 'bullmq';
+
+import { BacktestOrchestrationService } from './backtest-orchestration.service';
+import { OrchestrationJobData, STAGGER_INTERVAL_MS } from './dto/backtest-orchestration.dto';
+
+@Injectable()
+export class BacktestOrchestrationTask {
+  private readonly logger = new Logger(BacktestOrchestrationTask.name);
+
+  constructor(
+    @InjectQueue('backtest-orchestration')
+    private readonly orchestrationQueue: Queue<OrchestrationJobData>,
+    private readonly orchestrationService: BacktestOrchestrationService
+  ) {}
+
+  /**
+   * Daily cron job at 3 AM UTC.
+   * Queries eligible users and adds staggered jobs to the queue.
+   */
+  @Cron('0 3 * * *')
+  async scheduleOrchestration(): Promise<void> {
+    this.logger.log('Starting daily backtest orchestration scheduling');
+
+    try {
+      const eligibleUsers = await this.orchestrationService.getEligibleUsers();
+      this.logger.log(`Found ${eligibleUsers.length} eligible users for orchestration`);
+
+      if (eligibleUsers.length === 0) {
+        this.logger.log('No eligible users found, skipping orchestration');
+        return;
+      }
+
+      // Queue jobs with staggered delays
+      for (let i = 0; i < eligibleUsers.length; i++) {
+        const user = eligibleUsers[i];
+        const delay = i * STAGGER_INTERVAL_MS;
+
+        const jobData: OrchestrationJobData = {
+          userId: user.id,
+          scheduledAt: new Date().toISOString(),
+          riskLevel: user.risk?.level ?? 3
+        };
+
+        await this.orchestrationQueue.add('orchestrate-user', jobData, {
+          delay,
+          attempts: 3,
+          backoff: {
+            type: 'exponential',
+            delay: 60000 // 1 minute base delay
+          },
+          removeOnComplete: true,
+          removeOnFail: false // Keep failed jobs for inspection
+        });
+
+        this.logger.debug(`Queued orchestration for user ${user.id} with ${delay}ms delay`);
+      }
+
+      this.logger.log(`Successfully queued ${eligibleUsers.length} orchestration jobs`);
+    } catch (error) {
+      this.logger.error(`Failed to schedule orchestration: ${error.message}`, error.stack);
+    }
+  }
+
+  /**
+   * Manually trigger orchestration for a specific user or all eligible users.
+   * Useful for admin operations and testing.
+   */
+  async triggerManualOrchestration(userId?: string): Promise<{ queued: number }> {
+    this.logger.log(`Manual orchestration triggered${userId ? ` for user ${userId}` : ' for all eligible users'}`);
+
+    if (userId) {
+      // Queue single user
+      const jobData: OrchestrationJobData = {
+        userId,
+        scheduledAt: new Date().toISOString(),
+        riskLevel: 3 // Will be resolved from user in processor
+      };
+
+      await this.orchestrationQueue.add('orchestrate-user', jobData, {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 60000
+        },
+        removeOnComplete: true,
+        removeOnFail: false
+      });
+
+      return { queued: 1 };
+    }
+
+    // Trigger full orchestration
+    await this.scheduleOrchestration();
+    const eligibleCount = (await this.orchestrationService.getEligibleUsers()).length;
+    return { queued: eligibleCount };
+  }
+
+  /**
+   * Get queue statistics for monitoring.
+   */
+  async getQueueStats(): Promise<{
+    waiting: number;
+    active: number;
+    completed: number;
+    failed: number;
+    delayed: number;
+  }> {
+    const [waiting, active, completed, failed, delayed] = await Promise.all([
+      this.orchestrationQueue.getWaitingCount(),
+      this.orchestrationQueue.getActiveCount(),
+      this.orchestrationQueue.getCompletedCount(),
+      this.orchestrationQueue.getFailedCount(),
+      this.orchestrationQueue.getDelayedCount()
+    ]);
+
+    return { waiting, active, completed, failed, delayed };
+  }
+}

--- a/apps/api/src/tasks/dto/backtest-orchestration.dto.ts
+++ b/apps/api/src/tasks/dto/backtest-orchestration.dto.ts
@@ -1,0 +1,152 @@
+/**
+ * Backtest Orchestration DTOs
+ *
+ * Types and configuration for automatic backtest orchestration.
+ * Defines risk-based configuration matrix and job data structures.
+ */
+
+import { MarketDataTimeframe } from '../../order/backtest/market-data-set.entity';
+import { SlippageModelType } from '../../order/backtest/slippage-model';
+
+/**
+ * Risk-level based backtest configuration
+ */
+export interface RiskLevelConfig {
+  /** Number of days to look back for historical data */
+  lookbackDays: number;
+  /** Type of slippage model to use */
+  slippageModel: SlippageModelType;
+  /** Slippage in basis points */
+  slippageBps: number;
+  /** Trading fee as decimal (e.g., 0.0015 = 0.15%) */
+  tradingFee: number;
+  /** Preferred timeframes for dataset selection */
+  preferredTimeframes: MarketDataTimeframe[];
+}
+
+/**
+ * Risk Configuration Matrix
+ *
+ * Maps user risk levels (1-5) to backtest configuration parameters.
+ * Lower risk levels use longer lookback periods and more conservative slippage.
+ *
+ * | Level | Description      | Lookback | Slippage Model | BPS | Fee    | Timeframes         |
+ * |-------|------------------|----------|----------------|-----|--------|-------------------|
+ * | 1     | Conservative     | 180 days | volume-based   | 10  | 0.15%  | HOUR, DAY         |
+ * | 2     | Low-Moderate     | 120 days | volume-based   | 8   | 0.12%  | HOUR, DAY         |
+ * | 3     | Moderate         | 90 days  | fixed          | 5   | 0.10%  | MINUTE, HOUR      |
+ * | 4     | Moderate-High    | 60 days  | fixed          | 5   | 0.10%  | MINUTE, HOUR      |
+ * | 5     | Aggressive       | 30 days  | fixed          | 3   | 0.08%  | MINUTE, SECOND    |
+ */
+export const RISK_CONFIG_MATRIX: Record<number, RiskLevelConfig> = {
+  1: {
+    lookbackDays: 180,
+    slippageModel: SlippageModelType.VOLUME_BASED,
+    slippageBps: 10,
+    tradingFee: 0.0015,
+    preferredTimeframes: [MarketDataTimeframe.HOUR, MarketDataTimeframe.DAY]
+  },
+  2: {
+    lookbackDays: 120,
+    slippageModel: SlippageModelType.VOLUME_BASED,
+    slippageBps: 8,
+    tradingFee: 0.0012,
+    preferredTimeframes: [MarketDataTimeframe.HOUR, MarketDataTimeframe.DAY]
+  },
+  3: {
+    lookbackDays: 90,
+    slippageModel: SlippageModelType.FIXED,
+    slippageBps: 5,
+    tradingFee: 0.001,
+    preferredTimeframes: [MarketDataTimeframe.MINUTE, MarketDataTimeframe.HOUR]
+  },
+  4: {
+    lookbackDays: 60,
+    slippageModel: SlippageModelType.FIXED,
+    slippageBps: 5,
+    tradingFee: 0.001,
+    preferredTimeframes: [MarketDataTimeframe.MINUTE, MarketDataTimeframe.HOUR]
+  },
+  5: {
+    lookbackDays: 30,
+    slippageModel: SlippageModelType.FIXED,
+    slippageBps: 3,
+    tradingFee: 0.0008,
+    preferredTimeframes: [MarketDataTimeframe.MINUTE, MarketDataTimeframe.SECOND]
+  }
+};
+
+/** Default risk level when user's risk level is not set */
+export const DEFAULT_RISK_LEVEL = 3;
+
+/** Minimum capital for orchestrated backtests (in USD) */
+export const MIN_ORCHESTRATION_CAPITAL = 1000;
+
+/** Minimum dataset integrity score for selection */
+export const MIN_DATASET_INTEGRITY_SCORE = 70;
+
+/** Stagger interval between users in milliseconds (30 seconds) */
+export const STAGGER_INTERVAL_MS = 30_000;
+
+/**
+ * Job data passed to the orchestration queue processor
+ */
+export interface OrchestrationJobData {
+  /** User ID to process */
+  userId: string;
+  /** ISO timestamp when the job was scheduled */
+  scheduledAt: string;
+  /** User's risk level (used for config lookup) */
+  riskLevel: number;
+}
+
+/**
+ * Result of orchestration for a single user
+ */
+export interface OrchestrationResult {
+  /** User ID that was processed */
+  userId: string;
+  /** Number of backtests successfully created */
+  backtestsCreated: number;
+  /** IDs of created backtests */
+  backtestIds: string[];
+  /** Algorithms that were skipped with reasons */
+  skippedAlgorithms: SkippedAlgorithm[];
+  /** Any errors encountered during orchestration */
+  errors: string[];
+}
+
+/**
+ * Information about a skipped algorithm
+ */
+export interface SkippedAlgorithm {
+  /** Algorithm ID that was skipped */
+  algorithmId: string;
+  /** Algorithm name for logging */
+  algorithmName: string;
+  /** Reason the algorithm was skipped */
+  reason: string;
+}
+
+/**
+ * Extended configSnapshot fields added for orchestrated backtests.
+ * Merged with the base configSnapshot from BacktestService.createBacktest().
+ */
+export interface OrchestratedConfigSnapshot {
+  /** Flag indicating this backtest was created by orchestration */
+  orchestrated: true;
+  /** ISO timestamp when orchestration created this backtest */
+  orchestratedAt: string;
+  /** User's risk level at time of orchestration */
+  riskLevel: number;
+  /** Allow additional fields from base configSnapshot */
+  [key: string]: any;
+}
+
+/**
+ * Get risk configuration for a given risk level
+ * Falls back to default (level 3) if level is invalid
+ */
+export function getRiskConfig(riskLevel: number): RiskLevelConfig {
+  return RISK_CONFIG_MATRIX[riskLevel] ?? RISK_CONFIG_MATRIX[DEFAULT_RISK_LEVEL];
+}


### PR DESCRIPTION
## Summary
- Implement scheduled system that runs daily at 3 AM UTC to automatically create backtests for users with `algoTradingEnabled=true`
- Configure risk-appropriate backtest parameters using a 5-level risk matrix
- Add BullMQ queue processing with staggered job execution to prevent resource spikes

## Changes

### New Files
- `backtest-orchestration.dto.ts` - Risk configuration matrix (levels 1-5), job interfaces, typed config snapshot
- `backtest-orchestration.service.ts` - Core business logic:
  - User eligibility checking (`algoTradingEnabled` + valid risk assignment)
  - Capital calculation: `portfolioValue × userAllocation% × activationAllocation%` (min $1000)
  - Dataset selection with preferred timeframe matching and fallback
  - 24-hour deduplication to prevent duplicate backtests
- `backtest-orchestration.task.ts` - Daily cron job at 3 AM UTC with 30-second stagger between users
- `backtest-orchestration.processor.ts` - BullMQ worker with exponential backoff retry
- `*.spec.ts` - Unit tests for service, task, and processor
- Migration - Database indexes for efficient deduplication and eligibility queries

### Modified Files
- `tasks.module.ts` - Register new providers and BullMQ queue

## Risk Configuration Matrix

| Level | Description | Lookback | Slippage Model | BPS | Fee | Timeframes |
|-------|-------------|----------|----------------|-----|-----|------------|
| 1 | Conservative | 180 days | volume-based | 10 | 0.15% | HOUR, DAY |
| 2 | Low-Moderate | 120 days | volume-based | 8 | 0.12% | HOUR, DAY |
| 3 | Moderate | 90 days | fixed | 5 | 0.10% | MINUTE, HOUR |
| 4 | Moderate-High | 60 days | fixed | 5 | 0.10% | MINUTE, HOUR |
| 5 | Aggressive | 30 days | fixed | 3 | 0.08% | MINUTE, SECOND |

## Test Plan
- [x] Unit tests pass (676 total)
- [x] Build succeeds
- [x] Lint passes
- [ ] Run migration on staging
- [ ] Verify cron job triggers at 3 AM UTC
- [ ] Verify backtests created with `configSnapshot.orchestrated: true`

## Related Issues
Closes #94