### PR TITLE
feat(health): add comprehensive health check indicators

### DIFF
--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -1,18 +1,84 @@
-import { ConfigModule } from '@nestjs/config';
-import { TerminusModule } from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import {
+  DiskHealthIndicator,
+  HealthCheckService,
+  MemoryHealthIndicator,
+  MicroserviceHealthIndicator,
+  TypeOrmHealthIndicator
+} from '@nestjs/terminus';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { HealthController } from './health.controller';
+import {
+  BullMQHealthIndicator,
+  DatabasePoolHealthIndicator,
+  ExchangeHealthIndicator,
+  OHLCHealthIndicator,
+  RedisHealthIndicator
+} from './indicators';
 
 describe('HealthController', () => {
   let controller: HealthController;
+  let config: { get: jest.Mock };
+  let health: { check: jest.Mock };
+  let memory: { checkHeap: jest.Mock };
+  let microservice: { pingCheck: jest.Mock };
+  let typeOrm: { pingCheck: jest.Mock };
+  let disk: { checkStorage: jest.Mock };
+  let bullmq: { isHealthy: jest.Mock };
+  let databasePool: { isHealthy: jest.Mock };
+  let exchange: { isHealthy: jest.Mock };
+  let ohlc: { isHealthy: jest.Mock };
+  let redisPerformance: { isHealthy: jest.Mock };
 
   beforeEach(async () => {
+    config = {
+      get: jest.fn((key: string) => {
+        switch (key) {
+          case 'REDIS_HOST':
+            return 'redis.local';
+          case 'REDIS_USER':
+            return 'redis-user';
+          case 'REDIS_PASSWORD':
+            return 'redis-pass';
+          case 'REDIS_PORT':
+            return '6379';
+          case 'REDIS_TLS':
+            return 'true';
+          case 'MINIO_HOST':
+            return 'minio.local';
+          case 'MINIO_PORT':
+            return '9000';
+          default:
+            return undefined;
+        }
+      })
+    };
+    health = { check: jest.fn().mockResolvedValue({ status: 'ok' }) };
+    memory = { checkHeap: jest.fn().mockResolvedValue({}) };
+    microservice = { pingCheck: jest.fn().mockResolvedValue({}) };
+    typeOrm = { pingCheck: jest.fn().mockResolvedValue({}) };
+    disk = { checkStorage: jest.fn().mockResolvedValue({}) };
+    bullmq = { isHealthy: jest.fn().mockResolvedValue({}) };
+    databasePool = { isHealthy: jest.fn().mockResolvedValue({}) };
+    exchange = { isHealthy: jest.fn().mockResolvedValue({}) };
+    ohlc = { isHealthy: jest.fn().mockResolvedValue({}) };
+    redisPerformance = { isHealthy: jest.fn().mockResolvedValue({}) };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
-      imports: [
-        TerminusModule,
-        ConfigModule.forRoot()
+      providers: [
+        { provide: ConfigService, useValue: config },
+        { provide: HealthCheckService, useValue: health },
+        { provide: MemoryHealthIndicator, useValue: memory },
+        { provide: MicroserviceHealthIndicator, useValue: microservice },
+        { provide: TypeOrmHealthIndicator, useValue: typeOrm },
+        { provide: DiskHealthIndicator, useValue: disk },
+        { provide: BullMQHealthIndicator, useValue: bullmq },
+        { provide: DatabasePoolHealthIndicator, useValue: databasePool },
+        { provide: ExchangeHealthIndicator, useValue: exchange },
+        { provide: OHLCHealthIndicator, useValue: ohlc },
+        { provide: RedisHealthIndicator, useValue: redisPerformance }
       ]
     }).compile();
 
@@ -21,5 +87,74 @@ describe('HealthController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should compose the health checks with expected options', async () => {
+    const result = await controller.check();
+
+    expect(result).toEqual({ status: 'ok' });
+    expect(health.check).toHaveBeenCalledTimes(1);
+
+    const checks = health.check.mock.calls[0]?.[0];
+    expect(Array.isArray(checks)).toBe(true);
+    expect(checks).toHaveLength(10);
+
+    await checks[0]();
+    expect(typeOrm.pingCheck).toHaveBeenCalledWith('database');
+
+    await checks[1]();
+    expect(databasePool.isHealthy).toHaveBeenCalledWith('database_pool');
+
+    await checks[2]();
+    expect(microservice.pingCheck).toHaveBeenNthCalledWith(
+      1,
+      'redis',
+      expect.objectContaining({
+        transport: expect.anything(),
+        options: {
+          family: 0,
+          host: 'redis.local',
+          username: 'redis-user',
+          password: 'redis-pass',
+          port: 6379,
+          tls: {}
+        }
+      })
+    );
+
+    await checks[3]();
+    expect(redisPerformance.isHealthy).toHaveBeenCalledWith('redis_performance');
+
+    await checks[4]();
+    expect(microservice.pingCheck).toHaveBeenNthCalledWith(
+      2,
+      'minio',
+      expect.objectContaining({
+        transport: expect.anything(),
+        timeout: 15000,
+        options: {
+          host: 'minio.local',
+          port: 9000
+        }
+      })
+    );
+
+    await checks[5]();
+    expect(memory.checkHeap).toHaveBeenCalledWith('memory_heap', 512 * 1024 * 1024);
+
+    await checks[6]();
+    expect(disk.checkStorage).toHaveBeenCalledWith('disk_storage', {
+      path: '/',
+      thresholdPercent: 0.9
+    });
+
+    await checks[7]();
+    expect(bullmq.isHealthy).toHaveBeenCalledWith('queues');
+
+    await checks[8]();
+    expect(exchange.isHealthy).toHaveBeenCalledWith('exchanges');
+
+    await checks[9]();
+    expect(ohlc.isHealthy).toHaveBeenCalledWith('ohlc_data');
   });
 });

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,14 +1,41 @@
+import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 
 import { HealthController } from './health.controller';
+import {
+  BullMQHealthIndicator,
+  DatabasePoolHealthIndicator,
+  ExchangeHealthIndicator,
+  OHLCHealthIndicator,
+  RedisHealthIndicator
+} from './indicators';
+
+import { ExchangeModule } from '../exchange/exchange.module';
+import { OHLCModule } from '../ohlc/ohlc.module';
 
 @Module({
   imports: [
     TerminusModule.forRoot({
       errorLogStyle: 'pretty'
-    })
+    }),
+    BullModule.registerQueue(
+      { name: 'order-queue' },
+      { name: 'backtest-queue' },
+      { name: 'coin-queue' },
+      { name: 'ohlc-queue' },
+      { name: 'price-queue' }
+    ),
+    ExchangeModule,
+    OHLCModule
   ],
-  controllers: [HealthController]
+  controllers: [HealthController],
+  providers: [
+    BullMQHealthIndicator,
+    DatabasePoolHealthIndicator,
+    ExchangeHealthIndicator,
+    OHLCHealthIndicator,
+    RedisHealthIndicator
+  ]
 })
 export class HealthModule {}

