### PR TITLE
feat(exchange): auto-enable algo trading when user connects exchange

### DIFF
--- a/apps/api/src/config/logger.config.ts
+++ b/apps/api/src/config/logger.config.ts
@@ -237,7 +237,8 @@ export function createLoggerConfig(): Params {
   return {
     pinoHttp: pinoHttpOptions as Params['pinoHttp'],
     // Forward logs to NestJS Logger for consistent output
-    forRoutes: ['*'],
+    // Note: Using '{*path}' to comply with path-to-regexp v8+ syntax (fixes FSTDEP deprecation warning)
+    forRoutes: ['{*path}'],
     // Exclude routes from request logging
     exclude: []
   };

--- a/apps/api/src/exchange/exchange-key/exchange-key.service.spec.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key.service.spec.ts
@@ -1,0 +1,147 @@
+import { getQueueToken } from '@nestjs/bullmq';
+import { ConflictException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ExchangeKey } from './exchange-key.entity';
+import { ExchangeKeyService } from './exchange-key.service';
+
+import { User } from '../../users/users.entity';
+import { ExchangeManagerService } from '../exchange-manager.service';
+import { ExchangeService } from '../exchange.service';
+
+describe('ExchangeKeyService', () => {
+  let service: ExchangeKeyService;
+  let exchangeKeyRepository: {
+    create: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+    findOne: jest.Mock;
+    count: jest.Mock;
+    remove: jest.Mock;
+  };
+  let userRepository: {
+    findOne: jest.Mock;
+    save: jest.Mock;
+  };
+  let exchangeService: {
+    findOne: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    exchangeKeyRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      count: jest.fn(),
+      remove: jest.fn()
+    };
+    userRepository = {
+      findOne: jest.fn(),
+      save: jest.fn()
+    };
+    exchangeService = {
+      findOne: jest.fn()
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExchangeKeyService,
+        { provide: getRepositoryToken(ExchangeKey), useValue: exchangeKeyRepository },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: ExchangeService, useValue: exchangeService },
+        { provide: ExchangeManagerService, useValue: { getExchangeService: jest.fn() } },
+        { provide: getQueueToken('order-queue'), useValue: { add: jest.fn() } }
+      ]
+    }).compile();
+
+    service = module.get(ExchangeKeyService);
+  });
+
+  describe('create', () => {
+    it('auto-enables algo trading when a valid key is created', async () => {
+      const userId = 'user-1';
+      const dto = { exchangeId: 'exchange-1', apiKey: 'api', secretKey: 'secret' } as any;
+      const createdKey = { id: 'key-1', exchangeId: dto.exchangeId, userId } as ExchangeKey;
+      const savedKey = { ...createdKey, isActive: true } as ExchangeKey;
+
+      exchangeService.findOne.mockResolvedValue({ id: dto.exchangeId, name: 'Binance', slug: 'binance' });
+      jest.spyOn(service, 'findOneByExchangeId').mockResolvedValue(null);
+      jest.spyOn(service, 'validateExchangeKeys').mockResolvedValue(true);
+      exchangeKeyRepository.create.mockReturnValue(createdKey);
+      exchangeKeyRepository.save.mockResolvedValue(savedKey);
+      const autoEnableSpy = jest.spyOn(service as any, 'autoEnableAlgoTrading').mockResolvedValue(undefined);
+
+      const result = await service.create(userId, dto);
+
+      expect(exchangeService.findOne).toHaveBeenCalledWith(dto.exchangeId);
+      expect(exchangeKeyRepository.save).toHaveBeenCalledWith(expect.objectContaining({ isActive: true }));
+      expect(autoEnableSpy).toHaveBeenCalledWith(userId);
+      expect(result).toBe(savedKey);
+    });
+
+    it('does not auto-enable algo trading when validation fails', async () => {
+      const userId = 'user-1';
+      const dto = { exchangeId: 'exchange-1', apiKey: 'api', secretKey: 'secret' } as any;
+      const createdKey = { id: 'key-1', exchangeId: dto.exchangeId, userId } as ExchangeKey;
+      const savedKey = { ...createdKey, isActive: false } as ExchangeKey;
+
+      exchangeService.findOne.mockResolvedValue({ id: dto.exchangeId, name: 'Binance', slug: 'binance' });
+      jest.spyOn(service, 'findOneByExchangeId').mockResolvedValue(null);
+      jest.spyOn(service, 'validateExchangeKeys').mockResolvedValue(false);
+      exchangeKeyRepository.create.mockReturnValue(createdKey);
+      exchangeKeyRepository.save.mockResolvedValue(savedKey);
+      const autoEnableSpy = jest.spyOn(service as any, 'autoEnableAlgoTrading').mockResolvedValue(undefined);
+
+      const result = await service.create(userId, dto);
+
+      expect(exchangeKeyRepository.save).toHaveBeenCalledWith(expect.objectContaining({ isActive: false }));
+      expect(autoEnableSpy).not.toHaveBeenCalled();
+      expect(result).toBe(savedKey);
+    });
+
+    it('throws when key already exists for exchange', async () => {
+      const userId = 'user-1';
+      const dto = { exchangeId: 'exchange-1', apiKey: 'api', secretKey: 'secret' } as any;
+
+      exchangeService.findOne.mockResolvedValue({ id: dto.exchangeId, name: 'Binance', slug: 'binance' });
+      jest.spyOn(service, 'findOneByExchangeId').mockResolvedValue({ id: 'existing-key' } as ExchangeKey);
+
+      await expect(service.create(userId, dto)).rejects.toBeInstanceOf(ConflictException);
+      expect(exchangeKeyRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('auto-disables algo trading when last key is removed', async () => {
+      const userId = 'user-1';
+      const exchangeKey = { id: 'key-1' } as ExchangeKey;
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(exchangeKey);
+      exchangeKeyRepository.count.mockResolvedValue(1);
+      exchangeKeyRepository.remove.mockResolvedValue(exchangeKey);
+      const autoDisableSpy = jest.spyOn(service as any, 'autoDisableAlgoTrading').mockResolvedValue(undefined);
+
+      const result = await service.remove(exchangeKey.id, userId);
+
+      expect(exchangeKeyRepository.count).toHaveBeenCalledWith({ where: { userId } });
+      expect(autoDisableSpy).toHaveBeenCalledWith(userId);
+      expect(result).toBe(exchangeKey);
+    });
+
+    it('does not auto-disable algo trading when more keys remain', async () => {
+      const userId = 'user-1';
+      const exchangeKey = { id: 'key-1' } as ExchangeKey;
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(exchangeKey);
+      exchangeKeyRepository.count.mockResolvedValue(2);
+      exchangeKeyRepository.remove.mockResolvedValue(exchangeKey);
+      const autoDisableSpy = jest.spyOn(service as any, 'autoDisableAlgoTrading').mockResolvedValue(undefined);
+
+      await service.remove(exchangeKey.id, userId);
+
+      expect(autoDisableSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/tasks/backtest-orchestration.service.spec.ts
+++ b/apps/api/src/tasks/backtest-orchestration.service.spec.ts
@@ -168,7 +168,6 @@ describe('BacktestOrchestrationService', () => {
       const result = await service.getEligibleUsers();
 
       expect(mockQueryBuilder.where).toHaveBeenCalledWith('user.algoTradingEnabled = :enabled', { enabled: true });
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('risk.id IS NOT NULL');
       expect(result).toHaveLength(1);
     });
 

--- a/apps/api/src/tasks/backtest-orchestration.service.ts
+++ b/apps/api/src/tasks/backtest-orchestration.service.ts
@@ -51,7 +51,8 @@ export class BacktestOrchestrationService {
 
   /**
    * Get all users eligible for automatic backtest orchestration.
-   * Users must have algoTradingEnabled=true and a valid risk assignment.
+   * Users must have algoTradingEnabled=true.
+   * Risk defaults to level 3 in orchestrateForUser() if not set.
    */
   async getEligibleUsers(): Promise<User[]> {
     try {
@@ -59,7 +60,6 @@ export class BacktestOrchestrationService {
         .createQueryBuilder('user')
         .leftJoinAndSelect('user.risk', 'risk')
         .where('user.algoTradingEnabled = :enabled', { enabled: true })
-        .andWhere('risk.id IS NOT NULL')
         .getMany();
 
       this.logger.log(`Found ${users.length} eligible users for orchestration`);

--- a/apps/chansey/src/app/pages/admin/algorithms/components/algorithm-edit-drawer/algorithm-edit-drawer.component.ts
+++ b/apps/chansey/src/app/pages/admin/algorithms/components/algorithm-edit-drawer/algorithm-edit-drawer.component.ts
@@ -69,7 +69,7 @@ export class AlgorithmEditDrawerComponent {
     weight: [1.0],
     cron: [
       '0 */4 * * *',
-      [Validators.required, Validators.pattern(/^(\*|[0-9]+) (\*|[0-9]+) (\*|[0-9]+) (\*|[0-9]+) (\*|[0-9]+)$/)]
+      [Validators.required, Validators.pattern(/^([0-9*,/-]+) ([0-9*,/-]+) ([0-9*,/-]+) ([0-9*,/-]+) ([0-9*,/-]+)$/)]
     ],
     version: [''],
     author: ['']


### PR DESCRIPTION
## Summary

- Automatically enable `algoTradingEnabled` when a user adds a valid exchange key
- Automatically disable when user removes their last exchange key
- Remove risk profile requirement from backtest orchestration eligibility (defaults to level 3)

## Changes

**Core Feature** (`exchange-key.service.ts`):
- Add `autoEnableAlgoTrading()` - sets `algoTradingEnabled=true` and `algoEnrolledAt` on first valid key
- Add `autoDisableAlgoTrading()` - sets `algoTradingEnabled=false` when last key removed
- Inject User repository for updating user settings

**Backtest Orchestration** (`backtest-orchestration.service.ts`):
- Remove `risk.id IS NOT NULL` requirement from eligible users query
- Users only need `algoTradingEnabled=true` to be eligible

**Bug Fixes**:
- `logger.config.ts`: Fix path-to-regexp v8+ deprecation warning (`'*'` → `'{*path}'`)
- `algorithm-edit-drawer.component.ts`: Improve cron validation pattern to support `*/4`, `1-5`, `0,30`

## Test Plan

- [x] Unit tests added for auto-enable/disable logic
- [x] Build passes
- [x] Lint passes
- [ ] Manual testing: Add exchange key → verify `algoTradingEnabled` becomes true
- [ ] Manual testing: Remove last key → verify `algoTradingEnabled` becomes false

Closes #122