### PR TITLE
fix(api): reduce backtest memory footprint and tighten resource limits

### DIFF
--- a/apps/api/src/coin/coin.entity.ts
+++ b/apps/api/src/coin/coin.entity.ts
@@ -45,7 +45,7 @@ export class Coin {
   })
   symbol: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'text', nullable: true })
   @ApiProperty({
     description: 'Description of the coin',
     example: 'Bitcoin is a decentralized digital currency...',

--- a/apps/api/src/config/database.config.ts
+++ b/apps/api/src/config/database.config.ts
@@ -19,6 +19,10 @@ export const databaseConfig = registerAs(
     migrationsRun: process.env.NODE_ENV === 'production',
     synchronize: process.env.NODE_ENV !== 'production',
     logging: process.env.NODE_ENV !== 'production',
-    uuidExtension: 'pgcrypto'
+    uuidExtension: 'pgcrypto',
+    extra: {
+      max: parseInt(process.env.PG_POOL_MAX || '20', 10),
+      idleTimeoutMillis: parseInt(process.env.PG_POOL_IDLE_TIMEOUT_MS || '30000', 10)
+    }
   })
 );

--- a/apps/api/src/order/backtest/backtest.processor.spec.ts
+++ b/apps/api/src/order/backtest/backtest.processor.spec.ts
@@ -32,6 +32,7 @@ describe('BacktestProcessor', () => {
       coinResolver: any;
       backtestStream: any;
       backtestResultService: any;
+      backtestService: any;
       metricsService: any;
     }> = {}
   ) => {
@@ -39,6 +40,7 @@ describe('BacktestProcessor', () => {
     const coinResolver = { resolveCoins: jest.fn() };
     const backtestStream = { publishStatus: jest.fn(), publishLog: jest.fn() };
     const backtestResultService = { persistSuccess: jest.fn(), markFailed: jest.fn() };
+    const backtestService = { clearDatasetCache: jest.fn() };
     const metricsService = createMockMetricsService();
     const backtestRepository = { findOne: jest.fn(), save: jest.fn() };
     const marketDataSetRepository = { findOne: jest.fn() };
@@ -48,6 +50,7 @@ describe('BacktestProcessor', () => {
       overrides.coinResolver ?? (coinResolver as any),
       overrides.backtestStream ?? (backtestStream as any),
       overrides.backtestResultService ?? (backtestResultService as any),
+      overrides.backtestService ?? (backtestService as any),
       overrides.metricsService ?? (metricsService as any),
       overrides.backtestRepository ?? (backtestRepository as any),
       overrides.marketDataSetRepository ?? (marketDataSetRepository as any)

--- a/apps/api/src/order/backtest/live-replay.processor.spec.ts
+++ b/apps/api/src/order/backtest/live-replay.processor.spec.ts
@@ -21,6 +21,7 @@ describe('LiveReplayProcessor', () => {
       backtestStream: any;
       backtestResultService: any;
       backtestPauseService: any;
+      backtestService: any;
       metricsService: any;
     }> = {}
   ) => {
@@ -29,6 +30,7 @@ describe('LiveReplayProcessor', () => {
     const backtestStream = { publishStatus: jest.fn() };
     const backtestResultService = { persistSuccess: jest.fn(), markFailed: jest.fn() };
     const backtestPauseService = { clearPauseFlag: jest.fn(), isPauseRequested: jest.fn() };
+    const backtestService = { clearDatasetCache: jest.fn() };
     const metricsService = {
       startBacktestTimer: jest.fn(),
       recordBacktestCompleted: jest.fn(),
@@ -43,6 +45,7 @@ describe('LiveReplayProcessor', () => {
       overrides.backtestStream ?? (backtestStream as any),
       overrides.backtestResultService ?? (backtestResultService as any),
       overrides.backtestPauseService ?? (backtestPauseService as any),
+      overrides.backtestService ?? (backtestService as any),
       overrides.metricsService ?? (metricsService as any),
       overrides.backtestRepository ?? (backtestRepository as any),
       overrides.marketDataSetRepository ?? (marketDataSetRepository as any)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:all": "nx run-many --target=build --projects=api,chansey",
     "build:api": "nx build api --configuration=production",
     "build:client": "nx build chansey --configuration=production",
-    "start:prod": "node --expose-gc --max-old-space-size=6144 dist/api/main.js",
+    "start:prod": "node --expose-gc --max-old-space-size=2048 dist/api/main.js",
     "start:client": "serve -s dist/client -p 4200",
     "api": "nx serve api",
     "site": "nx serve chansey",


### PR DESCRIPTION
## Summary

- Clear in-memory dataset cache after backtest/live-replay completion to allow garbage collection of large dataset references
- Lower V8 heap limit from 6 GB to 2 GB and add PostgreSQL connection pool limits (max 20, idle timeout 30s)
- Fix coin description column type to explicit `text` to prevent silent truncation of long descriptions

## Changes

**Memory cleanup** (`backtest.processor.ts`, `live-replay.processor.ts`, `backtest.service.ts`)
- Add `clearDatasetCache()` method to `BacktestService` that nulls the `defaultDatasetCache`
- Call `clearDatasetCache()` in both processors' `finally` blocks so cached dataset references are released after every run
- Implement `OnModuleDestroy` lifecycle hook to release cache on shutdown

**Resource limits** (`package.json`, `database.config.ts`)
- Reduce `--max-old-space-size` from 6144 to 2048 (aligned with recent streaming/memory optimizations)
- Add `extra.max: 20` and `extra.idleTimeoutMillis: 30_000` to TypeORM database config

**Entity fix** (`coin.entity.ts`)
- Set `description` column to explicit `type: 'text'` to avoid `varchar(255)` default truncation

**Tests** (`backtest.processor.spec.ts`, `live-replay.processor.spec.ts`)
- Wire up `backtestService` mock in both processor test helpers

## Test Plan

- [x] `nx test api --testFile='backtest.processor'` — 4/4 passing
- [x] `nx test api --testFile='live-replay.processor'` — 5/5 passing
- [x] `nx build api` — builds successfully
- [ ] Monitor production RSS after deploy to verify 2 GB heap is sufficient under load