--- a/apps/api/src/health/indicators/bullmq.health.ts
+++ b/apps/api/src/health/indicators/bullmq.health.ts
@@ -1,0 +1,98 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+
+import { Queue } from 'bullmq';
+
+interface QueueStats {
+  waiting: number;
+  failed: number;
+}
+
+/**
+ * Health indicator that monitors BullMQ queue health.
+ * Tracks waiting and failed jobs across critical queues.
+ * Fails if total failed jobs exceed threshold.
+ */
+@Injectable()
+export class BullMQHealthIndicator {
+  private readonly logger = new Logger(BullMQHealthIndicator.name);
+  private readonly FAILED_JOBS_THRESHOLD = 100;
+  private readonly TIMEOUT_MS = 5000;
+
+  /**
+   * Wrap a promise with a timeout to prevent indefinite hangs
+   */
+  private withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    let timeoutId: NodeJS.Timeout;
+    const timeoutPromise = new Promise<T>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('BullMQ health check timeout')), ms);
+    });
+    return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeoutId));
+  }
+
+  constructor(
+    private readonly healthIndicatorService: HealthIndicatorService,
+    @InjectQueue('order-queue') private readonly orderQueue: Queue,
+    @InjectQueue('backtest-queue') private readonly backtestQueue: Queue,
+    @InjectQueue('coin-queue') private readonly coinQueue: Queue,
+    @InjectQueue('ohlc-queue') private readonly ohlcQueue: Queue,
+    @InjectQueue('price-queue') private readonly priceQueue: Queue
+  ) {}
+
+  /**
+   * Check BullMQ queues health
+   * Fails if total failed jobs exceed 100
+   * Uses timeout to prevent indefinite hangs on Redis issues
+   */
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+
+    try {
+      const queues = [
+        { name: 'order-queue', queue: this.orderQueue },
+        { name: 'backtest-queue', queue: this.backtestQueue },
+        { name: 'coin-queue', queue: this.coinQueue },
+        { name: 'ohlc-queue', queue: this.ohlcQueue },
+        { name: 'price-queue', queue: this.priceQueue }
+      ];
+
+      // Check queues in parallel with timeout to avoid indefinite hangs
+      const checkPromises = queues.map(async ({ name, queue }) => {
+        const counts = await this.withTimeout(queue.getJobCounts('waiting', 'failed'), this.TIMEOUT_MS);
+        return { name, counts };
+      });
+
+      const results = await Promise.all(checkPromises);
+
+      const queueStats: Record<string, QueueStats> = {};
+      let totalFailed = 0;
+
+      for (const { name, counts } of results) {
+        queueStats[name] = {
+          waiting: counts.waiting || 0,
+          failed: counts.failed || 0
+        };
+        totalFailed += counts.failed || 0;
+      }
+
+      const result = {
+        ...queueStats,
+        totalFailed
+      };
+
+      // Fail if total failed jobs exceed threshold
+      if (totalFailed > this.FAILED_JOBS_THRESHOLD) {
+        return indicator.down({
+          ...result,
+          message: `Total failed jobs (${totalFailed}) exceeds threshold (${this.FAILED_JOBS_THRESHOLD})`
+        });
+      }
+
+      return indicator.up(result);
+    } catch (error) {
+      this.logger.error(`BullMQ health check failed: ${error.message}`);
+      return indicator.down({ error: error.message });
+    }
+  }
+}

