### PR TITLE
refactor(backtest): extract shared services into reusable module

### DIFF
--- a/apps/api/src/order/backtest/backtest-engine.storage.integration.spec.ts
+++ b/apps/api/src/order/backtest/backtest-engine.storage.integration.spec.ts
@@ -1,10 +1,57 @@
 import { BacktestEngine } from './backtest-engine.service';
 import { MarketDataReaderService } from './market-data-reader.service';
+import {
+  FeeCalculatorService,
+  MetricsCalculatorService,
+  PortfolioStateService,
+  PositionManagerService,
+  SlippageService
+} from './shared';
 
 import { SignalType } from '../../algorithm/interfaces';
+import { DrawdownCalculator } from '../../common/metrics/drawdown.calculator';
 import { SharpeRatioCalculator } from '../../common/metrics/sharpe-ratio.calculator';
+import { OHLCCandle } from '../../ohlc/ohlc-candle.entity';
+
+// Create shared service instances for tests
+const sharpeCalculator = new SharpeRatioCalculator();
+const drawdownCalculator = new DrawdownCalculator();
+const slippageService = new SlippageService();
+const feeCalculator = new FeeCalculatorService();
+const positionManager = new PositionManagerService();
+const metricsCalculator = new MetricsCalculatorService(sharpeCalculator, drawdownCalculator);
+const portfolioState = new PortfolioStateService();
 
 describe('BacktestEngine storage flow', () => {
+  const createEngine = (overrides?: {
+    algorithmRegistry?: any;
+    ohlcService?: any;
+    marketDataReader?: MarketDataReaderService;
+    quoteCurrencyResolver?: any;
+  }) => {
+    const algorithmRegistry =
+      overrides?.algorithmRegistry ??
+      ({ executeAlgorithm: jest.fn().mockResolvedValue({ success: true, signals: [] }) } as any);
+    const ohlcService = overrides?.ohlcService ?? ({ getCandlesByDateRange: jest.fn() } as any);
+    const marketDataReader = overrides?.marketDataReader ?? ({} as MarketDataReaderService);
+    const quoteCurrencyResolver =
+      overrides?.quoteCurrencyResolver ??
+      ({ resolveQuoteCurrency: jest.fn().mockResolvedValue({ id: 'usdt', symbol: 'USDT' }) } as any);
+
+    return new BacktestEngine(
+      { publishMetric: jest.fn(), publishStatus: jest.fn() } as any,
+      algorithmRegistry,
+      ohlcService,
+      marketDataReader,
+      quoteCurrencyResolver,
+      slippageService,
+      feeCalculator,
+      positionManager,
+      metricsCalculator,
+      portfolioState
+    );
+  };
+
   it('loads CSV-backed market data and runs the backtest loop', async () => {
     const csv = [
       'timestamp,open,high,low,close,volume,symbol',
@@ -51,15 +98,12 @@ describe('BacktestEngine storage flow', () => {
       resolveQuoteCurrency: jest.fn().mockResolvedValue({ id: 'usdc', symbol: 'USDC' })
     };
 
-    const engine = new BacktestEngine(
-      { publishMetric: jest.fn(), publishStatus: jest.fn() } as any,
-      algorithmRegistry as any,
-      {} as any,
-      ohlcService as any,
+    const engine = createEngine({
+      algorithmRegistry,
+      ohlcService,
       marketDataReader,
-      new SharpeRatioCalculator(),
-      quoteCurrencyResolver as any
-    );
+      quoteCurrencyResolver
+    });
 
     const result = await engine.executeHistoricalBacktest(
       {
@@ -110,5 +154,93 @@ describe('BacktestEngine storage flow', () => {
     expect(result.trades[0].quoteCoin?.symbol).toBe('USDC');
     expect(result.simulatedFills).toHaveLength(1);
     expect(result.simulatedFills[0].slippageBps).toBe(50);
+  });
+
+  it('falls back to database candles when dataset has no storage location', async () => {
+    const algorithmRegistry = {
+      executeAlgorithm: jest.fn().mockResolvedValue({ success: true, signals: [] })
+    };
+
+    const startDate = new Date('2024-01-01T00:00:00Z');
+    const endDate = new Date('2024-01-01T02:00:00Z');
+    const candles = [
+      new OHLCCandle({
+        coinId: 'BTC',
+        exchangeId: 'exchange-1',
+        timestamp: startDate,
+        open: 100,
+        high: 110,
+        low: 90,
+        close: 105,
+        volume: 1000
+      }),
+      new OHLCCandle({
+        coinId: 'BTC',
+        exchangeId: 'exchange-1',
+        timestamp: new Date('2024-01-01T01:00:00Z'),
+        open: 105,
+        high: 115,
+        low: 95,
+        close: 108,
+        volume: 1200
+      })
+    ];
+
+    const ohlcService = {
+      getCandlesByDateRange: jest.fn().mockResolvedValue(candles)
+    };
+
+    const storageService = {
+      getFileStats: jest.fn(),
+      getFile: jest.fn()
+    };
+    const marketDataReader = new MarketDataReaderService(storageService as any);
+
+    const quoteCurrencyResolver = {
+      resolveQuoteCurrency: jest.fn().mockResolvedValue({ id: 'usdt', symbol: 'USDT' })
+    };
+
+    const engine = createEngine({
+      algorithmRegistry,
+      ohlcService,
+      marketDataReader,
+      quoteCurrencyResolver
+    });
+
+    const result = await engine.executeHistoricalBacktest(
+      {
+        id: 'backtest-db',
+        name: 'DB Backtest',
+        initialCapital: 1000,
+        tradingFee: 0,
+        startDate,
+        endDate,
+        algorithm: { id: 'algo-1' },
+        configSnapshot: {
+          parameters: {},
+          run: {},
+          slippage: { model: 'fixed', fixedBps: 5 }
+        }
+      } as any,
+      [{ id: 'BTC', symbol: 'BTC' } as any],
+      {
+        deterministicSeed: 'seed',
+        dataset: {
+          id: 'dataset-2',
+          storageLocation: '',
+          instrumentUniverse: ['BTC'],
+          startAt: startDate,
+          endAt: endDate
+        } as any
+      }
+    );
+
+    expect(ohlcService.getCandlesByDateRange).toHaveBeenCalledWith(['BTC'], startDate, endDate);
+    expect(storageService.getFileStats).not.toHaveBeenCalled();
+    expect(storageService.getFile).not.toHaveBeenCalled();
+    expect(quoteCurrencyResolver.resolveQuoteCurrency).toHaveBeenCalledWith('USDT');
+    expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(2);
+    expect(result.snapshots).toHaveLength(2);
+    expect(result.trades).toHaveLength(0);
   });
 });

--- a/apps/api/src/order/backtest/shared/fees/fee-calculator.interface.ts
+++ b/apps/api/src/order/backtest/shared/fees/fee-calculator.interface.ts
@@ -1,0 +1,95 @@
+/**
+ * Fee Calculator Interfaces
+ *
+ * Provides fee calculation for backtesting with support for multiple fee structures.
+ */
+
+/**
+ * Fee calculation type
+ */
+export enum FeeType {
+  /** Single flat rate for all trades */
+  FLAT = 'flat',
+  /** Different rates for maker vs taker orders */
+  MAKER_TAKER = 'maker_taker'
+}
+
+/**
+ * Fee configuration for trade execution
+ */
+export interface FeeConfig {
+  /** Type of fee structure */
+  type: FeeType;
+  /** Flat rate as decimal (e.g., 0.001 = 0.1%) - used for FLAT type */
+  flatRate?: number;
+  /** Maker rate as decimal - used for MAKER_TAKER type */
+  makerRate?: number;
+  /** Taker rate as decimal - used for MAKER_TAKER type */
+  takerRate?: number;
+}
+
+/**
+ * Result of fee calculation
+ */
+export interface FeeResult {
+  /** Fee amount in quote currency */
+  fee: number;
+  /** Rate applied as decimal */
+  rate: number;
+  /** Whether this was a maker or taker order (if applicable) */
+  orderType?: 'maker' | 'taker';
+}
+
+/**
+ * Input parameters for fee calculation
+ */
+export interface FeeInput {
+  /** Total trade value in quote currency */
+  tradeValue: number;
+  /** Whether this is a maker order (adds liquidity) */
+  isMaker?: boolean;
+}
+
+/**
+ * Default fee configuration
+ * Uses flat 0.1% (10 bps) fee as a typical exchange rate
+ */
+export const DEFAULT_FEE_CONFIG: FeeConfig = {
+  type: FeeType.FLAT,
+  flatRate: 0.001 // 0.1%
+};
+
+/**
+ * Fee calculator service interface
+ */
+export interface IFeeCalculator {
+  /**
+   * Calculate fee for a trade
+   * @param input Trade details including value and order type
+   * @param config Fee configuration
+   * @returns FeeResult with fee amount and rate
+   */
+  calculateFee(input: FeeInput, config?: FeeConfig): FeeResult;
+
+  /**
+   * Get the fee rate for an order type
+   * @param config Fee configuration
+   * @param isMaker Whether the order is a maker order
+   * @returns Fee rate as decimal
+   */
+  getRate(config: FeeConfig, isMaker?: boolean): number;
+
+  /**
+   * Build complete fee configuration from partial input
+   * @param config Partial configuration
+   * @returns Complete FeeConfig with defaults
+   */
+  buildConfig(config?: Partial<FeeConfig>): FeeConfig;
+
+  /**
+   * Create FeeConfig from a simple flat rate
+   * @param rate Fee rate as decimal (e.g., 0.001 for 0.1%)
+   * @returns FeeConfig with flat rate
+   */
+  fromFlatRate(rate: number): FeeConfig;
+}

--- a/apps/api/src/order/backtest/shared/fees/fee-calculator.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/fees/fee-calculator.service.spec.ts
@@ -1,0 +1,304 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DEFAULT_FEE_CONFIG, FeeConfig, FeeType } from './fee-calculator.interface';
+import { FeeCalculatorService } from './fee-calculator.service';
+
+describe('FeeCalculatorService', () => {
+  let service: FeeCalculatorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FeeCalculatorService]
+    }).compile();
+
+    service = module.get<FeeCalculatorService>(FeeCalculatorService);
+  });
+
+  describe('calculateFee', () => {
+    describe('FLAT fee type', () => {
+      it('should calculate fee with default flat rate', () => {
+        const result = service.calculateFee({ tradeValue: 10000 });
+
+        // Default 0.1% = 10
+        expect(result.fee).toBe(10);
+        expect(result.rate).toBe(0.001);
+        expect(result.orderType).toBeUndefined();
+      });
+
+      it('should calculate fee with custom flat rate', () => {
+        const config: FeeConfig = {
+          type: FeeType.FLAT,
+          flatRate: 0.002 // 0.2%
+        };
+
+        const result = service.calculateFee({ tradeValue: 10000 }, config);
+
+        expect(result.fee).toBe(20);
+        expect(result.rate).toBe(0.002);
+      });
+
+      it('should handle zero trade value', () => {
+        const result = service.calculateFee({ tradeValue: 0 });
+
+        expect(result.fee).toBe(0);
+      });
+
+      it('should handle very small trade values', () => {
+        const result = service.calculateFee({ tradeValue: 1 });
+
+        expect(result.fee).toBe(0.001);
+      });
+
+      it('should handle large trade values', () => {
+        const result = service.calculateFee({ tradeValue: 1000000 });
+
+        expect(result.fee).toBe(1000);
+      });
+
+      it('should throw error for negative trade value', () => {
+        expect(() => service.calculateFee({ tradeValue: -1000 })).toThrow('Trade value cannot be negative');
+      });
+
+      it('should ignore isMaker flag for flat rate', () => {
+        const result1 = service.calculateFee({ tradeValue: 10000, isMaker: true });
+        const result2 = service.calculateFee({ tradeValue: 10000, isMaker: false });
+
+        expect(result1.fee).toBe(result2.fee);
+        expect(result1.orderType).toBeUndefined();
+        expect(result2.orderType).toBeUndefined();
+      });
+    });
+
+    describe('MAKER_TAKER fee type', () => {
+      const makerTakerConfig: FeeConfig = {
+        type: FeeType.MAKER_TAKER,
+        makerRate: 0.0005, // 0.05%
+        takerRate: 0.001 // 0.1%
+      };
+
+      it('should calculate maker fee', () => {
+        const result = service.calculateFee({ tradeValue: 10000, isMaker: true }, makerTakerConfig);
+
+        expect(result.fee).toBe(5);
+        expect(result.rate).toBe(0.0005);
+        expect(result.orderType).toBe('maker');
+      });
+
+      it('should calculate taker fee', () => {
+        const result = service.calculateFee({ tradeValue: 10000, isMaker: false }, makerTakerConfig);
+
+        expect(result.fee).toBe(10);
+        expect(result.rate).toBe(0.001);
+        expect(result.orderType).toBe('taker');
+      });
+
+      it('should default to taker when isMaker not specified', () => {
+        const result = service.calculateFee({ tradeValue: 10000 }, makerTakerConfig);
+
+        expect(result.rate).toBe(0.001);
+        expect(result.orderType).toBe('taker');
+      });
+
+      it('should use default rates when not specified', () => {
+        const config: FeeConfig = { type: FeeType.MAKER_TAKER };
+
+        const makerResult = service.calculateFee({ tradeValue: 10000, isMaker: true }, config);
+        const takerResult = service.calculateFee({ tradeValue: 10000, isMaker: false }, config);
+
+        // Default maker: 0.05%, taker: 0.1%
+        expect(makerResult.rate).toBe(0.0005);
+        expect(takerResult.rate).toBe(0.001);
+      });
+    });
+  });
+
+  describe('getRate', () => {
+    it('should return flat rate for FLAT type', () => {
+      const config: FeeConfig = { type: FeeType.FLAT, flatRate: 0.002 };
+
+      expect(service.getRate(config)).toBe(0.002);
+      expect(service.getRate(config, true)).toBe(0.002);
+      expect(service.getRate(config, false)).toBe(0.002);
+    });
+
+    it('should return default flat rate when flatRate is missing', () => {
+      const config: FeeConfig = { type: FeeType.FLAT };
+
+      expect(service.getRate(config)).toBe(0.001);
+    });
+
+    it('should return maker rate for MAKER_TAKER when isMaker is true', () => {
+      const config: FeeConfig = {
+        type: FeeType.MAKER_TAKER,
+        makerRate: 0.0003,
+        takerRate: 0.0008
+      };
+
+      expect(service.getRate(config, true)).toBe(0.0003);
+    });
+
+    it('should return taker rate for MAKER_TAKER when isMaker is false', () => {
+      const config: FeeConfig = {
+        type: FeeType.MAKER_TAKER,
+        makerRate: 0.0003,
+        takerRate: 0.0008
+      };
+
+      expect(service.getRate(config, false)).toBe(0.0008);
+    });
+
+    it('should return taker rate when isMaker is undefined', () => {
+      const config: FeeConfig = {
+        type: FeeType.MAKER_TAKER,
+        makerRate: 0.0003,
+        takerRate: 0.0008
+      };
+
+      expect(service.getRate(config)).toBe(0.0008);
+    });
+
+    it('should return default maker/taker rates when missing', () => {
+      const config: FeeConfig = { type: FeeType.MAKER_TAKER };
+
+      expect(service.getRate(config, true)).toBe(0.0005);
+      expect(service.getRate(config, false)).toBe(0.001);
+    });
+
+    it('should return default rate for unknown type', () => {
+      const config = { type: 'unknown' as FeeType };
+
+      expect(service.getRate(config)).toBe(0.001);
+    });
+  });
+
+  describe('buildConfig', () => {
+    it('should build config with all parameters', () => {
+      const config = service.buildConfig({
+        type: FeeType.MAKER_TAKER,
+        flatRate: 0.002,
+        makerRate: 0.0004,
+        takerRate: 0.0008
+      });
+
+      expect(config.type).toBe(FeeType.MAKER_TAKER);
+      expect(config.flatRate).toBe(0.002);
+      expect(config.makerRate).toBe(0.0004);
+      expect(config.takerRate).toBe(0.0008);
+    });
+
+    it('should use defaults when not specified', () => {
+      const config = service.buildConfig();
+
+      expect(config.type).toBe(FeeType.FLAT);
+      expect(config.flatRate).toBe(0.001);
+      expect(config.makerRate).toBe(0.0005);
+      expect(config.takerRate).toBe(0.001);
+    });
+
+    it('should handle partial parameters', () => {
+      const config = service.buildConfig({
+        type: FeeType.MAKER_TAKER,
+        makerRate: 0.0002
+      });
+
+      expect(config.type).toBe(FeeType.MAKER_TAKER);
+      expect(config.makerRate).toBe(0.0002);
+      expect(config.takerRate).toBe(0.001); // default
+    });
+  });
+
+  describe('maker/taker defaults', () => {
+    it('uses default maker rate when missing', () => {
+      const config: FeeConfig = { type: FeeType.MAKER_TAKER, takerRate: 0.002 };
+
+      const result = service.calculateFee({ tradeValue: 10000, isMaker: true }, config);
+
+      expect(result.rate).toBe(0.0005);
+      expect(result.orderType).toBe('maker');
+      expect(result.fee).toBe(5);
+    });
+
+    it('uses default taker rate when missing', () => {
+      const config: FeeConfig = { type: FeeType.MAKER_TAKER, makerRate: 0.0002 };
+
+      const result = service.calculateFee({ tradeValue: 10000, isMaker: false }, config);
+
+      expect(result.rate).toBe(0.001);
+      expect(result.orderType).toBe('taker');
+      expect(result.fee).toBe(10);
+    });
+  });
+
+  describe('fromFlatRate', () => {
+    it('should create FLAT config from rate', () => {
+      const config = service.fromFlatRate(0.0015);
+
+      expect(config.type).toBe(FeeType.FLAT);
+      expect(config.flatRate).toBe(0.0015);
+    });
+
+    it('should handle typical exchange rates', () => {
+      // Binance default spot rate
+      const config = service.fromFlatRate(0.001);
+
+      expect(config.flatRate).toBe(0.001);
+    });
+
+    it('should handle zero fee rate', () => {
+      const config = service.fromFlatRate(0);
+
+      expect(config.flatRate).toBe(0);
+    });
+
+    it('should throw error for negative rate', () => {
+      expect(() => service.fromFlatRate(-0.001)).toThrow('Fee rate must be a non-negative finite number');
+    });
+
+    it('should throw error for NaN rate', () => {
+      expect(() => service.fromFlatRate(NaN)).toThrow('Fee rate must be a non-negative finite number');
+    });
+
+    it('should throw error for Infinity rate', () => {
+      expect(() => service.fromFlatRate(Infinity)).toThrow('Fee rate must be a non-negative finite number');
+    });
+  });
+
+  describe('DEFAULT_FEE_CONFIG', () => {
+    it('should be FLAT type with 0.1% rate', () => {
+      expect(DEFAULT_FEE_CONFIG.type).toBe(FeeType.FLAT);
+      expect(DEFAULT_FEE_CONFIG.flatRate).toBe(0.001);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle precision for very small fees', () => {
+      const config: FeeConfig = {
+        type: FeeType.FLAT,
+        flatRate: 0.0001 // 1 basis point
+      };
+
+      const result = service.calculateFee({ tradeValue: 100 }, config);
+
+      expect(result.fee).toBeCloseTo(0.01, 10);
+    });
+
+    it('should handle precision for very large trades', () => {
+      const result = service.calculateFee({ tradeValue: 1_000_000_000 });
+
+      expect(result.fee).toBe(1_000_000);
+    });
+
+    it('should match backtest tradingFee parameter usage', () => {
+      // The backtest uses tradingFee as a decimal rate directly
+      // e.g., tradingFee: 0.001 means 0.1%
+      const tradingFee = 0.001;
+      const tradeValue = 50000;
+
+      const config = service.fromFlatRate(tradingFee);
+      const result = service.calculateFee({ tradeValue }, config);
+
+      // Expected: 50000 * 0.001 = 50
+      expect(result.fee).toBe(50);
+    });
+  });
+});

