### PR TITLE
fix(api): add detailed pipeline failure reasons and backtest hold time tracking

### DIFF
--- a/apps/api/src/order/backtest/backtest-checkpoint.interface.ts
+++ b/apps/api/src/order/backtest/backtest-checkpoint.interface.ts
@@ -5,6 +5,7 @@ export interface CheckpointPosition {
   coinId: string;
   quantity: number;
   averagePrice: number;
+  entryDate?: string;
 }
 
 /**

--- a/apps/api/src/order/backtest/shared/portfolio/portfolio-state.interface.ts
+++ b/apps/api/src/order/backtest/shared/portfolio/portfolio-state.interface.ts
@@ -44,6 +44,7 @@ export interface SerializablePosition {
   coinId: string;
   quantity: number;
   averagePrice: number;
+  entryDate?: string;
 }
 
 /**

--- a/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.spec.ts
@@ -477,5 +477,37 @@ describe('PortfolioStateService', () => {
       expect(restored.positions.get('bitcoin')?.quantity).toBe(original.positions.get('bitcoin')?.quantity);
       expect(restored.positions.get('bitcoin')?.averagePrice).toBe(original.positions.get('bitcoin')?.averagePrice);
     });
+
+    it('should round-trip entryDate through serialize/deserialize', () => {
+      const entryDate = new Date('2024-06-15T10:30:00.000Z');
+      const original: Portfolio = {
+        cashBalance: 5000,
+        positions: new Map([
+          ['bitcoin', { coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000, totalValue: 4500, entryDate }]
+        ]),
+        totalValue: 9500
+      };
+
+      const serialized = service.serialize(original);
+
+      expect(serialized.positions[0].entryDate).toBe('2024-06-15T10:30:00.000Z');
+
+      const restored = service.deserialize(serialized);
+      const restoredPos = restored.positions.get('bitcoin');
+
+      expect(restoredPos?.entryDate).toBeInstanceOf(Date);
+      expect(restoredPos?.entryDate?.toISOString()).toBe('2024-06-15T10:30:00.000Z');
+    });
+
+    it('should deserialize legacy checkpoint without entryDate', () => {
+      const serialized: SerializablePortfolio = {
+        cashBalance: 5000,
+        positions: [{ coinId: 'bitcoin', quantity: 0.1, averagePrice: 45000 }]
+      };
+
+      const restored = service.deserialize(serialized);
+
+      expect(restored.positions.get('bitcoin')?.entryDate).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.ts
+++ b/apps/api/src/order/backtest/shared/portfolio/portfolio-state.service.ts
@@ -309,7 +309,8 @@ export class PortfolioStateService implements IPortfolioState {
       positions: Array.from(portfolio.positions.entries()).map(([coinId, pos]) => ({
         coinId,
         quantity: pos.quantity,
-        averagePrice: pos.averagePrice
+        averagePrice: pos.averagePrice,
+        ...(pos.entryDate && { entryDate: pos.entryDate.toISOString() })
       }))
     };
   }
@@ -329,7 +330,8 @@ export class PortfolioStateService implements IPortfolioState {
         coinId: pos.coinId,
         quantity: pos.quantity,
         averagePrice: pos.averagePrice,
-        totalValue
+        totalValue,
+        ...(pos.entryDate && { entryDate: new Date(pos.entryDate) })
       });
 
       positionsValue += totalValue;

--- a/apps/api/src/order/backtest/shared/positions/position-manager.interface.ts
+++ b/apps/api/src/order/backtest/shared/positions/position-manager.interface.ts
@@ -16,6 +16,8 @@ export interface Position {
   averagePrice: number;
   /** Current market value of the position */
   totalValue: number;
+  /** Timestamp when the position was first opened (used for hold-time calculation) */
+  entryDate?: Date;
 }
 
 /**

--- a/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
@@ -136,6 +136,8 @@ export interface StageProgressionThresholds {
   minImprovement?: number;
   /** Maximum degradation from previous stage (percentage) */
   maxDegradation?: number;
+  /** Minimum total trades required (opt-in) */
+  minTotalTrades?: number;
 }
 
 /**

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
@@ -370,7 +370,12 @@ describe('PipelineOrchestratorService', () => {
         3 // Only 3% improvement, below 10% threshold
       );
 
-      expect(pipelineRepository.save).toHaveBeenCalledWith(expect.objectContaining({ status: PipelineStatus.FAILED }));
+      expect(pipelineRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: PipelineStatus.FAILED,
+          failureReason: expect.stringContaining('3.00% < min 10.00%')
+        })
+      );
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:all": "nx run-many --target=build --projects=api,chansey",
     "build:api": "nx build api --configuration=production",
     "build:client": "nx build chansey --configuration=production",
-    "start:prod": "node dist/api/main.js",
+    "start:prod": "node --max-old-space-size=6144 dist/api/main.js",
     "start:client": "serve -s dist/client -p 4200",
     "api": "nx serve api",
     "site": "nx serve chansey",


### PR DESCRIPTION
## Summary
- Refactor pipeline stage progression evaluation to return specific metric violations instead of pass/fail booleans, so failures show exactly which thresholds were missed (e.g., "Sharpe ratio 0.320 < min 1.000; Win rate 38.5% < min 45.0%")
- Add position entry date tracking and hold time calculation for backtest trades
- Add `minTotalTrades` threshold support to stage progression evaluation

## Changes
- **Pipeline orchestrator**: `evaluateStageProgression` and `evaluateOptimizationProgression` now return `{ passed, failures }` with human-readable failure descriptions
- **Pipeline config**: Add `minTotalTrades` to `StageProgressionThresholds` interface
- **Portfolio state**: Serialize/deserialize `entryDate` through checkpoint round-trips for hold time tracking
- **Backtest engine**: Persist `entryDate` in checkpoint positions
- **Production config**: Increase Node.js heap limit to 6GB

## Test Plan
- [x] Portfolio state serialization round-trip tests for entryDate
- [x] Legacy checkpoint deserialization backward compatibility test
- [x] Pipeline orchestrator failure reason assertion test
- [x] All affected tests pass