### PR TITLE
refactor(config): use forRootAsync for TypeORM and BullMQ configuration

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git diff:*), Bash(git log:*)
-argument-hint: [message] | --no-verify | --amend
+argument-hint: [message] | --no-verify | --amend | --issue <number>
 description: Create well-formatted commits with conventional commit format
 ---
 
@@ -49,6 +49,7 @@ Create well-formatted commit: $ARGUMENTS
   - `db`: Database related changes
 - **Present tense, imperative mood**: Write commit messages as commands (e.g., "add feature" not "added feature")
 - **Concise first line**: Keep the first line under 72 characters
+- **Link GitHub issues**: When working on a tracked issue, add `Closes #<number>` on a separate line at the bottom of the commit body
 
 ## Guidelines for Splitting Commits
 
@@ -63,6 +64,7 @@ When analyzing the diff, consider splitting commits based on these criteria:
 ## Examples
 
 Good commit messages:
+
 - feat: add user authentication system
 - fix: resolve memory leak in rendering process
 - docs: update API documentation with new endpoints
@@ -70,17 +72,23 @@ Good commit messages:
 - fix: resolve linter warnings in component files
 - chore: improve developer tooling setup process
 - feat: implement business logic for transaction validation
-- fix: address minor styling inconsistency in header
 - fix: patch critical security vulnerability in auth flow
-- style: reorganize component structure for better readability
-- fix: remove deprecated legacy code
 - feat: add input validation for user registration form
-- fix: resolve failing CI pipeline tests
-- feat: implement analytics tracking for user engagement
-- fix: strengthen authentication password requirements
-- feat: improve form accessibility for screen readers
+
+Example with issue reference (multi-line commit):
+
+```
+feat: add user authentication system
+
+- Implement JWT-based authentication
+- Add login and logout endpoints
+- Create user session management
+
+Closes #123
+```
 
 Example of splitting commits:
+
 - First commit: feat: add new solc version type definitions
 - Second commit: docs: update documentation for new solc versions
 - Third commit: chore: update package.json dependencies
@@ -93,6 +101,8 @@ Example of splitting commits:
 ## Command Options
 
 - `--no-verify`: Skip running the pre-commit checks (lint, build, generate:docs)
+- `--issue <number>` or `-i <number>`: Link the commit to a GitHub issue (adds `Closes #<number>` at the bottom of the commit body)
+- `--amend`: Amend the previous commit instead of creating a new one
 
 ## Important Notes
 
@@ -104,3 +114,5 @@ Example of splitting commits:
 - Before committing, the command will review the diff to identify if multiple commits would be more appropriate
 - If suggesting multiple commits, it will help you stage and commit the changes separately
 - Always reviews the commit diff to ensure the message matches the changes
+- When `--issue` is provided, add `Closes #<number>` on a separate line at the bottom of the commit body
+- Using `Closes #<number>` automatically closes the referenced issue when the commit is merged to the default branch

--- a/apps/api/src/config/database.config.ts
+++ b/apps/api/src/config/database.config.ts
@@ -1,0 +1,24 @@
+import { registerAs } from '@nestjs/config';
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+
+import { join } from 'path';
+
+export const databaseConfig = registerAs(
+  'database',
+  (): TypeOrmModuleOptions => ({
+    type: 'postgres',
+    host: process.env.PGHOST,
+    port: parseInt(process.env.PGPORT || '5432', 10),
+    database: process.env.PGDATABASE,
+    username: process.env.PGUSER,
+    password: process.env.PGPASSWORD,
+    autoLoadEntities: true,
+    entities: [join(__dirname, '../**/*.entity{.ts,.js}')],
+    migrations: [join(__dirname, '../migrations/*.{ts,js}')],
+    migrationsTableName: 'migration',
+    migrationsRun: process.env.NODE_ENV === 'production',
+    synchronize: process.env.NODE_ENV !== 'production',
+    logging: process.env.NODE_ENV !== 'production',
+    uuidExtension: 'pgcrypto'
+  })
+);

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -35,6 +35,7 @@ const envSchema = z.object({
     .string()
     .optional()
     .transform((val) => val === 'true'),
+  REDIS_URL: z.string().url().optional(),
 
   // Authentication & Security
   COOKIE_SECRET: z

--- a/apps/api/src/config/redis.config.ts
+++ b/apps/api/src/config/redis.config.ts
@@ -1,0 +1,22 @@
+import { registerAs } from '@nestjs/config';
+
+export interface RedisConfig {
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  tls: boolean;
+  url?: string;
+}
+
+export const redisConfig = registerAs(
+  'redis',
+  (): RedisConfig => ({
+    host: process.env.REDIS_HOST,
+    port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    username: process.env.REDIS_USER || undefined,
+    password: process.env.REDIS_PASSWORD || undefined,
+    tls: process.env.REDIS_TLS === 'true',
+    url: process.env.REDIS_URL
+  })
+);

--- a/apps/api/src/shared-cache.module.ts
+++ b/apps/api/src/shared-cache.module.ts
@@ -1,23 +1,28 @@
 import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 import { createKeyv, Keyv } from '@keyv/redis';
 import { CacheableMemory } from 'cacheable';
 
+import { RedisConfig } from './config/redis.config';
+
 @Module({
   imports: [
     CacheModule.registerAsync({
-      useFactory: async () => {
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        const redis = configService.get<RedisConfig>('redis');
         return {
           stores: [
             new Keyv({
               store: new CacheableMemory({ ttl: '1m', lruSize: 5000 })
             }),
             createKeyv({
-              url: process.env.REDIS_URL,
+              url: redis.url,
               database: 2,
-              username: process.env.REDIS_USER,
-              password: process.env.REDIS_PASSWORD
+              username: redis.username,
+              password: redis.password
             })
           ]
         };


### PR DESCRIPTION
## Summary

- Convert module configuration from direct `process.env` access to NestJS ConfigService with typed factories
- Extract database and redis configs to dedicated files using `registerAs()`
- Enable proper dependency injection for configuration values

## Changes

- **apps/api/src/config/database.config.ts** - New typed TypeORM configuration factory
- **apps/api/src/config/redis.config.ts** - New typed Redis configuration with `RedisConfig` interface
- **apps/api/src/app.module.ts** - Convert to `forRootAsync` for TypeORM and BullMQ
- **apps/api/src/shared-cache.module.ts** - Use ConfigService injection for cache module
- **apps/api/src/config/env.validation.ts** - Add `REDIS_URL` validation
- **.claude/commands/commit.md** - Add `--issue` flag for GitHub issue linking

## Test Plan

- [x] All 1334 unit tests pass
- [x] Build succeeds
- [x] Lint passes

Closes #149