--- a/apps/api/src/order/backtest/shared/fees/fee-calculator.service.ts
+++ b/apps/api/src/order/backtest/shared/fees/fee-calculator.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  DEFAULT_FEE_CONFIG,
+  FeeConfig,
+  FeeInput,
+  FeeResult,
+  FeeType,
+  IFeeCalculator
+} from './fee-calculator.interface';
+
+/**
+ * Fee Calculator Service
+ *
+ * Provides fee calculation for backtesting with support for multiple fee structures:
+ * - FLAT: Single rate for all trades (default)
+ * - MAKER_TAKER: Different rates for maker vs taker orders
+ *
+ * Note: This service calculates fees but does NOT deduct them from balances.
+ * The calling code is responsible for deducting fees exactly once from the
+ * appropriate balance (typically cashBalance).
+ *
+ * @example
+ * ```typescript
+ * // Calculate fee for a $10,000 trade
+ * const result = feeCalculator.calculateFee({ tradeValue: 10000 });
+ * // result.fee = 10 (with 0.1% default rate)
+ *
+ * // Deduct fee from cash balance (do this ONCE)
+ * portfolio.cashBalance -= result.fee;
+ * ```
+ */
+@Injectable()
+export class FeeCalculatorService implements IFeeCalculator {
+  /**
+   * Calculate fee for a trade
+   * @throws Error if tradeValue is negative
+   */
+  calculateFee(input: FeeInput, config: FeeConfig = DEFAULT_FEE_CONFIG): FeeResult {
+    if (input.tradeValue < 0) {
+      throw new Error('Trade value cannot be negative');
+    }
+
+    const effectiveConfig = this.buildConfig(config);
+    const rate = this.getRate(effectiveConfig, input.isMaker);
+    const fee = input.tradeValue * rate;
+
+    const result: FeeResult = {
+      fee,
+      rate
+    };
+
+    if (effectiveConfig.type === FeeType.MAKER_TAKER) {
+      result.orderType = input.isMaker ? 'maker' : 'taker';
+    }
+
+    return result;
+  }
+
+  /**
+   * Get the applicable fee rate based on configuration and order type
+   */
+  getRate(config: FeeConfig, isMaker?: boolean): number {
+    const effectiveConfig = this.buildConfig(config);
+
+    switch (effectiveConfig.type) {
+      case FeeType.FLAT:
+        return effectiveConfig.flatRate ?? 0.001;
+
+      case FeeType.MAKER_TAKER:
+        if (isMaker) {
+          return effectiveConfig.makerRate ?? 0.0005;
+        }
+        return effectiveConfig.takerRate ?? 0.001;
+
+      default:
+        return 0.001;
+    }
+  }
+
+  /**
+   * Build complete fee configuration from partial input with defaults
+   */
+  buildConfig(config?: Partial<FeeConfig>): FeeConfig {
+    const type = config?.type ?? FeeType.FLAT;
+
+    return {
+      type,
+      flatRate: config?.flatRate ?? 0.001,
+      makerRate: config?.makerRate ?? 0.0005,
+      takerRate: config?.takerRate ?? 0.001
+    };
+  }
+
+  /**
+   * Create FeeConfig from a simple flat rate
+   * Convenience method for backward compatibility with existing backtest code
+   * @throws Error if rate is not a non-negative finite number
+   */
+  fromFlatRate(rate: number): FeeConfig {
+    if (!Number.isFinite(rate) || rate < 0) {
+      throw new Error('Fee rate must be a non-negative finite number');
+    }
+
+    return {
+      type: FeeType.FLAT,
+      flatRate: rate
+    };
+  }
+}

--- a/apps/api/src/order/backtest/shared/fees/index.ts
+++ b/apps/api/src/order/backtest/shared/fees/index.ts
@@ -1,0 +1,2 @@
+export * from './fee-calculator.interface';
+export * from './fee-calculator.service';

--- a/apps/api/src/order/backtest/shared/index.ts
+++ b/apps/api/src/order/backtest/shared/index.ts
@@ -1,0 +1,19 @@
+// Barrel exports for shared backtest components
+
+// Module
+export * from './shared.module';
+
+// Slippage
+export * from './slippage';
+
+// Fees
+export * from './fees';
+
+// Positions
+export * from './positions';
+
+// Metrics
+export * from './metrics';
+
+// Portfolio
+export * from './portfolio';

--- a/apps/api/src/order/backtest/shared/metrics/index.ts
+++ b/apps/api/src/order/backtest/shared/metrics/index.ts
@@ -1,0 +1,2 @@
+export * from './metrics-calculator.interface';
+export * from './metrics-calculator.service';

--- a/apps/api/src/order/backtest/shared/metrics/metrics-calculator.interface.ts
+++ b/apps/api/src/order/backtest/shared/metrics/metrics-calculator.interface.ts
@@ -1,0 +1,187 @@
+/**
+ * Metrics Calculator Interfaces
+ *
+ * Provides comprehensive performance metrics calculation for backtesting
+ * with proper timeframe awareness for annualization.
+ */
+
+/**
+ * Timeframe type for return calculations
+ * Determines the annualization factor for metrics
+ */
+export enum TimeframeType {
+  /** Hourly data: 8760 periods/year (24 * 365 for crypto 24/7 markets) */
+  HOURLY = 'hourly',
+  /** Daily data: 365 for crypto (24/7), 252 for traditional markets */
+  DAILY = 'daily',
+  /** Weekly data: 52 periods/year */
+  WEEKLY = 'weekly',
+  /** Monthly data: 12 periods/year */
+  MONTHLY = 'monthly'
+}
+
+/**
+ * Configuration for metrics calculation
+ */
+export interface MetricsConfig {
+  /** Timeframe of the return data */
+  timeframe: TimeframeType;
+  /** Annual risk-free rate as decimal (default: 0.02 = 2%) */
+  riskFreeRate?: number;
+  /** Whether to use 365 days (crypto) or 252 days (traditional) for daily data */
+  useCryptoCalendar?: boolean;
+}
+
+/**
+ * Input data for metrics calculation
+ */
+export interface MetricsInput {
+  /** Array of portfolio values over time */
+  portfolioValues: number[];
+  /** Initial capital (for total return calculation) */
+  initialCapital: number;
+  /** Array of completed trades for win rate and profit factor */
+  trades?: TradeMetrics[];
+  /** Peak portfolio value (for drawdown verification) */
+  peakValue?: number;
+}
+
+/**
+ * Trade data needed for metrics calculation
+ */
+export interface TradeMetrics {
+  /** Realized P&L for the trade */
+  realizedPnL: number;
+  /** Trade type: 'BUY' or 'SELL' */
+  type: 'BUY' | 'SELL';
+}
+
+/**
+ * Complete metrics result
+ */
+export interface MetricsResult {
+  /** Sharpe ratio (risk-adjusted return) */
+  sharpeRatio: number;
+  /** Sortino ratio (downside risk-adjusted return) */
+  sortinoRatio: number;
+  /** Maximum drawdown as decimal (e.g., 0.15 = 15%) */
+  maxDrawdown: number;
+  /** Win rate as decimal (e.g., 0.6 = 60%) */
+  winRate: number;
+  /** Profit factor (gross profit / gross loss) */
+  profitFactor: number;
+  /** Annualized volatility as decimal */
+  volatility: number;
+  /** Downside deviation (for Sortino ratio) */
+  downsideDeviation: number;
+  /** Total return as decimal (e.g., 0.25 = 25%) */
+  totalReturn: number;
+  /** Annualized return as decimal */
+  annualizedReturn: number;
+  /** Total number of trades */
+  totalTrades: number;
+  /** Number of winning trades */
+  winningTrades: number;
+  /** Final portfolio value */
+  finalValue: number;
+}
+
+/**
+ * Default metrics configuration
+ */
+export const DEFAULT_METRICS_CONFIG: MetricsConfig = {
+  timeframe: TimeframeType.DAILY,
+  riskFreeRate: 0.02,
+  useCryptoCalendar: true
+};
+
+/**
+ * Get periods per year based on timeframe and calendar type
+ */
+export function getPeriodsPerYear(timeframe: TimeframeType, useCryptoCalendar = true): number {
+  switch (timeframe) {
+    case TimeframeType.HOURLY:
+      return useCryptoCalendar ? 8760 : 6552; // 24*365 or 24*252+24*21 (approx)
+    case TimeframeType.DAILY:
+      return useCryptoCalendar ? 365 : 252;
+    case TimeframeType.WEEKLY:
+      return 52;
+    case TimeframeType.MONTHLY:
+      return 12;
+    default:
+      return 252;
+  }
+}
+
+/**
+ * Metrics calculator service interface
+ */
+export interface IMetricsCalculator {
+  /**
+   * Calculate all performance metrics from portfolio values and trades
+   * @param input Portfolio values and trade data
+   * @param config Metrics configuration
+   * @returns Complete MetricsResult
+   */
+  calculateMetrics(input: MetricsInput, config?: MetricsConfig): MetricsResult;
+
+  /**
+   * Calculate Sharpe ratio from returns
+   * @param returns Array of period returns
+   * @param config Metrics configuration
+   * @returns Sharpe ratio
+   */
+  calculateSharpeRatio(returns: number[], config?: MetricsConfig): number;
+
+  /**
+   * Calculate Sortino ratio from returns
+   * @param returns Array of period returns
+   * @param config Metrics configuration
+   * @returns Sortino ratio
+   */
+  calculateSortinoRatio(returns: number[], config?: MetricsConfig): number;
+
+  /**
+   * Calculate maximum drawdown from portfolio values
+   * @param portfolioValues Array of portfolio values
+   * @returns Maximum drawdown as decimal
+   */
+  calculateMaxDrawdown(portfolioValues: number[]): number;
+
+  /**
+   * Calculate win rate from trades
+   * @param trades Array of trades with P&L
+   * @returns Win rate as decimal
+   */
+  calculateWinRate(trades: TradeMetrics[]): number;
+
+  /**
+   * Calculate profit factor from trades
+   * @param trades Array of trades with P&L
+   * @returns Profit factor (gross profit / gross loss)
+   */
+  calculateProfitFactor(trades: TradeMetrics[]): number;
+
+  /**
+   * Calculate volatility (standard deviation of returns)
+   * @param returns Array of period returns
+   * @param config Metrics configuration
+   * @returns Annualized volatility
+   */
+  calculateVolatility(returns: number[], config?: MetricsConfig): number;
+
+  /**
+   * Calculate downside deviation (standard deviation of negative returns)
+   * @param returns Array of period returns
+   * @param config Metrics configuration
+   * @returns Annualized downside deviation
+   */
+  calculateDownsideDeviation(returns: number[], config?: MetricsConfig): number;
+
+  /**
+   * Convert portfolio values to period returns
+   * @param portfolioValues Array of portfolio values
+   * @returns Array of period returns
+   */
+  calculateReturns(portfolioValues: number[]): number[];
+}

