### PR TITLE
refactor(backtest): consolidate API around pipeline-first architecture

### DIFF
--- a/apps/api/src/order/backtest/backtest.controller.ts
+++ b/apps/api/src/order/backtest/backtest.controller.ts
@@ -31,7 +31,6 @@ import {
   BacktestProgressDto,
   BacktestSignalQueryDto,
   BacktestTradesQueryDto,
-  CreateBacktestDto,
   CreateComparisonReportDto,
   UpdateBacktestDto
 } from './dto/backtest.dto';
@@ -46,21 +45,6 @@ import { User } from '../../users/users.entity';
 @Controller('backtests')
 export class BacktestController {
   constructor(private readonly backtestService: BacktestService) {}
-
-  @Post()
-  @HttpCode(HttpStatus.ACCEPTED)
-  @ApiOperation({
-    summary: 'Create a new backtest',
-    description: 'Creates a comprehensive backtest run with historical data and performance analysis'
-  })
-  @ApiResponse({ status: HttpStatus.ACCEPTED })
-  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid backtest parameters' })
-  async createBacktest(
-    @GetUser() user: User,
-    @Body(new ValidationPipe({ transform: true })) createBacktestDto: CreateBacktestDto
-  ): Promise<BacktestRunDetail> {
-    return this.backtestService.createBacktest(user, createBacktestDto);
-  }
 
   @Get()
   @ApiOperation({ summary: 'Get all backtests with optional filtering' })
@@ -160,33 +144,6 @@ export class BacktestController {
   @ApiResponse({ status: HttpStatus.OK, type: BacktestProgressDto })
   async getBacktestProgress(@GetUser() user: User, @Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
     return this.backtestService.getBacktestProgress(user, id);
-  }
-
-  @Post(':id/cancel')
-  @ApiOperation({ summary: 'Cancel a running backtest' })
-  @ApiParam({ name: 'id', type: String, format: 'uuid' })
-  @ApiResponse({ status: HttpStatus.OK, description: 'Backtest cancelled' })
-  async cancelBacktest(@GetUser() user: User, @Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
-    await this.backtestService.cancelBacktest(user, id);
-    return { message: 'Backtest cancelled successfully' };
-  }
-
-  @Post(':id/resume')
-  @ApiOperation({ summary: 'Resume a paused backtest' })
-  @ApiParam({ name: 'id', type: String, format: 'uuid' })
-  async resumeBacktest(@GetUser() user: User, @Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
-    return this.backtestService.resumeBacktest(user, id);
-  }
-
-  @Post(':id/pause')
-  @HttpCode(HttpStatus.ACCEPTED)
-  @ApiOperation({ summary: 'Pause a running live replay backtest' })
-  @ApiParam({ name: 'id', type: String, format: 'uuid' })
-  @ApiResponse({ status: HttpStatus.ACCEPTED, description: 'Backtest pause requested' })
-  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Backtest cannot be paused' })
-  async pauseBacktest(@GetUser() user: User, @Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
-    await this.backtestService.pauseBacktest(user, id);
-    return { message: 'Backtest pause requested. The backtest will pause at the next checkpoint.' };
   }
 }
 

--- a/apps/api/src/order/backtest/backtest.service.create.spec.ts
+++ b/apps/api/src/order/backtest/backtest.service.create.spec.ts
@@ -71,10 +71,12 @@ describe('BacktestService.createBacktest', () => {
     };
   };
 
+  // Note: Only HISTORICAL and LIVE_REPLAY can be created via createBacktest().
+  // PAPER_TRADING and STRATEGY_OPTIMIZATION must use their dedicated services.
   const baseDto = {
     name: 'Test Backtest',
     description: 'test',
-    type: BacktestType.PAPER_TRADING,
+    type: BacktestType.HISTORICAL,
     algorithmId: 'algo-1',
     marketDataSetId: 'dataset-1',
     initialCapital: 1000,
@@ -149,18 +151,17 @@ describe('BacktestService.createBacktest', () => {
       } as any
     );
 
-    expect(result.warningFlags).toEqual(
-      expect.arrayContaining(['dataset_integrity_low', 'dataset_not_replay_capable', 'partial overlap'])
-    );
+    // Note: 'dataset_not_replay_capable' is only added for non-HISTORICAL types
+    expect(result.warningFlags).toEqual(expect.arrayContaining(['dataset_integrity_low', 'partial overlap']));
     expect(historicalQueue.add).toHaveBeenCalledWith(
       'execute-backtest',
       expect.objectContaining({
         backtestId: 'backtest-1',
         deterministicSeed: 'seed-1',
-        mode: BacktestType.PAPER_TRADING
+        mode: BacktestType.HISTORICAL
       }),
       { jobId: 'backtest-1', removeOnComplete: true }
     );
-    expect(metricsService.recordBacktestCreated).toHaveBeenCalledWith(BacktestType.PAPER_TRADING, 'Algo');
+    expect(metricsService.recordBacktestCreated).toHaveBeenCalledWith(BacktestType.HISTORICAL, 'Algo');
   });
 });

