### PR TITLE
fix(api): enable JWT auth guards on deployment and monitoring controllers

### DIFF
--- a/apps/api/src/exchange/exchange-key/exchange-key.controller.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key.controller.ts
@@ -1,18 +1,18 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Param,
-  Delete,
-  UseGuards,
-  HttpStatus,
   ClassSerializerInterceptor,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
   UseInterceptors
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-import { CreateExchangeKeyDto, ExchangeKeyResponseDto, UpdateExchangeKeyDto } from './dto';
+import { CreateExchangeKeyDto, ExchangeKeyResponseDto } from './dto';
 import { ExchangeKey } from './exchange-key.entity';
 import { ExchangeKeyService } from './exchange-key.service';
 
@@ -23,7 +23,7 @@ import { User } from '../../users/users.entity';
 @ApiTags('Exchange Keys')
 @Controller('exchange-keys')
 @UseGuards(JwtAuthenticationGuard)
-@ApiBearerAuth()
+@ApiBearerAuth('token')
 @UseInterceptors(ClassSerializerInterceptor)
 export class ExchangeKeyController {
   constructor(private readonly exchangeKeyService: ExchangeKeyService) {}

--- a/apps/api/src/market-regime/market-regime.controller.ts
+++ b/apps/api/src/market-regime/market-regime.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { MarketRegimeService } from './market-regime.service';
 
@@ -12,7 +12,7 @@ import { JwtAuthenticationGuard } from '../authentication/guard/jwt-authenticati
 @ApiTags('market-regime')
 @Controller('market-regime')
 @UseGuards(JwtAuthenticationGuard)
-@ApiBearerAuth()
+@ApiBearerAuth('token')
 export class MarketRegimeController {
   constructor(private readonly marketRegimeService: MarketRegimeService) {}
 

--- a/apps/api/src/monitoring/monitoring.controller.ts
+++ b/apps/api/src/monitoring/monitoring.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { DriftDetectorService } from './drift-detector.service';
 import { MonitoringService } from './monitoring.service';
+
+import { JwtAuthenticationGuard } from '../authentication/guard/jwt-authentication.guard';
 
 /**
  * MonitoringController
@@ -18,7 +20,8 @@ import { MonitoringService } from './monitoring.service';
  */
 @ApiTags('Monitoring')
 @Controller('monitoring/deployments')
-// @UseGuards(JwtAuthGuard) // TODO: Uncomment when auth is implemented
+@UseGuards(JwtAuthenticationGuard)
+@ApiBearerAuth('token')
 export class MonitoringController {
   constructor(
     private readonly monitoringService: MonitoringService,

--- a/apps/api/src/optimization/optimization.controller.ts
+++ b/apps/api/src/optimization/optimization.controller.ts
@@ -19,7 +19,7 @@ import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
 @Controller('strategies/:strategyId/optimize')
 @ApiTags('Strategy Optimization')
 @UseGuards(JwtAuthenticationGuard)
-@ApiBearerAuth()
+@ApiBearerAuth('token')
 export class OptimizationController {
   constructor(private readonly orchestratorService: OptimizationOrchestratorService) {}
 

--- a/apps/api/src/order/paper-trading/paper-trading.controller.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.controller.ts
@@ -40,7 +40,7 @@ import { User } from '../../users/users.entity';
 @ApiTags('Paper Trading')
 @Controller('paper-trading')
 @UseGuards(JwtAuthenticationGuard)
-@ApiBearerAuth()
+@ApiBearerAuth('token')
 export class PaperTradingController {
   constructor(private readonly paperTradingService: PaperTradingService) {}
 

--- a/apps/api/src/strategy/deployment.controller.ts
+++ b/apps/api/src/strategy/deployment.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards, HttpStatus, HttpCode } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { DeploymentService } from './deployment.service';
 import { Deployment } from './entities/deployment.entity';
 import { PerformanceMetric } from './entities/performance-metric.entity';
+
+import { JwtAuthenticationGuard } from '../authentication/guard/jwt-authentication.guard';
 
 /**
  * DeploymentController
@@ -24,7 +26,8 @@ import { PerformanceMetric } from './entities/performance-metric.entity';
  */
 @ApiTags('Deployments')
 @Controller('deployments')
-// @UseGuards(JwtAuthGuard) // TODO: Uncomment when auth is implemented
+@UseGuards(JwtAuthenticationGuard)
+@ApiBearerAuth('token')
 export class DeploymentController {
   constructor(private readonly deploymentService: DeploymentService) {}
 

--- a/apps/api/src/strategy/strategy.controller.ts
+++ b/apps/api/src/strategy/strategy.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Post, Patch, Delete, Body, Param, Query, UseGuards, Request } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-import { CreateStrategyConfigDto, UpdateStrategyConfigDto, StrategyConfigListFilters } from '@chansey/api-interfaces';
+import { CreateStrategyConfigDto, StrategyConfigListFilters, UpdateStrategyConfigDto } from '@chansey/api-interfaces';
 
 import { StrategyService } from './strategy.service';
 
@@ -14,7 +14,7 @@ import { JwtAuthenticationGuard } from '../authentication/guard/jwt-authenticati
 @ApiTags('strategies')
 @Controller('strategies')
 @UseGuards(JwtAuthenticationGuard)
-@ApiBearerAuth()
+@ApiBearerAuth('token')
 export class StrategyController {
   constructor(private readonly strategyService: StrategyService) {}
 


### PR DESCRIPTION
## Summary

- Enable JWT authentication guards on `DeploymentController` and `MonitoringController` which had `@UseGuards` commented out with a TODO
- Fix `@ApiBearerAuth()` → `@ApiBearerAuth('token')` across 5 additional controllers to match the Swagger security scheme name

## Changes

**Auth guards enabled (previously unprotected):**
- `monitoring.controller.ts` — Added `JwtAuthenticationGuard` and `@ApiBearerAuth('token')`
- `deployment.controller.ts` — Added `JwtAuthenticationGuard` and `@ApiBearerAuth('token')`

**Swagger security scheme fix (`@ApiBearerAuth('token')`):**
- `exchange-key.controller.ts`
- `market-regime.controller.ts`
- `optimization.controller.ts`
- `paper-trading.controller.ts`
- `strategy.controller.ts`

## Test Plan

- [ ] Verify deployment and monitoring endpoints now return 401 without a valid JWT
- [ ] Verify all endpoints still work with a valid JWT token
- [ ] Confirm Swagger UI shows the lock icon and sends the Bearer token for all affected endpoints

Closes #161