--- a/apps/api/src/order/backtest/shared/metrics/metrics-calculator.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/metrics/metrics-calculator.service.spec.ts
@@ -1,0 +1,423 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { getPeriodsPerYear, MetricsConfig, TimeframeType, TradeMetrics } from './metrics-calculator.interface';
+import { MetricsCalculatorService } from './metrics-calculator.service';
+
+import { DrawdownCalculator } from '../../../../common/metrics/drawdown.calculator';
+import { SharpeRatioCalculator } from '../../../../common/metrics/sharpe-ratio.calculator';
+
+describe('MetricsCalculatorService', () => {
+  let service: MetricsCalculatorService;
+  let sharpeCalculator: SharpeRatioCalculator;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MetricsCalculatorService, SharpeRatioCalculator, DrawdownCalculator]
+    }).compile();
+
+    service = module.get<MetricsCalculatorService>(MetricsCalculatorService);
+    sharpeCalculator = module.get<SharpeRatioCalculator>(SharpeRatioCalculator);
+  });
+
+  describe('calculateMetrics', () => {
+    it('should calculate all metrics for profitable portfolio', () => {
+      const portfolioValues = [10000, 10500, 10200, 10800, 11000, 11500, 11300, 12000];
+      const trades: TradeMetrics[] = [
+        { type: 'BUY', realizedPnL: 0 },
+        { type: 'SELL', realizedPnL: 500 },
+        { type: 'BUY', realizedPnL: 0 },
+        { type: 'SELL', realizedPnL: -300 },
+        { type: 'SELL', realizedPnL: 800 }
+      ];
+
+      const result = service.calculateMetrics({
+        portfolioValues,
+        initialCapital: 10000,
+        trades
+      });
+
+      expect(result.finalValue).toBe(12000);
+      expect(result.totalReturn).toBe(0.2); // 20% return
+      expect(result.totalTrades).toBe(5);
+      expect(result.winningTrades).toBe(2);
+      expect(result.winRate).toBeCloseTo(0.6667, 2); // 2 winning / 3 sell trades
+      expect(result.sharpeRatio).toBeDefined();
+      expect(result.sortinoRatio).toBeDefined();
+      expect(result.volatility).toBeGreaterThan(0);
+    });
+
+    it('should return empty metrics for empty portfolio values', () => {
+      const result = service.calculateMetrics({
+        portfolioValues: [],
+        initialCapital: 10000
+      });
+
+      expect(result.sharpeRatio).toBe(0);
+      expect(result.maxDrawdown).toBe(0);
+      expect(result.winRate).toBe(0);
+      expect(result.finalValue).toBe(10000);
+    });
+
+    it('should handle losing portfolio', () => {
+      const portfolioValues = [10000, 9500, 9000, 8500, 8000];
+
+      const result = service.calculateMetrics({
+        portfolioValues,
+        initialCapital: 10000,
+        trades: [{ type: 'SELL', realizedPnL: -2000 }]
+      });
+
+      expect(result.totalReturn).toBe(-0.2); // -20% return
+      expect(result.maxDrawdown).toBeGreaterThan(0);
+      expect(result.winRate).toBe(0);
+    });
+
+    it('should use correct timeframe for annualization', () => {
+      const portfolioValues = [10000, 10100, 10200, 10300];
+
+      const dailyResult = service.calculateMetrics(
+        { portfolioValues, initialCapital: 10000 },
+        { timeframe: TimeframeType.DAILY, useCryptoCalendar: true }
+      );
+
+      const hourlyResult = service.calculateMetrics(
+        { portfolioValues, initialCapital: 10000 },
+        { timeframe: TimeframeType.HOURLY, useCryptoCalendar: true }
+      );
+
+      // Hourly should have higher annualized return (more periods to compound)
+      expect(hourlyResult.annualizedReturn).toBeGreaterThan(dailyResult.annualizedReturn);
+    });
+
+    it('should annualize return based on configured periods', () => {
+      const portfolioValues = [10000, 11000];
+
+      const result = service.calculateMetrics({
+        portfolioValues,
+        initialCapital: 10000
+      });
+
+      expect(result.totalReturn).toBe(0.1);
+      const periods = getPeriodsPerYear(TimeframeType.DAILY, true);
+      const expectedAnnualized = Math.pow(1 + 0.1, periods / 1) - 1;
+      expect(result.annualizedReturn).toBe(expectedAnnualized);
+    });
+
+    it('should ignore BUY trades when computing win rate and profit factor', () => {
+      const portfolioValues = [10000, 10200, 10100, 10400];
+      const trades: TradeMetrics[] = [
+        { type: 'BUY', realizedPnL: 999 },
+        { type: 'SELL', realizedPnL: 200 },
+        { type: 'SELL', realizedPnL: -100 }
+      ];
+
+      const result = service.calculateMetrics({
+        portfolioValues,
+        initialCapital: 10000,
+        trades
+      });
+
+      expect(result.winRate).toBe(0.5);
+      expect(result.profitFactor).toBe(2);
+    });
+  });
+
+  describe('calculateSharpeRatio', () => {
+    it('should calculate Sharpe ratio with default config', () => {
+      const returns = [0.01, 0.02, -0.01, 0.015, 0.005];
+
+      const sharpe = service.calculateSharpeRatio(returns);
+
+      expect(sharpe).toBeGreaterThan(0);
+    });
+
+    it('should return 0 for empty returns', () => {
+      expect(service.calculateSharpeRatio([])).toBe(0);
+    });
+
+    it('should use correct periods for timeframe', () => {
+      const returns = [0.01, 0.02, -0.01, 0.015, 0.005];
+
+      const dailySharpe = service.calculateSharpeRatio(returns, { timeframe: TimeframeType.DAILY });
+      const hourlySharpe = service.calculateSharpeRatio(returns, { timeframe: TimeframeType.HOURLY });
+
+      // Different annualization factors should produce different Sharpe ratios
+      expect(dailySharpe).not.toBe(hourlySharpe);
+    });
+
+    it('should match existing SharpeRatioCalculator output', () => {
+      const returns = [0.01, 0.02, -0.01, 0.015, 0.005];
+      const config: MetricsConfig = { timeframe: TimeframeType.DAILY, useCryptoCalendar: false };
+
+      const serviceSharpe = service.calculateSharpeRatio(returns, config);
+      const directSharpe = sharpeCalculator.calculate(returns, 0.02, 252);
+
+      expect(serviceSharpe).toBeCloseTo(directSharpe, 10);
+    });
+
+    it('should decrease Sharpe when risk-free rate increases', () => {
+      const returns = [0.01, 0.012, 0.011, 0.009, 0.013];
+      const lowRf = service.calculateSharpeRatio(returns, {
+        timeframe: TimeframeType.DAILY,
+        useCryptoCalendar: true,
+        riskFreeRate: 0.01
+      });
+      const highRf = service.calculateSharpeRatio(returns, {
+        timeframe: TimeframeType.DAILY,
+        useCryptoCalendar: true,
+        riskFreeRate: 0.05
+      });
+
+      expect(highRf).toBeLessThan(lowRf);
+    });
+  });
+
+  describe('calculateSortinoRatio', () => {
+    it('should calculate Sortino ratio', () => {
+      const returns = [0.01, 0.02, -0.01, 0.015, -0.005, 0.005];
+
+      const sortino = service.calculateSortinoRatio(returns);
+
+      expect(sortino).toBeGreaterThan(0);
+    });
+
+    it('should return 0 for empty returns', () => {
+      expect(service.calculateSortinoRatio([])).toBe(0);
+    });
+
+    it('should be higher than Sharpe when few negative returns', () => {
+      // Mostly positive returns
+      const returns = [0.02, 0.015, 0.01, -0.002, 0.018, 0.012];
+
+      const sharpe = service.calculateSharpeRatio(returns);
+      const sortino = service.calculateSortinoRatio(returns);
+
+      // Sortino should be higher since it only penalizes downside
+      expect(sortino).toBeGreaterThanOrEqual(sharpe);
+    });
+  });
+
+  describe('calculateMaxDrawdown', () => {
+    it('should calculate max drawdown correctly', () => {
+      const portfolioValues = [100, 110, 105, 120, 100, 115];
+
+      const maxDrawdown = service.calculateMaxDrawdown(portfolioValues);
+
+      // Peak at 120, trough at 100, drawdown = 20/120 = 16.67%
+      expect(maxDrawdown).toBeCloseTo(0.1667, 2);
+    });
+
+    it('should return 0 for monotonically increasing values', () => {
+      const portfolioValues = [100, 110, 120, 130, 140];
+
+      const maxDrawdown = service.calculateMaxDrawdown(portfolioValues);
+
+      expect(maxDrawdown).toBe(0);
+    });
+
+    it('should return 0 for empty array', () => {
+      expect(service.calculateMaxDrawdown([])).toBe(0);
+    });
+  });
+
+  describe('calculateWinRate', () => {
+    it('should calculate win rate from sell trades', () => {
+      const trades: TradeMetrics[] = [
+        { type: 'BUY', realizedPnL: 0 },
+        { type: 'SELL', realizedPnL: 500 },
+        { type: 'SELL', realizedPnL: -200 },
+        { type: 'SELL', realizedPnL: 300 },
+        { type: 'SELL', realizedPnL: -100 }
+      ];
+
+      const winRate = service.calculateWinRate(trades);
+
+      // 2 winning / 4 sell trades = 50%
+      expect(winRate).toBe(0.5);
+    });
+
+    it('should return 0 for no trades', () => {
+      expect(service.calculateWinRate([])).toBe(0);
+    });
+
+    it('should ignore BUY trades', () => {
+      const trades: TradeMetrics[] = [
+        { type: 'BUY', realizedPnL: 1000 },
+        { type: 'BUY', realizedPnL: 2000 }
+      ];
+
+      const winRate = service.calculateWinRate(trades);
+
+      expect(winRate).toBe(0);
+    });
+  });
+
+  describe('calculateProfitFactor', () => {
+    it('should calculate profit factor', () => {
+      const trades: TradeMetrics[] = [
+        { type: 'SELL', realizedPnL: 1000 },
+        { type: 'SELL', realizedPnL: 500 },
+        { type: 'SELL', realizedPnL: -300 },
+        { type: 'SELL', realizedPnL: -200 }
+      ];
+
+      const profitFactor = service.calculateProfitFactor(trades);
+
+      // Gross profit: 1500, Gross loss: 500
+      expect(profitFactor).toBe(3);
+    });
+
+    it('should return Infinity when no losses', () => {
+      const trades: TradeMetrics[] = [
+        { type: 'SELL', realizedPnL: 1000 },
+        { type: 'SELL', realizedPnL: 500 }
+      ];
+
+      const profitFactor = service.calculateProfitFactor(trades);
+
+      expect(profitFactor).toBe(Infinity);
+    });
+
+    it('should return 1 when no trades', () => {
+      expect(service.calculateProfitFactor([])).toBe(1);
+    });
+
+    it('should handle break-even scenario', () => {
+      const trades: TradeMetrics[] = [
+        { type: 'SELL', realizedPnL: 500 },
+        { type: 'SELL', realizedPnL: -500 }
+      ];
+
+      const profitFactor = service.calculateProfitFactor(trades);
+
+      expect(profitFactor).toBe(1);
+    });
+  });
+
+  describe('calculateVolatility', () => {
+    it('should calculate annualized volatility', () => {
+      const returns = [0.01, 0.02, -0.01, 0.015, 0.005];
+
+      const volatility = service.calculateVolatility(returns);
+
+      expect(volatility).toBeGreaterThan(0);
+    });
+
+    it('should return 0 for empty returns', () => {
+      expect(service.calculateVolatility([])).toBe(0);
+    });
+
+    it('should return 0 for constant returns', () => {
+      const returns = [0.01, 0.01, 0.01, 0.01];
+
+      const volatility = service.calculateVolatility(returns);
+
+      expect(volatility).toBe(0);
+    });
+
+    it('should scale with timeframe', () => {
+      const returns = [0.01, 0.02, -0.01, 0.015, 0.005];
+
+      const dailyVol = service.calculateVolatility(returns, { timeframe: TimeframeType.DAILY });
+      const hourlyVol = service.calculateVolatility(returns, { timeframe: TimeframeType.HOURLY });
+
+      // Hourly has more periods, so higher annualized vol
+      expect(hourlyVol).toBeGreaterThan(dailyVol);
+    });
+  });
+
+  describe('calculateDownsideDeviation', () => {
+    it('should calculate downside deviation', () => {
+      const returns = [0.01, 0.02, -0.01, -0.02, 0.015, -0.005];
+
+      const downsideDev = service.calculateDownsideDeviation(returns);
+
+      expect(downsideDev).toBeGreaterThan(0);
+    });
+
+    it('should return 0 for empty returns', () => {
+      expect(service.calculateDownsideDeviation([])).toBe(0);
+    });
+
+    it('should return 0 when all returns above risk-free', () => {
+      // All returns above daily risk-free rate (0.02/365 ≈ 0.000055)
+      const returns = [0.01, 0.02, 0.015, 0.025];
+
+      const downsideDev = service.calculateDownsideDeviation(returns);
+
+      expect(downsideDev).toBe(0);
+    });
+
+    it('should be less than or equal to total volatility', () => {
+      const returns = [0.01, 0.02, -0.01, -0.02, 0.015, -0.005];
+
+      const volatility = service.calculateVolatility(returns);
+      const downsideDev = service.calculateDownsideDeviation(returns);
+
+      expect(downsideDev).toBeLessThanOrEqual(volatility);
+    });
+
+    it('should increase downside deviation with higher risk-free rate', () => {
+      const returns = [0.0001, -0.0001, 0.0002, -0.00005];
+      const lowRf = service.calculateDownsideDeviation(returns, {
+        timeframe: TimeframeType.DAILY,
+        useCryptoCalendar: true,
+        riskFreeRate: 0.01
+      });
+      const highRf = service.calculateDownsideDeviation(returns, {
+        timeframe: TimeframeType.DAILY,
+        useCryptoCalendar: true,
+        riskFreeRate: 0.1
+      });
+
+      expect(highRf).toBeGreaterThan(lowRf);
+    });
+  });
+
+  describe('calculateReturns', () => {
+    it('should convert portfolio values to returns', () => {
+      const portfolioValues = [100, 110, 105, 115];
+
+      const returns = service.calculateReturns(portfolioValues);
+
+      expect(returns).toHaveLength(3);
+      expect(returns[0]).toBeCloseTo(0.1, 5); // (110-100)/100
+      expect(returns[1]).toBeCloseTo(-0.0455, 3); // (105-110)/110
+      expect(returns[2]).toBeCloseTo(0.0952, 3); // (115-105)/105
+    });
+
+    it('should return empty array for single value', () => {
+      expect(service.calculateReturns([100])).toEqual([]);
+    });
+
+    it('should return empty array for empty input', () => {
+      expect(service.calculateReturns([])).toEqual([]);
+    });
+
+    it('should handle zero value gracefully', () => {
+      const portfolioValues = [100, 0, 50];
+
+      const returns = service.calculateReturns(portfolioValues);
+
+      expect(returns[0]).toBe(-1); // (0-100)/100
+      expect(returns[1]).toBe(0); // (50-0)/0 -> 0 to avoid NaN
+    });
+  });
+
+  describe('getPeriodsPerYear', () => {
+    it('should return correct periods for crypto calendar', () => {
+      expect(getPeriodsPerYear(TimeframeType.HOURLY, true)).toBe(8760);
+      expect(getPeriodsPerYear(TimeframeType.DAILY, true)).toBe(365);
+      expect(getPeriodsPerYear(TimeframeType.WEEKLY, true)).toBe(52);
+      expect(getPeriodsPerYear(TimeframeType.MONTHLY, true)).toBe(12);
+    });
+
+    it('should return correct periods for traditional calendar', () => {
+      expect(getPeriodsPerYear(TimeframeType.DAILY, false)).toBe(252);
+    });
+
+    it('should return correct periods for hourly traditional calendar', () => {
+      expect(getPeriodsPerYear(TimeframeType.HOURLY, false)).toBe(6552);
+    });
+  });
+});

--- a/apps/api/src/order/backtest/shared/metrics/metrics-calculator.service.ts
+++ b/apps/api/src/order/backtest/shared/metrics/metrics-calculator.service.ts
@@ -1,0 +1,243 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  DEFAULT_METRICS_CONFIG,
+  getPeriodsPerYear,
+  IMetricsCalculator,
+  MetricsConfig,
+  MetricsInput,
+  MetricsResult,
+  TradeMetrics
+} from './metrics-calculator.interface';
+
+import { DrawdownCalculator } from '../../../../common/metrics/drawdown.calculator';
+import { SharpeRatioCalculator } from '../../../../common/metrics/sharpe-ratio.calculator';
+
+/**
+ * Metrics Calculator Service
+ *
+ * Provides comprehensive performance metrics calculation for backtesting.
+ * Integrates with existing SharpeRatioCalculator and DrawdownCalculator
+ * while adding proper timeframe awareness for annualization.
+ *
+ * Key improvements over inline calculations:
+ * - Proper timeframe awareness (hourly vs daily vs weekly)
+ * - Consistent annualization across all metrics
+ * - Correct downside deviation calculation for Sortino
+ *
+ * @example
+ * ```typescript
+ * const metrics = metricsCalculator.calculateMetrics({
+ *   portfolioValues: [10000, 10500, 10200, 11000],
+ *   initialCapital: 10000,
+ *   trades: sellTrades
+ * }, {
+ *   timeframe: TimeframeType.DAILY,
+ *   useCryptoCalendar: true
+ * });
+ * ```
+ */
+@Injectable()
+export class MetricsCalculatorService implements IMetricsCalculator {
+  constructor(
+    private readonly sharpeCalculator: SharpeRatioCalculator,
+    private readonly drawdownCalculator: DrawdownCalculator
+  ) {}
+
+  /**
+   * Calculate all performance metrics from portfolio values and trades
+   */
+  calculateMetrics(input: MetricsInput, config: MetricsConfig = DEFAULT_METRICS_CONFIG): MetricsResult {
+    const { portfolioValues, initialCapital, trades = [] } = input;
+
+    if (portfolioValues.length === 0) {
+      return this.getEmptyMetrics(initialCapital);
+    }
+
+    // Calculate returns from portfolio values
+    const returns = this.calculateReturns(portfolioValues);
+
+    // Get annualization factor
+    const periodsPerYear = getPeriodsPerYear(config.timeframe, config.useCryptoCalendar);
+
+    // Calculate individual metrics
+    const sharpeRatio = this.calculateSharpeRatio(returns, config);
+    const sortinoRatio = this.calculateSortinoRatio(returns, config);
+    const maxDrawdown = this.calculateMaxDrawdown(portfolioValues);
+    const volatility = this.calculateVolatility(returns, config);
+    const downsideDeviation = this.calculateDownsideDeviation(returns, config);
+
+    // Trade-based metrics (methods handle SELL filtering internally)
+    const winRate = this.calculateWinRate(trades);
+    const profitFactor = this.calculateProfitFactor(trades);
+    const sellTrades = trades.filter((t) => t.type === 'SELL');
+
+    // Return metrics
+    const finalValue = portfolioValues[portfolioValues.length - 1];
+    const totalReturn = (finalValue - initialCapital) / initialCapital;
+
+    // Annualized return
+    const durationPeriods = portfolioValues.length - 1;
+    const annualizedReturn =
+      durationPeriods > 0 ? Math.pow(1 + totalReturn, periodsPerYear / durationPeriods) - 1 : totalReturn;
+
+    return {
+      sharpeRatio,
+      sortinoRatio,
+      maxDrawdown,
+      winRate,
+      profitFactor,
+      volatility,
+      downsideDeviation,
+      totalReturn,
+      annualizedReturn,
+      totalTrades: trades.length,
+      winningTrades: sellTrades.filter((t) => t.realizedPnL > 0).length,
+      finalValue
+    };
+  }
+
+  /**
+   * Calculate Sharpe ratio using centralized calculator
+   */
+  calculateSharpeRatio(returns: number[], config: MetricsConfig = DEFAULT_METRICS_CONFIG): number {
+    if (returns.length === 0) return 0;
+
+    const periodsPerYear = getPeriodsPerYear(config.timeframe, config.useCryptoCalendar);
+    const riskFreeRate = config.riskFreeRate ?? DEFAULT_METRICS_CONFIG.riskFreeRate ?? 0.02;
+
+    return this.sharpeCalculator.calculate(returns, riskFreeRate, periodsPerYear);
+  }
+
+  /**
+   * Calculate Sortino ratio using centralized calculator
+   */
+  calculateSortinoRatio(returns: number[], config: MetricsConfig = DEFAULT_METRICS_CONFIG): number {
+    if (returns.length === 0) return 0;
+
+    const periodsPerYear = getPeriodsPerYear(config.timeframe, config.useCryptoCalendar);
+    const riskFreeRate = config.riskFreeRate ?? DEFAULT_METRICS_CONFIG.riskFreeRate ?? 0.02;
+
+    return this.sharpeCalculator.calculateSortino(returns, riskFreeRate, periodsPerYear);
+  }
+
+  /**
+   * Calculate maximum drawdown using centralized calculator
+   */
+  calculateMaxDrawdown(portfolioValues: number[]): number {
+    if (portfolioValues.length === 0) return 0;
+
+    const result = this.drawdownCalculator.calculateMaxDrawdown(portfolioValues);
+    return result.maxDrawdownPercentage / 100; // Convert from percentage to decimal
+  }
+
+  /**
+   * Calculate win rate from trades
+   * Win rate = winning SELL trades / total SELL trades
+   * Automatically filters for SELL trades (only SELL trades have realized P&L)
+   */
+  calculateWinRate(trades: TradeMetrics[]): number {
+    const sellTrades = trades.filter((t) => t.type === 'SELL');
+    if (sellTrades.length === 0) return 0;
+
+    const winningTrades = sellTrades.filter((t) => t.realizedPnL > 0).length;
+    return winningTrades / sellTrades.length;
+  }
+
+  /**
+   * Calculate profit factor from trades
+   * Profit Factor = Gross Profit / Gross Loss
+   * Automatically filters for SELL trades (only SELL trades have realized P&L)
+   */
+  calculateProfitFactor(trades: TradeMetrics[]): number {
+    const sellTrades = trades.filter((t) => t.type === 'SELL');
+
+    const grossProfit = sellTrades.filter((t) => t.realizedPnL > 0).reduce((sum, t) => sum + t.realizedPnL, 0);
+
+    const grossLoss = Math.abs(sellTrades.filter((t) => t.realizedPnL < 0).reduce((sum, t) => sum + t.realizedPnL, 0));
+
+    if (grossLoss === 0) {
+      return grossProfit > 0 ? Infinity : 1;
+    }
+
+    return grossProfit / grossLoss;
+  }
+
+  /**
+   * Calculate annualized volatility
+   */
+  calculateVolatility(returns: number[], config: MetricsConfig = DEFAULT_METRICS_CONFIG): number {
+    if (returns.length === 0) return 0;
+
+    const periodsPerYear = getPeriodsPerYear(config.timeframe, config.useCryptoCalendar);
+
+    // Calculate mean return
+    const meanReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
+
+    // Calculate variance
+    const variance = returns.reduce((sum, r) => sum + Math.pow(r - meanReturn, 2), 0) / returns.length;
+
+    // Return annualized volatility
+    return Math.sqrt(variance) * Math.sqrt(periodsPerYear);
+  }
+
+  /**
+   * Calculate annualized downside deviation
+   * Uses same formula as SharpeRatioCalculator.calculateSortino for consistency
+   */
+  calculateDownsideDeviation(returns: number[], config: MetricsConfig = DEFAULT_METRICS_CONFIG): number {
+    if (returns.length === 0) return 0;
+
+    const periodsPerYear = getPeriodsPerYear(config.timeframe, config.useCryptoCalendar);
+    const riskFreeRate = config.riskFreeRate ?? DEFAULT_METRICS_CONFIG.riskFreeRate ?? 0.02;
+    const periodRiskFreeRate = riskFreeRate / periodsPerYear;
+
+    // Filter to downside returns (below risk-free rate)
+    const downsideReturns = returns.filter((r) => r < periodRiskFreeRate);
+
+    if (downsideReturns.length === 0) return 0;
+
+    // Calculate downside variance using full sample size (consistent with SharpeRatioCalculator)
+    const downsideVariance =
+      downsideReturns.reduce((sum, r) => sum + Math.pow(r - periodRiskFreeRate, 2), 0) / returns.length;
+
+    // Return annualized downside deviation
+    return Math.sqrt(downsideVariance) * Math.sqrt(periodsPerYear);
+  }
+
+  /**
+   * Convert portfolio values to period returns
+   */
+  calculateReturns(portfolioValues: number[]): number[] {
+    if (portfolioValues.length < 2) return [];
+
+    const returns: number[] = [];
+    for (let i = 1; i < portfolioValues.length; i++) {
+      const previous = portfolioValues[i - 1];
+      const current = portfolioValues[i];
+      returns.push(previous === 0 ? 0 : (current - previous) / previous);
+    }
+
+    return returns;
+  }
+
+  /**
+   * Return empty metrics when no data available
+   */
+  private getEmptyMetrics(initialCapital: number): MetricsResult {
+    return {
+      sharpeRatio: 0,
+      sortinoRatio: 0,
+      maxDrawdown: 0,
+      winRate: 0,
+      profitFactor: 1,
+      volatility: 0,
+      downsideDeviation: 0,
+      totalReturn: 0,
+      annualizedReturn: 0,
+      totalTrades: 0,
+      winningTrades: 0,
+      finalValue: initialCapital
+    };
+  }
+}

