### PR TITLE
refactor(backtest): simplify orchestration with standard capital

### DIFF
--- a/apps/api/src/portfolio/portfolio.service.spec.ts
+++ b/apps/api/src/portfolio/portfolio.service.spec.ts
@@ -2,8 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { PortfolioType } from './portfolio-type.enum';
-import { PortfolioRelations } from './portfolio.entity';
-import { Portfolio } from './portfolio.entity';
+import { Portfolio, PortfolioRelations } from './portfolio.entity';
 import { PortfolioService } from './portfolio.service';
 import { PortfolioHistoricalPriceTask } from './tasks/portfolio-historical-price.task';
 

--- a/apps/api/src/tasks/dto/backtest-orchestration.dto.ts
+++ b/apps/api/src/tasks/dto/backtest-orchestration.dto.ts
@@ -79,8 +79,8 @@ export const RISK_CONFIG_MATRIX: Record<number, RiskLevelConfig> = {
 /** Default risk level when user's risk level is not set */
 export const DEFAULT_RISK_LEVEL = 3;
 
-/** Minimum capital for orchestrated backtests (in USD) */
-export const MIN_ORCHESTRATION_CAPITAL = 1000;
+/** Standard capital for all orchestrated backtests (USD) */
+export const BACKTEST_STANDARD_CAPITAL = 10000;
 
 /** Minimum dataset integrity score for selection */
 export const MIN_DATASET_INTEGRITY_SCORE = 70;


### PR DESCRIPTION
## Summary

- Simplify backtest orchestration to run **all testable algorithms** for **all eligible users** with **standardized $10,000 capital**
- Remove dependency on `AlgorithmActivation` records and complex portfolio-based capital calculations
- Reduce external API calls by removing `BalanceService` dependency

## Changes

### `backtest-orchestration.service.ts`
- Replace `AlgorithmActivationService` with `AlgorithmService`
- Remove `BalanceService` dependency (no longer need to fetch user balances)
- Update `orchestrateForUser()` to use `algorithmService.getAlgorithmsForTesting()`
- Rename `processActivation()` → `processAlgorithm()` with updated signature
- Remove `calculateAllocatedCapital()` method entirely
- Update `createOrchestratedBacktest()` to accept `Algorithm` instead of `AlgorithmActivation`

### `backtest-orchestration.dto.ts`
- Add `BACKTEST_STANDARD_CAPITAL = 10000` constant
- Remove unused `MIN_ORCHESTRATION_CAPITAL` constant

### `backtest-orchestration.service.spec.ts`
- Update all tests to mock `AlgorithmService.getAlgorithmsForTesting()` 
- Remove tests for `calculateAllocatedCapital()`
- Add new tests for standard capital verification
- Add tests for default risk level handling and error cases

## Behavior Changes

| Aspect | Before | After |
|--------|--------|-------|
| **Algorithms** | Only user-activated algorithms | All algorithms with `evaluate=true AND status=ACTIVE` |
| **Capital** | `portfolio × userAlloc% × activationAlloc%` | Standard $10,000 |
| **User Setup** | Required `AlgorithmActivation` records | Just need connected exchange |
| **Eligibility** | `algoTradingEnabled=true AND risk IS NOT NULL` | `algoTradingEnabled=true` (risk defaults to 3) |

## Test Plan

- [x] All 25 unit tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes (no errors)
- [x] Build succeeds
- [ ] Manual verification: New user with connected exchange gets backtests for all active algorithms
- [ ] Verify backtest `initialCapital` is $10,000

## Notes

- `AlgorithmActivation` records are preserved for future live trading use
- `algoCapitalAllocationPercentage` field remains for future live trading
- No database migration required
- Backward compatible (no breaking changes to existing data)

Closes #123