### PR TITLE
fix(backtest): standardize max drawdown sign convention

### DIFF
--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -893,7 +893,7 @@ export class BacktestEngine {
     return {
       sharpeRatio,
       totalReturn,
-      maxDrawdown: -maxDrawdown, // Convention: negative for drawdown
+      maxDrawdown,
       winRate,
       volatility,
       profitFactor: Math.min(profitFactor, 10), // Cap at 10 to avoid infinity issues

--- a/apps/chansey/src/app/pages/backtesting/comparison-dashboard.component.html
+++ b/apps/chansey/src/app/pages/backtesting/comparison-dashboard.component.html
@@ -76,7 +76,7 @@
         <td>{{ item.run.algorithm?.name }}</td>
         <td>{{ item.metrics?.totalReturn | percent: '1.0-2' }}</td>
         <td>{{ item.metrics?.sharpeRatio | number: '1.2-2' }}</td>
-        <td>{{ item.metrics?.maxDrawdown | percent: '1.0-2' }}</td>
+        <td>{{ item.metrics?.maxDrawdown ? '-' + (item.metrics.maxDrawdown | percent: '1.0-2') : '-' }}</td>
       </tr>
     </ng-template>
   </p-table>


### PR DESCRIPTION
## Summary

- Resolve inconsistency where historical backtests returned positive maxDrawdown values while optimization backtests returned negative
- Standardize on positive values (0.2 = 20% drawdown) as this is more intuitive and matches frontend expectations

## Changes

- **`apps/api/src/order/backtest/backtest-engine.service.ts`** - Remove negation from optimization backtest return value
- **`apps/chansey/src/app/pages/backtesting/comparison-dashboard.component.html`** - Add explicit negative sign display for UI consistency

## Test Plan

- [x] All 777 tests pass
- [x] Build succeeds for both API and frontend
- [x] Code review passed

## Related Issues

Closes #108