--- a/apps/api/src/order/backtest/shared/portfolio/index.ts
+++ b/apps/api/src/order/backtest/shared/portfolio/index.ts
@@ -1,0 +1,2 @@
+export * from './portfolio-state.interface';
+export * from './portfolio-state.service';

--- a/apps/api/src/order/backtest/shared/portfolio/portfolio-state.interface.ts
+++ b/apps/api/src/order/backtest/shared/portfolio/portfolio-state.interface.ts
@@ -1,0 +1,185 @@
+/**
+ * Portfolio State Interfaces
+ *
+ * Provides portfolio state management for backtesting including
+ * initialization, updates, snapshots, and checkpoint serialization.
+ */
+
+import { Position } from '../positions';
+
+/**
+ * Portfolio state representing current holdings and cash
+ */
+export interface Portfolio {
+  /** Cash balance in quote currency */
+  cashBalance: number;
+  /** Map of coinId to Position */
+  positions: Map<string, Position>;
+  /** Total portfolio value (cash + positions) */
+  totalValue: number;
+}
+
+/**
+ * Point-in-time snapshot of portfolio for charting and analysis
+ */
+export interface PortfolioSnapshot {
+  /** Timestamp of the snapshot */
+  timestamp: Date;
+  /** Total portfolio value at this time */
+  portfolioValue: number;
+  /** Cash balance at this time */
+  cashBalance: number;
+  /** Holdings map: coinId -> { quantity, value, price } */
+  holdings: Record<string, { quantity: number; value: number; price: number }>;
+  /** Cumulative return from initial capital */
+  cumulativeReturn: number;
+  /** Current drawdown from peak */
+  drawdown: number;
+}
+
+/**
+ * Serializable position for checkpointing
+ */
+export interface SerializablePosition {
+  coinId: string;
+  quantity: number;
+  averagePrice: number;
+}
+
+/**
+ * Serializable portfolio state for checkpointing
+ */
+export interface SerializablePortfolio {
+  cashBalance: number;
+  positions: SerializablePosition[];
+}
+
+/**
+ * Drawdown tracking state
+ */
+export interface DrawdownState {
+  /** Peak portfolio value observed */
+  peakValue: number;
+  /** Maximum drawdown observed */
+  maxDrawdown: number;
+  /** Current drawdown from peak */
+  currentDrawdown: number;
+}
+
+/**
+ * Result of applying a trade to portfolio
+ */
+export interface ApplyTradeResult {
+  /** Updated portfolio after trade */
+  portfolio: Portfolio;
+  /** Whether the trade was applied successfully */
+  success: boolean;
+  /** Error message if trade failed */
+  error?: string;
+}
+
+/**
+ * Portfolio state service interface
+ */
+export interface IPortfolioState {
+  /**
+   * Initialize a new portfolio with starting capital
+   * @param initialCapital Starting cash balance
+   * @returns New Portfolio instance
+   */
+  initialize(initialCapital: number): Portfolio;
+
+  /**
+   * Update portfolio values with current market prices
+   * @param portfolio Current portfolio
+   * @param prices Map of coinId to current price
+   * @returns Updated portfolio with recalculated values
+   */
+  updateValues(portfolio: Portfolio, prices: Map<string, number>): Portfolio;
+
+  /**
+   * Apply a buy trade to the portfolio
+   * @param portfolio Current portfolio
+   * @param coinId Asset to buy
+   * @param quantity Quantity to buy
+   * @param price Execution price
+   * @param fee Trading fee
+   * @param currentPrices Optional map of current prices for all positions (for accurate totalValue)
+   * @returns Updated portfolio
+   */
+  applyBuy(
+    portfolio: Portfolio,
+    coinId: string,
+    quantity: number,
+    price: number,
+    fee: number,
+    currentPrices?: Map<string, number>
+  ): ApplyTradeResult;
+
+  /**
+   * Apply a sell trade to the portfolio
+   * @param portfolio Current portfolio
+   * @param coinId Asset to sell
+   * @param quantity Quantity to sell
+   * @param price Execution price
+   * @param fee Trading fee
+   * @param currentPrices Optional map of current prices for all positions (for accurate totalValue)
+   * @returns Updated portfolio
+   */
+  applySell(
+    portfolio: Portfolio,
+    coinId: string,
+    quantity: number,
+    price: number,
+    fee: number,
+    currentPrices?: Map<string, number>
+  ): ApplyTradeResult;
+
+  /**
+   * Create a snapshot of the current portfolio state
+   * @param portfolio Current portfolio
+   * @param timestamp Snapshot timestamp
+   * @param prices Current prices
+   * @param initialCapital Initial capital for return calculation
+   * @param drawdownState Current drawdown tracking
+   * @returns PortfolioSnapshot
+   */
+  createSnapshot(
+    portfolio: Portfolio,
+    timestamp: Date,
+    prices: Map<string, number>,
+    initialCapital: number,
+    drawdownState: DrawdownState
+  ): PortfolioSnapshot;
+
+  /**
+   * Update drawdown tracking with current portfolio value
+   * @param currentValue Current portfolio value
+   * @param currentState Current drawdown state
+   * @returns Updated drawdown state
+   */
+  updateDrawdown(currentValue: number, currentState: DrawdownState): DrawdownState;
+
+  /**
+   * Calculate total positions value
+   * @param positions Map of positions
+   * @param prices Map of current prices
+   * @returns Total value of all positions
+   */
+  calculatePositionsValue(positions: Map<string, Position>, prices: Map<string, number>): number;
+
+  /**
+   * Serialize portfolio for checkpointing
+   * @param portfolio Portfolio to serialize
+   * @returns Serializable portfolio object
+   */
+  serialize(portfolio: Portfolio): SerializablePortfolio;
+
+  /**
+   * Deserialize portfolio from checkpoint
+   * @param serialized Serialized portfolio
+   * @param currentPrices Current prices for value calculation
+   * @returns Restored Portfolio
+   */
+  deserialize(serialized: SerializablePortfolio, currentPrices?: Map<string, number>): Portfolio;
+}

--- a/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.spec.ts
@@ -1,0 +1,481 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DrawdownState, Portfolio, SerializablePortfolio } from './portfolio-state.interface';
+import { PortfolioStateService } from './portfolio-state.service';
+
+describe('PortfolioStateService', () => {
+  let service: PortfolioStateService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PortfolioStateService]
+    }).compile();
+
+    service = module.get<PortfolioStateService>(PortfolioStateService);
+  });
+
+  describe('initialize', () => {
+    it('should create portfolio with initial capital', () => {
+      const portfolio = service.initialize(10000);
+
+      expect(portfolio.cashBalance).toBe(10000);
+      expect(portfolio.totalValue).toBe(10000);
+      expect(portfolio.positions.size).toBe(0);
+    });
+
+    it('should handle zero initial capital', () => {
+      const portfolio = service.initialize(0);
+
+      expect(portfolio.cashBalance).toBe(0);
+      expect(portfolio.totalValue).toBe(0);
+    });
+  });
+
+  describe('updateValues', () => {
+    it('should update position values with current prices', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([
+          ['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }],
+          ['ethereum', { coinId: 'ethereum', quantity: 1, averagePrice: 2000, totalValue: 2000 }]
+        ]),
+        totalValue: 11500
+      };
+
+      const prices = new Map([
+        ['bitcoin', 50000],
+        ['ethereum', 2500]
+      ]);
+
+      const updated = service.updateValues(portfolio, prices);
+
+      expect(updated.cashBalance).toBe(5000);
+      expect(updated.positions.get('bitcoin')?.totalValue).toBe(5000);
+      expect(updated.positions.get('ethereum')?.totalValue).toBe(2500);
+      expect(updated.totalValue).toBe(12500); // 5000 + 5000 + 2500
+    });
+
+    it('should handle missing prices', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }]]),
+        totalValue: 9500
+      };
+
+      // No price for bitcoin
+      const prices = new Map<string, number>();
+
+      const updated = service.updateValues(portfolio, prices);
+
+      // Value should use stored totalValue when no price provided
+      expect(updated.totalValue).toBe(9500);
+    });
+
+    it('should not mutate original portfolio (immutability)', () => {
+      const originalPosition = { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 };
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([['bitcoin', originalPosition]]),
+        totalValue: 9500
+      };
+
+      const prices = new Map([['bitcoin', 60000]]);
+      const updated = service.updateValues(portfolio, prices);
+
+      // Verify original portfolio is unchanged
+      expect(portfolio.totalValue).toBe(9500);
+      expect(portfolio.cashBalance).toBe(5000);
+      expect(portfolio.positions.get('bitcoin')?.totalValue).toBe(4500);
+      expect(originalPosition.totalValue).toBe(4500);
+
+      // Verify updated portfolio has new values
+      expect(updated.positions.get('bitcoin')?.totalValue).toBe(6000);
+      expect(updated.totalValue).toBe(11000);
+
+      // Verify positions maps are different objects
+      expect(updated.positions).not.toBe(portfolio.positions);
+    });
+  });
+
+  describe('applyBuy', () => {
+    it('should apply buy trade for new position', () => {
+      const portfolio = service.initialize(10000);
+
+      const result = service.applyBuy(portfolio, 'bitcoin', 0.1, 50000, 5);
+
+      expect(result.success).toBe(true);
+      expect(result.portfolio.cashBalance).toBe(4995); // 10000 - 5000 - 5
+      expect(result.portfolio.positions.get('bitcoin')?.quantity).toBe(0.1);
+      expect(result.portfolio.positions.get('bitcoin')?.averagePrice).toBe(50000);
+    });
+
+    it('should apply buy trade to increase existing position', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 10000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }]]),
+        totalValue: 14500
+      };
+
+      const result = service.applyBuy(portfolio, 'bitcoin', 0.1, 55000, 5);
+
+      expect(result.success).toBe(true);
+      expect(result.portfolio.positions.get('bitcoin')?.quantity).toBe(0.2);
+      // New avg: (45000 * 0.1 + 55000 * 0.1) / 0.2 = 50000
+      expect(result.portfolio.positions.get('bitcoin')?.averagePrice).toBe(50000);
+    });
+
+    it('should not mutate original portfolio on buy', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 10000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }]]),
+        totalValue: 14500
+      };
+
+      const result = service.applyBuy(portfolio, 'bitcoin', 0.1, 55000, 5);
+
+      expect(result.success).toBe(true);
+      // Verify original portfolio is unchanged
+      expect(portfolio.cashBalance).toBe(10000);
+      expect(portfolio.positions.get('bitcoin')?.quantity).toBe(0.1);
+      expect(portfolio.positions.get('bitcoin')?.averagePrice).toBe(45000);
+      expect(portfolio.positions.get('bitcoin')?.totalValue).toBe(4500);
+      expect(portfolio.totalValue).toBe(14500);
+    });
+
+    it('should reject buy with insufficient funds', () => {
+      const portfolio = service.initialize(1000);
+
+      const result = service.applyBuy(portfolio, 'bitcoin', 0.1, 50000, 5);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Insufficient');
+      expect(result.portfolio.cashBalance).toBe(1000); // Unchanged
+    });
+
+    it('should deduct fee from cash balance', () => {
+      const portfolio = service.initialize(10000);
+
+      const result = service.applyBuy(portfolio, 'bitcoin', 0.1, 50000, 50);
+
+      // Cost: 0.1 * 50000 = 5000, Fee: 50
+      expect(result.portfolio.cashBalance).toBe(4950);
+    });
+  });
+
+  describe('applySell', () => {
+    it('should apply sell trade and close position', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }]]),
+        totalValue: 9500
+      };
+
+      const result = service.applySell(portfolio, 'bitcoin', 0.1, 55000, 5);
+
+      expect(result.success).toBe(true);
+      // Proceeds: 0.1 * 55000 = 5500, less fee 5 = 5495 added to cash
+      expect(result.portfolio.cashBalance).toBe(10495);
+      expect(result.portfolio.positions.has('bitcoin')).toBe(false);
+    });
+
+    it('should apply partial sell and reduce position', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 1, averagePrice: 45000, totalValue: 45000 }]]),
+        totalValue: 50000
+      };
+
+      const result = service.applySell(portfolio, 'bitcoin', 0.5, 55000, 5);
+
+      expect(result.success).toBe(true);
+      expect(result.portfolio.positions.get('bitcoin')?.quantity).toBe(0.5);
+      expect(result.portfolio.positions.get('bitcoin')?.averagePrice).toBe(45000); // Unchanged
+      // Remaining position valued at sell price
+      expect(result.portfolio.positions.get('bitcoin')?.totalValue).toBe(27500);
+    });
+
+    it('should reject sell with no position', () => {
+      const portfolio = service.initialize(10000);
+
+      const result = service.applySell(portfolio, 'bitcoin', 0.1, 55000, 5);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('No position');
+    });
+
+    it('should cap sell quantity to available', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }]]),
+        totalValue: 9500
+      };
+
+      // Try to sell more than we have
+      const result = service.applySell(portfolio, 'bitcoin', 1, 55000, 5);
+
+      expect(result.success).toBe(true);
+      // Should sell only 0.1 (what we have)
+      expect(result.portfolio.positions.has('bitcoin')).toBe(false);
+      expect(result.portfolio.cashBalance).toBe(10495); // 5000 + 5500 - 5
+    });
+
+    it('should not mutate original portfolio on sell', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 1, averagePrice: 45000, totalValue: 45000 }]]),
+        totalValue: 50000
+      };
+
+      const result = service.applySell(portfolio, 'bitcoin', 0.25, 55000, 5);
+
+      expect(result.success).toBe(true);
+      expect(portfolio.cashBalance).toBe(5000);
+      expect(portfolio.positions.get('bitcoin')?.quantity).toBe(1);
+    });
+  });
+
+  describe('createSnapshot', () => {
+    it('should create snapshot with all fields', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([
+          ['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 5500 }],
+          ['ethereum', { coinId: 'ethereum', quantity: 1, averagePrice: 2000, totalValue: 2500 }]
+        ]),
+        totalValue: 13000
+      };
+
+      const prices = new Map([
+        ['bitcoin', 55000],
+        ['ethereum', 2500]
+      ]);
+
+      const drawdownState: DrawdownState = {
+        peakValue: 15000,
+        maxDrawdown: 0.2,
+        currentDrawdown: 0.1333
+      };
+
+      const snapshot = service.createSnapshot(portfolio, new Date('2024-01-15'), prices, 10000, drawdownState);
+
+      expect(snapshot.portfolioValue).toBe(13000);
+      expect(snapshot.cashBalance).toBe(5000);
+      expect(snapshot.cumulativeReturn).toBe(0.3); // (13000-10000)/10000
+      expect(snapshot.drawdown).toBeCloseTo(0.1333, 3);
+      expect(snapshot.holdings['bitcoin'].quantity).toBe(0.1);
+      expect(snapshot.holdings['bitcoin'].price).toBe(55000);
+      expect(snapshot.holdings['ethereum'].value).toBe(2500);
+    });
+
+    it('should handle zero initial capital', () => {
+      const portfolio = service.initialize(0);
+      const drawdownState: DrawdownState = { peakValue: 0, maxDrawdown: 0, currentDrawdown: 0 };
+
+      const snapshot = service.createSnapshot(portfolio, new Date(), new Map(), 0, drawdownState);
+
+      expect(snapshot.cumulativeReturn).toBe(0);
+    });
+
+    it('should set holding price to 0 when missing from price map', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 0,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 1, averagePrice: 30000, totalValue: 30000 }]]),
+        totalValue: 30000
+      };
+      const drawdownState: DrawdownState = { peakValue: 30000, maxDrawdown: 0, currentDrawdown: 0 };
+
+      const snapshot = service.createSnapshot(portfolio, new Date('2024-01-01'), new Map(), 10000, drawdownState);
+
+      expect(snapshot.holdings['bitcoin'].price).toBe(0);
+      expect(snapshot.holdings['bitcoin'].value).toBe(0);
+    });
+  });
+
+  describe('updateDrawdown', () => {
+    it('should update peak on new high', () => {
+      const state: DrawdownState = {
+        peakValue: 10000,
+        maxDrawdown: 0.1,
+        currentDrawdown: 0
+      };
+
+      const updated = service.updateDrawdown(12000, state);
+
+      expect(updated.peakValue).toBe(12000);
+      expect(updated.currentDrawdown).toBe(0);
+    });
+
+    it('should calculate current drawdown', () => {
+      const state: DrawdownState = {
+        peakValue: 10000,
+        maxDrawdown: 0.1,
+        currentDrawdown: 0
+      };
+
+      const updated = service.updateDrawdown(8000, state);
+
+      expect(updated.peakValue).toBe(10000); // Unchanged
+      expect(updated.currentDrawdown).toBe(0.2); // (10000-8000)/10000
+    });
+
+    it('should update max drawdown if larger', () => {
+      const state: DrawdownState = {
+        peakValue: 10000,
+        maxDrawdown: 0.1,
+        currentDrawdown: 0.05
+      };
+
+      const updated = service.updateDrawdown(7000, state);
+
+      expect(updated.maxDrawdown).toBe(0.3); // (10000-7000)/10000
+    });
+
+    it('should not reduce max drawdown', () => {
+      const state: DrawdownState = {
+        peakValue: 10000,
+        maxDrawdown: 0.3,
+        currentDrawdown: 0.2
+      };
+
+      const updated = service.updateDrawdown(9500, state);
+
+      expect(updated.maxDrawdown).toBe(0.3); // Unchanged
+      expect(updated.currentDrawdown).toBe(0.05);
+    });
+
+    it('should handle zero peak value', () => {
+      const state: DrawdownState = {
+        peakValue: 0,
+        maxDrawdown: 0,
+        currentDrawdown: 0
+      };
+
+      const updated = service.updateDrawdown(0, state);
+
+      expect(updated.currentDrawdown).toBe(0);
+    });
+  });
+
+  describe('calculatePositionsValue', () => {
+    it('should calculate total positions value', () => {
+      const positions = new Map([
+        ['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }],
+        ['ethereum', { coinId: 'ethereum', quantity: 2, averagePrice: 2000, totalValue: 4000 }]
+      ]);
+
+      const prices = new Map([
+        ['bitcoin', 50000],
+        ['ethereum', 2500]
+      ]);
+
+      const value = service.calculatePositionsValue(positions, prices);
+
+      expect(value).toBe(10000); // 0.1*50000 + 2*2500
+    });
+
+    it('should use stored value when price not available', () => {
+      const positions = new Map([
+        ['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }]
+      ]);
+
+      const value = service.calculatePositionsValue(positions, new Map());
+
+      expect(value).toBe(4500); // Falls back to totalValue
+    });
+
+    it('should combine priced and unpriced positions', () => {
+      const positions = new Map([
+        ['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }],
+        ['ethereum', { coinId: 'ethereum', quantity: 2, averagePrice: 2000, totalValue: 4000 }]
+      ]);
+
+      const prices = new Map([['ethereum', 2500]]);
+
+      const value = service.calculatePositionsValue(positions, prices);
+
+      // bitcoin uses stored totalValue (4500), ethereum uses price (2*2500=5000)
+      expect(value).toBe(9500);
+    });
+  });
+
+  describe('serialize/deserialize', () => {
+    it('should serialize portfolio', () => {
+      const portfolio: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([
+          ['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }],
+          ['ethereum', { coinId: 'ethereum', quantity: 1, averagePrice: 2000, totalValue: 2000 }]
+        ]),
+        totalValue: 11500
+      };
+
+      const serialized = service.serialize(portfolio);
+
+      expect(serialized.cashBalance).toBe(5000);
+      expect(serialized.positions).toHaveLength(2);
+      expect(serialized.positions.find((p) => p.coinId === 'bitcoin')?.quantity).toBe(0.1);
+    });
+
+    it('should deserialize portfolio', () => {
+      const serialized: SerializablePortfolio = {
+        cashBalance: 5000,
+        positions: [
+          { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000 },
+          { coinId: 'ethereum', quantity: 1, averagePrice: 2000 }
+        ]
+      };
+
+      const prices = new Map([
+        ['bitcoin', 50000],
+        ['ethereum', 2500]
+      ]);
+
+      const portfolio = service.deserialize(serialized, prices);
+
+      expect(portfolio.cashBalance).toBe(5000);
+      expect(portfolio.positions.size).toBe(2);
+      expect(portfolio.positions.get('bitcoin')?.quantity).toBe(0.1);
+      expect(portfolio.positions.get('bitcoin')?.totalValue).toBe(5000);
+      expect(portfolio.totalValue).toBe(12500); // 5000 + 5000 + 2500
+    });
+
+    it('should deserialize without current prices using average price', () => {
+      const serialized: SerializablePortfolio = {
+        cashBalance: 5000,
+        positions: [{ coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000 }]
+      };
+
+      const portfolio = service.deserialize(serialized);
+
+      expect(portfolio.positions.get('bitcoin')?.totalValue).toBe(4500);
+      expect(portfolio.totalValue).toBe(9500);
+    });
+
+    it('should prefer current prices when provided', () => {
+      const serialized: SerializablePortfolio = {
+        cashBalance: 1000,
+        positions: [{ coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000 }]
+      };
+
+      const portfolio = service.deserialize(serialized, new Map([['bitcoin', 50000]]));
+
+      expect(portfolio.positions.get('bitcoin')?.totalValue).toBe(5000);
+      expect(portfolio.totalValue).toBe(6000);
+    });
+
+    it('should round-trip serialize/deserialize', () => {
+      const original: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500 }]]),
+        totalValue: 9500
+      };
+
+      const serialized = service.serialize(original);
+      const restored = service.deserialize(serialized);
+
+      expect(restored.cashBalance).toBe(original.cashBalance);
+      expect(restored.positions.get('bitcoin')?.quantity).toBe(original.positions.get('bitcoin')?.quantity);
+      expect(restored.positions.get('bitcoin')?.averagePrice).toBe(original.positions.get('bitcoin')?.averagePrice);
+    });
+  });
+});

