### PR TITLE
refactor(api): resolve circular dependencies with interface-based DI

### DIFF
--- a/apps/api/src/algorithm/algorithm-activation.entity.ts
+++ b/apps/api/src/algorithm/algorithm-activation.entity.ts
@@ -8,13 +8,15 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Relation,
   UpdateDateColumn
 } from 'typeorm';
 
-import { Algorithm, AlgorithmConfig } from './algorithm.entity';
+import type { Algorithm } from './algorithm.entity';
+import { AlgorithmConfig } from './algorithm.entity';
 
-import { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
-import { User } from '../users/users.entity';
+import type { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
+import type { User } from '../users/users.entity';
 
 /**
  * AlgorithmActivation Entity
@@ -41,12 +43,12 @@ export class AlgorithmActivation {
   })
   userId: string;
 
-  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
+  @ManyToOne('User', { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   @ApiProperty({
     description: 'User who activated the algorithm'
   })
-  user: User;
+  user: Relation<User>;
 
   @Column({ type: 'uuid' })
   @ApiProperty({
@@ -55,12 +57,12 @@ export class AlgorithmActivation {
   })
   algorithmId: string;
 
-  @ManyToOne(() => Algorithm, { nullable: false, onDelete: 'CASCADE' })
+  @ManyToOne('Algorithm', { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'algorithmId' })
   @ApiProperty({
     description: 'Algorithm that is activated'
   })
-  algorithm: Algorithm;
+  algorithm: Relation<Algorithm>;
 
   @Column({ type: 'uuid' })
   @ApiProperty({
@@ -69,12 +71,12 @@ export class AlgorithmActivation {
   })
   exchangeKeyId: string;
 
-  @ManyToOne(() => ExchangeKey, { nullable: false, onDelete: 'CASCADE' })
+  @ManyToOne('ExchangeKey', { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'exchangeKeyId' })
   @ApiProperty({
     description: 'Exchange key to use for trading'
   })
-  exchangeKey: ExchangeKey;
+  exchangeKey: Relation<ExchangeKey>;
 
   @Column({ type: 'boolean', default: false })
   @ApiProperty({
@@ -88,7 +90,7 @@ export class AlgorithmActivation {
     description: 'Percentage of portfolio per trade (dynamically adjusted by ranking)',
     example: 1.5,
     minimum: 0.01,
-    maximum: 100.00
+    maximum: 100.0
   })
   allocationPercentage: number;
 

--- a/apps/api/src/algorithm/algorithm.module.ts
+++ b/apps/api/src/algorithm/algorithm.module.ts
@@ -28,7 +28,6 @@ import { SimpleMovingAverageCrossoverStrategy } from './strategies/simple-moving
 import { TripleEMAStrategy } from './strategies/triple-ema.strategy';
 import { PerformanceRankingTask } from './tasks/performance-ranking.task';
 
-import { AppModule } from '../app.module';
 import { Coin } from '../coin/coin.entity';
 import { CoinService } from '../coin/coin.service';
 import { TickerPairs } from '../coin/ticker-pairs/ticker-pairs.entity';
@@ -44,7 +43,6 @@ import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
-    forwardRef(() => AppModule),
     TypeOrmModule.forFeature([Algorithm, AlgorithmActivation, AlgorithmPerformance, Coin, Order, TickerPairs]),
     BullModule.registerQueue({ name: 'performance-ranking' }),
     SharedCacheModule,

--- a/apps/api/src/balance/balance.module.ts
+++ b/apps/api/src/balance/balance.module.ts
@@ -1,14 +1,14 @@
 import { BullModule } from '@nestjs/bullmq';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { ExchangeModule } from './../exchange/exchange.module';
 import { BalanceController } from './balance.controller';
 import { BalanceService } from './balance.service';
 import { HistoricalBalance } from './historical-balance.entity';
 import { BalanceSyncTask } from './tasks/balance-sync.task';
 
 import { CoinModule } from '../coin/coin.module';
+import { ExchangeModule } from '../exchange/exchange.module';
 import { SharedCacheModule } from '../shared-cache.module';
 import { UsersModule } from '../users/users.module';
 import { CustomCacheInterceptor } from '../utils/interceptors/custom-cache.interceptor';
@@ -16,14 +16,12 @@ import { CustomCacheInterceptor } from '../utils/interceptors/custom-cache.inter
 @Module({
   controllers: [BalanceController],
   imports: [
-    CoinModule,
-    ExchangeModule,
-    UsersModule,
-    SharedCacheModule,
     TypeOrmModule.forFeature([HistoricalBalance]),
-    BullModule.registerQueue({
-      name: 'balance-queue'
-    })
+    BullModule.registerQueue({ name: 'balance-queue' }),
+    SharedCacheModule,
+    forwardRef(() => CoinModule),
+    forwardRef(() => ExchangeModule),
+    forwardRef(() => UsersModule)
   ],
   providers: [BalanceService, BalanceSyncTask, CustomCacheInterceptor],
   exports: [BalanceService]

--- a/apps/api/src/category/category.module.ts
+++ b/apps/api/src/category/category.module.ts
@@ -1,5 +1,6 @@
+import { HttpModule } from '@nestjs/axios';
 import { BullModule } from '@nestjs/bullmq';
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CategoryController } from './category.controller';
@@ -7,14 +8,8 @@ import { Category } from './category.entity';
 import { CategoryService } from './category.service';
 import { CategorySyncTask } from './tasks/category-sync.task';
 
-import { AppModule } from '../app.module';
-
 @Module({
-  imports: [
-    forwardRef(() => AppModule),
-    TypeOrmModule.forFeature([Category]),
-    BullModule.registerQueue({ name: 'category-queue' })
-  ],
+  imports: [TypeOrmModule.forFeature([Category]), HttpModule, BullModule.registerQueue({ name: 'category-queue' })],
   providers: [CategoryService, CategorySyncTask],
   controllers: [CategoryController],
   exports: [CategoryService]

--- a/apps/api/src/coin/coin.entity.ts
+++ b/apps/api/src/coin/coin.entity.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn
+} from 'typeorm';
 
 import { TickerPairs } from './ticker-pairs/ticker-pairs.entity';
 
@@ -385,50 +393,50 @@ export class Coin {
   })
   updatedAt: Date;
 
-  @OneToMany(() => Order, (order) => order.baseCoin)
+  @OneToMany('Order', 'baseCoin')
   @ApiProperty({
     description: 'List of orders where this coin is the base coin',
     type: () => Order,
     isArray: true,
     required: false
   })
-  baseOrders: Order[];
+  baseOrders: Relation<Order[]>;
 
-  @OneToMany(() => Order, (order) => order.quoteCoin)
+  @OneToMany('Order', 'quoteCoin')
   @ApiProperty({
     description: 'List of orders where this coin is the quote coin',
     type: () => Order,
     isArray: true,
     required: false
   })
-  quoteOrders: Order[];
+  quoteOrders: Relation<Order[]>;
 
-  @OneToMany(() => Portfolio, (portfolio) => portfolio.coin)
+  @OneToMany('Portfolio', 'coin')
   @ApiProperty({
     description: 'List of portfolios associated with the coin',
     type: () => Portfolio,
     isArray: true,
     required: false
   })
-  portfolios: Portfolio[];
+  portfolios: Relation<Portfolio[]>;
 
-  @OneToMany(() => TickerPairs, (pair) => pair.baseAsset)
+  @OneToMany('TickerPairs', 'baseAsset')
   @ApiProperty({
     description: 'Trading pairs where this coin is the base asset',
     type: () => TickerPairs,
     isArray: true,
     required: false
   })
-  baseAssetPairs: TickerPairs[];
+  baseAssetPairs: Relation<TickerPairs[]>;
 
-  @OneToMany(() => TickerPairs, (pair) => pair.quoteAsset)
+  @OneToMany('TickerPairs', 'quoteAsset')
   @ApiProperty({
     description: 'Trading pairs where this coin is the quote asset',
     type: () => TickerPairs,
     isArray: true,
     required: false
   })
-  quoteAssetPairs: TickerPairs[];
+  quoteAssetPairs: Relation<TickerPairs[]>;
 
   constructor(partial: Partial<Coin>) {
     Object.assign(this, partial);

--- a/apps/api/src/coin/coin.module.ts
+++ b/apps/api/src/coin/coin.module.ts
@@ -11,7 +11,6 @@ import { TickerPairSyncTask } from './ticker-pairs/tasks/ticker-pairs-sync.task'
 import { TickerPairs } from './ticker-pairs/ticker-pairs.entity';
 import { TickerPairService } from './ticker-pairs/ticker-pairs.service';
 
-import { AppModule } from '../app.module';
 import { ExchangeKeyModule } from '../exchange/exchange-key/exchange-key.module';
 import { ExchangeModule } from '../exchange/exchange.module';
 import { OrderModule } from '../order/order.module';
@@ -22,7 +21,6 @@ import { SharedCacheModule } from '../shared-cache.module';
   controllers: [CoinController, CoinsController, SimplePriceController],
   exports: [CoinService, TickerPairService, TickerPairSyncTask],
   imports: [
-    forwardRef(() => AppModule),
     TypeOrmModule.forFeature([Coin, Portfolio, TickerPairs]),
     forwardRef(() => ExchangeModule),
     forwardRef(() => ExchangeKeyModule),

--- a/apps/api/src/coin/ticker-pairs/ticker-pairs.entity.ts
+++ b/apps/api/src/coin/ticker-pairs/ticker-pairs.entity.ts
@@ -10,6 +10,7 @@ import {
   Index,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Relation,
   Unique,
   UpdateDateColumn
 } from 'typeorm';
@@ -35,7 +36,7 @@ export class TickerPairs {
   id: string;
 
   @Index('ticker_pair_baseAssetId_index')
-  @ManyToOne(() => Coin, (coin) => coin.baseAssetPairs, {
+  @ManyToOne('Coin', 'baseAssetPairs', {
     cascade: true,
     eager: false,
     nullable: true,
@@ -46,9 +47,9 @@ export class TickerPairs {
     type: () => Coin,
     required: false
   })
-  baseAsset?: Coin;
+  baseAsset?: Relation<Coin>;
 
-  @ManyToOne(() => Coin, (coin) => coin.quoteAssetPairs, {
+  @ManyToOne('Coin', 'quoteAssetPairs', {
     cascade: true,
     eager: false,
     nullable: true,
@@ -59,7 +60,7 @@ export class TickerPairs {
     type: () => Coin,
     required: false
   })
-  quoteAsset?: Coin;
+  quoteAsset?: Relation<Coin>;
 
   @Column({ length: 20, update: false })
   @Length(1, 20)
@@ -176,11 +177,11 @@ export class TickerPairs {
   updatedAt: Date;
 
   @Index('ticker_pair_exchangeId_index')
-  @ManyToOne(() => Exchange, (exchange) => exchange.ticker, {
+  @ManyToOne('Exchange', 'ticker', {
     onDelete: 'CASCADE',
     eager: true
   })
-  exchange: Exchange;
+  exchange: Relation<Exchange>;
 
   @BeforeInsert()
   @BeforeUpdate()

--- a/apps/api/src/common/exceptions/auth/email-not-verified.exception.ts
+++ b/apps/api/src/common/exceptions/auth/email-not-verified.exception.ts
@@ -1,4 +1,5 @@
-import { ErrorCode, ForbiddenException } from '../';
+import { ForbiddenException } from '../base';
+import { ErrorCode } from '../error-codes.enum';
 
 /**
  * Thrown when a user attempts to log in without verifying their email.

--- a/apps/api/src/exchange/base-exchange.service.ts
+++ b/apps/api/src/exchange/base-exchange.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, InternalServerErrorException, Logger } from '@nestjs/common';
+import { Inject, InternalServerErrorException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import * as ccxt from 'ccxt';
@@ -6,8 +6,7 @@ import * as ccxt from 'ccxt';
 import * as http from 'http';
 import * as https from 'https';
 
-import { ExchangeKeyService } from './exchange-key/exchange-key.service';
-import { ExchangeService } from './exchange.service';
+import { EXCHANGE_KEY_SERVICE, EXCHANGE_SERVICE, IExchangeKeyService, IExchangeService } from './interfaces';
 
 import { AssetBalanceDto } from '../balance/dto/balance-response.dto';
 import { User } from '../users/users.entity';
@@ -26,10 +25,10 @@ export abstract class BaseExchangeService {
 
   constructor(
     protected readonly configService?: ConfigService,
-    @Inject(forwardRef(() => ExchangeKeyService))
-    protected readonly exchangeKeyService?: ExchangeKeyService,
-    @Inject(forwardRef(() => ExchangeService))
-    protected readonly exchangeService?: ExchangeService
+    @Inject(EXCHANGE_KEY_SERVICE)
+    protected readonly exchangeKeyService?: IExchangeKeyService,
+    @Inject(EXCHANGE_SERVICE)
+    protected readonly exchangeService?: IExchangeService
   ) {}
 
   /**

--- a/apps/api/src/exchange/exchange-key/dto/index.ts
+++ b/apps/api/src/exchange/exchange-key/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './create-exchange-key.dto';
-export * from './update-exchange-key.dto';
 export * from './exchange-key-response.dto';
+export * from './supported-exchange-key.dto';
+export * from './update-exchange-key.dto';

--- a/apps/api/src/exchange/exchange-key/dto/supported-exchange-key.dto.ts
+++ b/apps/api/src/exchange/exchange-key/dto/supported-exchange-key.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * DTO representing a user's supported exchange key with exchange details.
+ * Used when checking which exchanges a user has active keys for.
+ */
+export class SupportedExchangeKeyDto {
+  @ApiProperty({
+    description: 'Unique identifier for the exchange key',
+    example: 'a3bb189e-8bf9-3888-9912-ace4e6543002'
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'The exchange ID this key belongs to',
+    example: 'a3bb189e-8bf9-3888-9912-ace4e6543002'
+  })
+  exchangeId: string;
+
+  @ApiProperty({
+    description: 'Whether this exchange key is active and validated',
+    example: true
+  })
+  isActive: boolean;
+
+  @ApiProperty({
+    description: 'The name of the exchange',
+    example: 'Binance US'
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'The slug identifier for the exchange',
+    example: 'binance_us'
+  })
+  slug: string;
+
+  @ApiPropertyOptional({
+    description: 'Decrypted API key (only included for internal/top-level requests)',
+    example: 'abc123...'
+  })
+  decryptedApiKey?: string;
+
+  @ApiPropertyOptional({
+    description: 'Decrypted secret key (only included for internal/top-level requests)',
+    example: 'xyz789...'
+  })
+  decryptedSecretKey?: string;
+}

--- a/apps/api/src/exchange/exchange-key/exchange-key.entity.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key.entity.ts
@@ -9,14 +9,15 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Relation,
   UpdateDateColumn
 } from 'typeorm';
 
 import { createCipheriv, createDecipheriv, randomBytes, scrypt, scryptSync } from 'crypto';
 import { promisify } from 'util';
 
-import { User } from '../../users/users.entity';
-import { Exchange } from '../exchange.entity';
+import type { User } from '../../users/users.entity';
+import type { Exchange } from '../exchange.entity';
 
 @Entity()
 export class ExchangeKey {
@@ -27,22 +28,22 @@ export class ExchangeKey {
   })
   id: string;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne('User', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   @ApiProperty({
     description: 'User that owns this exchange key'
   })
-  user: User;
+  user: Relation<User>;
 
   @Column()
   userId: string;
 
-  @ManyToOne(() => Exchange, { onDelete: 'CASCADE' })
+  @ManyToOne('Exchange', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'exchangeId' })
   @ApiProperty({
-    description: 'Exchange this key belongs o'
+    description: 'Exchange this key belongs to'
   })
-  exchange: Exchange;
+  exchange: Relation<Exchange>;
 
   @Column({ nullable: true })
   exchangeId: string;

--- a/apps/api/src/exchange/exchange-key/exchange-key.module.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key.module.ts
@@ -8,6 +8,7 @@ import { ExchangeKeyService } from './exchange-key.service';
 
 import { User } from '../../users/users.entity';
 import { ExchangeModule } from '../exchange.module';
+import { EXCHANGE_KEY_SERVICE } from '../interfaces';
 
 @Module({
   imports: [
@@ -16,7 +17,13 @@ import { ExchangeModule } from '../exchange.module';
     BullModule.registerQueue({ name: 'order-queue' })
   ],
   controllers: [ExchangeKeyController],
-  providers: [ExchangeKeyService],
-  exports: [ExchangeKeyService]
+  providers: [
+    ExchangeKeyService,
+    {
+      provide: EXCHANGE_KEY_SERVICE,
+      useExisting: ExchangeKeyService
+    }
+  ],
+  exports: [ExchangeKeyService, EXCHANGE_KEY_SERVICE]
 })
 export class ExchangeKeyModule {}

--- a/apps/api/src/exchange/exchange-key/exchange-key.service.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key.service.ts
@@ -1,25 +1,30 @@
 import { InjectQueue } from '@nestjs/bullmq';
-import { forwardRef, Inject, Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Queue } from 'bullmq';
 import { Repository } from 'typeorm';
 
-import { CreateExchangeKeyDto } from './dto';
+import { CreateExchangeKeyDto, SupportedExchangeKeyDto } from './dto';
 import { ExchangeKey } from './exchange-key.entity';
 
-import { ExchangeManagerService } from '../exchange-manager.service';
-import { ExchangeService } from '../exchange.service';
+import {
+  EXCHANGE_MANAGER_SERVICE,
+  EXCHANGE_SERVICE,
+  IExchangeKeyService,
+  IExchangeManagerService,
+  IExchangeService
+} from '../interfaces';
 
 @Injectable()
-export class ExchangeKeyService {
+export class ExchangeKeyService implements IExchangeKeyService {
   constructor(
     @InjectRepository(ExchangeKey)
     private readonly exchangeKeyRepository: Repository<ExchangeKey>,
-    @Inject(forwardRef(() => ExchangeService))
-    private readonly exchangeService: ExchangeService,
-    @Inject(forwardRef(() => ExchangeManagerService))
-    private readonly exchangeManagerService: ExchangeManagerService,
+    @Inject(EXCHANGE_SERVICE)
+    private readonly exchangeService: IExchangeService,
+    @Inject(EXCHANGE_MANAGER_SERVICE)
+    private readonly exchangeManagerService: IExchangeManagerService,
     @InjectQueue('order-queue') private readonly orderQueue: Queue
   ) {}
 
@@ -31,36 +36,27 @@ export class ExchangeKeyService {
   }
 
   /**
-   * Checks if a user has any active keys for supported exchanges and returns exchange details
-   * @param userId - The ID of the user to check
-   * @returns An object containing a boolean flag and the list of supported exchanges with active keys
+   * Gets the user's exchange keys for supported exchanges with exchange details.
+   * Returns a deduplicated list of supported exchange keys with their exchange information.
+   *
+   * @param userId - The ID of the user
+   * @param includeSecrets - Whether to include decrypted API keys (for internal use only)
+   * @returns List of supported exchange keys with exchange details
    */
-  async hasSupportedExchangeKeys(userId: string, top_level = false): Promise<ExchangeKey[]> {
+  async getSupportedExchangeKeys(userId: string, includeSecrets = false): Promise<SupportedExchangeKeyDto[]> {
     const keys = await this.exchangeKeyRepository.find({
-      where: {
-        userId
-      },
+      where: { userId },
       relations: ['exchange']
     });
 
     const supportedExchangeKeys = keys.filter((key) => key.exchange?.supported === true);
 
     // Create a map to deduplicate exchanges (user might have multiple keys for same exchange)
-    const exchangeMap = new Map<string, any>();
+    const exchangeMap = new Map<string, SupportedExchangeKeyDto>();
 
-    supportedExchangeKeys.forEach((key) => {
+    for (const key of supportedExchangeKeys) {
       if (key.exchange) {
-        interface ExchangeKeyData {
-          id: string;
-          exchangeId: string;
-          isActive: boolean;
-          name: string;
-          slug: string;
-          decryptedApiKey?: string;
-          decryptedSecretKey?: string;
-        }
-
-        const keyData: ExchangeKeyData = {
+        const keyDto: SupportedExchangeKeyDto = {
           id: key.id,
           exchangeId: key.exchange.id,
           isActive: key.isActive,
@@ -68,20 +64,18 @@ export class ExchangeKeyService {
           slug: key.exchange.slug
         };
 
-        // Include decrypted API keys when top_level is true
-        // This will make them available for internal services without exposing them externally
-        if (top_level) {
-          keyData.decryptedApiKey = key.decryptedApiKey;
-          keyData.decryptedSecretKey = key.decryptedSecretKey;
+        // Include decrypted API keys when includeSecrets is true
+        // This makes them available for internal services without exposing them externally
+        if (includeSecrets) {
+          keyDto.decryptedApiKey = key.decryptedApiKey;
+          keyDto.decryptedSecretKey = key.decryptedSecretKey;
         }
 
-        exchangeMap.set(key.exchange.id, keyData);
+        exchangeMap.set(key.exchange.id, keyDto);
       }
-    });
+    }
 
-    const exchanges = Array.from(exchangeMap.values());
-
-    return exchanges;
+    return Array.from(exchangeMap.values());
   }
 
   async findOne(id: string, userId: string): Promise<ExchangeKey> {

--- a/apps/api/src/exchange/exchange-manager.service.ts
+++ b/apps/api/src/exchange/exchange-manager.service.ts
@@ -1,23 +1,22 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 import * as ccxt from 'ccxt';
 
-import { BaseExchangeService } from './base-exchange.service';
 import { BinanceUSService } from './binance/binance-us.service';
 import { CoinbaseExchangeService } from './coinbase-exchange/coinbase-exchange.service';
 // eslint-disable-next-line import/order
 import { CoinbaseService } from './coinbase/coinbase.service';
-import { ExchangeService } from './exchange.service';
+import { EXCHANGE_SERVICE, IBaseExchangeService, IExchangeManagerService, IExchangeService } from './interfaces';
 import { KrakenService } from './kraken/kraken.service';
 
-import { User } from '../users/users.entity';
+import type { User } from '../users/users.entity';
 
 /**
  * Centralized exchange manager that provides access to all exchange services
  * Leverages the existing BaseExchangeService implementations without duplicating functionality
  */
 @Injectable()
-export class ExchangeManagerService {
+export class ExchangeManagerService implements IExchangeManagerService {
   private readonly logger = new Logger(ExchangeManagerService.name);
 
   constructor(
@@ -25,8 +24,8 @@ export class ExchangeManagerService {
     private readonly coinbaseService: CoinbaseService,
     private readonly coinbaseExchangeService: CoinbaseExchangeService,
     private readonly krakenService: KrakenService,
-    @Inject(forwardRef(() => ExchangeService))
-    private readonly exchangeService: ExchangeService
+    @Inject(EXCHANGE_SERVICE)
+    private readonly exchangeService: IExchangeService
   ) {}
 
   /**
@@ -34,7 +33,7 @@ export class ExchangeManagerService {
    * @param exchangeSlug The exchange identifier
    * @returns The exchange service instance
    */
-  getExchangeService(exchangeSlug: string): BaseExchangeService {
+  getExchangeService(exchangeSlug: string): IBaseExchangeService {
     switch (exchangeSlug) {
       case 'binance_us':
         return this.binanceUSService;

--- a/apps/api/src/exchange/exchange.entity.ts
+++ b/apps/api/src/exchange/exchange.entity.ts
@@ -1,6 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { Column, CreateDateColumn, Entity, Index, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn
+} from 'typeorm';
 
 import { TickerPairs } from '../coin/ticker-pairs/ticker-pairs.entity';
 
@@ -185,7 +194,7 @@ export class Exchange {
   @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt: Date;
 
-  @OneToMany(() => TickerPairs, (ticker) => ticker.exchange, {
+  @OneToMany('TickerPairs', 'exchange', {
     cascade: true,
     onDelete: 'CASCADE',
     eager: false
@@ -194,7 +203,7 @@ export class Exchange {
     description: 'List of ticker pairs associated with the exchange',
     type: () => [TickerPairs]
   })
-  ticker: TickerPairs[];
+  ticker: Relation<TickerPairs[]>;
 
   constructor(partial: Partial<Exchange>) {
     Object.assign(this, partial);

--- a/apps/api/src/exchange/exchange.module.ts
+++ b/apps/api/src/exchange/exchange.module.ts
@@ -12,10 +12,10 @@ import { ExchangeManagerService } from './exchange-manager.service';
 import { ExchangeController } from './exchange.controller';
 import { Exchange } from './exchange.entity';
 import { ExchangeService } from './exchange.service';
+import { EXCHANGE_MANAGER_SERVICE, EXCHANGE_SERVICE } from './interfaces';
 import { KrakenService } from './kraken/kraken.service';
 import { ExchangeSyncTask } from './tasks/exchange-sync.task';
 
-import { AppModule } from '../app.module';
 import { Coin } from '../coin/coin.entity';
 import { CoinService } from '../coin/coin.service';
 import { TickerPairs } from '../coin/ticker-pairs/ticker-pairs.entity';
@@ -25,7 +25,6 @@ import { SharedCacheModule } from '../shared-cache.module';
 @Module({
   controllers: [ExchangeController],
   imports: [
-    forwardRef(() => AppModule),
     TypeOrmModule.forFeature([Coin, Exchange, ExchangeKey, TickerPairs]),
     forwardRef(() => ExchangeKeyModule),
     SharedCacheModule,
@@ -38,17 +37,27 @@ import { SharedCacheModule } from '../shared-cache.module';
     KrakenService,
     CoinService,
     ExchangeService,
+    {
+      provide: EXCHANGE_SERVICE,
+      useExisting: ExchangeService
+    },
     ExchangeSyncTask,
     ExchangeManagerService,
+    {
+      provide: EXCHANGE_MANAGER_SERVICE,
+      useExisting: ExchangeManagerService
+    },
     TickerPairService
   ],
   exports: [
     ExchangeService,
+    EXCHANGE_SERVICE,
     BinanceUSService,
     CoinbaseService,
     CoinbaseExchangeService,
     KrakenService,
-    ExchangeManagerService
+    ExchangeManagerService,
+    EXCHANGE_MANAGER_SERVICE
   ]
 })
 export class ExchangeModule {}

--- a/apps/api/src/exchange/exchange.service.spec.ts
+++ b/apps/api/src/exchange/exchange.service.spec.ts
@@ -1,61 +1,58 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { ExchangeKeyService } from './exchange-key/exchange-key.service';
 import { Exchange } from './exchange.entity';
 import { ExchangeService } from './exchange.service';
+import { EXCHANGE_KEY_SERVICE } from './interfaces';
 
 import { TickerPairService } from '../coin/ticker-pairs/ticker-pairs.service';
+import { ExchangeNotFoundException } from '../common/exceptions/resource';
 
 describe('ExchangeService', () => {
   let service: ExchangeService;
+  let exchangeRepository: {
+    find: jest.Mock;
+    findOne: jest.Mock;
+    insert: jest.Mock;
+    save: jest.Mock;
+    delete: jest.Mock;
+  };
+  let exchangeKeyService: {
+    findByExchange: jest.Mock;
+  };
+  let tickerPairService: {
+    getTickerPairsByExchange: jest.Mock;
+  };
 
   beforeEach(async () => {
+    exchangeRepository = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      insert: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn()
+    };
+    exchangeKeyService = {
+      findByExchange: jest.fn()
+    };
+    tickerPairService = {
+      getTickerPairsByExchange: jest.fn()
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ExchangeService,
         {
           provide: getRepositoryToken(Exchange),
-          useValue: {
-            find: jest.fn(() => []),
-            findOne: jest.fn(() => ({})),
-            save: jest.fn(() => ({})),
-            update: jest.fn(() => ({})),
-            delete: jest.fn(() => ({}))
-          }
+          useValue: exchangeRepository
         },
         {
-          provide: ExchangeKeyService,
-          useValue: {
-            findAll: jest.fn(() => []),
-            findOne: jest.fn(() => ({})),
-            findByExchange: jest.fn(() => []),
-            create: jest.fn(() => ({})),
-            update: jest.fn(() => ({})),
-            remove: jest.fn(() => ({}))
-          }
+          provide: EXCHANGE_KEY_SERVICE,
+          useValue: exchangeKeyService
         },
         {
           provide: TickerPairService,
-          useValue: {
-            getTickerPairs: jest.fn(() => []),
-            getTickerPairsByExchange: jest.fn(() => []),
-            getTickerPairBySymbol: jest.fn(() => ({})),
-            getBasePairsBySymbol: jest.fn(() => []),
-            getQuotePairsBySymbol: jest.fn(() => []),
-            getBasePairsById: jest.fn(() => ({})),
-            createTickerPair: jest.fn(() => ({})),
-            removeTickerPair: jest.fn(),
-            saveTickerPair: jest.fn(() => [])
-          }
-        },
-        {
-          provide: 'BullQueue_exchange-queue',
-          useValue: {
-            add: jest.fn(),
-            getRepeatableJobs: jest.fn()
-            // Add other methods as needed for your tests
-          }
+          useValue: tickerPairService
         }
       ]
     }).compile();
@@ -63,7 +60,142 @@ describe('ExchangeService', () => {
     service = module.get<ExchangeService>(ExchangeService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('gets exchanges with supported filtering and removes nulls', async () => {
+    exchangeRepository.find.mockResolvedValueOnce([
+      { id: '1', name: 'Binance', supported: true, description: null } as Exchange
+    ]);
+
+    const result = await service.getExchanges({ supported: true });
+
+    expect(exchangeRepository.find).toHaveBeenCalledWith({
+      where: { supported: true },
+      order: { name: 'ASC' }
+    });
+    expect(result[0]).not.toHaveProperty('description');
+  });
+
+  it('throws when exchange id is missing', async () => {
+    exchangeRepository.findOne.mockResolvedValueOnce(null);
+
+    await expect(service.getExchangeById('missing-id')).rejects.toBeInstanceOf(ExchangeNotFoundException);
+  });
+
+  describe('createExchange', () => {
+    it('returns existing exchange when name already exists', async () => {
+      const existing = { id: '1', name: 'Binance' } as Exchange;
+      exchangeRepository.findOne.mockResolvedValueOnce(existing);
+
+      const dto = { name: 'Binance', url: 'https://binance.com', supported: true };
+      const result = await service.createExchange(dto);
+
+      expect(exchangeRepository.insert).not.toHaveBeenCalled();
+      expect(result).toBe(existing);
+    });
+
+    it('inserts and returns generated exchange when name is new', async () => {
+      exchangeRepository.findOne.mockResolvedValueOnce(null);
+      exchangeRepository.insert.mockResolvedValueOnce({ generatedMaps: [{ id: 'new-id' }] });
+
+      const dto = { name: 'Kraken', url: 'https://kraken.com', supported: true };
+      const result = await service.createExchange(dto);
+
+      expect(exchangeRepository.insert).toHaveBeenCalledWith(dto);
+      expect(result).toEqual({ id: 'new-id' });
+    });
+  });
+
+  describe('deleteExchange', () => {
+    it('throws when delete affects no rows', async () => {
+      exchangeRepository.delete.mockResolvedValueOnce({ affected: 0 });
+
+      await expect(service.deleteExchange('missing-id')).rejects.toBeInstanceOf(ExchangeNotFoundException);
+    });
+
+    it('returns delete response when successful', async () => {
+      const response = { affected: 1 };
+      exchangeRepository.delete.mockResolvedValueOnce(response);
+
+      const result = await service.deleteExchange('existing-id');
+
+      expect(result).toBe(response);
+    });
+  });
+
+  it('maps ticker pairs into response format', async () => {
+    const exchangeId = 'exchange-1';
+    const lastTraded = new Date('2024-01-01T00:00:00.000Z');
+    const fetchAt = new Date('2024-01-02T00:00:00.000Z');
+
+    jest.spyOn(service, 'getExchangeById').mockResolvedValueOnce({ id: exchangeId } as Exchange);
+    tickerPairService.getTickerPairsByExchange.mockResolvedValueOnce([
+      {
+        baseAsset: null,
+        baseAssetSymbol: 'USD',
+        quoteAsset: {
+          id: 'btc-id',
+          name: 'Bitcoin',
+          symbol: 'BTC',
+          slug: 'bitcoin'
+        },
+        quoteAssetSymbol: 'BTC',
+        volume: 10,
+        tradeUrl: 'https://trade.example.com',
+        spreadPercentage: 0.1,
+        lastTraded,
+        status: 'active',
+        isSpotTradingAllowed: true,
+        isMarginTradingAllowed: false,
+        isFiatPair: true,
+        fetchAt
+      }
+    ]);
+
+    const result = await service.getExchangeTickers(exchangeId);
+
+    expect(service.getExchangeById).toHaveBeenCalledWith(exchangeId);
+    expect(tickerPairService.getTickerPairsByExchange).toHaveBeenCalledWith(exchangeId);
+    expect(result).toEqual([
+      {
+        symbol: 'USD/BTC',
+        base: 'USD',
+        quote: 'BTC',
+        baseAsset: {
+          id: null,
+          name: 'USD',
+          symbol: 'USD',
+          slug: 'USD'
+        },
+        quoteAsset: {
+          id: 'btc-id',
+          name: 'Bitcoin',
+          symbol: 'BTC',
+          slug: 'bitcoin'
+        },
+        volume: 10,
+        tradeUrl: 'https://trade.example.com',
+        spreadPercentage: 0.1,
+        lastTraded,
+        status: 'active',
+        isSpotTradingAllowed: true,
+        isMarginTradingAllowed: false,
+        isFiatPair: true,
+        fetchAt,
+        currentPrice: null
+      }
+    ]);
+  });
+
+  it('filters exchanges to ones with active user keys', async () => {
+    const exchanges = [{ id: 'one', supported: true } as Exchange, { id: 'two', supported: true } as Exchange];
+
+    jest.spyOn(service, 'getExchanges').mockResolvedValueOnce(exchanges);
+    exchangeKeyService.findByExchange.mockResolvedValueOnce([{ isActive: true }]);
+    exchangeKeyService.findByExchange.mockResolvedValueOnce([{ isActive: false }]);
+
+    const result = await service.findAllWithUserKeys('user-1');
+
+    expect(exchangeKeyService.findByExchange).toHaveBeenCalledWith('one', 'user-1');
+    expect(exchangeKeyService.findByExchange).toHaveBeenCalledWith('two', 'user-1');
+    expect(result).toEqual([exchanges[0]]);
   });
 });

--- a/apps/api/src/exchange/exchange.service.ts
+++ b/apps/api/src/exchange/exchange.service.ts
@@ -1,21 +1,21 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { In, Repository } from 'typeorm';
 
 import { CreateExchangeDto, UpdateExchangeDto } from './dto';
-import { ExchangeKeyService } from './exchange-key/exchange-key.service';
 import { Exchange } from './exchange.entity';
+import { EXCHANGE_KEY_SERVICE, IExchangeKeyService, IExchangeService } from './interfaces';
 
 import { TickerPairService } from '../coin/ticker-pairs/ticker-pairs.service';
 import { ExchangeNotFoundException } from '../common/exceptions/resource';
 
 @Injectable()
-export class ExchangeService {
+export class ExchangeService implements IExchangeService {
   constructor(
     @InjectRepository(Exchange) private readonly exchange: Repository<Exchange>,
-    @Inject(forwardRef(() => ExchangeKeyService))
-    private readonly exchangeKeyService: ExchangeKeyService,
+    @Inject(EXCHANGE_KEY_SERVICE)
+    private readonly exchangeKeyService: IExchangeKeyService,
     private readonly tickerPairService: TickerPairService
   ) {}
 

--- a/apps/api/src/exchange/interfaces/base-exchange.interface.ts
+++ b/apps/api/src/exchange/interfaces/base-exchange.interface.ts
@@ -1,0 +1,26 @@
+import * as ccxt from 'ccxt';
+
+import type { AssetBalanceDto } from '../../balance/dto/balance-response.dto';
+import type { User } from '../../users/users.entity';
+
+/**
+ * DI token for IBaseExchangeService implementations
+ */
+export const BASE_EXCHANGE_SERVICE = Symbol('BASE_EXCHANGE_SERVICE');
+
+/**
+ * Interface for BaseExchangeService implementations
+ * Used to break circular dependencies between exchange-related services
+ */
+export interface IBaseExchangeService {
+  getClient(user?: User): Promise<ccxt.Exchange>;
+  getDefaultClient(): Promise<ccxt.Exchange>;
+  getPublicClient(): Promise<ccxt.Exchange>;
+  getTemporaryClient(apiKey: string, apiSecret: string): Promise<ccxt.Exchange>;
+  getBalance(user: User): Promise<AssetBalanceDto[]>;
+  getFreeBalance(user: User): Promise<AssetBalanceDto[]>;
+  getPriceBySymbol(symbol: string, user?: User): Promise<number>;
+  getPrice(symbol: string, user?: User): Promise<{ symbol: string; price: string; timestamp: number }>;
+  validateKeys(apiKey: string, apiSecret: string): Promise<void>;
+  formatSymbol(symbol: string): string;
+}

--- a/apps/api/src/exchange/interfaces/exchange-key.interface.ts
+++ b/apps/api/src/exchange/interfaces/exchange-key.interface.ts
@@ -1,0 +1,18 @@
+import type { SupportedExchangeKeyDto } from '../exchange-key/dto';
+import type { ExchangeKey } from '../exchange-key/exchange-key.entity';
+
+/**
+ * Interface for ExchangeKeyService
+ * Used to break circular dependencies between exchange-related services
+ */
+export interface IExchangeKeyService {
+  findAll(userId: string): Promise<ExchangeKey[]>;
+  findOneByExchangeId(exchangeId: string, userId: string): Promise<ExchangeKey | null>;
+  findByExchange(exchangeId: string, userId: string): Promise<ExchangeKey[]>;
+  getSupportedExchangeKeys(userId: string, includeSecrets?: boolean): Promise<SupportedExchangeKeyDto[]>;
+}
+
+/**
+ * DI token for IExchangeKeyService
+ */
+export const EXCHANGE_KEY_SERVICE = Symbol('EXCHANGE_KEY_SERVICE');

--- a/apps/api/src/exchange/interfaces/exchange-manager.interface.ts
+++ b/apps/api/src/exchange/interfaces/exchange-manager.interface.ts
@@ -1,0 +1,36 @@
+import * as ccxt from 'ccxt';
+
+import type { IBaseExchangeService } from './base-exchange.interface';
+
+import type { AssetBalanceDto } from '../../balance/dto/balance-response.dto';
+import type { User } from '../../users/users.entity';
+
+/**
+ * Interface for ExchangeManagerService
+ * Used to break circular dependencies between exchange-related services
+ */
+export interface IExchangeManagerService {
+  getExchangeService(exchangeSlug: string): IBaseExchangeService;
+  getExchangeClient(exchangeSlug: string, user?: User): Promise<ccxt.Exchange>;
+  getPublicClient(exchangeSlug?: string): Promise<ccxt.Exchange>;
+  getPrice(
+    exchangeSlug: string,
+    symbol: string,
+    user?: User
+  ): Promise<{ symbol: string; price: string; timestamp: number }>;
+  getBalance(exchangeSlug: string, user: User): Promise<AssetBalanceDto[]>;
+  formatSymbol(exchangeSlug: string, symbol: string): string;
+  getBalancesFromAllExchanges(user: User): Promise<
+    Array<{
+      exchange: string;
+      success: boolean;
+      data?: AssetBalanceDto[];
+      error?: string;
+    }>
+  >;
+}
+
+/**
+ * DI token for IExchangeManagerService
+ */
+export const EXCHANGE_MANAGER_SERVICE = Symbol('EXCHANGE_MANAGER_SERVICE');

--- a/apps/api/src/exchange/interfaces/exchange.interface.ts
+++ b/apps/api/src/exchange/interfaces/exchange.interface.ts
@@ -1,0 +1,19 @@
+import type { Exchange } from '../exchange.entity';
+
+/**
+ * Interface for ExchangeService
+ * Used to break circular dependencies between exchange-related services
+ */
+export interface IExchangeService {
+  findOne(id: string): Promise<Exchange>;
+  findBySlug(slug: string): Promise<Exchange>;
+  getExchanges(options?: { supported?: boolean }): Promise<Exchange[]>;
+  getExchangeById(exchangeId: string): Promise<Exchange>;
+  getExchangeByName(name: string): Promise<Exchange>;
+  findAllWithUserKeys(userId: string): Promise<Exchange[]>;
+}
+
+/**
+ * DI token for IExchangeService
+ */
+export const EXCHANGE_SERVICE = Symbol('EXCHANGE_SERVICE');

--- a/apps/api/src/exchange/interfaces/index.ts
+++ b/apps/api/src/exchange/interfaces/index.ts
@@ -1,0 +1,4 @@
+export * from './base-exchange.interface';
+export * from './exchange-key.interface';
+export * from './exchange-manager.interface';
+export * from './exchange.interface';

--- a/apps/api/src/optimization/entities/optimization-result.entity.ts
+++ b/apps/api/src/optimization/entities/optimization-result.entity.ts
@@ -1,6 +1,15 @@
-import { Column, CreateDateColumn, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation
+} from 'typeorm';
 
-import { OptimizationRun } from './optimization-run.entity';
+import type { OptimizationRun } from './optimization-run.entity';
 
 /**
  * Window result within an optimization result
@@ -31,9 +40,9 @@ export class OptimizationResult {
   @Column({ type: 'uuid' })
   optimizationRunId: string;
 
-  @ManyToOne(() => OptimizationRun, (run) => run.results, { onDelete: 'CASCADE' })
+  @ManyToOne('OptimizationRun', 'results', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'optimizationRunId' })
-  optimizationRun: OptimizationRun;
+  optimizationRun: Relation<OptimizationRun>;
 
   @Column({ type: 'int' })
   combinationIndex: number;

--- a/apps/api/src/optimization/entities/optimization-run.entity.ts
+++ b/apps/api/src/optimization/entities/optimization-run.entity.ts
@@ -6,8 +6,11 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
-  PrimaryGeneratedColumn
+  PrimaryGeneratedColumn,
+  Relation
 } from 'typeorm';
+
+import type { OptimizationResult } from './optimization-result.entity';
 
 import { StrategyConfig } from '../../strategy/entities/strategy-config.entity';
 import { OptimizationConfig, ParameterSpace } from '../interfaces';
@@ -135,5 +138,5 @@ export class OptimizationRun {
   completedAt: Date;
 
   @OneToMany('OptimizationResult', 'optimizationRun')
-  results: import('./optimization-result.entity').OptimizationResult[];
+  results: Relation<OptimizationResult[]>;
 }

--- a/apps/api/src/order/backtest/backtest.entity.ts
+++ b/apps/api/src/order/backtest/backtest.entity.ts
@@ -10,6 +10,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  Relation,
   UpdateDateColumn
 } from 'typeorm';
 
@@ -176,22 +177,22 @@ export class Backtest {
   completedAt?: Date;
 
   @Index('backtest_userId_index')
-  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
+  @ManyToOne('User', { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn()
   @ApiProperty({ description: 'User who created the backtest' })
-  user: User;
+  user: Relation<User>;
 
   @Index('backtest_algorithmId_index')
-  @ManyToOne(() => Algorithm, { nullable: false, onDelete: 'CASCADE' })
+  @ManyToOne('Algorithm', { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn()
   @ApiProperty({ description: 'Algorithm used for the backtest' })
-  algorithm: Algorithm;
+  algorithm: Relation<Algorithm>;
 
   @IsOptional()
-  @ManyToOne(() => MarketDataSet, (dataset) => dataset.backtests, { nullable: true, onDelete: 'SET NULL' })
+  @ManyToOne('MarketDataSet', 'backtests', { nullable: true, onDelete: 'SET NULL' })
   @JoinColumn()
   @ApiProperty({ description: 'Market data set leveraged for the run', required: false, type: () => MarketDataSet })
-  marketDataSet?: MarketDataSet;
+  marketDataSet?: Relation<MarketDataSet>;
 
   @OneToMany(() => BacktestTrade, (trade) => trade.backtest, { cascade: true })
   @ApiProperty({ description: 'Trades executed during the backtest', type: () => [BacktestTrade] })
@@ -308,15 +309,15 @@ export class BacktestTrade {
   @ApiProperty({ description: 'Backtest this trade belongs to' })
   backtest: Backtest;
 
-  @ManyToOne(() => Coin, { nullable: false })
+  @ManyToOne('Coin', { nullable: false })
   @JoinColumn()
   @ApiProperty({ description: 'Base coin being traded' })
-  baseCoin: Coin;
+  baseCoin: Relation<Coin>;
 
-  @ManyToOne(() => Coin, { nullable: false })
+  @ManyToOne('Coin', { nullable: false })
   @JoinColumn()
   @ApiProperty({ description: 'Quote coin (usually USD/USDT)' })
-  quoteCoin: Coin;
+  quoteCoin: Relation<Coin>;
 
   constructor(partial: Partial<BacktestTrade>) {
     Object.assign(this, partial);

--- a/apps/api/src/order/backtest/market-data-set.entity.ts
+++ b/apps/api/src/order/backtest/market-data-set.entity.ts
@@ -1,7 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { IsBoolean, IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
-import { Column, CreateDateColumn, Entity, Index, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { IsBoolean, IsEnum, IsInt, IsNotEmpty, IsString, Max, Min } from 'class-validator';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn
+} from 'typeorm';
 
 import { Backtest } from './backtest.entity';
 
@@ -89,7 +98,7 @@ export class MarketDataSet {
   @ApiProperty({ description: 'Last time dataset metadata was updated' })
   updatedAt: Date;
 
-  @OneToMany(() => Backtest, (backtest) => backtest.marketDataSet)
+  @OneToMany('Backtest', 'marketDataSet')
   @ApiProperty({ description: 'Backtests referencing this dataset', type: () => [Backtest] })
-  backtests: Backtest[];
+  backtests: Relation<Backtest[]>;
 }

--- a/apps/api/src/order/order.entity.ts
+++ b/apps/api/src/order/order.entity.ts
@@ -2,7 +2,16 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { Transform } from 'class-transformer';
 import { IsDate, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, Min } from 'class-validator';
-import { Column, CreateDateColumn, Entity, Index, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn
+} from 'typeorm';
 
 import { AlgorithmActivation } from '../algorithm/algorithm-activation.entity';
 import { Coin } from '../coin/coin.entity';
@@ -312,7 +321,7 @@ export class Order {
   })
   type: OrderType;
 
-  @ManyToOne(() => User, (user) => user.orders, {
+  @ManyToOne('User', 'orders', {
     nullable: false,
     onDelete: 'CASCADE'
   })
@@ -320,9 +329,9 @@ export class Order {
     description: 'User who placed the order',
     type: () => User
   })
-  user: User;
+  user: Relation<User>;
 
-  @ManyToOne(() => Coin, (coin) => coin.baseOrders, {
+  @ManyToOne('Coin', 'baseOrders', {
     nullable: true,
     onDelete: 'SET NULL'
   })
@@ -331,9 +340,9 @@ export class Order {
     type: () => Coin,
     required: false
   })
-  baseCoin?: Coin;
+  baseCoin?: Relation<Coin>;
 
-  @ManyToOne(() => Coin, (coin) => coin.quoteOrders, {
+  @ManyToOne('Coin', 'quoteOrders', {
     nullable: true,
     onDelete: 'SET NULL'
   })
@@ -342,15 +351,15 @@ export class Order {
     type: () => Coin,
     required: false
   })
-  quoteCoin?: Coin;
+  quoteCoin?: Relation<Coin>;
 
-  @ManyToOne(() => Exchange, { nullable: true, onDelete: 'SET NULL' })
+  @ManyToOne('Exchange', { nullable: true, onDelete: 'SET NULL' })
   @ApiProperty({
     description: 'Exchange where the order was placed',
     type: () => Exchange,
     required: false
   })
-  exchange?: Exchange;
+  exchange?: Relation<Exchange>;
 
   @Column({ type: 'uuid', nullable: true })
   @IsUUID()
@@ -363,13 +372,13 @@ export class Order {
   })
   algorithmActivationId?: string;
 
-  @ManyToOne(() => AlgorithmActivation, { nullable: true, onDelete: 'SET NULL' })
+  @ManyToOne('AlgorithmActivation', { nullable: true, onDelete: 'SET NULL' })
   @ApiProperty({
     description: 'Algorithm activation that generated this order',
     type: () => AlgorithmActivation,
     required: false
   })
-  algorithmActivation?: AlgorithmActivation;
+  algorithmActivation?: Relation<AlgorithmActivation>;
 
   @Column({ type: 'uuid', nullable: true })
   @IsUUID()

--- a/apps/api/src/order/services/order-sync.service.ts
+++ b/apps/api/src/order/services/order-sync.service.ts
@@ -535,8 +535,8 @@ export class OrderSyncService {
     try {
       this.logger.log(`Syncing orders for user: ${user.id}`);
 
-      // Get exchange keys for the user
-      const exchangeKeys = await this.exchangeKeyService.hasSupportedExchangeKeys(user.id, true);
+      // Get exchange keys for the user (with secrets for API authentication)
+      const exchangeKeys = await this.exchangeKeyService.getSupportedExchangeKeys(user.id, true);
       if (!exchangeKeys || exchangeKeys.length === 0) {
         this.logger.debug(`No active exchange keys found for user: ${user.id}`);
         return 0;

--- a/apps/api/src/order/tasks/position-monitor.task.ts
+++ b/apps/api/src/order/tasks/position-monitor.task.ts
@@ -227,7 +227,7 @@ export class PositionMonitorTask extends WorkerHost implements OnModuleInit {
     return this.positionExitRepo
       .createQueryBuilder('pe')
       .where('pe.status = :status', { status: PositionExitStatus.ACTIVE })
-      .andWhere("pe.exitConfig->>'enableTrailingStop' = :enabled", { enabled: 'true' })
+      .andWhere('pe."exitConfig"->>\'enableTrailingStop\' = :enabled', { enabled: 'true' })
       .leftJoinAndSelect('pe.user', 'user')
       .leftJoinAndSelect('pe.entryOrder', 'entryOrder')
       .getMany();

--- a/apps/api/src/portfolio/portfolio.entity.ts
+++ b/apps/api/src/portfolio/portfolio.entity.ts
@@ -1,6 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { Column, CreateDateColumn, Entity, Index, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn
+} from 'typeorm';
 
 import { PortfolioType } from './portfolio-type.enum';
 
@@ -37,7 +46,7 @@ export class Portfolio {
   updatedAt: Date;
 
   @Index('portfolio_coinId_index')
-  @ManyToOne(() => Coin, (coin) => coin.portfolios, {
+  @ManyToOne('Coin', 'portfolios', {
     nullable: false,
     onDelete: 'CASCADE',
     eager: true
@@ -46,10 +55,10 @@ export class Portfolio {
     description: 'Coin associated with this portfolio item',
     type: () => Coin
   })
-  coin: Coin;
+  coin: Relation<Coin>;
 
   @Index('portfolio_userId_index')
-  @ManyToOne(() => User, (user) => user.portfolios, {
+  @ManyToOne('User', 'portfolios', {
     nullable: false,
     onDelete: 'CASCADE',
     eager: true
@@ -58,7 +67,7 @@ export class Portfolio {
     description: 'User who owns this portfolio item',
     type: () => User
   })
-  user: User;
+  user: Relation<User>;
 
   constructor(partial: Partial<Portfolio>) {
     Object.assign(this, partial);

--- a/apps/api/src/risk/risk.entity.ts
+++ b/apps/api/src/risk/risk.entity.ts
@@ -1,10 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn
+} from 'typeorm';
 
 import { Risk as RiskInterface } from '@chansey/api-interfaces';
 
-import { User } from '../users/users.entity';
+import type { User } from '../users/users.entity';
 
 @Entity()
 export class Risk implements RiskInterface {
@@ -44,6 +52,6 @@ export class Risk implements RiskInterface {
   })
   updatedAt: Date;
 
-  @OneToMany(() => User, (user) => user.risk)
-  users: User[];
+  @OneToMany('User', 'risk')
+  users: Relation<User[]>;
 }

--- a/apps/api/src/strategy/entities/deployment.entity.ts
+++ b/apps/api/src/strategy/entities/deployment.entity.ts
@@ -6,13 +6,14 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  Relation,
   UpdateDateColumn
 } from 'typeorm';
 
 import { DeploymentStatus } from '@chansey/api-interfaces';
 
-import { PerformanceMetric } from './performance-metric.entity';
-import { StrategyConfig } from './strategy-config.entity';
+import type { PerformanceMetric } from './performance-metric.entity';
+import type { StrategyConfig } from './strategy-config.entity';
 
 /**
  * Deployment Entity
@@ -35,12 +36,12 @@ export class Deployment {
   @Column({ type: 'uuid', comment: 'FK to strategy_configs' })
   strategyConfigId: string;
 
-  @ManyToOne(() => StrategyConfig, { eager: true, onDelete: 'CASCADE' })
+  @ManyToOne('StrategyConfig', { eager: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'strategyConfigId' })
-  strategyConfig: StrategyConfig;
+  strategyConfig: Relation<StrategyConfig>;
 
-  @OneToMany(() => PerformanceMetric, (metric) => metric.deployment, { cascade: true })
-  performanceMetrics: PerformanceMetric[];
+  @OneToMany('PerformanceMetric', 'deployment', { cascade: true })
+  performanceMetrics: Relation<PerformanceMetric[]>;
 
   // Deployment Configuration
   @Column({

--- a/apps/api/src/strategy/entities/performance-metric.entity.ts
+++ b/apps/api/src/strategy/entities/performance-metric.entity.ts
@@ -1,6 +1,15 @@
-import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Index } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation
+} from 'typeorm';
 
-import { Deployment } from './deployment.entity';
+import type { Deployment } from './deployment.entity';
 
 /**
  * PerformanceMetric Entity
@@ -21,9 +30,9 @@ export class PerformanceMetric {
   @Column({ type: 'uuid', comment: 'FK to deployments' })
   deploymentId: string;
 
-  @ManyToOne(() => Deployment, (deployment) => deployment.performanceMetrics, { onDelete: 'CASCADE' })
+  @ManyToOne('Deployment', 'performanceMetrics', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'deploymentId' })
-  deployment: Deployment;
+  deployment: Relation<Deployment>;
 
   // Time Period
   @Column({ type: 'date', comment: 'Date for this metric snapshot (YYYY-MM-DD)' })

--- a/apps/api/src/strategy/live-trading.service.ts
+++ b/apps/api/src/strategy/live-trading.service.ts
@@ -12,7 +12,7 @@ import { MarketData, StrategyExecutorService, TradingSignal } from './strategy-e
 import { TradingStateService } from '../admin/trading-state/trading-state.service';
 import { BalanceService } from '../balance/balance.service';
 import { ExchangeBalanceDto } from '../balance/dto';
-import { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
+import { SupportedExchangeKeyDto } from '../exchange/exchange-key/dto';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
 import { OrderService } from '../order/order.service';
 import { LOCK_DEFAULTS, LOCK_KEYS } from '../shared/distributed-lock.constants';
@@ -212,7 +212,7 @@ export class LiveTradingService implements OnApplicationShutdown {
    * Select the best exchange for a given trading symbol.
    * Prioritizes active exchanges that support the symbol.
    */
-  private selectBestExchange(exchanges: ExchangeKey[], symbol: string): ExchangeKey | null {
+  private selectBestExchange(exchanges: SupportedExchangeKeyDto[], symbol: string): SupportedExchangeKeyDto | null {
     if (!exchanges || exchanges.length === 0) {
       return null;
     }

--- a/apps/api/src/users/users.entity.ts
+++ b/apps/api/src/users/users.entity.ts
@@ -7,13 +7,14 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryColumn,
+  Relation,
   UpdateDateColumn
 } from 'typeorm';
 
-import { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
-import { Order } from '../order/order.entity';
-import { Portfolio } from '../portfolio/portfolio.entity';
-import { Risk } from '../risk/risk.entity';
+import type { SupportedExchangeKeyDto } from '../exchange/exchange-key/dto';
+import type { Order } from '../order/order.entity';
+import type { Portfolio } from '../portfolio/portfolio.entity';
+import type { Risk } from '../risk/risk.entity';
 
 @Entity()
 export class User {
@@ -130,21 +131,21 @@ export class User {
   @UpdateDateColumn({ select: false, type: 'timestamptz' })
   updatedAt: Date;
 
-  @OneToMany(() => Portfolio, (portfolio) => portfolio.user, {
+  @OneToMany('Portfolio', 'user', {
     cascade: true
   })
-  portfolios: Portfolio[];
+  portfolios: Relation<Portfolio[]>;
 
-  @OneToMany(() => Order, (order) => order.user, { cascade: true })
-  orders: Order[];
+  @OneToMany('Order', 'user', { cascade: true })
+  orders: Relation<Order[]>;
 
-  @ManyToOne(() => Risk, (risk) => risk.users, {
+  @ManyToOne('Risk', 'users', {
     eager: true
   })
   @JoinColumn({ name: 'risk' })
-  risk: Risk;
+  risk: Relation<Risk>;
 
-  exchanges: ExchangeKey[];
+  exchanges: SupportedExchangeKeyDto[];
 
   constructor(partial: Partial<User>) {
     Object.assign(this, partial);

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -9,7 +9,6 @@ import { UserController } from './users.controller';
 import { User } from './users.entity';
 import { UsersService } from './users.service';
 
-import { AppModule } from '../app.module';
 import { ExchangeKeyModule } from '../exchange/exchange-key/exchange-key.module';
 import { ExchangeModule } from '../exchange/exchange.module';
 import { PortfolioModule } from '../portfolio/portfolio.module';
@@ -21,7 +20,6 @@ import { StrategyModule } from '../strategy/strategy.module';
 @Module({
   controllers: [UserController],
   imports: [
-    forwardRef(() => AppModule),
     TypeOrmModule.forFeature([Coin, Risk, User]),
     forwardRef(() => ExchangeModule),
     forwardRef(() => ExchangeKeyModule),

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -95,7 +95,7 @@ export class UsersService {
   async getById(id: string, top_level = false): Promise<User> {
     try {
       const user = await this.user.findOneOrFail({ where: { id } });
-      const exchanges = await this.exchangeKeyService.hasSupportedExchangeKeys(user.id, top_level);
+      const exchanges = await this.exchangeKeyService.getSupportedExchangeKeys(user.id, top_level);
 
       this.logger.debug(`User retrieved with ID: ${id}`);
       return {
@@ -112,8 +112,8 @@ export class UsersService {
    * Get exchange keys for a user without fetching user data
    * Useful when caller already has user data and just needs exchange info
    */
-  async getExchangeKeysForUser(userId: string): Promise<any[]> {
-    return this.exchangeKeyService.hasSupportedExchangeKeys(userId);
+  async getExchangeKeysForUser(userId: string) {
+    return this.exchangeKeyService.getSupportedExchangeKeys(userId);
   }
 
   async findAll() {
@@ -130,7 +130,7 @@ export class UsersService {
       const dbUser = await this.getById(user.id);
 
       // Get supported exchange keys information
-      const exchanges = await this.exchangeKeyService.hasSupportedExchangeKeys(user.id);
+      const exchanges = await this.exchangeKeyService.getSupportedExchangeKeys(user.id);
 
       return {
         ...dbUser,
@@ -278,7 +278,7 @@ export class UsersService {
         activeStrategies = strategies.length;
       }
 
-      const exchanges = await this.exchangeKeyService.hasSupportedExchangeKeys(user.id);
+      const exchanges = await this.exchangeKeyService.getSupportedExchangeKeys(user.id);
 
       return {
         enabled: user.algoTradingEnabled,


### PR DESCRIPTION
## Summary

- Reduce circular dependencies from 43 to 28 (35% reduction)
- Introduce interface-based dependency injection with Symbol tokens for exchange services
- Update entity files to use TypeORM string-based relations with `Relation<T>` wrapper

## Changes

### New Interface Files
- `apps/api/src/exchange/interfaces/` - 5 new interface files with DI tokens for:
  - `IBaseExchangeService` / `BASE_EXCHANGE_SERVICE`
  - `IExchangeService` / `EXCHANGE_SERVICE`
  - `IExchangeKeyService` / `EXCHANGE_KEY_SERVICE`
  - `IExchangeManagerService` / `EXCHANGE_MANAGER_SERVICE`

### Entity Updates (15 files)
- Use string-based TypeORM relations (`@ManyToOne('EntityName', ...)`)
- Add `Relation<T>` wrapper for type safety
- Preserve Swagger documentation with `type: () => Class` annotations

### Module Updates
- Use `forwardRef()` where needed to break remaining cycles
- Update DI registration to use new tokens

### Test Updates
- Updated tests to inject services using new DI tokens

## Test Plan

- [x] `nx build api` passes
- [x] `nx test api` passes (770 tests)
- [x] Pre-commit hooks pass (lint + affected tests)

Closes #84