### PR TITLE
perf(api): release backtest memory after completion to reduce RSS

### DIFF
--- a/apps/api/src/order/backtest/backtest.processor.ts
+++ b/apps/api/src/order/backtest/backtest.processor.ts
@@ -237,6 +237,12 @@ export class BacktestProcessor extends WorkerHost {
       // Decrement active backtest count
       this.metricsService.decrementActiveBacktests(mode ?? 'historical');
       endTimer();
+
+      // Request V8 to perform a full GC and release memory back to the OS.
+      // Requires --expose-gc flag (set in start:prod script).
+      if (typeof global.gc === 'function') {
+        global.gc();
+      }
     }
   }
 

--- a/apps/api/src/order/backtest/live-replay.processor.ts
+++ b/apps/api/src/order/backtest/live-replay.processor.ts
@@ -238,6 +238,12 @@ export class LiveReplayProcessor extends WorkerHost {
       this.metricsService.recordBacktestCompleted(strategyName, 'failed');
     } finally {
       endTimer();
+
+      // Request V8 to perform a full GC and release memory back to the OS.
+      // Requires --expose-gc flag (set in start:prod script).
+      if (typeof global.gc === 'function') {
+        global.gc();
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:all": "nx run-many --target=build --projects=api,chansey",
     "build:api": "nx build api --configuration=production",
     "build:client": "nx build chansey --configuration=production",
-    "start:prod": "node --max-old-space-size=6144 dist/api/main.js",
+    "start:prod": "node --expose-gc --max-old-space-size=6144 dist/api/main.js",
     "start:client": "serve -s dist/client -p 4200",
     "api": "nx serve api",
     "site": "nx serve chansey",


### PR DESCRIPTION
## Summary

- Reduce backtest engine RSS by eagerly releasing large data structures after the main processing loop
- Replace `historyByCoin` (`OHLCCandle[]`) with `timestampsByCoin` (`Date[]`) in `PriceTrackingContext` since only timestamps are needed for sliding-window advancement
- Trigger explicit `global.gc()` in processor `finally` blocks to reclaim heap between runs

## Changes

- **`backtest-engine.service.ts`** — Narrow `PriceTrackingContext.historyByCoin` to `timestampsByCoin` (Date-only); drop `historicalPrices` reference after grouping; add `clearPriceData()` to release `pricesByTimestamp` and `priceCtx` in-place after the main loop; applied consistently across all three backtest paths (historical, live-replay, optimization)
- **`backtest.processor.ts`** / **`live-replay.processor.ts`** — Call `global.gc()` (guarded) in `finally` blocks after backtest completion
- **`package.json`** — Add `--expose-gc` flag to `start:prod` script

## Test Plan

- [ ] `nx test api --testFile='backtest-engine'` passes
- [ ] `nx test api --testFile='backtest-recovery'` passes
- [ ] `nx build api` succeeds
- [ ] Deploy to staging and monitor RSS after sequential backtest runs — memory should drop back toward baseline between jobs