--- a/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.ts
+++ b/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.ts
@@ -1,0 +1,344 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  ApplyTradeResult,
+  DrawdownState,
+  IPortfolioState,
+  Portfolio,
+  PortfolioSnapshot,
+  SerializablePortfolio
+} from './portfolio-state.interface';
+
+import { Position } from '../positions';
+
+/**
+ * Portfolio State Service
+ *
+ * Manages portfolio state throughout backtest execution including:
+ * - Initialization with starting capital
+ * - Value updates with market prices
+ * - Trade application (buy/sell)
+ * - Snapshot creation for charting
+ * - Checkpoint serialization/deserialization
+ *
+ * @example
+ * ```typescript
+ * // Initialize portfolio
+ * const portfolio = portfolioState.initialize(10000);
+ *
+ * // Apply a buy trade
+ * const result = portfolioState.applyBuy(portfolio, 'bitcoin', 0.1, 50000, 5);
+ *
+ * // Update values with current prices
+ * const updated = portfolioState.updateValues(result.portfolio, priceMap);
+ *
+ * // Create snapshot for charting
+ * const snapshot = portfolioState.createSnapshot(updated, new Date(), priceMap, 10000, drawdownState);
+ * ```
+ */
+@Injectable()
+export class PortfolioStateService implements IPortfolioState {
+  /**
+   * Initialize a new portfolio with starting capital
+   */
+  initialize(initialCapital: number): Portfolio {
+    return {
+      cashBalance: initialCapital,
+      positions: new Map<string, Position>(),
+      totalValue: initialCapital
+    };
+  }
+
+  /**
+   * Update portfolio values with current market prices
+   * Creates a new portfolio with updated position values (immutable)
+   */
+  updateValues(portfolio: Portfolio, prices: Map<string, number>): Portfolio {
+    let totalValue = portfolio.cashBalance;
+    const newPositions = new Map<string, Position>();
+
+    for (const [coinId, position] of portfolio.positions) {
+      const currentPrice = prices.get(coinId);
+      const newTotalValue = currentPrice !== undefined ? position.quantity * currentPrice : position.totalValue;
+
+      // Create new position object (immutable)
+      newPositions.set(coinId, {
+        ...position,
+        totalValue: newTotalValue
+      });
+
+      totalValue += newTotalValue;
+    }
+
+    return {
+      cashBalance: portfolio.cashBalance,
+      positions: newPositions,
+      totalValue
+    };
+  }
+
+  /**
+   * Apply a buy trade to the portfolio
+   * Deducts cost + fee from cash, adds or increases position
+   *
+   * @param portfolio Current portfolio state
+   * @param coinId The coin to buy
+   * @param quantity Amount to buy
+   * @param price Execution price
+   * @param fee Trading fee
+   * @param currentPrices Optional map of current prices for all positions (for accurate totalValue calculation)
+   *                      If not provided, uses stored totalValue for other positions
+   */
+  applyBuy(
+    portfolio: Portfolio,
+    coinId: string,
+    quantity: number,
+    price: number,
+    fee: number,
+    currentPrices?: Map<string, number>
+  ): ApplyTradeResult {
+    const totalCost = quantity * price + fee;
+
+    // Validate sufficient funds
+    if (portfolio.cashBalance < totalCost) {
+      return {
+        portfolio,
+        success: false,
+        error: 'Insufficient cash balance for buy trade'
+      };
+    }
+
+    // Deduct cost from cash
+    const newCashBalance = portfolio.cashBalance - quantity * price - fee;
+
+    // Get or create position
+    const existingPosition = portfolio.positions.get(coinId);
+    let newPosition: Position;
+
+    if (existingPosition && existingPosition.quantity > 0) {
+      // Increase existing position - calculate new average price
+      const newQuantity = existingPosition.quantity + quantity;
+      const newAveragePrice =
+        (existingPosition.averagePrice * existingPosition.quantity + price * quantity) / newQuantity;
+
+      newPosition = {
+        coinId,
+        quantity: newQuantity,
+        averagePrice: newAveragePrice,
+        totalValue: newQuantity * price
+      };
+    } else {
+      // New position
+      newPosition = {
+        coinId,
+        quantity,
+        averagePrice: price,
+        totalValue: quantity * price
+      };
+    }
+
+    // Create new positions map
+    const newPositions = new Map(portfolio.positions);
+    newPositions.set(coinId, newPosition);
+
+    // Calculate new total value using provided prices or fallback to stored values
+    const pricesForCalculation = currentPrices ?? new Map([[coinId, price]]);
+    const newTotalValue = newCashBalance + this.calculatePositionsValue(newPositions, pricesForCalculation);
+
+    return {
+      portfolio: {
+        cashBalance: newCashBalance,
+        positions: newPositions,
+        totalValue: newTotalValue
+      },
+      success: true
+    };
+  }
+
+  /**
+   * Apply a sell trade to the portfolio
+   * Adds proceeds to cash (after fee deduction), reduces or closes position
+   *
+   * @param portfolio Current portfolio state
+   * @param coinId The coin to sell
+   * @param quantity Amount to sell
+   * @param price Execution price
+   * @param fee Trading fee
+   * @param currentPrices Optional map of current prices for all positions (for accurate totalValue calculation)
+   *                      If not provided, uses stored totalValue for other positions
+   */
+  applySell(
+    portfolio: Portfolio,
+    coinId: string,
+    quantity: number,
+    price: number,
+    fee: number,
+    currentPrices?: Map<string, number>
+  ): ApplyTradeResult {
+    const existingPosition = portfolio.positions.get(coinId);
+
+    // Validate position exists
+    if (!existingPosition || existingPosition.quantity === 0) {
+      return {
+        portfolio,
+        success: false,
+        error: 'No position to sell'
+      };
+    }
+
+    // Cap quantity to available
+    const actualQuantity = Math.min(quantity, existingPosition.quantity);
+    const proceeds = actualQuantity * price;
+
+    // Add proceeds and deduct fee from cash
+    const newCashBalance = portfolio.cashBalance + proceeds - fee;
+
+    // Update position
+    const remainingQuantity = existingPosition.quantity - actualQuantity;
+    const newPositions = new Map(portfolio.positions);
+
+    if (remainingQuantity <= 0) {
+      // Close position completely
+      newPositions.delete(coinId);
+    } else {
+      // Reduce position
+      newPositions.set(coinId, {
+        coinId,
+        quantity: remainingQuantity,
+        averagePrice: existingPosition.averagePrice, // Average price unchanged on sell
+        totalValue: remainingQuantity * price
+      });
+    }
+
+    // Calculate new total value using provided prices or fallback to stored values
+    const pricesForCalculation = currentPrices ?? new Map([[coinId, price]]);
+    const newTotalValue = newCashBalance + this.calculatePositionsValue(newPositions, pricesForCalculation);
+
+    return {
+      portfolio: {
+        cashBalance: newCashBalance,
+        positions: newPositions,
+        totalValue: newTotalValue
+      },
+      success: true
+    };
+  }
+
+  /**
+   * Create a snapshot of the current portfolio state
+   */
+  createSnapshot(
+    portfolio: Portfolio,
+    timestamp: Date,
+    prices: Map<string, number>,
+    initialCapital: number,
+    drawdownState: DrawdownState
+  ): PortfolioSnapshot {
+    const holdings: Record<string, { quantity: number; value: number; price: number }> = {};
+
+    for (const [coinId, position] of portfolio.positions) {
+      const price = prices.get(coinId) ?? 0;
+      holdings[coinId] = {
+        quantity: position.quantity,
+        value: position.quantity * price,
+        price
+      };
+    }
+
+    return {
+      timestamp,
+      portfolioValue: portfolio.totalValue,
+      cashBalance: portfolio.cashBalance,
+      holdings,
+      cumulativeReturn: initialCapital > 0 ? (portfolio.totalValue - initialCapital) / initialCapital : 0,
+      drawdown: drawdownState.currentDrawdown
+    };
+  }
+
+  /**
+   * Update drawdown tracking with current portfolio value
+   */
+  updateDrawdown(currentValue: number, currentState: DrawdownState): DrawdownState {
+    let { peakValue, maxDrawdown } = currentState;
+
+    // Update peak if new high
+    if (currentValue > peakValue) {
+      peakValue = currentValue;
+    }
+
+    // Calculate current drawdown
+    const currentDrawdown = peakValue === 0 ? 0 : (peakValue - currentValue) / peakValue;
+
+    // Update max drawdown if this is larger
+    if (currentDrawdown > maxDrawdown) {
+      maxDrawdown = currentDrawdown;
+    }
+
+    return {
+      peakValue,
+      maxDrawdown,
+      currentDrawdown
+    };
+  }
+
+  /**
+   * Calculate total positions value
+   */
+  calculatePositionsValue(positions: Map<string, Position>, prices: Map<string, number>): number {
+    let total = 0;
+
+    for (const [coinId, position] of positions) {
+      const price = prices.get(coinId);
+      if (price !== undefined) {
+        total += position.quantity * price;
+      } else {
+        // Use stored totalValue if no current price
+        total += position.totalValue;
+      }
+    }
+
+    return total;
+  }
+
+  /**
+   * Serialize portfolio for checkpointing
+   */
+  serialize(portfolio: Portfolio): SerializablePortfolio {
+    return {
+      cashBalance: portfolio.cashBalance,
+      positions: Array.from(portfolio.positions.entries()).map(([coinId, pos]) => ({
+        coinId,
+        quantity: pos.quantity,
+        averagePrice: pos.averagePrice
+      }))
+    };
+  }
+
+  /**
+   * Deserialize portfolio from checkpoint
+   */
+  deserialize(serialized: SerializablePortfolio, currentPrices?: Map<string, number>): Portfolio {
+    const positions = new Map<string, Position>();
+    let positionsValue = 0;
+
+    for (const pos of serialized.positions) {
+      const price = currentPrices?.get(pos.coinId) ?? pos.averagePrice;
+      const totalValue = pos.quantity * price;
+
+      positions.set(pos.coinId, {
+        coinId: pos.coinId,
+        quantity: pos.quantity,
+        averagePrice: pos.averagePrice,
+        totalValue
+      });
+
+      positionsValue += totalValue;
+    }
+
+    return {
+      cashBalance: serialized.cashBalance,
+      positions,
+      totalValue: serialized.cashBalance + positionsValue
+    };
+  }
+}

--- a/apps/api/src/order/backtest/shared/positions/index.ts
+++ b/apps/api/src/order/backtest/shared/positions/index.ts
@@ -1,0 +1,2 @@
+export * from './position-manager.interface';
+export * from './position-manager.service';