--- a/apps/api/src/order/backtest/backtest.service.ts
+++ b/apps/api/src/order/backtest/backtest.service.ts
@@ -590,7 +590,22 @@ export class BacktestService implements OnModuleInit {
   }
 
   private getQueueForType(type: BacktestType): Queue {
-    return type === BacktestType.LIVE_REPLAY ? this.replayQueue : this.historicalQueue;
+    switch (type) {
+      case BacktestType.HISTORICAL:
+        return this.historicalQueue;
+      case BacktestType.LIVE_REPLAY:
+        return this.replayQueue;
+      case BacktestType.PAPER_TRADING:
+      case BacktestType.STRATEGY_OPTIMIZATION:
+        throw new Error(
+          `BacktestType.${type} should not be created via backtestService.createBacktest(). ` +
+            `Use the appropriate service: paperTradingService or optimizationService.`
+        );
+      default: {
+        const _exhaustive: never = type;
+        throw new Error(`Unknown backtest type: ${type}`);
+      }
+    }
   }
 
   private async loadBacktestsForUser(userId: string, ids: string[]): Promise<Backtest[]> {

--- a/apps/api/src/order/backtest/live-replay.processor.ts
+++ b/apps/api/src/order/backtest/live-replay.processor.ts
@@ -56,8 +56,13 @@ export class LiveReplayProcessor extends WorkerHost {
         throw new Error(`Backtest ${backtestId} not found`);
       }
 
+      // Type guard: ensure this processor only handles LIVE_REPLAY backtests
       if (backtest.type !== BacktestType.LIVE_REPLAY) {
-        this.logger.warn(`Backtest ${backtestId} is not configured for live replay. Type: ${backtest.type}`);
+        this.logger.error(`LiveReplayProcessor received wrong type: ${backtest.type}, expected LIVE_REPLAY`);
+        await this.backtestResultService.markFailed(
+          backtestId,
+          `System error: BacktestType.${backtest.type} incorrectly routed to replay processor.`
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary

- Remove public mutation endpoints from backtest controller since backtests should only be created via pipelines
- Add exhaustive type guards to route backtests to correct processors and prevent invalid types from being created directly
- Document the pipeline/backtest architecture in CLAUDE.md for future reference

## Changes

### Controller (`backtest.controller.ts`)
- Remove `POST /backtests` endpoint (create)
- Remove `POST /backtests/:id/cancel` endpoint
- Remove `POST /backtests/:id/pause` endpoint
- Remove `POST /backtests/:id/resume` endpoint
- Keep all GET endpoints, PUT (update), DELETE, and compare functionality

### Service (`backtest.service.ts`)
- Add exhaustive switch in `getQueueForType()` with proper error handling
- `PAPER_TRADING` and `STRATEGY_OPTIMIZATION` types now throw explicit errors directing to the correct services
- Uses TypeScript `never` type for exhaustiveness checking

### Processors
- Add type guards in `BacktestProcessor` to reject non-HISTORICAL types
- Add type guards in `LiveReplayProcessor` to reject non-LIVE_REPLAY types
- Mark incorrectly routed backtests as failed with clear error messages

### Documentation (`CLAUDE.md`)
- Document user isolation model (strict per-user ownership)
- Document what makes each backtest run unique
- Document shared vs user-specific resources
- Document risk-based configuration table
- Document pipeline stage flow

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (`nx lint api`)
- [x] Unit tests pass for affected files
- [ ] Manual verification that existing GET endpoints still work
- [ ] Verify pipeline creation flow creates backtests correctly

## Breaking Changes

**Removed API endpoints:**
- `POST /backtests` - Use pipeline service instead
- `POST /backtests/:id/cancel` - Manage via pipeline
- `POST /backtests/:id/pause` - Manage via pipeline  
- `POST /backtests/:id/resume` - Manage via pipeline

Closes #128