### PR TITLE
fix(backtest): fail explicitly when algorithm has no registered strategy

### DIFF
--- a/apps/api/src/algorithm/registry/algorithm-registry.service.spec.ts
+++ b/apps/api/src/algorithm/registry/algorithm-registry.service.spec.ts
@@ -1,0 +1,13 @@
+import { AlgorithmRegistry } from './algorithm-registry.service';
+
+import { AlgorithmNotRegisteredException } from '../../common/exceptions';
+import { AlgorithmContext } from '../interfaces';
+
+describe('AlgorithmRegistry.executeAlgorithm', () => {
+  it('throws when no strategy is registered for the algorithm', async () => {
+    const registry = new AlgorithmRegistry({} as any, {} as any);
+    const context = {} as AlgorithmContext;
+
+    await expect(registry.executeAlgorithm('algo-1', context)).rejects.toBeInstanceOf(AlgorithmNotRegisteredException);
+  });
+});

--- a/apps/api/src/common/exceptions/backtest/algorithm-not-registered.exception.ts
+++ b/apps/api/src/common/exceptions/backtest/algorithm-not-registered.exception.ts
@@ -1,0 +1,15 @@
+import { BusinessRuleException } from '../base/business-rule.exception';
+import { ErrorCode } from '../error-codes.enum';
+
+/**
+ * Thrown when a backtest is run against an algorithm that has no registered strategy.
+ */
+export class AlgorithmNotRegisteredException extends BusinessRuleException {
+  constructor(algorithmId: string) {
+    super(
+      `No strategy registered for algorithm ${algorithmId}. Ensure the algorithm has an active strategy before running backtests.`,
+      ErrorCode.BUSINESS_ALGORITHM_NOT_REGISTERED,
+      { algorithmId }
+    );
+  }
+}

--- a/apps/api/src/common/exceptions/backtest/index.ts
+++ b/apps/api/src/common/exceptions/backtest/index.ts
@@ -1,0 +1,1 @@
+export * from './algorithm-not-registered.exception';

--- a/apps/api/src/common/exceptions/index.ts
+++ b/apps/api/src/common/exceptions/index.ts
@@ -3,6 +3,7 @@ export * from './base';
 
 // Domain-specific exceptions
 export * from './auth';
+export * from './backtest';
 export * from './external';
 export * from './order';
 export * from './resource';

--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -33,6 +33,7 @@ import {
 import { AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
 import { Coin } from '../../coin/coin.entity';
 import { CoinService } from '../../coin/coin.service';
+import { AlgorithmNotRegisteredException } from '../../common/exceptions';
 import { OHLCCandle } from '../../ohlc/ohlc-candle.entity';
 import { OHLCService } from '../../ohlc/ohlc.service';
 
@@ -289,6 +290,9 @@ export class BacktestEngine {
           strategySignals = result.signals.map(mapStrategySignal).filter((signal) => signal.action !== 'HOLD');
         }
       } catch (error) {
+        if (error instanceof AlgorithmNotRegisteredException) {
+          throw error;
+        }
         this.logger.warn(`Algorithm execution failed at ${timestamp.toISOString()}: ${error.message}`);
       }
 
@@ -814,6 +818,9 @@ export class BacktestEngine {
           strategySignals = result.signals.map(mapStrategySignal).filter((signal) => signal.action !== 'HOLD');
         }
       } catch (error) {
+        if (error instanceof AlgorithmNotRegisteredException) {
+          throw error;
+        }
         // Log but continue - optimization should be resilient to occasional failures
         this.logger.warn(`Algorithm execution failed at ${timestamp.toISOString()}: ${error.message}`);
       }


### PR DESCRIPTION
## Summary

- Fix silent failure when running backtests against algorithms without registered strategies
- Previously, backtests would complete with 0 trades and 0% return, misleading users
- Now fails immediately with a clear error message explaining the issue

## Changes

### New Exception Class
- `apps/api/src/common/exceptions/backtest/algorithm-not-registered.exception.ts` - `AlgorithmNotRegisteredException` extending `BusinessRuleException`

### Algorithm Registry
- `apps/api/src/algorithm/registry/algorithm-registry.service.ts` - Throw exception instead of returning failure result when no strategy found

### Backtest Engine  
- `apps/api/src/order/backtest/backtest-engine.service.ts` - Re-throw `AlgorithmNotRegisteredException` in both historical and optimization backtest paths (configuration errors fail immediately, transient errors still handled gracefully)

### Tests
- `apps/api/src/algorithm/registry/algorithm-registry.service.spec.ts` - New test for exception throw
- `apps/api/src/order/backtest/backtest-engine.service.spec.ts` - Updated tests for exception propagation

## Test Plan

- [x] Build passes
- [x] Lint passes  
- [x] All 755 existing tests pass
- [x] New unit tests verify exception behavior

**Before**: Backtest completes with status `COMPLETED`, 0 trades, 0% return, no error
**After**: Backtest fails with status `FAILED`, clear error: "No strategy registered for algorithm {id}"

Closes #102