### PR TITLE
fix(backtest): standardize win rate scale to decimal (0.0-1.0)

### DIFF
--- a/apps/api/src/algorithm/services/algorithm-performance.service.ts
+++ b/apps/api/src/algorithm/services/algorithm-performance.service.ts
@@ -85,7 +85,7 @@ export class AlgorithmPerformanceService {
       algorithmActivationId: activationId,
       userId: activation.userId,
       roi: Number(roi.toFixed(2)),
-      winRate: Number(winRate.toFixed(2)),
+      winRate: Number(winRate.toFixed(4)), // Decimal format (0.0-1.0)
       sharpeRatio: Number(sharpeRatio.toFixed(4)),
       maxDrawdown: Number(maxDrawdown.toFixed(2)),
       totalTrades,
@@ -139,16 +139,16 @@ export class AlgorithmPerformanceService {
   }
 
   /**
-   * Calculate win rate (percentage of profitable trades)
+   * Calculate win rate (ratio of profitable trades)
    * @param orders - Array of orders
-   * @returns Win rate percentage
+   * @returns Win rate as decimal (0.0-1.0), e.g., 0.65 = 65% win rate
    */
   private calculateWinRate(orders: Order[]): number {
     if (orders.length === 0) return 0;
 
     const profitableTrades = orders.filter((order) => order.gainLoss && order.gainLoss > 0).length;
 
-    return (profitableTrades / orders.length) * 100;
+    return profitableTrades / orders.length;
   }
 
   /**

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.ts
@@ -401,7 +401,7 @@ export class OptimizationOrchestratorService {
     const volatility = 0.1 + Math.random() * 0.2;
     const sharpeRatio = baseReturn / volatility;
     const maxDrawdown = -(0.05 + Math.random() * 0.15);
-    const winRate = 45 + Math.random() * 20;
+    const winRate = 0.45 + Math.random() * 0.2; // Decimal scale (0.0-1.0)
     const profitFactor = 1 + Math.random() * 1.5;
 
     return {
@@ -472,7 +472,7 @@ export class OptimizationOrchestratorService {
     const normalizedCalmar = Math.max(0, Math.min(1, calmarRatio / 3)); // 0 to 3 -> 0 to 1
     const normalizedPF = Math.max(0, Math.min(1, ((metrics.profitFactor || 1) - 0.5) / 2.5)); // 0.5 to 3 -> 0 to 1
     const normalizedDD = Math.max(0, Math.min(1, 1 + metrics.maxDrawdown)); // -1 to 0 -> 0 to 1
-    const normalizedWR = metrics.winRate / 100; // 0 to 100 -> 0 to 1
+    const normalizedWR = Math.max(0, Math.min(1, metrics.winRate)); // Already decimal (0.0-1.0)
 
     return (
       normalizedSharpe * (w.sharpeRatio || 0) +

--- a/apps/api/src/order/backtest/backtest.entity.ts
+++ b/apps/api/src/order/backtest/backtest.entity.ts
@@ -129,7 +129,7 @@ export class Backtest {
 
   @IsNumber()
   @Column({ type: 'decimal', precision: 8, scale: 4, nullable: true, transformer: new ColumnNumericTransformer() })
-  @ApiProperty({ description: 'Win rate percentage', required: false })
+  @ApiProperty({ description: 'Win rate as decimal (0.0-1.0), e.g., 0.65 = 65%', required: false })
   winRate?: number;
 
   @IsString()

--- a/apps/api/src/scoring/metrics/win-rate.calculator.ts
+++ b/apps/api/src/scoring/metrics/win-rate.calculator.ts
@@ -2,29 +2,31 @@ import { Injectable } from '@nestjs/common';
 
 /**
  * Win Rate Calculator
- * Calculates percentage of winning trades
+ * Calculates win rate as decimal (0.0 to 1.0)
  */
 @Injectable()
 export class WinRateCalculator {
   /**
    * Calculate win rate from trade results
    * @param trades Array of trade P&L values
+   * @returns Win rate as decimal (0.0 to 1.0), e.g., 0.65 = 65% win rate
    */
   calculate(trades: number[]): number {
     if (trades.length === 0) return 0;
 
     const winningTrades = trades.filter((trade) => trade > 0).length;
-    return (winningTrades / trades.length) * 100;
+    return winningTrades / trades.length;
   }
 
   /**
    * Calculate win rate with separate wins/losses counts
+   * @returns Win rate as decimal (0.0 to 1.0)
    */
   calculateFromCounts(wins: number, losses: number): number {
     const total = wins + losses;
     if (total === 0) return 0;
 
-    return (wins / total) * 100;
+    return wins / total;
   }
 
   /**
@@ -58,16 +60,17 @@ export class WinRateCalculator {
 
   /**
    * Interpret win rate quality
+   * @param winRate Win rate as decimal (0.0 to 1.0)
    */
   interpret(winRate: number): {
     grade: 'excellent' | 'good' | 'acceptable' | 'poor';
     description: string;
   } {
-    if (winRate >= 60) {
+    if (winRate >= 0.6) {
       return { grade: 'excellent', description: 'Excellent win rate - highly consistent' };
-    } else if (winRate >= 50) {
+    } else if (winRate >= 0.5) {
       return { grade: 'good', description: 'Good win rate - above breakeven' };
-    } else if (winRate >= 45) {
+    } else if (winRate >= 0.45) {
       return { grade: 'acceptable', description: 'Acceptable win rate - needs strong win/loss ratio' };
     } else {
       return { grade: 'poor', description: 'Low win rate - requires exceptional win/loss ratio' };

--- a/apps/api/src/scoring/scoring.service.ts
+++ b/apps/api/src/scoring/scoring.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import { ComponentScores, StrategyGrade, GRADE_RANGES } from '@chansey/api-interfaces';
+import { ComponentScores, GRADE_RANGES, StrategyGrade } from '@chansey/api-interfaces';
 
 import { CalmarRatioCalculator } from './metrics/calmar-ratio.calculator';
 import { ProfitFactorCalculator } from './metrics/profit-factor.calculator';
@@ -111,11 +111,11 @@ export class ScoringService {
       poor: 0
     });
 
-    // Win Rate (10% weight)
+    // Win Rate (10% weight) - expects decimal (0.0-1.0)
     const winRateScore = this.scoreMetric(results.winRate, {
-      excellent: 60,
-      good: 50,
-      acceptable: 45,
+      excellent: 0.6,
+      good: 0.5,
+      acceptable: 0.45,
       poor: 0
     });
 
@@ -310,7 +310,7 @@ export class ScoringService {
       warnings.push('High walk-forward degradation suggests overfitting');
     }
 
-    if (results.winRate < 45) {
+    if (results.winRate < 0.45) {
       warnings.push('Low win rate below 45% threshold');
     }
 

--- a/apps/api/src/scoring/walk-forward/window-processor.ts
+++ b/apps/api/src/scoring/walk-forward/window-processor.ts
@@ -105,8 +105,8 @@ export class WindowProcessor {
       return true;
     }
 
-    // Win rate drops more than 20 percentage points
-    if (trainMetrics.winRate - testMetrics.winRate > 20) {
+    // Win rate drops more than 20 percentage points (0.20 in decimal scale)
+    if (trainMetrics.winRate - testMetrics.winRate > 0.2) {
       return true;
     }
 

--- a/apps/api/src/strategy/user-performance.service.ts
+++ b/apps/api/src/strategy/user-performance.service.ts
@@ -232,9 +232,9 @@ export class UserPerformanceService {
   }
 
   /**
-   * Calculate win rate from orders (% of profitable trades).
+   * Calculate win rate from orders (ratio of profitable trades).
    * Uses the gainLoss field on sell orders to determine profitability.
-   * Win rate = (profitable sell orders / total sell orders) * 100
+   * @returns Win rate as decimal (0.0-1.0), e.g., 0.65 = 65% win rate
    */
   private calculateWinRate(orders: Order[]): number {
     // Filter to only filled sell orders (where we can determine profit/loss)
@@ -247,7 +247,7 @@ export class UserPerformanceService {
       (o) => o.gainLoss !== null && o.gainLoss !== undefined && Number(o.gainLoss) > 0
     ).length;
 
-    return (profitableTrades / filledSellOrders.length) * 100;
+    return profitableTrades / filledSellOrders.length;
   }
 
   /**
@@ -341,6 +341,7 @@ export interface AlgoPerformanceMetrics {
   totalReturnPct: number;
   monthlyReturnPct: number;
   weeklyReturnPct: number;
+  /** Win rate as decimal (0.0-1.0), e.g., 0.65 = 65% win rate */
   winRate: number;
   totalTrades: number;
   activePositions: number;

--- a/libs/api-interfaces/src/lib/strategy/backtest-result.interface.ts
+++ b/libs/api-interfaces/src/lib/strategy/backtest-result.interface.ts
@@ -75,6 +75,7 @@ export interface WindowMetrics {
   totalReturn: number;
   sharpeRatio: number;
   maxDrawdown: number;
+  /** Win rate as decimal (0.0 to 1.0), e.g., 0.65 = 65% win rate */
   winRate: number;
   tradeCount: number;
   profitFactor: number;


### PR DESCRIPTION
## Summary

- Standardize all win rate values to decimal format (0.0-1.0) instead of percentage (0-100)
- Fix inconsistent scale handling that caused scoring thresholds to never trigger correctly
- Remove legacy percentage handling since no existing data requires conversion

## Changes

### Calculations Updated
- `algorithm-performance.service.ts` - `calculateWinRate()` returns decimal
- `user-performance.service.ts` - `calculateWinRate()` returns decimal
- `win-rate.calculator.ts` - `calculate()` and `calculateFromCounts()` return decimal

### Thresholds Fixed
- `scoring.service.ts` - Updated thresholds from 60/50/45 to 0.6/0.5/0.45
- `algorithm-performance.entity.ts` - `meetsPerformanceThreshold()` uses 0.5 instead of 50
- `win-rate.calculator.ts` - `interpret()` uses decimal thresholds

### Documentation & Schema
- `backtest.entity.ts` - API docs clarify decimal format
- `algorithm-performance.entity.ts` - Column scale increased from 2 to 4 decimal places
- JSDoc comments added across interfaces clarifying decimal format

### Cleanup
- Removed `getNormalizedWinRate()` legacy handler (no existing data to convert)

## Test Plan

- [x] Build passes
- [x] All unit tests pass
- [x] Database verified empty (no legacy data migration needed)
- [ ] Manual verification of scoring calculations