### PR TITLE
fix(api): use live market prices in portfolio aggregation instead of cost basis

### DIFF
--- a/apps/api/src/portfolio/portfolio-aggregation.service.ts
+++ b/apps/api/src/portfolio/portfolio-aggregation.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import { Decimal } from 'decimal.js';
+
+import { CoinService } from '../coin/coin.service';
+import { RealtimeTickerService } from '../ohlc/services/realtime-ticker.service';
 import { PositionTrackingService } from '../strategy/position-tracking.service';
+
+const USD_QUOTE_CURRENCIES = new Set(['USDT', 'USDC', 'BUSD', 'DAI', 'USD']);
 
 /**
  * Aggregates portfolio data across all algorithmic trading strategies.
@@ -10,7 +16,78 @@ import { PositionTrackingService } from '../strategy/position-tracking.service';
 export class PortfolioAggregationService {
   private readonly logger = new Logger(PortfolioAggregationService.name);
 
-  constructor(private readonly positionTracking: PositionTrackingService) {}
+  constructor(
+    private readonly positionTracking: PositionTrackingService,
+    private readonly coinService: CoinService,
+    private readonly realtimeTickerService: RealtimeTickerService
+  ) {}
+
+  /**
+   * Parses a CCXT-format trading pair symbol for USD-quoted pricing.
+   * Returns the base symbol lowercased, or null if not USD-quoted or malformed.
+   *
+   * E.g., BTC/USDT → { base: 'btc' }, ETH/BTC → null, BTCUSDT → null
+   */
+  private parseSymbolForPricing(symbol: string): { base: string } | null {
+    const parts = symbol.split('/');
+    if (parts.length !== 2) return null;
+
+    const [base, quote] = parts;
+    if (!base || !quote) return null;
+    if (!USD_QUOTE_CURRENCIES.has(quote.toUpperCase())) return null;
+
+    return { base: base.toLowerCase() };
+  }
+
+  /**
+   * Fetches current market prices for trading pair symbols.
+   * Uses RealtimeTickerService with Coin.currentPrice as fallback.
+   * Returns empty map on failure so callers can fall back to avgPrice.
+   */
+  private async fetchCurrentPrices(symbols: string[]): Promise<Map<string, number>> {
+    const priceMap = new Map<string, number>();
+
+    try {
+      // Extract unique base symbols from trading pairs
+      const symbolToBase = new Map<string, string>();
+      for (const symbol of symbols) {
+        const parsed = this.parseSymbolForPricing(symbol);
+        if (parsed) {
+          symbolToBase.set(symbol, parsed.base);
+        }
+      }
+
+      const uniqueBases = [...new Set(symbolToBase.values())];
+      if (uniqueBases.length === 0) return priceMap;
+
+      // Batch-fetch coins by base symbol
+      const coins = await this.coinService.getMultipleCoinsBySymbol(uniqueBases);
+      const baseToCoins = new Map(coins.map((c) => [c.symbol.toLowerCase(), c]));
+
+      // Collect coin IDs for realtime price fetch
+      const coinIds = coins.filter((c) => c.id).map((c) => c.id);
+      const tickerPrices = coinIds.length > 0 ? await this.realtimeTickerService.getPrices(coinIds) : new Map();
+
+      // Map prices back to original trading pair symbols
+      for (const [symbol, base] of symbolToBase) {
+        const coin = baseToCoins.get(base);
+        if (!coin) continue;
+
+        // Fallback chain: ticker price → coin.currentPrice
+        const ticker = tickerPrices.get(coin.id);
+        const price = ticker?.price ?? coin.currentPrice;
+        if (price != null && price > 0) {
+          priceMap.set(symbol, price);
+        }
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch current prices, will fall back to avg prices: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    return priceMap;
+  }
 
   /**
    * Get aggregated portfolio for a user across all algo trading strategies.
@@ -24,40 +101,86 @@ export class PortfolioAggregationService {
     unrealizedPnL: number;
   }> {
     try {
-      // Get all positions across all strategies
+      // Single DB call — compute by-symbol aggregation and realized PnL in-memory
       const allPositions = await this.positionTracking.getPositions(userId);
 
-      // Get positions grouped by symbol
-      const positionsBySymbol = await this.positionTracking.getAllUserPositionsBySymbol(userId);
+      // Aggregate positions by symbol (replicates getAllUserPositionsBySymbol logic)
+      const positionsBySymbol = new Map<string, { quantity: Decimal; weightedCost: Decimal; pnl: Decimal }>();
+      let totalRealizedPnL = new Decimal(0);
 
-      // Get total P&L
-      const pnlSummary = await this.positionTracking.getUserTotalPnL(userId);
+      for (const position of allPositions) {
+        const qty = new Decimal(position.quantity);
+        const price = new Decimal(position.avgEntryPrice);
+        const realized = new Decimal(position.realizedPnL);
+        const unrealized = new Decimal(position.unrealizedPnL);
+
+        totalRealizedPnL = totalRealizedPnL.plus(realized);
+
+        const existing = positionsBySymbol.get(position.symbol);
+        if (existing) {
+          const newWeightedCost = existing.weightedCost.plus(qty.times(price));
+          existing.quantity = existing.quantity.plus(qty);
+          existing.weightedCost = newWeightedCost;
+          existing.pnl = existing.pnl.plus(realized).plus(unrealized);
+        } else {
+          positionsBySymbol.set(position.symbol, {
+            quantity: qty,
+            weightedCost: qty.times(price),
+            pnl: realized.plus(unrealized)
+          });
+        }
+      }
+
+      // Fetch current market prices for all symbols
+      const symbols = [...positionsBySymbol.keys()];
+      const currentPrices = await this.fetchCurrentPrices(symbols);
 
       // Convert Map to array of aggregated positions
       const aggregatedPositions: AggregatedPosition[] = [];
-      positionsBySymbol.forEach((data, symbol) => {
+      let totalUnrealizedPnL = new Decimal(0);
+
+      for (const [symbol, data] of positionsBySymbol) {
+        const quantity = data.quantity.toNumber();
+        const avgPrice = data.quantity.gt(0) ? data.weightedCost.div(data.quantity).toNumber() : 0;
+        const marketPrice = currentPrices.get(symbol);
+
+        const currentValue = new Decimal(quantity).times(marketPrice ?? avgPrice).toNumber();
+        const unrealizedPnL = marketPrice
+          ? new Decimal(marketPrice).minus(avgPrice).times(quantity).toNumber()
+          : data.pnl.toNumber();
+
+        totalUnrealizedPnL = totalUnrealizedPnL.plus(unrealizedPnL);
+
         aggregatedPositions.push({
           symbol,
-          quantity: data.quantity,
-          avgEntryPrice: data.avgPrice,
-          currentValue: data.quantity * data.avgPrice, // TODO: Use current market price
-          unrealizedPnL: data.pnl,
+          quantity,
+          avgEntryPrice: avgPrice,
+          currentPrice: marketPrice,
+          currentValue,
+          unrealizedPnL,
           strategies: this.getStrategiesForSymbol(allPositions, symbol)
         });
-      });
+      }
 
       // Calculate total portfolio value
-      const totalValue = aggregatedPositions.reduce((sum, pos) => sum + pos.currentValue, 0);
+      const totalValue = aggregatedPositions.reduce(
+        (sum, pos) => new Decimal(sum).plus(pos.currentValue).toNumber(),
+        0
+      );
+      const totalPnL = new Decimal(totalRealizedPnL).plus(totalUnrealizedPnL).toNumber();
 
       return {
         totalValue,
         positions: aggregatedPositions,
-        totalPnL: pnlSummary.totalPnL,
-        realizedPnL: pnlSummary.realizedPnL,
-        unrealizedPnL: pnlSummary.unrealizedPnL
+        totalPnL,
+        realizedPnL: totalRealizedPnL.toNumber(),
+        unrealizedPnL: totalUnrealizedPnL.toNumber()
       };
     } catch (error) {
-      this.logger.error(`Failed to get aggregated portfolio for user ${userId}: ${error.message}`, error.stack);
+      this.logger.error(
+        `Failed to get aggregated portfolio for user ${userId}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -70,6 +193,10 @@ export class PortfolioAggregationService {
     try {
       const positions = await this.positionTracking.getPositions(userId);
 
+      // Fetch current market prices for all position symbols
+      const allSymbols = [...new Set(positions.map((p) => p.symbol))];
+      const currentPrices = await this.fetchCurrentPrices(allSymbols);
+
       // Group by strategy
       const positionsByStrategy = new Map<string, typeof positions>();
       for (const position of positions) {
@@ -80,28 +207,48 @@ export class PortfolioAggregationService {
         positionsByStrategy.get(strategyId).push(position);
       }
 
-      // Calculate P&L per strategy
+      // Calculate P&L per strategy from already-fetched positions (no extra DB calls)
       const breakdown: StrategyPositionBreakdown[] = [];
       for (const [strategyId, strategyPositions] of positionsByStrategy.entries()) {
-        const pnl = await this.positionTracking.getStrategyPnL(userId, strategyId);
+        const realizedPnL = strategyPositions.reduce(
+          (sum, pos) => new Decimal(sum).plus(pos.realizedPnL).toNumber(),
+          0
+        );
+
+        let strategyUnrealizedPnL = new Decimal(0);
+        const mappedPositions = strategyPositions.map((p) => {
+          const qty = new Decimal(p.quantity);
+          const avgPrice = new Decimal(p.avgEntryPrice);
+          const marketPrice = currentPrices.get(p.symbol);
+          const unrealizedPnL = marketPrice
+            ? new Decimal(marketPrice).minus(avgPrice).times(qty).toNumber()
+            : Number(p.unrealizedPnL);
+          strategyUnrealizedPnL = strategyUnrealizedPnL.plus(unrealizedPnL);
+
+          return {
+            symbol: p.symbol,
+            quantity: qty.toNumber(),
+            avgEntryPrice: avgPrice.toNumber(),
+            currentPrice: marketPrice,
+            unrealizedPnL
+          };
+        });
 
         breakdown.push({
           strategyId,
-          positions: strategyPositions.map((p) => ({
-            symbol: p.symbol,
-            quantity: Number(p.quantity),
-            avgEntryPrice: Number(p.avgEntryPrice),
-            unrealizedPnL: Number(p.unrealizedPnL)
-          })),
-          totalPnL: pnl.totalPnL,
-          realizedPnL: pnl.realizedPnL,
-          unrealizedPnL: pnl.unrealizedPnL
+          positions: mappedPositions,
+          totalPnL: new Decimal(realizedPnL).plus(strategyUnrealizedPnL).toNumber(),
+          realizedPnL,
+          unrealizedPnL: strategyUnrealizedPnL.toNumber()
         });
       }
 
       return breakdown;
     } catch (error) {
-      this.logger.error(`Failed to get positions by strategy for user ${userId}: ${error.message}`, error.stack);
+      this.logger.error(
+        `Failed to get positions by strategy for user ${userId}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -130,11 +277,14 @@ export class PortfolioAggregationService {
       return portfolio.positions.map((position) => ({
         symbol: position.symbol,
         value: position.currentValue,
-        percentage: (position.currentValue / portfolio.totalValue) * 100,
+        percentage: new Decimal(position.currentValue).div(portfolio.totalValue).times(100).toNumber(),
         quantity: position.quantity
       }));
     } catch (error) {
-      this.logger.error(`Failed to get allocation breakdown for user ${userId}: ${error.message}`, error.stack);
+      this.logger.error(
+        `Failed to get allocation breakdown for user ${userId}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined
+      );
       throw error;
     }
   }
@@ -147,6 +297,7 @@ export interface AggregatedPosition {
   symbol: string;
   quantity: number;
   avgEntryPrice: number;
+  currentPrice?: number; // Live market price (undefined if unavailable)
   currentValue: number;
   unrealizedPnL: number;
   strategies: string[]; // Strategy IDs that hold this symbol
@@ -161,6 +312,7 @@ export interface StrategyPositionBreakdown {
     symbol: string;
     quantity: number;
     avgEntryPrice: number;
+    currentPrice?: number;
     unrealizedPnL: number;
   }[];
   totalPnL: number;

--- a/apps/api/src/portfolio/portfolio.module.ts
+++ b/apps/api/src/portfolio/portfolio.module.ts
@@ -8,22 +8,22 @@ import { Portfolio } from './portfolio.entity';
 import { PortfolioService } from './portfolio.service';
 import { PortfolioHistoricalPriceTask } from './tasks/portfolio-historical-price.task';
 
-import { Coin } from '../coin/coin.entity';
-import { CoinService } from '../coin/coin.service';
+import { CoinModule } from '../coin/coin.module';
 import { OHLCModule } from '../ohlc/ohlc.module';
 import { SharedCacheModule } from '../shared-cache.module';
 import { StrategyModule } from '../strategy/strategy.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Portfolio, Coin]),
+    TypeOrmModule.forFeature([Portfolio]),
     BullModule.registerQueue({ name: 'portfolio-queue' }),
+    forwardRef(() => CoinModule),
     forwardRef(() => OHLCModule),
     forwardRef(() => StrategyModule),
     SharedCacheModule
   ],
   controllers: [PortfolioController],
-  providers: [PortfolioService, PortfolioAggregationService, PortfolioHistoricalPriceTask, CoinService],
+  providers: [PortfolioService, PortfolioAggregationService, PortfolioHistoricalPriceTask],
   exports: [PortfolioService, PortfolioAggregationService, PortfolioHistoricalPriceTask]
 })
 export class PortfolioModule {}


### PR DESCRIPTION
## Summary

- Portfolio `currentValue` was incorrectly calculated as `quantity × avgPrice` (cost basis) instead of actual market value
- Integrates `RealtimeTickerService` with fallback chain (exchange ticker → `Coin.currentPrice` → `avgPrice`) for live pricing
- Adds `currentPrice` field to response interfaces so consumers can distinguish market price from entry price

## Changes

- **`portfolio-aggregation.service.ts`** — Major rework of portfolio valuation:
  - New `fetchCurrentPrices()` method batch-fetches live prices via `RealtimeTickerService` + `CoinService` fallback
  - New `parseSymbolForPricing()` parses CCXT-format symbols (`BTC/USDT`) for USD-quoted pairs
  - `getAggregatedPortfolio()` now uses live market prices for `currentValue` and `unrealizedPnL`
  - `getPositionsByStrategy()` also uses live prices for per-strategy P&L
  - Consolidated multiple DB calls into single `getPositions()` with in-memory aggregation
  - All financial math now uses `Decimal.js` to avoid floating-point errors
  - Type-safe error handling with `instanceof Error` checks
- **`portfolio.module.ts`** — Import `CoinModule` instead of duplicating `CoinService` provider; removed redundant `Coin` entity from `TypeOrmModule.forFeature()`

## Test Plan

- [ ] Verify portfolio endpoint returns `currentPrice` field with live market prices
- [ ] Verify `currentValue` reflects market price, not cost basis
- [ ] Confirm fallback works when realtime ticker is unavailable (falls back to `Coin.currentPrice`, then `avgPrice`)
- [ ] Verify non-USD-quoted pairs (e.g., `ETH/BTC`) gracefully fall back to `avgPrice`
- [ ] Confirm no N+1 query issues — prices are batch-fetched

Closes #162