### PR TITLE
fix(api): add backtest stall resilience with watchdog, heartbeat, and error circuit breaker

### DIFF
--- a/apps/api/src/order/backtest/backtest-pacing.interface.ts
+++ b/apps/api/src/order/backtest/backtest-pacing.interface.ts
@@ -86,6 +86,9 @@ export interface LiveReplayExecuteOptions {
   /** Callback invoked at each checkpoint */
   onCheckpoint?: CheckpointCallback;
 
+  /** Lightweight callback for progress updates (called at most every ~30 seconds) */
+  onHeartbeat?: (index: number, totalTimestamps: number) => Promise<void>;
+
   /** Checkpoint state to resume from (if resuming a previous run) */
   resumeFrom?: BacktestCheckpointState;
 

--- a/apps/api/src/order/backtest/live-replay.processor.ts
+++ b/apps/api/src/order/backtest/live-replay.processor.ts
@@ -22,7 +22,11 @@ import { MetricsService } from '../../metrics/metrics.service';
 const BACKTEST_QUEUE_NAMES = backtestConfig();
 
 @Injectable()
-@Processor(BACKTEST_QUEUE_NAMES.replayQueue)
+@Processor(BACKTEST_QUEUE_NAMES.replayQueue, {
+  lockDuration: 7_200_000,
+  stalledInterval: 7_200_000,
+  maxStalledCount: 1
+})
 export class LiveReplayProcessor extends WorkerHost {
   private readonly logger = new Logger(LiveReplayProcessor.name);
 
@@ -171,6 +175,28 @@ export class LiveReplayProcessor extends WorkerHost {
         );
       };
 
+      let heartbeatCallCount = 0;
+      const onHeartbeat = async (index: number, totalTimestamps: number) => {
+        heartbeatCallCount++;
+
+        // Check external FAILED status every ~90s (every 3rd heartbeat)
+        if (heartbeatCallCount % 3 === 0) {
+          const current = await this.backtestRepository.findOne({
+            where: { id: backtestId },
+            select: ['id', 'status']
+          });
+          if (current && current.status === BacktestStatus.FAILED) {
+            throw new Error('Backtest was externally marked as FAILED — aborting execution');
+          }
+        }
+
+        await this.backtestRepository.update(backtestId, {
+          lastCheckpointAt: new Date(),
+          processedTimestampCount: index + 1,
+          totalTimestampCount: totalTimestamps
+        });
+      };
+
       // Execute live replay with pacing, pause support, and checkpoints
       const results = await this.backtestEngine.executeLiveReplayBacktest(backtest, coins, {
         dataset,
@@ -179,6 +205,7 @@ export class LiveReplayProcessor extends WorkerHost {
         replaySpeed: backtest.liveReplayState.replaySpeed,
         checkpointInterval: DEFAULT_LIVE_REPLAY_CHECKPOINT_INTERVAL,
         onCheckpoint,
+        onHeartbeat,
         resumeFrom: backtest.checkpointState ?? undefined,
         shouldPause,
         onPaused
@@ -199,7 +226,15 @@ export class LiveReplayProcessor extends WorkerHost {
       this.metricsService.recordBacktestCompleted(strategyName, 'success');
     } catch (error) {
       this.logger.error(`Live replay backtest ${backtestId} failed: ${error.message}`, error.stack);
-      await this.backtestResultService.markFailed(backtestId, error.message);
+
+      // Skip markFailed if already externally failed (e.g. by stale watchdog)
+      const current = await this.backtestRepository.findOne({
+        where: { id: backtestId },
+        select: ['id', 'status']
+      });
+      if (!current || current.status !== BacktestStatus.FAILED) {
+        await this.backtestResultService.markFailed(backtestId, error.message);
+      }
       this.metricsService.recordBacktestCompleted(strategyName, 'failed');
     } finally {
       endTimer();

--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -74,6 +74,7 @@ const BACKTEST_DEFAULTS = backtestConfig();
     BacktestService,
     BacktestEngine,
     BacktestStreamService,
+    BacktestResultService,
     SlippageAnalysisService,
     PositionManagementService,
     OrderStateMachineService

--- a/apps/api/src/tasks/backtest-orchestration.task.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.ts
@@ -8,12 +8,16 @@
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import { Queue } from 'bullmq';
+import { IsNull, LessThan, Repository } from 'typeorm';
 
 import { BacktestOrchestrationService } from './backtest-orchestration.service';
 import { OrchestrationJobData, STAGGER_INTERVAL_MS } from './dto/backtest-orchestration.dto';
 
+import { BacktestResultService } from '../order/backtest/backtest-result.service';
+import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
 import { BacktestService } from '../order/backtest/backtest.service';
 
 @Injectable()
@@ -24,7 +28,9 @@ export class BacktestOrchestrationTask {
     @InjectQueue('backtest-orchestration')
     private readonly orchestrationQueue: Queue<OrchestrationJobData>,
     private readonly orchestrationService: BacktestOrchestrationService,
-    private readonly backtestService: BacktestService
+    private readonly backtestService: BacktestService,
+    private readonly backtestResultService: BacktestResultService,
+    @InjectRepository(Backtest) private readonly backtestRepository: Repository<Backtest>
   ) {}
 
   /**
@@ -131,5 +137,76 @@ export class BacktestOrchestrationTask {
     ]);
 
     return { waiting, active, completed, failed, delayed };
+  }
+
+  /**
+   * Watchdog that detects and fails stale RUNNING backtests.
+   * Uses type-aware thresholds: 30 min for HISTORICAL, 60 min for LIVE_REPLAY.
+   * PAPER_TRADING and STRATEGY_OPTIMIZATION are excluded entirely.
+   * Errors on individual markFailed calls do not abort the loop.
+   */
+  @Cron('*/15 * * * *')
+  async detectStaleBacktests(): Promise<void> {
+    const HISTORICAL_THRESHOLD_MS = 30 * 60 * 1000;
+    const LIVE_REPLAY_THRESHOLD_MS = 60 * 60 * 1000;
+
+    const historicalCutoff = new Date(Date.now() - HISTORICAL_THRESHOLD_MS);
+    const liveReplayCutoff = new Date(Date.now() - LIVE_REPLAY_THRESHOLD_MS);
+
+    // Query stale HISTORICAL backtests (30-min threshold)
+    const staleHistorical = await this.backtestRepository.find({
+      where: [
+        { status: BacktestStatus.RUNNING, type: BacktestType.HISTORICAL, lastCheckpointAt: LessThan(historicalCutoff) },
+        {
+          status: BacktestStatus.RUNNING,
+          type: BacktestType.HISTORICAL,
+          lastCheckpointAt: IsNull(),
+          updatedAt: LessThan(historicalCutoff)
+        }
+      ]
+    });
+
+    // Query stale LIVE_REPLAY backtests (60-min threshold)
+    const staleLiveReplay = await this.backtestRepository.find({
+      where: [
+        {
+          status: BacktestStatus.RUNNING,
+          type: BacktestType.LIVE_REPLAY,
+          lastCheckpointAt: LessThan(liveReplayCutoff)
+        },
+        {
+          status: BacktestStatus.RUNNING,
+          type: BacktestType.LIVE_REPLAY,
+          lastCheckpointAt: IsNull(),
+          updatedAt: LessThan(liveReplayCutoff)
+        }
+      ]
+    });
+
+    const staleBacktests = [
+      ...staleHistorical.map((bt) => ({ backtest: bt, thresholdMs: HISTORICAL_THRESHOLD_MS })),
+      ...staleLiveReplay.map((bt) => ({ backtest: bt, thresholdMs: LIVE_REPLAY_THRESHOLD_MS }))
+    ];
+
+    for (const { backtest, thresholdMs } of staleBacktests) {
+      try {
+        this.logger.warn(
+          `Marking stale ${backtest.type} backtest ${backtest.id} as FAILED ` +
+            `(last checkpoint: ${backtest.lastCheckpointAt?.toISOString()}, ` +
+            `progress: ${backtest.processedTimestampCount}/${backtest.totalTimestampCount})`
+        );
+        await this.backtestResultService.markFailed(
+          backtest.id,
+          `Stale: no checkpoint progress for ${Math.round(thresholdMs / 60000)} min. ` +
+            `Last index: ${backtest.checkpointState?.lastProcessedIndex ?? 'unknown'}`
+        );
+      } catch (error) {
+        this.logger.error(`Failed to mark stale backtest ${backtest.id} as FAILED: ${error.message}`);
+      }
+    }
+
+    if (staleBacktests.length > 0) {
+      this.logger.log(`Stale watchdog marked ${staleBacktests.length} backtest(s) as FAILED`);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add stall detection watchdog, time-based heartbeats, and circuit breaker resilience to backtest execution
- Fix timer leak, reduce DB load from heartbeat polling, and extend resilience to live replay path
- Make watchdog type-aware with per-type stale thresholds and error-tolerant loop

## Changes

### Timer Leak Fix
- `indicator.service.ts` — Clear timeout in `.finally()` to prevent leaked timers when the main promise wins the race

### Time-Based Heartbeats
- `backtest-engine.service.ts` — Replace iteration-based heartbeat (`i % 50`) with wall-clock interval (~30s)
- `backtest.processor.ts` — Check external FAILED status every 3rd heartbeat (~90s) instead of every heartbeat, reducing `findOne` DB calls

### Live Replay Resilience
- `backtest-pacing.interface.ts` — Add `onHeartbeat` to `LiveReplayExecuteOptions`
- `backtest-engine.service.ts` — Add circuit breaker (consecutive error tracking) and time-based heartbeat to `executeLiveReplayBacktest`
- `live-replay.processor.ts` — Wire `onHeartbeat` callback with selective status check; add externally-failed guard in catch block

### Watchdog Type Filtering + Error Resilience
- `backtest-orchestration.task.ts` — Two separate queries: HISTORICAL (30-min threshold) and LIVE_REPLAY (60-min threshold); exclude PAPER_TRADING/STRATEGY_OPTIMIZATION; try/catch per `markFailed` call
- `backtest-orchestration.task.spec.ts` — 5 test cases covering both backtest types, threshold boundaries, and error resilience

## Test Plan

- [x] All 1376 API unit tests pass (`nx test api`)
- [x] API builds successfully (`nx build api`)
- [ ] Verify stale HISTORICAL backtests are detected after 30 min of no heartbeat
- [ ] Verify stale LIVE_REPLAY backtests are detected after 60 min of no heartbeat
- [ ] Verify PAPER_TRADING backtests are not flagged by watchdog