--- a/apps/api/src/order/backtest/shared/positions/position-manager.interface.ts
+++ b/apps/api/src/order/backtest/shared/positions/position-manager.interface.ts
@@ -1,0 +1,194 @@
+/**
+ * Position Manager Interfaces
+ *
+ * Provides position lifecycle management for backtesting.
+ */
+
+/**
+ * Position state for a single asset
+ */
+export interface Position {
+  /** Unique identifier for the coin/asset */
+  coinId: string;
+  /** Quantity held */
+  quantity: number;
+  /** Volume-weighted average price of the position */
+  averagePrice: number;
+  /** Current market value of the position */
+  totalValue: number;
+}
+
+/**
+ * Result of a position action
+ */
+export interface PositionActionResult {
+  /** Whether the action was successful */
+  success: boolean;
+  /** The position after the action (if successful) */
+  position?: Position;
+  /** Realized P&L (for partial/full closes) */
+  realizedPnL?: number;
+  /** Realized P&L as percentage of cost basis */
+  realizedPnLPercent?: number;
+  /** Cost basis of the closed portion */
+  costBasis?: number;
+  /** Actual quantity affected */
+  quantity: number;
+  /** Execution price */
+  price: number;
+  /** Total value of the action */
+  totalValue: number;
+  /** Error message if action failed */
+  error?: string;
+}
+
+/**
+ * Position sizing configuration
+ */
+export interface PositionSizingConfig {
+  /** Maximum allocation per position as percentage of portfolio (0-1) */
+  maxAllocation?: number;
+  /** Minimum allocation per position as percentage of portfolio (0-1) */
+  minAllocation?: number;
+  /** Maximum number of open positions */
+  maxPositions?: number;
+  /** Maximum position size relative to daily volume (0-1) */
+  maxVolumeParticipation?: number;
+}
+
+/**
+ * Parameters for opening/increasing a position
+ */
+export interface OpenPositionInput {
+  /** Coin/asset identifier */
+  coinId: string;
+  /** Execution price */
+  price: number;
+  /** Quantity to add (mutually exclusive with percentage/confidence) */
+  quantity?: number;
+  /** Percentage of available capital to use (0-1) */
+  percentage?: number;
+  /** Confidence level for position sizing (0-1) */
+  confidence?: number;
+  /** Available capital for the position */
+  availableCapital: number;
+  /** Total portfolio value for allocation calculations */
+  portfolioValue: number;
+}
+
+/**
+ * Parameters for closing/reducing a position
+ */
+export interface ClosePositionInput {
+  /** Coin/asset identifier */
+  coinId: string;
+  /** Execution price */
+  price: number;
+  /** Quantity to sell (mutually exclusive with percentage/confidence) */
+  quantity?: number;
+  /** Percentage of position to sell (0-1) */
+  percentage?: number;
+  /** Confidence level for exit sizing (0-1) */
+  confidence?: number;
+}
+
+/**
+ * Position validation error
+ */
+export interface PositionValidationError {
+  /** Error code */
+  code:
+    | 'ZERO_QUANTITY'
+    | 'NEGATIVE_QUANTITY'
+    | 'INSUFFICIENT_CAPITAL'
+    | 'NO_POSITION'
+    | 'MAX_POSITIONS'
+    | 'INVALID_PRICE';
+  /** Human-readable error message */
+  message: string;
+}
+
+/**
+ * Default position sizing configuration
+ */
+export const DEFAULT_POSITION_CONFIG: PositionSizingConfig = {
+  maxAllocation: 0.2, // 20% max per position
+  minAllocation: 0.05, // 5% min per position
+  maxPositions: 20,
+  maxVolumeParticipation: 0.01 // 1% of daily volume
+};
+
+/**
+ * Confidence-based exit sizing constants
+ * When exiting based on confidence, the exit percentage scales from MIN to MAX
+ * Higher confidence = sell more of the position
+ */
+export const CONFIDENCE_EXIT_MIN_PERCENT = 0.25; // 25% minimum exit at 0 confidence
+export const CONFIDENCE_EXIT_MAX_PERCENT = 1.0; // 100% maximum exit at 1.0 confidence
+
+/**
+ * Position manager service interface
+ */
+export interface IPositionManager {
+  /**
+   * Open or increase a position
+   * @param existingPosition Current position (if any)
+   * @param input Open position parameters
+   * @param config Position sizing configuration
+   * @returns PositionActionResult with updated position
+   */
+  openPosition(
+    existingPosition: Position | undefined,
+    input: OpenPositionInput,
+    config?: PositionSizingConfig
+  ): PositionActionResult;
+
+  /**
+   * Close or reduce a position
+   * @param position Current position
+   * @param input Close position parameters
+   * @param config Position sizing configuration
+   * @returns PositionActionResult with P&L details
+   */
+  closePosition(position: Position, input: ClosePositionInput, config?: PositionSizingConfig): PositionActionResult;
+
+  /**
+   * Calculate position size based on confidence and configuration
+   * @param portfolioValue Total portfolio value
+   * @param confidence Signal confidence (0-1)
+   * @param price Current price
+   * @param config Position sizing configuration
+   * @returns Quantity to trade
+   */
+  calculatePositionSize(
+    portfolioValue: number,
+    confidence: number,
+    price: number,
+    config?: PositionSizingConfig
+  ): number;
+
+  /**
+   * Validate a position action before execution
+   * @param action 'open' or 'close'
+   * @param existingPosition Current position (if any)
+   * @param input Position parameters
+   * @param openPositionsCount Number of currently open positions
+   * @param config Position sizing configuration
+   * @returns Validation error or undefined if valid
+   */
+  validatePosition(
+    action: 'open' | 'close',
+    existingPosition: Position | undefined,
+    input: OpenPositionInput | ClosePositionInput,
+    openPositionsCount: number,
+    config?: PositionSizingConfig
+  ): PositionValidationError | undefined;
+
+  /**
+   * Update position value with current market price
+   * @param position Position to update
+   * @param currentPrice Current market price
+   * @returns Updated position
+   */
+  updatePositionValue(position: Position, currentPrice: number): Position;
+}

--- a/apps/api/src/order/backtest/shared/positions/position-manager.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/positions/position-manager.service.spec.ts
@@ -1,0 +1,519 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { Position, PositionSizingConfig } from './position-manager.interface';
+import { PositionManagerService } from './position-manager.service';
+
+describe('PositionManagerService', () => {
+  let service: PositionManagerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PositionManagerService]
+    }).compile();
+
+    service = module.get<PositionManagerService>(PositionManagerService);
+  });
+
+  describe('openPosition', () => {
+    const baseInput = {
+      coinId: 'bitcoin',
+      price: 50000,
+      availableCapital: 100000,
+      portfolioValue: 100000
+    };
+
+    describe('new position', () => {
+      it('should open position with explicit quantity', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          quantity: 0.5
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.quantity).toBe(0.5);
+        expect(result.price).toBe(50000);
+        expect(result.totalValue).toBe(25000);
+        expect(result.position?.quantity).toBe(0.5);
+        expect(result.position?.averagePrice).toBe(50000);
+      });
+
+      it('should open position with percentage', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          percentage: 0.1 // 10% of portfolio
+        });
+
+        expect(result.success).toBe(true);
+        // 10% of 100000 = 10000 / 50000 price = 0.2 quantity
+        expect(result.quantity).toBe(0.2);
+        expect(result.totalValue).toBe(10000);
+      });
+
+      it('should open position with confidence-based sizing', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          confidence: 0.8
+        });
+
+        expect(result.success).toBe(true);
+        // With default config: min=5%, max=20%
+        // allocation = 5% + 0.8 * 15% = 17%
+        // 17% of 100000 = 17000 / 50000 = 0.34
+        expect(result.quantity).toBeCloseTo(0.34, 2);
+      });
+
+      it('should prioritize explicit quantity over percentage/confidence', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          quantity: 0.1,
+          percentage: 0.5,
+          confidence: 1
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.quantity).toBe(0.1);
+        expect(result.totalValue).toBe(5000);
+      });
+
+      it('should use minimum allocation when no sizing provided', () => {
+        const result = service.openPosition(undefined, baseInput);
+
+        expect(result.success).toBe(true);
+        // Default min allocation = 5%
+        // 5% of 100000 = 5000 / 50000 = 0.1
+        expect(result.quantity).toBe(0.1);
+      });
+
+      it('should fail when insufficient capital', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          quantity: 10, // $500,000 worth
+          availableCapital: 10000
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Insufficient capital');
+      });
+    });
+
+    describe('increase existing position', () => {
+      const existingPosition: Position = {
+        coinId: 'bitcoin',
+        quantity: 1,
+        averagePrice: 45000,
+        totalValue: 50000
+      };
+
+      it('should increase position and calculate new average price', () => {
+        const result = service.openPosition(existingPosition, {
+          ...baseInput,
+          quantity: 0.5
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.position?.quantity).toBe(1.5);
+        // New avg: (45000 * 1 + 50000 * 0.5) / 1.5 = 70000 / 1.5 = 46666.67
+        expect(result.position?.averagePrice).toBeCloseTo(46666.67, 0);
+      });
+
+      it('should handle adding to zero-quantity position', () => {
+        const emptyPosition: Position = {
+          coinId: 'bitcoin',
+          quantity: 0,
+          averagePrice: 0,
+          totalValue: 0
+        };
+
+        const result = service.openPosition(emptyPosition, {
+          ...baseInput,
+          quantity: 0.5
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.position?.quantity).toBe(0.5);
+        expect(result.position?.averagePrice).toBe(50000);
+      });
+
+      it('should preserve coinId when increasing position', () => {
+        const result = service.openPosition(existingPosition, {
+          ...baseInput,
+          quantity: 0.25
+        });
+
+        expect(result.position?.coinId).toBe('bitcoin');
+      });
+    });
+
+    describe('validation', () => {
+      it('should reject zero quantity', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          quantity: 0
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('greater than zero');
+      });
+
+      it('should reject negative quantity', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          quantity: -1
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('negative');
+      });
+
+      it('should reject zero price', () => {
+        const result = service.openPosition(undefined, {
+          ...baseInput,
+          price: 0,
+          quantity: 1
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Price');
+      });
+    });
+  });
+
+  describe('closePosition', () => {
+    const existingPosition: Position = {
+      coinId: 'bitcoin',
+      quantity: 1,
+      averagePrice: 45000,
+      totalValue: 50000
+    };
+
+    describe('full close', () => {
+      it('should close entire position with profit', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.quantity).toBe(1);
+        expect(result.price).toBe(55000);
+        expect(result.totalValue).toBe(55000);
+        expect(result.realizedPnL).toBe(10000); // (55000 - 45000) * 1
+        expect(result.realizedPnLPercent).toBeCloseTo(0.2222, 3); // 10000/45000
+        expect(result.costBasis).toBe(45000);
+        expect(result.position).toBeUndefined();
+      });
+
+      it('should close entire position with loss', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 40000
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.realizedPnL).toBe(-5000); // (40000 - 45000) * 1
+        expect(result.realizedPnLPercent).toBeCloseTo(-0.1111, 3);
+      });
+    });
+
+    describe('partial close', () => {
+      it('should close partial position with explicit quantity', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000,
+          quantity: 0.5
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.quantity).toBe(0.5);
+        expect(result.realizedPnL).toBe(5000); // (55000 - 45000) * 0.5
+        expect(result.position?.quantity).toBe(0.5);
+        expect(result.position?.averagePrice).toBe(45000); // Unchanged
+      });
+
+      it('should close partial position with percentage', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000,
+          percentage: 0.25 // 25%
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.quantity).toBe(0.25);
+        expect(result.position?.quantity).toBe(0.75);
+      });
+
+      it('should close with confidence-based sizing', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000,
+          confidence: 0.5
+        });
+
+        expect(result.success).toBe(true);
+        // confidence 0.5: 25% + 0.5 * 75% = 62.5%
+        expect(result.quantity).toBeCloseTo(0.625, 3);
+      });
+
+      it('should prioritize explicit quantity over percentage/confidence on close', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000,
+          quantity: 0.2,
+          percentage: 0.9,
+          confidence: 1
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.quantity).toBe(0.2);
+      });
+
+      it('should not sell more than available', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000,
+          quantity: 10 // More than we have
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.quantity).toBe(1); // Capped to available
+      });
+    });
+
+    describe('validation', () => {
+      it('should reject zero price when closing position', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 0,
+          quantity: 0.1
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Price');
+      });
+
+      it('should reject closing non-existent position', () => {
+        const result = service.closePosition(
+          { coinId: 'bitcoin', quantity: 0, averagePrice: 0, totalValue: 0 },
+          { coinId: 'bitcoin', price: 55000 }
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('No position');
+      });
+
+      it('should reject zero quantity', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000,
+          quantity: 0
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('greater than zero');
+      });
+
+      it('should reject negative quantity', () => {
+        const result = service.closePosition(existingPosition, {
+          coinId: 'bitcoin',
+          price: 55000,
+          quantity: -1
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('negative');
+      });
+    });
+  });
+
+  describe('calculatePositionSize', () => {
+    it('should calculate size with default config', () => {
+      const quantity = service.calculatePositionSize(100000, 0.5, 50000);
+
+      // 50% confidence: allocation = 5% + 0.5 * 15% = 12.5%
+      // 12.5% of 100000 = 12500 / 50000 = 0.25
+      expect(quantity).toBeCloseTo(0.25, 3);
+    });
+
+    it('should calculate minimum size at 0 confidence', () => {
+      const quantity = service.calculatePositionSize(100000, 0, 50000);
+
+      // 0% confidence: allocation = 5% (min)
+      expect(quantity).toBeCloseTo(0.1, 3);
+    });
+
+    it('should calculate maximum size at 1.0 confidence', () => {
+      const quantity = service.calculatePositionSize(100000, 1.0, 50000);
+
+      // 100% confidence: allocation = 20% (max)
+      expect(quantity).toBeCloseTo(0.4, 3);
+    });
+
+    it('should clamp confidence to valid range', () => {
+      const overConfidence = service.calculatePositionSize(100000, 1.5, 50000);
+      const negativeConfidence = service.calculatePositionSize(100000, -0.5, 50000);
+
+      // Should clamp to 1.0 and 0.0 respectively
+      expect(overConfidence).toBeCloseTo(0.4, 3); // max allocation
+      expect(negativeConfidence).toBeCloseTo(0.1, 3); // min allocation
+    });
+
+    it('should use custom config', () => {
+      const config: PositionSizingConfig = {
+        minAllocation: 0.1,
+        maxAllocation: 0.5
+      };
+
+      const quantity = service.calculatePositionSize(100000, 0.5, 50000, config);
+
+      // 50% confidence: allocation = 10% + 0.5 * 40% = 30%
+      // 30% of 100000 = 30000 / 50000 = 0.6
+      expect(quantity).toBeCloseTo(0.6, 3);
+    });
+
+    it('should handle minAllocation equal to maxAllocation', () => {
+      const config: PositionSizingConfig = {
+        minAllocation: 0.2,
+        maxAllocation: 0.2
+      };
+
+      const quantity = service.calculatePositionSize(100000, 0.9, 50000, config);
+
+      // Allocation fixed at 20%
+      expect(quantity).toBeCloseTo(0.4, 3);
+    });
+  });
+
+  describe('validatePosition', () => {
+    const baseOpenInput = {
+      coinId: 'bitcoin',
+      price: 50000,
+      availableCapital: 100000,
+      portfolioValue: 100000
+    };
+
+    it('should return undefined for valid open', () => {
+      const error = service.validatePosition('open', undefined, { ...baseOpenInput, quantity: 1 }, 0);
+      expect(error).toBeUndefined();
+    });
+
+    it('should return undefined for valid close', () => {
+      const position: Position = {
+        coinId: 'bitcoin',
+        quantity: 1,
+        averagePrice: 50000,
+        totalValue: 50000
+      };
+
+      const error = service.validatePosition('close', position, { coinId: 'bitcoin', price: 55000 }, 1);
+      expect(error).toBeUndefined();
+    });
+
+    it('should detect zero quantity', () => {
+      const error = service.validatePosition('open', undefined, { ...baseOpenInput, quantity: 0 }, 0);
+
+      expect(error).toBeDefined();
+      expect(error?.code).toBe('ZERO_QUANTITY');
+    });
+
+    it('should detect negative quantity', () => {
+      const error = service.validatePosition('open', undefined, { ...baseOpenInput, quantity: -1 }, 0);
+
+      expect(error).toBeDefined();
+      expect(error?.code).toBe('NEGATIVE_QUANTITY');
+    });
+
+    it('should detect invalid price', () => {
+      const error = service.validatePosition('open', undefined, { ...baseOpenInput, price: 0, quantity: 1 }, 0);
+
+      expect(error).toBeDefined();
+      expect(error?.code).toBe('INVALID_PRICE');
+    });
+
+    it('should allow close with percentage over 1 (clamped by closePosition)', () => {
+      const position: Position = {
+        coinId: 'bitcoin',
+        quantity: 1,
+        averagePrice: 50000,
+        totalValue: 50000
+      };
+
+      const error = service.validatePosition('close', position, { coinId: 'bitcoin', price: 55000, percentage: 2 }, 0);
+
+      expect(error).toBeUndefined();
+    });
+
+    it('should detect max positions reached', () => {
+      const config: PositionSizingConfig = { maxPositions: 5 };
+
+      const error = service.validatePosition('open', undefined, { ...baseOpenInput, quantity: 1 }, 5, config);
+
+      expect(error).toBeDefined();
+      expect(error?.code).toBe('MAX_POSITIONS');
+    });
+
+    it('should allow increase when at max positions', () => {
+      const config: PositionSizingConfig = { maxPositions: 5 };
+      const existingPosition: Position = {
+        coinId: 'bitcoin',
+        quantity: 1,
+        averagePrice: 50000,
+        totalValue: 50000
+      };
+
+      const error = service.validatePosition('open', existingPosition, { ...baseOpenInput, quantity: 1 }, 5, config);
+
+      expect(error).toBeUndefined(); // Increasing existing is OK
+    });
+
+    it('should detect no position to close', () => {
+      const error = service.validatePosition('close', undefined, { coinId: 'bitcoin', price: 55000 }, 0);
+
+      expect(error).toBeDefined();
+      expect(error?.code).toBe('NO_POSITION');
+    });
+  });
+
+  describe('updatePositionValue', () => {
+    it('should update total value with new price', () => {
+      const position: Position = {
+        coinId: 'bitcoin',
+        quantity: 2,
+        averagePrice: 45000,
+        totalValue: 90000
+      };
+
+      const updated = service.updatePositionValue(position, 55000);
+
+      expect(updated.quantity).toBe(2);
+      expect(updated.averagePrice).toBe(45000); // Unchanged
+      expect(updated.totalValue).toBe(110000); // 2 * 55000
+    });
+
+    it('should handle zero price', () => {
+      const position: Position = {
+        coinId: 'bitcoin',
+        quantity: 2,
+        averagePrice: 45000,
+        totalValue: 90000
+      };
+
+      const updated = service.updatePositionValue(position, 0);
+
+      expect(updated.totalValue).toBe(0);
+    });
+
+    it('should not mutate original position', () => {
+      const position: Position = {
+        coinId: 'bitcoin',
+        quantity: 2,
+        averagePrice: 45000,
+        totalValue: 90000
+      };
+
+      const updated = service.updatePositionValue(position, 50000);
+
+      expect(updated).not.toBe(position);
+      expect(position.totalValue).toBe(90000);
+    });
+  });
+});