--- a/apps/api/src/health/indicators/database-pool.health.ts
+++ b/apps/api/src/health/indicators/database-pool.health.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+
+import { DataSource } from 'typeorm';
+
+interface PoolStats {
+  activeConnections: number;
+  idleConnections: number;
+  maxConnections: number;
+  usagePercent: number;
+}
+
+/**
+ * Health indicator that monitors PostgreSQL connection pool health via pg_stat_activity.
+ * Tracks active connections, idle connections, and usage percentage.
+ */
+@Injectable()
+export class DatabasePoolHealthIndicator {
+  private readonly logger = new Logger(DatabasePoolHealthIndicator.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly healthIndicatorService: HealthIndicatorService
+  ) {}
+
+  /**
+   * Check database connection pool health
+   * Fails if connection usage exceeds 80%
+   */
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+
+    try {
+      const stats = await this.getPoolStats();
+
+      const result = {
+        activeConnections: stats.activeConnections,
+        idleConnections: stats.idleConnections,
+        maxConnections: stats.maxConnections,
+        usagePercent: stats.usagePercent
+      };
+
+      // Fail if usage exceeds 80%
+      if (stats.usagePercent > 80) {
+        return indicator.down({ ...result, message: 'Connection pool usage exceeds 80%' });
+      }
+
+      return indicator.up(result);
+    } catch (error) {
+      this.logger.error(`Database pool health check failed: ${error.message}`);
+      return indicator.down({ error: error.message });
+    }
+  }
+
+  private async getPoolStats(): Promise<PoolStats> {
+    // Get active and idle connections from pg_stat_activity
+    const activityResult = await this.dataSource.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE state = 'active') as active_count,
+        COUNT(*) FILTER (WHERE state = 'idle') as idle_count,
+        COUNT(*) as total_count
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+    `);
+
+    // Get max_connections setting
+    const maxResult = await this.dataSource.query(`SHOW max_connections`);
+
+    const activeConnections = parseInt(activityResult[0]?.active_count || '0', 10);
+    const idleConnections = parseInt(activityResult[0]?.idle_count || '0', 10);
+    const totalConnections = parseInt(activityResult[0]?.total_count || '0', 10);
+    const maxConnections = parseInt(maxResult[0]?.max_connections || '100', 10);
+
+    const usagePercent = maxConnections > 0 ? Math.round((totalConnections / maxConnections) * 100) : 0;
+
+    return {
+      activeConnections,
+      idleConnections,
+      maxConnections,
+      usagePercent
+    };
+  }
+}

--- a/apps/api/src/health/indicators/exchange.health.ts
+++ b/apps/api/src/health/indicators/exchange.health.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+
+import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+
+type ExchangeStatus = 'healthy' | 'slow' | 'unhealthy';
+
+interface ExchangeHealthResult {
+  latencyMs: number;
+  status: ExchangeStatus;
+  error?: string;
+}
+
+/**
+ * Health indicator that monitors exchange connectivity and latency.
+ * Uses ExchangeManagerService.getPublicClient() to check each exchange.
+ * Fails if all exchanges are unhealthy; warns if latency > 2000ms.
+ */
+@Injectable()
+export class ExchangeHealthIndicator {
+  private readonly logger = new Logger(ExchangeHealthIndicator.name);
+  private readonly LATENCY_WARN_THRESHOLD_MS = 2000;
+  private readonly TIMEOUT_MS = 10000;
+
+  // Exchanges to monitor with their trading pairs
+  private readonly exchanges = [
+    { slug: 'binance_us', pair: 'BTC/USD' },
+    { slug: 'coinbase', pair: 'BTC/USD' },
+    { slug: 'kraken', pair: 'BTC/USD' }
+  ];
+
+  constructor(
+    private readonly exchangeManager: ExchangeManagerService,
+    private readonly healthIndicatorService: HealthIndicatorService
+  ) {}
+
+  /**
+   * Check exchange connectivity and latency
+   * Fails if all exchanges are unhealthy
+   * Runs all exchange checks in parallel to avoid sequential timeout accumulation
+   */
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+
+    // Run all exchange checks in parallel to avoid 30+ second timeouts
+    const checkPromises = this.exchanges.map(async ({ slug, pair }) => {
+      try {
+        return { slug, result: await this.checkExchange(slug, pair) };
+      } catch (error) {
+        this.logger.warn(`Exchange ${slug} health check failed: ${error.message}`);
+        return {
+          slug,
+          result: { latencyMs: -1, status: 'unhealthy' as ExchangeStatus, error: error.message }
+        };
+      }
+    });
+
+    const settledResults = await Promise.all(checkPromises);
+
+    const results: Record<string, ExchangeHealthResult> = {};
+    let healthyCount = 0;
+    for (const { slug, result } of settledResults) {
+      results[slug] = result;
+      if (result.status !== 'unhealthy') {
+        healthyCount++;
+      }
+    }
+
+    // Fail only if ALL exchanges are unhealthy
+    if (healthyCount === 0) {
+      return indicator.down({ ...results, message: 'All monitored exchanges are unavailable' });
+    }
+
+    return indicator.up(results);
+  }
+
+  private async checkExchange(slug: string, pair: string): Promise<ExchangeHealthResult> {
+    const startTime = Date.now();
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    try {
+      const client = await this.exchangeManager.getPublicClient(slug);
+
+      // Set a timeout for the fetch operation
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('Exchange request timeout')), this.TIMEOUT_MS);
+      });
+
+      // Race between the actual fetch and the timeout
+      await Promise.race([client.fetchTicker(pair), timeoutPromise]);
+
+      // Clear timeout on success to prevent memory leak
+      if (timeoutId) clearTimeout(timeoutId);
+
+      const latencyMs = Date.now() - startTime;
+
+      let status: ExchangeStatus;
+      if (latencyMs <= this.LATENCY_WARN_THRESHOLD_MS) {
+        status = 'healthy';
+      } else {
+        status = 'slow';
+      }
+
+      return { latencyMs, status };
+    } catch (error) {
+      // Clear timeout on error to prevent memory leak
+      if (timeoutId) clearTimeout(timeoutId);
+
+      const latencyMs = Date.now() - startTime;
+      return {
+        latencyMs,
+        status: 'unhealthy',
+        error: error.message
+      };
+    }
+  }
+}

--- a/apps/api/src/health/indicators/index.ts
+++ b/apps/api/src/health/indicators/index.ts
@@ -1,0 +1,5 @@
+export { BullMQHealthIndicator } from './bullmq.health';
+export { DatabasePoolHealthIndicator } from './database-pool.health';
+export { ExchangeHealthIndicator } from './exchange.health';
+export { OHLCHealthIndicator } from './ohlc.health';
+export { RedisHealthIndicator } from './redis.health';

--- a/apps/api/src/health/indicators/ohlc.health.ts
+++ b/apps/api/src/health/indicators/ohlc.health.ts
@@ -1,0 +1,82 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+
+import { OHLCService } from '../../ohlc/ohlc.service';
+
+type DataFreshness = 'fresh' | 'stale' | 'critical' | 'no_data';
+
+/**
+ * Health indicator that monitors OHLC data freshness.
+ * Uses OHLCService.getSyncStatus() to check data recency.
+ * Fails if newest candle is older than 3 hours.
+ */
+@Injectable()
+export class OHLCHealthIndicator {
+  private readonly logger = new Logger(OHLCHealthIndicator.name);
+  private readonly STALE_THRESHOLD_HOURS = 3;
+
+  constructor(
+    private readonly ohlcService: OHLCService,
+    private readonly healthIndicatorService: HealthIndicatorService
+  ) {}
+
+  /**
+   * Check OHLC data freshness
+   * Fails if newest candle is older than 3 hours
+   */
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+
+    try {
+      const syncStatus = await this.ohlcService.getSyncStatus();
+
+      // Handle case where there's no OHLC data
+      if (!syncStatus.newestCandle) {
+        const result = {
+          newestCandle: null,
+          timeSinceLastCandleMinutes: null,
+          dataFreshness: 'no_data' as DataFreshness,
+          totalCandles: syncStatus.totalCandles,
+          coinsWithData: syncStatus.coinsWithData
+        };
+        return indicator.up(result);
+      }
+
+      const now = new Date();
+      const timeSinceLastCandleMs = now.getTime() - syncStatus.newestCandle.getTime();
+      const timeSinceLastCandleMinutes = Math.round(timeSinceLastCandleMs / (1000 * 60));
+      const timeSinceLastCandleHours = timeSinceLastCandleMinutes / 60;
+
+      // Determine data freshness status
+      let dataFreshness: DataFreshness;
+      if (timeSinceLastCandleHours <= 1) {
+        dataFreshness = 'fresh';
+      } else if (timeSinceLastCandleHours <= this.STALE_THRESHOLD_HOURS) {
+        dataFreshness = 'stale';
+      } else {
+        dataFreshness = 'critical';
+      }
+
+      const result = {
+        newestCandle: syncStatus.newestCandle.toISOString(),
+        timeSinceLastCandleMinutes,
+        dataFreshness,
+        totalCandles: syncStatus.totalCandles,
+        coinsWithData: syncStatus.coinsWithData
+      };
+
+      // Fail if data is too old
+      if (dataFreshness === 'critical') {
+        return indicator.down({
+          ...result,
+          message: `Newest candle is ${timeSinceLastCandleMinutes} minutes old (threshold: ${this.STALE_THRESHOLD_HOURS * 60} minutes)`
+        });
+      }
+
+      return indicator.up(result);
+    } catch (error) {
+      this.logger.error(`OHLC health check failed: ${error.message}`);
+      return indicator.down({ error: error.message });
+    }
+  }
+}

--- a/apps/api/src/health/indicators/redis.health.ts
+++ b/apps/api/src/health/indicators/redis.health.ts
@@ -1,0 +1,114 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+
+import Redis from 'ioredis';
+
+/**
+ * Health indicator that monitors Redis performance metrics via INFO command.
+ * Tracks memory usage, connected clients, and cache hit rate.
+ */
+@Injectable()
+export class RedisHealthIndicator implements OnModuleDestroy {
+  private readonly logger = new Logger(RedisHealthIndicator.name);
+  private redis: Redis | null = null;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly healthIndicatorService: HealthIndicatorService
+  ) {}
+
+  onModuleDestroy() {
+    this.disconnect();
+  }
+
+  private disconnect(): void {
+    if (this.redis) {
+      this.redis.disconnect();
+      this.redis = null;
+    }
+  }
+
+  private getClient(): Redis {
+    if (!this.redis) {
+      this.redis = new Redis({
+        host: this.config.get('REDIS_HOST'),
+        port: parseInt(this.config.get('REDIS_PORT') || '6379', 10),
+        username: this.config.get('REDIS_USER'),
+        password: this.config.get('REDIS_PASSWORD'),
+        family: 0,
+        tls: this.config.get('REDIS_TLS') === 'true' ? {} : undefined,
+        maxRetriesPerRequest: 1,
+        retryStrategy: () => null // Don't retry in health checks
+      });
+    }
+    return this.redis;
+  }
+
+  /**
+   * Check Redis performance metrics
+   * Fails if memory usage exceeds 90%
+   */
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+
+    try {
+      const client = this.getClient();
+      const info = await client.info();
+      const metrics = this.parseRedisInfo(info);
+
+      const memoryUsedMB = Math.round(metrics.usedMemory / (1024 * 1024));
+      const maxMemoryMB = metrics.maxMemory > 0 ? Math.round(metrics.maxMemory / (1024 * 1024)) : null;
+      const memoryUsagePercent = maxMemoryMB ? Math.round((memoryUsedMB / maxMemoryMB) * 100) : null;
+
+      const result = {
+        memoryUsedMB,
+        maxMemoryMB,
+        memoryUsagePercent,
+        connectedClients: metrics.connectedClients,
+        cacheHitRate: metrics.cacheHitRate
+      };
+
+      // Fail if memory usage exceeds 90%
+      if (memoryUsagePercent !== null && memoryUsagePercent > 90) {
+        return indicator.down({ ...result, message: 'Memory usage exceeds 90%' });
+      }
+
+      return indicator.up(result);
+    } catch (error) {
+      // Reset connection on failure so next health check creates fresh connection
+      this.disconnect();
+      this.logger.error(`Redis health check failed: ${error.message}`);
+      return indicator.down({ error: error.message });
+    }
+  }
+
+  private parseRedisInfo(info: string): {
+    usedMemory: number;
+    maxMemory: number;
+    connectedClients: number;
+    cacheHitRate: number;
+  } {
+    const lines = info.split('\n');
+    const data: Record<string, string> = {};
+
+    for (const line of lines) {
+      const [key, value] = line.split(':');
+      if (key && value) {
+        data[key.trim()] = value.trim();
+      }
+    }
+
+    const usedMemory = parseInt(data['used_memory'] || '0', 10);
+    const maxMemory = parseInt(data['maxmemory'] || '0', 10);
+    const connectedClients = parseInt(data['connected_clients'] || '0', 10);
+
+    // Calculate cache hit rate
+    const keyspaceHits = parseInt(data['keyspace_hits'] || '0', 10);
+    const keyspaceMisses = parseInt(data['keyspace_misses'] || '0', 10);
+    const totalOperations = keyspaceHits + keyspaceMisses;
+    const cacheHitRate = totalOperations > 0 ? Math.round((keyspaceHits / totalOperations) * 100) : 100;
+
+    return { usedMemory, maxMemory, connectedClients, cacheHitRate };
+  }
+}

--- a/apps/api/src/ohlc/ohlc.service.spec.ts
+++ b/apps/api/src/ohlc/ohlc.service.spec.ts
@@ -8,15 +8,18 @@ type MockRepo<T> = jest.Mocked<Repository<T>>;
 
 const createQueryBuilder = () => ({
   select: jest.fn().mockReturnThis(),
+  addSelect: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
   orderBy: jest.fn().mockReturnThis(),
   addOrderBy: jest.fn().mockReturnThis(),
   distinctOn: jest.fn().mockReturnThis(),
   leftJoinAndSelect: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
   getMany: jest.fn(),
   getRawMany: jest.fn(),
-  getRawOne: jest.fn()
+  getRawOne: jest.fn(),
+  getOne: jest.fn()
 });
 
 describe('OHLCService', () => {
@@ -71,6 +74,24 @@ describe('OHLCService', () => {
     await service.upsertCandles([]);
 
     expect(ohlcRepository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('upsertCandles upserts with conflict paths', async () => {
+    const candles = [{ coinId: 'btc', exchangeId: 'binance' }] as Partial<OHLCCandle>[];
+
+    await service.upsertCandles(candles);
+
+    expect(ohlcRepository.upsert).toHaveBeenCalledWith(candles, {
+      conflictPaths: ['coinId', 'timestamp', 'exchangeId'],
+      skipUpdateIfNoValuesChanged: true
+    });
+  });
+
+  it('getCandlesByDateRange returns empty for empty coin list', async () => {
+    const result = await service.getCandlesByDateRange([], new Date('2024-01-01'), new Date('2024-01-02'));
+
+    expect(result).toEqual([]);
+    expect(ohlcRepository.createQueryBuilder).not.toHaveBeenCalled();
   });
 
   it('getCandlesByDateRange returns query results', async () => {
@@ -145,8 +166,54 @@ describe('OHLCService', () => {
 
     const result = await service.getLatestCandles(['btc', 'eth']);
 
+    expect(qb.distinctOn).toHaveBeenCalledWith(['candle.coinId']);
+    expect(qb.orderBy).toHaveBeenCalledWith('candle.coinId');
+    expect(qb.addOrderBy).toHaveBeenCalledWith('candle.timestamp', 'DESC');
     expect(result.get('btc')).toEqual(candles[0]);
     expect(result.get('eth')).toEqual(candles[1]);
+  });
+
+  it('getCandleCount supports optional coinId filter', async () => {
+    ohlcRepository.count.mockResolvedValueOnce(12).mockResolvedValueOnce(3);
+
+    await expect(service.getCandleCount()).resolves.toBe(12);
+    await expect(service.getCandleCount('btc')).resolves.toBe(3);
+
+    expect(ohlcRepository.count).toHaveBeenNthCalledWith(1, { where: {} });
+    expect(ohlcRepository.count).toHaveBeenNthCalledWith(2, { where: { coinId: 'btc' } });
+  });
+
+  it('getCoinsWithCandleData filters empty ids', async () => {
+    const qb = createQueryBuilder();
+    qb.getRawMany.mockResolvedValue([{ coinId: 'btc' }, { coinId: '' }, { coinId: null }]);
+    (ohlcRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+    const result = await service.getCoinsWithCandleData();
+
+    expect(result).toEqual(['btc']);
+  });
+
+  it('getCandleDataDateRange returns null when no data', async () => {
+    const qb = createQueryBuilder();
+    qb.getRawOne.mockResolvedValue(null);
+    (ohlcRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+    const result = await service.getCandleDataDateRange();
+
+    expect(result).toBeNull();
+  });
+
+  it('getCandleDataDateRange converts min/max to dates', async () => {
+    const qb = createQueryBuilder();
+    qb.getRawOne.mockResolvedValue({ minDate: '2024-01-01T00:00:00Z', maxDate: '2024-01-02T00:00:00Z' });
+    (ohlcRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+    const result = await service.getCandleDataDateRange();
+
+    expect(result).toEqual({
+      start: new Date('2024-01-01T00:00:00Z'),
+      end: new Date('2024-01-02T00:00:00Z')
+    });
   });
 
   it('detectGaps returns gap ranges', async () => {
@@ -163,6 +230,20 @@ describe('OHLCService', () => {
       { start: new Date('2024-01-01T01:00:00Z'), end: new Date('2024-01-01T02:00:00Z') },
       { start: new Date('2024-01-01T04:00:00Z'), end: new Date('2024-01-01T05:00:00Z') }
     ]);
+  });
+
+  it('detectGaps returns empty when consecutive hours are present', async () => {
+    const qb = createQueryBuilder();
+    qb.getMany.mockResolvedValue([
+      { timestamp: new Date('2024-01-01T00:00:00Z') },
+      { timestamp: new Date('2024-01-01T01:00:00Z') },
+      { timestamp: new Date('2024-01-01T02:00:00Z') }
+    ] as OHLCCandle[]);
+    (ohlcRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+    const gaps = await service.detectGaps('btc', new Date('2024-01-01T00:00:00Z'), new Date('2024-01-01T03:00:00Z'));
+
+    expect(gaps).toEqual([]);
   });
 
   it('getGapSummary returns coins with gaps', async () => {
@@ -213,6 +294,50 @@ describe('OHLCService', () => {
     expect(result.id).toBe('map-2');
   });
 
+  it('getActiveSymbolMaps filters by exchange when provided', async () => {
+    symbolMapRepository.find.mockResolvedValue([]);
+
+    await service.getActiveSymbolMaps('ex-1');
+
+    expect(symbolMapRepository.find).toHaveBeenCalledWith({
+      where: { isActive: true, exchangeId: 'ex-1' },
+      order: { priority: 'ASC' },
+      relations: ['coin', 'exchange']
+    });
+  });
+
+  it('getSymbolMapsForCoins skips empty input', async () => {
+    const result = await service.getSymbolMapsForCoins([]);
+
+    expect(result).toEqual([]);
+    expect(symbolMapRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('updateSymbolMapStatus updates isActive', async () => {
+    await service.updateSymbolMapStatus('map-1', false);
+
+    expect(symbolMapRepository.update).toHaveBeenCalledWith('map-1', { isActive: false });
+  });
+
+  it('incrementFailureCount increments failure count', async () => {
+    await service.incrementFailureCount('map-1');
+
+    expect(symbolMapRepository.increment).toHaveBeenCalledWith({ id: 'map-1' }, 'failureCount', 1);
+  });
+
+  it('markSyncSuccess resets failure count and sets lastSyncAt', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-03T00:00:00Z'));
+
+    await service.markSyncSuccess('map-1');
+
+    expect(symbolMapRepository.update).toHaveBeenCalledWith('map-1', {
+      failureCount: 0,
+      lastSyncAt: new Date('2024-01-03T00:00:00Z')
+    });
+
+    jest.useRealTimers();
+  });
+
   it('pruneOldCandles returns affected count', async () => {
     ohlcRepository.delete.mockResolvedValue({ affected: 4 } as any);
 
@@ -222,15 +347,23 @@ describe('OHLCService', () => {
     expect(ohlcRepository.delete).toHaveBeenCalled();
   });
 
+  it('pruneOldCandles returns 0 when nothing deleted', async () => {
+    ohlcRepository.delete.mockResolvedValue({ affected: undefined } as any);
+
+    const result = await service.pruneOldCandles(30);
+
+    expect(result).toBe(0);
+  });
+
   it('getSyncStatus returns summary', async () => {
     const qb = createQueryBuilder();
     qb.getRawOne.mockResolvedValue({ count: '2' });
+    qb.getOne
+      .mockResolvedValueOnce({ timestamp: new Date('2024-01-01T00:00:00Z') } as OHLCCandle)
+      .mockResolvedValueOnce({ timestamp: new Date('2024-01-02T00:00:00Z') } as OHLCCandle);
     (ohlcRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
 
     ohlcRepository.count.mockResolvedValue(10);
-    ohlcRepository.findOne
-      .mockResolvedValueOnce({ timestamp: new Date('2024-01-01T00:00:00Z') } as OHLCCandle)
-      .mockResolvedValueOnce({ timestamp: new Date('2024-01-02T00:00:00Z') } as OHLCCandle);
     symbolMapRepository.findOne.mockResolvedValue({ lastSyncAt: new Date('2024-01-02T01:00:00Z') } as any);
 
     const result = await service.getSyncStatus();
@@ -317,5 +450,20 @@ describe('OHLCService', () => {
     const result = await service.findAllByHour('btc', '1d');
 
     expect(result.btc).toHaveLength(2);
+  });
+
+  it('findAllByDay uses range-based dates', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-10T00:00:00Z'));
+    const candles = [{ coinId: 'btc', timestamp: new Date('2024-01-09T00:00:00Z') }] as OHLCCandle[];
+    jest.spyOn(service, 'getCandlesByDateRange').mockResolvedValue(candles);
+
+    await service.findAllByDay('btc', '7d');
+
+    const [coinIds, startDate, endDate] = (service.getCandlesByDateRange as jest.Mock).mock.calls[0];
+    expect(coinIds).toEqual(['btc']);
+    expect(endDate).toEqual(new Date('2024-01-10T00:00:00Z'));
+    expect(startDate).toEqual(new Date('2024-01-03T00:00:00Z'));
+
+    jest.useRealTimers();
   });
 });

--- a/apps/api/src/ohlc/ohlc.service.ts
+++ b/apps/api/src/ohlc/ohlc.service.ts
@@ -394,14 +394,18 @@ export class OHLCService {
     const [totalCandles, coinsWithDataResult, oldestCandle, newestCandle, lastSyncResult] = await Promise.all([
       this.ohlcRepository.count(),
       this.ohlcRepository.createQueryBuilder('candle').select('COUNT(DISTINCT candle.coinId)', 'count').getRawOne(),
-      this.ohlcRepository.findOne({
-        order: { timestamp: 'ASC' },
-        select: ['timestamp']
-      }),
-      this.ohlcRepository.findOne({
-        order: { timestamp: 'DESC' },
-        select: ['timestamp']
-      }),
+      this.ohlcRepository
+        .createQueryBuilder('candle')
+        .select('candle.timestamp')
+        .orderBy('candle.timestamp', 'ASC')
+        .take(1)
+        .getOne(),
+      this.ohlcRepository
+        .createQueryBuilder('candle')
+        .select('candle.timestamp')
+        .orderBy('candle.timestamp', 'DESC')
+        .take(1)
+        .getOne(),
       this.symbolMapRepository.findOne({
         where: { isActive: true },
         order: { lastSyncAt: 'DESC' },

--- a/apps/api/src/order/paper-trading/paper-trading.job-data.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.job-data.ts
@@ -6,7 +6,8 @@ export enum PaperTradingJobType {
   START_SESSION = 'START_SESSION',
   TICK = 'TICK',
   STOP_SESSION = 'STOP_SESSION',
-  PROCESS_SIGNAL = 'PROCESS_SIGNAL'
+  PROCESS_SIGNAL = 'PROCESS_SIGNAL',
+  NOTIFY_PIPELINE = 'NOTIFY_PIPELINE'
 }
 
 export interface PaperTradingJobData {
@@ -34,4 +35,15 @@ export interface ProcessSignalJobData extends PaperTradingJobData {
   signalId: string;
 }
 
-export type AnyPaperTradingJobData = StartSessionJobData | TickJobData | StopSessionJobData | ProcessSignalJobData;
+export interface NotifyPipelineJobData extends PaperTradingJobData {
+  type: PaperTradingJobType.NOTIFY_PIPELINE;
+  pipelineId: string;
+  stoppedReason?: string;
+}
+
+export type AnyPaperTradingJobData =
+  | StartSessionJobData
+  | TickJobData
+  | StopSessionJobData
+  | ProcessSignalJobData
+  | NotifyPipelineJobData;

--- a/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
@@ -38,6 +38,10 @@ describe('PaperTradingProcessor', () => {
       startBacktestTimer: jest.fn().mockReturnValue(jest.fn())
     };
 
+    const eventEmitter = {
+      emit: jest.fn()
+    };
+
     const config = { maxConsecutiveErrors: 2 };
 
     return {
@@ -48,13 +52,15 @@ describe('PaperTradingProcessor', () => {
         (overrides.paperTradingService ?? paperTradingService) as any,
         (overrides.engineService ?? engineService) as any,
         (overrides.streamService ?? streamService) as any,
-        (overrides.metricsService ?? metricsService) as any
+        (overrides.metricsService ?? metricsService) as any,
+        (overrides.eventEmitter ?? eventEmitter) as any
       ),
       sessionRepository,
       paperTradingService,
       engineService,
       streamService,
-      metricsService
+      metricsService,
+      eventEmitter
     };
   };
 


### PR DESCRIPTION
## Summary

- Add comprehensive health check indicators for monitoring BullMQ queues, Redis, exchanges, database pool, and OHLC data availability
- Improve paper-trading reliability with job-based pipeline notifications and typed error handling
- Fix memory leaks and timeout issues in health indicators

## Changes

### Health Indicators (New)
- **BullMQ Health**: Monitor queue health with failed job threshold tracking and timeout handling
- **Redis Health**: Track memory usage, connected clients, and cache hit rate with auto-reconnect on failure
- **Exchange Health**: Monitor connectivity and latency for Binance US, Coinbase, and Kraken with parallel checks
- **Database Pool Health**: Monitor connection pool utilization
- **OHLC Health**: Verify data freshness for trading operations

### Health Indicator Improvements
- Add timeout handling to prevent indefinite hangs during Redis issues
- Run exchange health checks in parallel to avoid 30+ second sequential timeouts
- Fix memory leaks by properly clearing timeouts on success/error
- Reset Redis connection on failure to ensure fresh connection on next check

### Paper Trading Reliability
- Add `NotifyPipeline` job type for reliable pipeline notifications (survives process crashes)
- Implement `RecoverableError`/`UnrecoverableError` classes for typed error classification
- Update service to use job-based pipeline notifications within transactions
- Fix processor and service tests to match new implementation

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Unit tests pass for health indicators
- [x] Paper trading processor and service tests updated and passing
- [ ] Manual verification of health endpoint response times
- [ ] Verify health checks gracefully handle service unavailability