### PR TITLE
fix(backtest): add transaction isolation for multi-table result saves

### DIFF
--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -2,6 +2,7 @@ import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 
 import * as dayjs from 'dayjs';
 
+import { BacktestFinalMetrics } from './backtest-result.service';
 import { BacktestStreamService } from './backtest-stream.service';
 import {
   Backtest,
@@ -150,7 +151,7 @@ export class BacktestEngine {
     signals: Partial<BacktestSignal>[];
     simulatedFills: Partial<SimulatedOrderFill>[];
     snapshots: Partial<BacktestPerformanceSnapshot>[];
-    finalMetrics: Record<string, unknown>;
+    finalMetrics: BacktestFinalMetrics;
   }> {
     if (!backtest.algorithm) {
       throw new Error('Backtest algorithm relation not loaded');
@@ -639,7 +640,7 @@ export class BacktestEngine {
     trades: Partial<BacktestTrade>[],
     snapshots: Partial<BacktestPerformanceSnapshot>[],
     maxDrawdown: number
-  ) {
+  ): BacktestFinalMetrics {
     const finalValue = portfolio.totalValue;
     const totalReturn = (finalValue - backtest.initialCapital) / backtest.initialCapital;
     const totalTrades = trades.length;
@@ -663,8 +664,7 @@ export class BacktestEngine {
       maxDrawdown,
       totalTrades,
       winningTrades,
-      winRate: sellTradeCount > 0 ? winningTrades / sellTradeCount : 0,
-      performanceHistory: snapshots
+      winRate: sellTradeCount > 0 ? winningTrades / sellTradeCount : 0
     };
   }
 


### PR DESCRIPTION
## Summary
- Wrap `persistSuccess` saves in a database transaction to ensure atomicity
- Prevents orphaned records when saves fail partway through multi-table operations
- Add type safety for backtest final metrics

Closes #109

## Changes

### Transaction Isolation (`backtest-result.service.ts`)
- Add `DataSource` injection for transaction management
- Use TypeORM `QueryRunner` with commit/rollback pattern
- Move stream publishing **after** transaction commits to ensure consistency
- Remove 4 unused repository injections (now using `queryRunner.manager.save()`)

### Type Safety (`backtest-result.service.ts`, `backtest-engine.service.ts`)
- Add `BacktestFinalMetrics` interface replacing `Record<string, unknown>`
- Update `executeHistoricalBacktest()` and `calculateFinalMetrics()` return types
- Remove redundant `performanceHistory` property (snapshots already returned separately)

### Tests (`backtest-result.service.spec.ts`)
- Add comprehensive unit tests for transaction behavior
- Test happy path with commit verification
- Test rollback on failure (immediate and partial)
- Test empty array handling
- Verify publish happens only after successful commit

## Test Plan
- [x] All 790 unit tests pass
- [x] Linter passes with no new warnings
- [x] Build succeeds
- [ ] CI pipeline passes

## Before/After

**Before**: Sequential saves without transaction
```typescript
await this.backtestSignalRepository.save(signals);  // Save 1
await this.simulatedFillRepository.save(fills);     // Save 2
await this.backtestTradeRepository.save(trades);    // Save 3 - FAILS
// Signals and fills are committed but trades/snapshots are not ❌
```

**After**: All saves wrapped in transaction
```typescript
const queryRunner = this.dataSource.createQueryRunner();
await queryRunner.startTransaction();
try {
  await queryRunner.manager.save(BacktestSignal, signals);
  await queryRunner.manager.save(SimulatedOrderFill, fills);
  await queryRunner.manager.save(BacktestTrade, trades);  // FAILS
  await queryRunner.commitTransaction();
} catch (error) {
  await queryRunner.rollbackTransaction();  // All changes rolled back ✅
  throw error;
}
```