--- a/apps/api/src/order/backtest/shared/positions/position-manager.service.ts
+++ b/apps/api/src/order/backtest/shared/positions/position-manager.service.ts
@@ -1,0 +1,310 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  ClosePositionInput,
+  CONFIDENCE_EXIT_MAX_PERCENT,
+  CONFIDENCE_EXIT_MIN_PERCENT,
+  DEFAULT_POSITION_CONFIG,
+  IPositionManager,
+  OpenPositionInput,
+  Position,
+  PositionActionResult,
+  PositionSizingConfig,
+  PositionValidationError
+} from './position-manager.interface';
+
+/**
+ * Position Manager Service
+ *
+ * Provides position lifecycle management for backtesting including:
+ * - Opening and increasing positions
+ * - Closing and reducing positions
+ * - Position sizing based on confidence
+ * - Position validation and limits
+ *
+ * @example
+ * ```typescript
+ * // Open a new position
+ * const result = positionManager.openPosition(undefined, {
+ *   coinId: 'bitcoin',
+ *   price: 50000,
+ *   confidence: 0.8,
+ *   availableCapital: 100000,
+ *   portfolioValue: 100000
+ * });
+ *
+ * // Close a position
+ * const closeResult = positionManager.closePosition(existingPosition, {
+ *   coinId: 'bitcoin',
+ *   price: 55000,
+ *   percentage: 0.5  // Sell 50%
+ * });
+ * ```
+ */
+@Injectable()
+export class PositionManagerService implements IPositionManager {
+  /**
+   * Open or increase a position
+   */
+  openPosition(
+    existingPosition: Position | undefined,
+    input: OpenPositionInput,
+    config: PositionSizingConfig = DEFAULT_POSITION_CONFIG
+  ): PositionActionResult {
+    // Validate input
+    const validation = this.validatePosition('open', existingPosition, input, 0, config);
+    if (validation) {
+      return {
+        success: false,
+        quantity: 0,
+        price: input.price,
+        totalValue: 0,
+        error: validation.message
+      };
+    }
+
+    // Calculate quantity based on input priority: quantity > percentage > confidence
+    let quantity: number;
+
+    if (input.quantity !== undefined && input.quantity > 0) {
+      quantity = input.quantity;
+    } else if (input.percentage !== undefined && input.percentage > 0) {
+      const investmentAmount = input.portfolioValue * input.percentage;
+      quantity = investmentAmount / input.price;
+    } else if (input.confidence !== undefined) {
+      quantity = this.calculatePositionSize(input.portfolioValue, input.confidence, input.price, config);
+    } else {
+      // Default to minimum allocation
+      const minAllocation = config.minAllocation ?? DEFAULT_POSITION_CONFIG.minAllocation ?? 0.05;
+      const investmentAmount = input.portfolioValue * minAllocation;
+      quantity = investmentAmount / input.price;
+    }
+
+    // Validate we have enough capital
+    const totalValue = quantity * input.price;
+    if (totalValue > input.availableCapital) {
+      return {
+        success: false,
+        quantity: 0,
+        price: input.price,
+        totalValue: 0,
+        error: 'Insufficient capital for trade'
+      };
+    }
+
+    // Calculate new position (or update existing)
+    let newPosition: Position;
+
+    if (existingPosition && existingPosition.quantity > 0) {
+      // Increase existing position - calculate new average price
+      const newQuantity = existingPosition.quantity + quantity;
+      const newAveragePrice =
+        (existingPosition.averagePrice * existingPosition.quantity + input.price * quantity) / newQuantity;
+
+      newPosition = {
+        coinId: input.coinId,
+        quantity: newQuantity,
+        averagePrice: newAveragePrice,
+        totalValue: newQuantity * input.price
+      };
+    } else {
+      // New position
+      newPosition = {
+        coinId: input.coinId,
+        quantity,
+        averagePrice: input.price,
+        totalValue: totalValue
+      };
+    }
+
+    return {
+      success: true,
+      position: newPosition,
+      quantity,
+      price: input.price,
+      totalValue
+    };
+  }
+
+  /**
+   * Close or reduce a position
+   */
+  closePosition(
+    position: Position,
+    input: ClosePositionInput,
+    config: PositionSizingConfig = DEFAULT_POSITION_CONFIG
+  ): PositionActionResult {
+    // Validate input
+    const validation = this.validatePosition('close', position, input, 0, config);
+    if (validation) {
+      return {
+        success: false,
+        quantity: 0,
+        price: input.price,
+        totalValue: 0,
+        error: validation.message
+      };
+    }
+
+    // Calculate quantity based on input priority: quantity > percentage > confidence
+    let quantity: number;
+
+    if (input.quantity !== undefined && input.quantity > 0) {
+      quantity = Math.min(input.quantity, position.quantity);
+    } else if (input.percentage !== undefined && input.percentage > 0) {
+      quantity = position.quantity * Math.min(1, input.percentage);
+    } else if (input.confidence !== undefined) {
+      // Higher confidence = sell more (scales from MIN to MAX of position)
+      const exitRange = CONFIDENCE_EXIT_MAX_PERCENT - CONFIDENCE_EXIT_MIN_PERCENT;
+      const confidenceBasedPercent = CONFIDENCE_EXIT_MIN_PERCENT + input.confidence * exitRange;
+      quantity = position.quantity * confidenceBasedPercent;
+    } else {
+      // Default: sell entire position
+      quantity = position.quantity;
+    }
+
+    // Ensure we don't sell more than we have
+    quantity = Math.min(quantity, position.quantity);
+
+    const totalValue = quantity * input.price;
+    const costBasis = position.averagePrice;
+
+    // Calculate realized P&L: (sell price - cost basis) * quantity
+    const realizedPnL = (input.price - costBasis) * quantity;
+    const realizedPnLPercent = costBasis > 0 ? (input.price - costBasis) / costBasis : 0;
+
+    // Calculate remaining position
+    const remainingQuantity = position.quantity - quantity;
+    let updatedPosition: Position | undefined;
+
+    if (remainingQuantity > 0) {
+      updatedPosition = {
+        coinId: input.coinId,
+        quantity: remainingQuantity,
+        averagePrice: position.averagePrice, // Average price doesn't change on partial close
+        totalValue: remainingQuantity * input.price
+      };
+    }
+
+    return {
+      success: true,
+      position: updatedPosition,
+      realizedPnL,
+      realizedPnLPercent,
+      costBasis,
+      quantity,
+      price: input.price,
+      totalValue
+    };
+  }
+
+  /**
+   * Calculate position size based on confidence level
+   * Higher confidence = larger position (scaled between min and max allocation)
+   */
+  calculatePositionSize(
+    portfolioValue: number,
+    confidence: number,
+    price: number,
+    config: PositionSizingConfig = DEFAULT_POSITION_CONFIG
+  ): number {
+    const minAllocation = config.minAllocation ?? DEFAULT_POSITION_CONFIG.minAllocation ?? 0.05;
+    const maxAllocation = config.maxAllocation ?? DEFAULT_POSITION_CONFIG.maxAllocation ?? 0.2;
+
+    // Clamp confidence to [0, 1]
+    const clampedConfidence = Math.max(0, Math.min(1, confidence));
+
+    // Scale allocation between min and max based on confidence
+    const allocation = minAllocation + clampedConfidence * (maxAllocation - minAllocation);
+    const investmentAmount = portfolioValue * allocation;
+
+    return investmentAmount / price;
+  }
+
+  /**
+   * Validate a position action before execution
+   */
+  validatePosition(
+    action: 'open' | 'close',
+    existingPosition: Position | undefined,
+    input: OpenPositionInput | ClosePositionInput,
+    openPositionsCount: number,
+    config: PositionSizingConfig = DEFAULT_POSITION_CONFIG
+  ): PositionValidationError | undefined {
+    // Validate price
+    if (input.price <= 0) {
+      return {
+        code: 'INVALID_PRICE',
+        message: 'Price must be greater than zero'
+      };
+    }
+
+    if (action === 'open') {
+      const openInput = input as OpenPositionInput;
+
+      // Validate quantity if provided
+      if (openInput.quantity !== undefined) {
+        if (openInput.quantity === 0) {
+          return {
+            code: 'ZERO_QUANTITY',
+            message: 'Quantity must be greater than zero'
+          };
+        }
+        if (openInput.quantity < 0) {
+          return {
+            code: 'NEGATIVE_QUANTITY',
+            message: 'Quantity cannot be negative'
+          };
+        }
+      }
+
+      // Check max positions (only for new positions)
+      const maxPositions = config.maxPositions ?? DEFAULT_POSITION_CONFIG.maxPositions ?? 20;
+      if (!existingPosition && openPositionsCount >= maxPositions) {
+        return {
+          code: 'MAX_POSITIONS',
+          message: `Maximum number of positions (${maxPositions}) reached`
+        };
+      }
+    } else {
+      // Close action
+      const closeInput = input as ClosePositionInput;
+
+      // Validate position exists
+      if (!existingPosition || existingPosition.quantity === 0) {
+        return {
+          code: 'NO_POSITION',
+          message: 'No position to close'
+        };
+      }
+
+      // Validate quantity if provided
+      if (closeInput.quantity !== undefined) {
+        if (closeInput.quantity === 0) {
+          return {
+            code: 'ZERO_QUANTITY',
+            message: 'Quantity must be greater than zero'
+          };
+        }
+        if (closeInput.quantity < 0) {
+          return {
+            code: 'NEGATIVE_QUANTITY',
+            message: 'Quantity cannot be negative'
+          };
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Update position value with current market price
+   */
+  updatePositionValue(position: Position, currentPrice: number): Position {
+    return {
+      ...position,
+      totalValue: position.quantity * currentPrice
+    };
+  }
+}

--- a/apps/api/src/order/backtest/shared/shared.module.ts
+++ b/apps/api/src/order/backtest/shared/shared.module.ts
@@ -1,0 +1,51 @@
+import { Module } from '@nestjs/common';
+
+import { FeeCalculatorService } from './fees';
+import { MetricsCalculatorService } from './metrics';
+import { PortfolioStateService } from './portfolio';
+import { PositionManagerService } from './positions';
+import { SlippageService } from './slippage';
+
+import { DrawdownCalculator } from '../../../common/metrics/drawdown.calculator';
+import { SharpeRatioCalculator } from '../../../common/metrics/sharpe-ratio.calculator';
+
+/**
+ * Shared Backtest Components Module
+ *
+ * Provides reusable services for backtest execution across all BacktestTypes:
+ * - HISTORICAL
+ * - LIVE_REPLAY
+ * - PAPER_TRADING
+ * - STRATEGY_OPTIMIZATION
+ *
+ * Services included:
+ * - SlippageService: Configurable slippage simulation
+ * - FeeCalculatorService: Fee calculation with flat/maker-taker support
+ * - PositionManagerService: Position lifecycle management
+ * - MetricsCalculatorService: Performance metrics with proper timeframe awareness
+ * - PortfolioStateService: Portfolio state management and checkpointing
+ */
+@Module({
+  providers: [
+    // Shared backtest services
+    SlippageService,
+    FeeCalculatorService,
+    PositionManagerService,
+    MetricsCalculatorService,
+    PortfolioStateService,
+
+    // Dependencies for MetricsCalculatorService
+    SharpeRatioCalculator,
+    DrawdownCalculator
+  ],
+  exports: [
+    SlippageService,
+    FeeCalculatorService,
+    PositionManagerService,
+    MetricsCalculatorService,
+    PortfolioStateService,
+    SharpeRatioCalculator,
+    DrawdownCalculator
+  ]
+})
+export class BacktestSharedModule {}

--- a/apps/api/src/order/backtest/shared/slippage/index.ts
+++ b/apps/api/src/order/backtest/shared/slippage/index.ts
@@ -1,0 +1,2 @@
+export * from './slippage.interface';
+export * from './slippage.service';

--- a/apps/api/src/order/backtest/shared/slippage/slippage.interface.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage.interface.ts
@@ -1,0 +1,113 @@
+/**
+ * Slippage Service Interfaces
+ *
+ * Provides configurable slippage simulation for backtesting.
+ * Supports multiple slippage models to approximate real-world execution costs.
+ */
+
+/**
+ * Type of slippage model to use
+ */
+export enum SlippageModelType {
+  /** No slippage applied (ideal execution) */
+  NONE = 'none',
+  /** Fixed slippage in basis points */
+  FIXED = 'fixed',
+  /** Slippage increases with order size relative to volume */
+  VOLUME_BASED = 'volume-based',
+  /** Use historical slippage data (placeholder for future implementation) */
+  HISTORICAL = 'historical'
+}
+
+/**
+ * Configuration for slippage calculation
+ */
+export interface SlippageConfig {
+  /** Type of slippage model to use */
+  type: SlippageModelType;
+  /** Fixed slippage in basis points (for FIXED model) */
+  fixedBps?: number;
+  /** Base slippage in basis points (for VOLUME_BASED model) */
+  baseSlippageBps?: number;
+  /** Multiplier for volume impact (for VOLUME_BASED model) */
+  volumeImpactFactor?: number;
+  /** Maximum slippage in basis points (default: 500 = 5%) */
+  maxSlippageBps?: number;
+}
+
+/**
+ * Result of slippage calculation
+ */
+export interface SlippageResult {
+  /** Slippage in basis points */
+  slippageBps: number;
+  /** Execution price after slippage */
+  executionPrice: number;
+  /** Price impact as a decimal (e.g., 0.001 = 0.1%) */
+  priceImpact: number;
+  /** Original price before slippage */
+  originalPrice: number;
+}
+
+/**
+ * Input parameters for slippage calculation
+ */
+export interface SlippageInput {
+  /** Base price before slippage */
+  price: number;
+  /** Order quantity */
+  quantity: number;
+  /** True for buy orders, false for sell orders */
+  isBuy: boolean;
+  /** Optional daily volume for volume-based calculations */
+  dailyVolume?: number;
+}
+
+/**
+ * Default slippage configuration
+ * Uses fixed 5 bps (0.05%) slippage as a conservative default
+ */
+export const DEFAULT_SLIPPAGE_CONFIG: SlippageConfig = {
+  type: SlippageModelType.FIXED,
+  fixedBps: 5,
+  maxSlippageBps: 500
+};
+
+/**
+ * Slippage service interface
+ */
+export interface ISlippageService {
+  /**
+   * Calculate slippage and execution price for an order
+   * @param input Order details including price, quantity, and direction
+   * @param config Slippage model configuration
+   * @returns SlippageResult with execution price and slippage details
+   */
+  calculateSlippage(input: SlippageInput, config?: SlippageConfig): SlippageResult;
+
+  /**
+   * Calculate slippage in basis points without applying to price
+   * @param quantity Order quantity
+   * @param price Order price
+   * @param config Slippage model configuration
+   * @param dailyVolume Optional daily volume for volume-based calculations
+   * @returns Slippage in basis points
+   */
+  calculateSlippageBps(quantity: number, price: number, config?: SlippageConfig, dailyVolume?: number): number;
+
+  /**
+   * Apply slippage to a price
+   * @param price Base price before slippage
+   * @param slippageBps Slippage in basis points
+   * @param isBuy True for buy orders, false for sell orders
+   * @returns Adjusted price after slippage
+   */
+  applySlippage(price: number, slippageBps: number, isBuy: boolean): number;
+
+  /**
+   * Build configuration from partial inputs with defaults
+   * @param config Partial configuration
+   * @returns Complete SlippageConfig with defaults applied
+   */
+  buildConfig(config?: Partial<SlippageConfig>): SlippageConfig;
+}

--- a/apps/api/src/order/backtest/shared/slippage/slippage.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage.service.spec.ts
@@ -1,0 +1,428 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DEFAULT_SLIPPAGE_CONFIG, SlippageConfig, SlippageModelType } from './slippage.interface';
+import { SlippageService } from './slippage.service';
+
+describe('SlippageService', () => {
+  let service: SlippageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SlippageService]
+    }).compile();
+
+    service = module.get<SlippageService>(SlippageService);
+  });
+
+  describe('calculateSlippageBps', () => {
+    describe('NONE model', () => {
+      it('should return 0 for NONE model', () => {
+        const config: SlippageConfig = { type: SlippageModelType.NONE };
+        expect(service.calculateSlippageBps(100, 50000, config)).toBe(0);
+      });
+    });
+
+    describe('FIXED model', () => {
+      it('should return fixed slippage from config', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.FIXED,
+          fixedBps: 10
+        };
+        expect(service.calculateSlippageBps(100, 50000, config)).toBe(10);
+      });
+
+      it('should default to 5 bps when fixedBps not specified', () => {
+        const config: SlippageConfig = { type: SlippageModelType.FIXED };
+        expect(service.calculateSlippageBps(100, 50000, config)).toBe(5);
+      });
+
+      it('should ignore quantity and price for fixed model', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.FIXED,
+          fixedBps: 15
+        };
+        expect(service.calculateSlippageBps(1, 1, config)).toBe(15);
+        expect(service.calculateSlippageBps(1000000, 100000, config)).toBe(15);
+      });
+    });
+
+    describe('VOLUME_BASED model', () => {
+      it('should increase slippage with larger order size relative to volume', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.VOLUME_BASED,
+          baseSlippageBps: 5,
+          volumeImpactFactor: 100
+        };
+
+        // Small order (1% of daily volume)
+        const smallOrder = service.calculateSlippageBps(100, 50000, config, 500000000);
+        // Medium order (10% of daily volume)
+        const mediumOrder = service.calculateSlippageBps(1000, 50000, config, 500000000);
+        // Large order (50% of daily volume)
+        const largeOrder = service.calculateSlippageBps(5000, 50000, config, 500000000);
+
+        expect(smallOrder).toBeLessThan(mediumOrder);
+        expect(mediumOrder).toBeLessThan(largeOrder);
+      });
+
+      it('should calculate slippage from order value and volume', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.VOLUME_BASED,
+          baseSlippageBps: 5,
+          volumeImpactFactor: 100
+        };
+
+        // orderValue = 10 * 100 = 1000; volumeRatio = 0.01
+        const result = service.calculateSlippageBps(10, 100, config, 100000);
+        expect(result).toBe(6);
+      });
+
+      it('should use default values when not specified', () => {
+        const config: SlippageConfig = { type: SlippageModelType.VOLUME_BASED };
+        const result = service.calculateSlippageBps(100, 50000, config, 500000000);
+        // Should be base 5 + volume impact
+        expect(result).toBeGreaterThanOrEqual(5);
+      });
+
+      it('should cap slippage at maxSlippageBps', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.VOLUME_BASED,
+          baseSlippageBps: 5,
+          volumeImpactFactor: 1000,
+          maxSlippageBps: 500
+        };
+        // Very large order relative to volume
+        const result = service.calculateSlippageBps(1000000, 50000, config, 1000000);
+        expect(result).toBeLessThanOrEqual(500);
+      });
+
+      it('should handle missing volume with small default ratio', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.VOLUME_BASED,
+          baseSlippageBps: 5,
+          volumeImpactFactor: 100
+        };
+        const result = service.calculateSlippageBps(100, 50000, config);
+        // Should use default 0.001 volume ratio
+        expect(result).toBeGreaterThanOrEqual(5);
+      });
+
+      it('should handle zero volume gracefully', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.VOLUME_BASED,
+          baseSlippageBps: 5,
+          volumeImpactFactor: 100
+        };
+        const result = service.calculateSlippageBps(100, 50000, config, 0);
+        expect(result).toBeGreaterThanOrEqual(5);
+      });
+
+      it('should fall back to default ratio when volume is negative', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.VOLUME_BASED,
+          baseSlippageBps: 5,
+          volumeImpactFactor: 100
+        };
+        const result = service.calculateSlippageBps(10, 100, config, -1000);
+        expect(result).toBeCloseTo(5.1, 5);
+      });
+
+      it('should cap slippage using default max when maxSlippageBps not provided', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.VOLUME_BASED,
+          baseSlippageBps: 5,
+          volumeImpactFactor: 1000
+        };
+        // Very large order; should be capped at default 500 bps
+        const result = service.calculateSlippageBps(1000000, 50000, config, 1000000);
+        expect(result).toBe(500);
+      });
+    });
+
+    describe('HISTORICAL model', () => {
+      it('should return fixedBps when available', () => {
+        const config: SlippageConfig = {
+          type: SlippageModelType.HISTORICAL,
+          fixedBps: 8
+        };
+        expect(service.calculateSlippageBps(100, 50000, config)).toBe(8);
+      });
+
+      it('should default to 10 bps when fixedBps not specified', () => {
+        const config: SlippageConfig = { type: SlippageModelType.HISTORICAL };
+        expect(service.calculateSlippageBps(100, 50000, config)).toBe(10);
+      });
+    });
+
+    describe('unknown model type', () => {
+      it('should return default 5 bps for unknown model', () => {
+        const config = { type: 'unknown' as SlippageModelType };
+        expect(service.calculateSlippageBps(100, 50000, config)).toBe(5);
+      });
+    });
+
+    it('should apply maxSlippageBps even for FIXED model', () => {
+      const config: SlippageConfig = {
+        type: SlippageModelType.FIXED,
+        fixedBps: 1000,
+        maxSlippageBps: 200
+      };
+      expect(service.calculateSlippageBps(1, 1, config)).toBe(200);
+    });
+  });
+
+  describe('applySlippage', () => {
+    const basePrice = 50000;
+
+    describe('BUY orders', () => {
+      it('should increase price for buy orders', () => {
+        const result = service.applySlippage(basePrice, 10, true);
+        // 10 bps = 0.1% increase = 50000 * 0.001 = 50
+        expect(result).toBeCloseTo(50050, 2);
+      });
+
+      it('should handle zero slippage', () => {
+        const result = service.applySlippage(basePrice, 0, true);
+        expect(result).toBe(basePrice);
+      });
+
+      it('should handle large slippage correctly', () => {
+        const result = service.applySlippage(basePrice, 100, true);
+        // 100 bps = 1% increase = 50000 * 0.01 = 500
+        expect(result).toBeCloseTo(50500, 2);
+      });
+    });
+
+    describe('SELL orders', () => {
+      it('should decrease price for sell orders', () => {
+        const result = service.applySlippage(basePrice, 10, false);
+        // 10 bps = 0.1% decrease = 50000 * 0.001 = 50
+        expect(result).toBeCloseTo(49950, 2);
+      });
+
+      it('should handle zero slippage', () => {
+        const result = service.applySlippage(basePrice, 0, false);
+        expect(result).toBe(basePrice);
+      });
+
+      it('should handle large slippage correctly', () => {
+        const result = service.applySlippage(basePrice, 100, false);
+        // 100 bps = 1% decrease = 50000 * 0.01 = 500
+        expect(result).toBeCloseTo(49500, 2);
+      });
+    });
+
+    it('should be symmetric for buy and sell', () => {
+      const slippageBps = 50;
+      const buyPrice = service.applySlippage(basePrice, slippageBps, true);
+      const sellPrice = service.applySlippage(basePrice, slippageBps, false);
+
+      // Buy adds, sell subtracts the same amount (within floating point tolerance)
+      expect(buyPrice - basePrice).toBeCloseTo(basePrice - sellPrice, 2);
+    });
+
+    it('should handle fractional bps with precision', () => {
+      const result = service.applySlippage(basePrice, 12.5, true);
+      expect(result).toBeCloseTo(50062.5, 5);
+    });
+
+    it('should increase price impact with higher bps', () => {
+      const low = service.applySlippage(basePrice, 5, true);
+      const high = service.applySlippage(basePrice, 50, true);
+      expect(high - basePrice).toBeGreaterThan(low - basePrice);
+    });
+  });
+
+  describe('calculateSlippage', () => {
+    it('should return complete SlippageResult for buy order', () => {
+      const result = service.calculateSlippage({
+        price: 50000,
+        quantity: 1,
+        isBuy: true,
+        dailyVolume: 1000000
+      });
+
+      expect(result).toHaveProperty('slippageBps');
+      expect(result).toHaveProperty('executionPrice');
+      expect(result).toHaveProperty('priceImpact');
+      expect(result).toHaveProperty('originalPrice');
+      expect(result.originalPrice).toBe(50000);
+      expect(result.executionPrice).toBeGreaterThan(50000);
+    });
+
+    it('should return complete SlippageResult for sell order', () => {
+      const result = service.calculateSlippage({
+        price: 50000,
+        quantity: 1,
+        isBuy: false,
+        dailyVolume: 1000000
+      });
+
+      expect(result.executionPrice).toBeLessThan(50000);
+      expect(result.priceImpact).toBeGreaterThan(0);
+    });
+
+    it('should calculate correct price impact', () => {
+      const result = service.calculateSlippage(
+        {
+          price: 50000,
+          quantity: 1,
+          isBuy: true
+        },
+        { type: SlippageModelType.FIXED, fixedBps: 10 }
+      );
+
+      // 10 bps = 0.1% = 0.001
+      expect(result.priceImpact).toBeCloseTo(0.001, 5);
+    });
+
+    it('should use custom config when provided', () => {
+      const customConfig: SlippageConfig = {
+        type: SlippageModelType.FIXED,
+        fixedBps: 20
+      };
+
+      const result = service.calculateSlippage(
+        {
+          price: 10000,
+          quantity: 1,
+          isBuy: true
+        },
+        customConfig
+      );
+
+      // 20 bps = 0.2% = 0.002 price impact
+      expect(result.slippageBps).toBe(20);
+      expect(result.priceImpact).toBeCloseTo(0.002, 5);
+    });
+
+    it('should use default config when not provided', () => {
+      const result = service.calculateSlippage({
+        price: 50000,
+        quantity: 1,
+        isBuy: true
+      });
+
+      // Default is FIXED with 5 bps
+      expect(result.slippageBps).toBe(5);
+    });
+
+    it('should return zero price impact when slippage is zero', () => {
+      const result = service.calculateSlippage(
+        {
+          price: 50000,
+          quantity: 1,
+          isBuy: true
+        },
+        { type: SlippageModelType.NONE }
+      );
+
+      expect(result.slippageBps).toBe(0);
+      expect(result.executionPrice).toBe(50000);
+      expect(result.priceImpact).toBe(0);
+    });
+
+    describe('input validation', () => {
+      it('should throw error for zero price', () => {
+        expect(() =>
+          service.calculateSlippage({
+            price: 0,
+            quantity: 1,
+            isBuy: true
+          })
+        ).toThrow('Price must be a positive finite number');
+      });
+
+      it('should throw error for negative price', () => {
+        expect(() =>
+          service.calculateSlippage({
+            price: -100,
+            quantity: 1,
+            isBuy: true
+          })
+        ).toThrow('Price must be a positive finite number');
+      });
+
+      it('should throw error for NaN price', () => {
+        expect(() =>
+          service.calculateSlippage({
+            price: NaN,
+            quantity: 1,
+            isBuy: true
+          })
+        ).toThrow('Price must be a positive finite number');
+      });
+
+      it('should throw error for Infinity price', () => {
+        expect(() =>
+          service.calculateSlippage({
+            price: Infinity,
+            quantity: 1,
+            isBuy: true
+          })
+        ).toThrow('Price must be a positive finite number');
+      });
+    });
+  });
+
+  describe('buildConfig', () => {
+    it('should build config with all parameters', () => {
+      const config = service.buildConfig({
+        type: SlippageModelType.VOLUME_BASED,
+        fixedBps: 10,
+        baseSlippageBps: 7,
+        volumeImpactFactor: 150,
+        maxSlippageBps: 300
+      });
+
+      expect(config.type).toBe(SlippageModelType.VOLUME_BASED);
+      expect(config.fixedBps).toBe(10);
+      expect(config.baseSlippageBps).toBe(7);
+      expect(config.volumeImpactFactor).toBe(150);
+      expect(config.maxSlippageBps).toBe(300);
+    });
+
+    it('should use defaults when parameters not provided', () => {
+      const config = service.buildConfig();
+
+      expect(config.type).toBe(SlippageModelType.FIXED);
+      expect(config.fixedBps).toBe(5);
+      expect(config.baseSlippageBps).toBe(5);
+      expect(config.volumeImpactFactor).toBe(100);
+      expect(config.maxSlippageBps).toBe(500);
+    });
+
+    it('should handle partial parameters', () => {
+      const config = service.buildConfig({
+        type: SlippageModelType.FIXED,
+        fixedBps: 20
+      });
+
+      expect(config.type).toBe(SlippageModelType.FIXED);
+      expect(config.fixedBps).toBe(20);
+      expect(config.baseSlippageBps).toBe(5);
+      expect(config.volumeImpactFactor).toBe(100);
+      expect(config.maxSlippageBps).toBe(500);
+    });
+
+    it('should default model when only other values are provided', () => {
+      const config = service.buildConfig({
+        fixedBps: 12,
+        volumeImpactFactor: 200
+      });
+
+      expect(config.type).toBe(SlippageModelType.FIXED);
+      expect(config.fixedBps).toBe(12);
+      expect(config.baseSlippageBps).toBe(5);
+      expect(config.volumeImpactFactor).toBe(200);
+    });
+  });
+
+  describe('DEFAULT_SLIPPAGE_CONFIG', () => {
+    it('should have FIXED model with 5 bps and 500 max', () => {
+      expect(DEFAULT_SLIPPAGE_CONFIG.type).toBe(SlippageModelType.FIXED);
+      expect(DEFAULT_SLIPPAGE_CONFIG.fixedBps).toBe(5);
+      expect(DEFAULT_SLIPPAGE_CONFIG.maxSlippageBps).toBe(500);
+    });
+  });
+});

