### PR TITLE
perf(api): optimize backtest price windows and relax stale detection thresholds

### DIFF
--- a/apps/api/src/test-setup.ts
+++ b/apps/api/src/test-setup.ts
@@ -1,3 +1,10 @@
+// Polyfill globalThis.crypto for Jest's node environment
+// Required by @nestjs/typeorm's generateString utility
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, 'crypto', { value: require('node:crypto').webcrypto });
+}
+
 import * as dotenv from 'dotenv';
 
 import { join } from 'path';


### PR DESCRIPTION
## Summary

- Extract duplicated price window init/advance logic into reusable `initPriceTracking` and `advancePriceWindows` helpers, removing ~60 lines of repeated code across 3 backtest methods
- Replace inline object types with existing `PriceSummary`/`PriceSummaryByPeriod` types and eliminate non-null assertions on Map lookups
- Relax stale backtest detection thresholds (30→90 min for HISTORICAL, 60→120 min for LIVE_REPLAY) to account for heartbeat-based progress tracking
- Fix unused test fixture and add boundary tests for exact threshold cutoff values

## Changes

**`backtest-engine.service.ts`**
- Add `PriceTrackingContext` interface and `initPriceTracking()`/`advancePriceWindows()` private helpers
- Replace 6 duplicated blocks (3 init + 3 advance) across `executeHistoricalBacktest`, `executeLiveReplayBacktest`, and `executeOptimizationBacktest` with single-line helper calls
- Update `buildPriceSummary()` return type from inline object to `PriceSummary`
- Replace `!` non-null assertions with `?? []` fallbacks in price window lookups
- Add JSDoc documenting shared mutable reference semantics

**`backtest-orchestration.task.ts`**
- Increase `HISTORICAL_THRESHOLD_MS` from 30→90 min
- Increase `LIVE_REPLAY_THRESHOLD_MS` from 60→120 min
- Update stale message terminology from "checkpoint" to "heartbeat"

**`backtest-orchestration.task.spec.ts`**
- Remove unused `recentReplay` object, add assertion on query structure
- Add two boundary tests verifying exact `LessThan` cutoff dates (90-min and 120-min)

## Test Plan

- [x] `npx nx test api --testFile='backtest-engine'` — 30 tests pass
- [x] `npx nx test api --testFile='backtest-orchestration.task'` — 12 tests pass (including 2 new boundary tests)
- [x] `npx nx lint api` — no new warnings