--- a/apps/api/src/order/backtest/shared/slippage/slippage.service.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage.service.ts
@@ -1,0 +1,123 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  DEFAULT_SLIPPAGE_CONFIG,
+  ISlippageService,
+  SlippageConfig,
+  SlippageInput,
+  SlippageModelType,
+  SlippageResult
+} from './slippage.interface';
+
+/**
+ * Slippage Service
+ *
+ * Provides configurable slippage simulation for backtesting.
+ * Wraps existing slippage calculation functions in an injectable service
+ * for consistent usage across all BacktestTypes.
+ *
+ * @example
+ * ```typescript
+ * const result = slippageService.calculateSlippage({
+ *   price: 50000,
+ *   quantity: 0.5,
+ *   isBuy: true,
+ *   dailyVolume: 1000000
+ * });
+ * // result.executionPrice = 50025 (with 5 bps slippage)
+ * ```
+ */
+@Injectable()
+export class SlippageService implements ISlippageService {
+  /**
+   * Calculate slippage and execution price for an order
+   * @throws Error if price is not a positive finite number
+   */
+  calculateSlippage(input: SlippageInput, config: SlippageConfig = DEFAULT_SLIPPAGE_CONFIG): SlippageResult {
+    if (!Number.isFinite(input.price) || input.price <= 0) {
+      throw new Error('Price must be a positive finite number');
+    }
+
+    const effectiveConfig = this.buildConfig(config);
+    const slippageBps = this.calculateSlippageBps(input.quantity, input.price, effectiveConfig, input.dailyVolume);
+    const executionPrice = this.applySlippage(input.price, slippageBps, input.isBuy);
+    const priceImpact = Math.abs(executionPrice - input.price) / input.price;
+
+    return {
+      slippageBps,
+      executionPrice,
+      priceImpact,
+      originalPrice: input.price
+    };
+  }
+
+  /**
+   * Calculate slippage in basis points based on model configuration
+   */
+  calculateSlippageBps(
+    quantity: number,
+    price: number,
+    config: SlippageConfig = DEFAULT_SLIPPAGE_CONFIG,
+    dailyVolume?: number
+  ): number {
+    const effectiveConfig = this.buildConfig(config);
+    const maxSlippage = effectiveConfig.maxSlippageBps ?? 500;
+
+    let slippageBps: number;
+
+    switch (effectiveConfig.type) {
+      case SlippageModelType.NONE:
+        slippageBps = 0;
+        break;
+
+      case SlippageModelType.FIXED:
+        slippageBps = effectiveConfig.fixedBps ?? 5;
+        break;
+
+      case SlippageModelType.VOLUME_BASED: {
+        // Slippage increases with order size relative to daily volume
+        const orderValue = quantity * price;
+        const volumeRatio = dailyVolume && dailyVolume > 0 ? orderValue / dailyVolume : 0.001;
+        const baseSlippage = effectiveConfig.baseSlippageBps ?? 5;
+        const volumeImpact = effectiveConfig.volumeImpactFactor ?? 100;
+        slippageBps = baseSlippage + volumeRatio * volumeImpact;
+        break;
+      }
+
+      case SlippageModelType.HISTORICAL:
+        // Placeholder for historical slippage data integration
+        // Would use actual historical slippage from similar orders
+        // Use original config.fixedBps (not effectiveConfig) to preserve 10 bps default for HISTORICAL
+        slippageBps = config?.fixedBps ?? 10;
+        break;
+
+      default:
+        slippageBps = 5;
+    }
+
+    // Apply maximum slippage cap
+    return Math.min(slippageBps, maxSlippage);
+  }
+
+  /**
+   * Apply slippage to execution price
+   * Buy orders pay more (price increases), sell orders receive less (price decreases)
+   */
+  applySlippage(price: number, slippageBps: number, isBuy: boolean): number {
+    const slippageFactor = slippageBps / 10000;
+    return isBuy ? price * (1 + slippageFactor) : price * (1 - slippageFactor);
+  }
+
+  /**
+   * Build complete configuration from partial inputs with defaults
+   */
+  buildConfig(config?: Partial<SlippageConfig>): SlippageConfig {
+    return {
+      type: config?.type ?? SlippageModelType.FIXED,
+      fixedBps: config?.fixedBps ?? 5,
+      baseSlippageBps: config?.baseSlippageBps ?? 5,
+      volumeImpactFactor: config?.volumeImpactFactor ?? 100,
+      maxSlippageBps: config?.maxSlippageBps ?? 500
+    };
+  }
+}

--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -24,6 +24,7 @@ import { LiveReplayProcessor } from './backtest/live-replay.processor';
 import { MarketDataReaderService } from './backtest/market-data-reader.service';
 import { MarketDataSet } from './backtest/market-data-set.entity';
 import { QuoteCurrencyResolverService } from './backtest/quote-currency-resolver.service';
+import { BacktestSharedModule } from './backtest/shared';
 import { slippageLimitsConfig } from './config/slippage-limits.config';
 import { OrderStatusHistory } from './entities/order-status-history.entity';
 import { PositionExit } from './entities/position-exit.entity';
@@ -49,7 +50,6 @@ import { Coin } from '../coin/coin.entity';
 import { CoinService } from '../coin/coin.service';
 import { TickerPairs } from '../coin/ticker-pairs/ticker-pairs.entity';
 import { TickerPairService } from '../coin/ticker-pairs/ticker-pairs.service';
-import { SharpeRatioCalculator } from '../common/metrics/sharpe-ratio.calculator';
 import { ExchangeKeyModule } from '../exchange/exchange-key/exchange-key.module';
 import { ExchangeModule } from '../exchange/exchange.module';
 import { MetricsModule } from '../metrics/metrics.module';
@@ -110,12 +110,12 @@ const BACKTEST_DEFAULTS = backtestConfig();
     forwardRef(() => UsersModule),
     IndicatorModule,
     MetricsModule,
-    StorageModule
+    StorageModule,
+    BacktestSharedModule
   ],
   providers: [
     AlgorithmService,
     BacktestEngine,
-    SharpeRatioCalculator,
     BacktestProcessor,
     LiveReplayProcessor,
     BacktestService,


### PR DESCRIPTION
## Summary

- Extract five single-responsibility services from backtest engine into `BacktestSharedModule`
- Add comprehensive interfaces with JSDoc documentation and 160+ test cases
- Fix code quality issues (duplicate types, lint warnings) identified during code review

## Changes

### New Shared Services Module (`apps/api/src/order/backtest/shared/`)

| Service | Purpose |
|---------|---------|
| `FeeCalculatorService` | Fee calculation with flat/maker-taker support |
| `SlippageService` | Slippage simulation (fixed, volume-based, historical) |
| `PositionManagerService` | Position sizing and validation |
| `MetricsCalculatorService` | Performance metrics (Sharpe, Sortino, volatility, etc.) |
| `PortfolioStateService` | Portfolio state management and serialization |

### Code Quality Fixes

- Import `Position`/`Portfolio` types from shared module (removes duplicate definitions)
- Replace non-null assertions with fallback defaults in:
  - `metrics-calculator.service.ts` (3 occurrences)
  - `position-manager.service.ts` (4 occurrences)
- Remove unused test variable in `metrics-calculator.service.spec.ts`

### Module Integration

- Create `BacktestSharedModule` with proper NestJS dependency injection
- Import module in `OrderModule` for use by `BacktestEngine`
- Add barrel exports for clean imports

## Test Plan

- [x] All 1124 tests pass
- [x] Lint passes with zero warnings on shared services
- [x] Build succeeds (NX cache hit)

```bash
# Run shared service tests
npx nx run api:test --testPathPattern="backtest/shared"

# Lint shared services
npx eslint --max-warnings=0 apps/api/src/order/backtest/shared/**/*.ts
```

## Architecture

```
BacktestSharedModule
├── SlippageService
├── FeeCalculatorService
├── PositionManagerService
├── MetricsCalculatorService (uses SharpeRatioCalculator, DrawdownCalculator)
└── PortfolioStateService
```

Each service follows interface-first design with comprehensive JSDoc documentation.