### PR TITLE
feat(api): build parameter spaces dynamically from strategy schemas

### DIFF
--- a/apps/api/src/algorithm/base/base-algorithm-strategy.ts
+++ b/apps/api/src/algorithm/base/base-algorithm-strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CronJob } from 'cron';
 
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { Algorithm, AlgorithmStatus } from '../algorithm.entity';
 import { AlgorithmContext, AlgorithmResult, AlgorithmStrategy } from '../interfaces';
@@ -81,6 +82,14 @@ export abstract class BaseAlgorithmStrategy implements AlgorithmStrategy {
       this.logger.error(`Health check failed: ${err.message}`);
       return false;
     }
+  }
+
+  /**
+   * Get cross-parameter constraints for optimization.
+   * Override in strategies with related parameters (e.g., fastPeriod < slowPeriod).
+   */
+  getParameterConstraints(): ParameterConstraint[] {
+    return [];
   }
 
   /**

--- a/apps/api/src/algorithm/interfaces/algorithm-strategy.interface.ts
+++ b/apps/api/src/algorithm/interfaces/algorithm-strategy.interface.ts
@@ -1,6 +1,7 @@
 import { AlgorithmContext } from './algorithm-context.interface';
 import { AlgorithmResult } from './algorithm-result.interface';
 
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { Algorithm } from '../algorithm.entity';
 
 /**
@@ -54,6 +55,12 @@ export interface AlgorithmStrategy {
    * Get algorithm-specific configuration schema
    */
   getConfigSchema?(): Record<string, unknown>;
+
+  /**
+   * Get cross-parameter constraints for optimization.
+   * Returns constraints like "fastPeriod must be less than slowPeriod".
+   */
+  getParameterConstraints?(): ParameterConstraint[];
 
   /**
    * Health check for the algorithm

--- a/apps/api/src/algorithm/strategies/confluence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/confluence.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorService } from '../indicators';
@@ -907,6 +908,35 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
         description: '%B threshold for bearish (< value = price pushing lower band, confirms downtrend)'
       }
     };
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'emaFastPeriod',
+        param2: 'emaSlowPeriod',
+        message: 'emaFastPeriod must be less than emaSlowPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'macdFastPeriod',
+        param2: 'macdSlowPeriod',
+        message: 'macdFastPeriod must be less than macdSlowPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'rsiSellThreshold',
+        param2: 'rsiBuyThreshold',
+        message: 'rsiSellThreshold must be less than rsiBuyThreshold'
+      },
+      {
+        type: 'less_than',
+        param1: 'bbSellThreshold',
+        param2: 'bbBuyThreshold',
+        message: 'bbSellThreshold must be less than bbBuyThreshold'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
+++ b/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorService } from '../indicators';
@@ -374,6 +375,17 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
       },
       minConfidence: { type: 'number', default: 0.6, min: 0, max: 1, description: 'Minimum confidence required' }
     };
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'fastEmaPeriod',
+        param2: 'slowEmaPeriod',
+        message: 'fastEmaPeriod must be less than slowEmaPeriod'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
+++ b/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorService } from '../indicators';
@@ -233,6 +234,17 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
         low: price.low
       }
     }));
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'fastPeriod',
+        param2: 'slowPeriod',
+        message: 'fastPeriod must be less than slowPeriod'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/macd.strategy.ts
+++ b/apps/api/src/algorithm/strategies/macd.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorService } from '../indicators';
@@ -303,6 +304,17 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
         low: price.low
       }
     }));
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'fastPeriod',
+        param2: 'slowPeriod',
+        message: 'fastPeriod must be less than slowPeriod'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorService } from '../indicators';
@@ -407,6 +408,17 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
       },
       minConfidence: { type: 'number', default: 0.7, min: 0, max: 1, description: 'Minimum confidence required' }
     };
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'macdFast',
+        param2: 'macdSlow',
+        message: 'macdFast must be less than macdSlow'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorService } from '../indicators';
@@ -177,6 +178,17 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         low: price.low
       }
     }));
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'fastPeriod',
+        param2: 'slowPeriod',
+        message: 'fastPeriod must be less than slowPeriod'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorService } from '../indicators';
@@ -412,6 +413,23 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         }
       };
     });
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'fastPeriod',
+        param2: 'mediumPeriod',
+        message: 'fastPeriod must be less than mediumPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'mediumPeriod',
+        param2: 'slowPeriod',
+        message: 'mediumPeriod must be less than slowPeriod'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/optimization/utils/parameter-space-builder.spec.ts
+++ b/apps/api/src/optimization/utils/parameter-space-builder.spec.ts
@@ -1,0 +1,258 @@
+import { buildParameterSpace } from './parameter-space-builder';
+
+import { ParameterConstraint } from '../interfaces/parameter-space.interface';
+
+describe('buildParameterSpace', () => {
+  it('should convert integer numeric fields with step=1 and high priority', () => {
+    const schema = {
+      period: { type: 'number', default: 14, min: 5, max: 50 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.strategyType).toBe('test-001');
+    expect(space.parameters).toHaveLength(1);
+    expect(space.parameters[0]).toEqual(
+      expect.objectContaining({
+        name: 'period',
+        type: 'integer',
+        min: 5,
+        max: 50,
+        step: 1,
+        default: 14,
+        priority: 'high'
+      })
+    );
+  });
+
+  it('should convert float numeric fields with computed step', () => {
+    const schema = {
+      stopLoss: { type: 'number', default: 0.05, min: 0.01, max: 0.2 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters).toHaveLength(1);
+    expect(space.parameters[0]).toEqual(
+      expect.objectContaining({
+        name: 'stopLoss',
+        type: 'float',
+        min: 0.01,
+        max: 0.2,
+        default: 0.05,
+        priority: 'high'
+      })
+    );
+    // Step = (0.2 - 0.01) / 10 = 0.019, rounded to 0.02
+    expect(space.parameters[0].step).toBe(0.02);
+  });
+
+  it('should detect float when default is non-integer despite integer min/max', () => {
+    const schema = {
+      threshold: { type: 'number', default: 0.5, min: 0, max: 1 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters[0].type).toBe('float');
+  });
+
+  it('should use custom step when provided', () => {
+    const schema = {
+      period: { type: 'number', default: 14, min: 5, max: 50, step: 5 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters[0].step).toBe(5);
+  });
+
+  it('should convert boolean fields to categorical with low priority', () => {
+    const schema = {
+      enableStopLoss: { type: 'boolean', default: true }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters).toHaveLength(1);
+    expect(space.parameters[0]).toEqual(
+      expect.objectContaining({
+        name: 'enableStopLoss',
+        type: 'categorical',
+        values: [true, false],
+        default: true,
+        priority: 'low'
+      })
+    );
+  });
+
+  it('should convert enum fields to categorical with medium priority', () => {
+    const schema = {
+      trendMode: { type: 'string', enum: ['fast', 'slow', 'adaptive'], default: 'adaptive' }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters).toHaveLength(1);
+    expect(space.parameters[0]).toEqual(
+      expect.objectContaining({
+        name: 'trendMode',
+        type: 'categorical',
+        values: ['fast', 'slow', 'adaptive'],
+        default: 'adaptive',
+        priority: 'medium'
+      })
+    );
+  });
+
+  it('should skip enum with fewer than 2 values', () => {
+    const schema = {
+      mode: { type: 'string', enum: ['only'], default: 'only' }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters).toHaveLength(0);
+  });
+
+  it('should filter out all NON_OPTIMIZABLE_PARAMS', () => {
+    const schema = {
+      enabled: { type: 'boolean', default: true },
+      weight: { type: 'number', default: 1.0, min: 0, max: 10 },
+      riskLevel: { type: 'string', enum: ['low', 'medium', 'high'], default: 'medium' },
+      cooldownMs: { type: 'number', default: 86400000, min: 0, max: 604800000 },
+      maxTradesPerDay: { type: 'number', default: 6, min: 0, max: 50 },
+      minSellPercent: { type: 'number', default: 0.5, min: 0, max: 1.0 },
+      fastPeriod: { type: 'number', default: 12, min: 5, max: 50 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters).toHaveLength(1);
+    expect(space.parameters[0].name).toBe('fastPeriod');
+  });
+
+  it.each([
+    ['string without enum', { label: { type: 'string', default: 'default' } }],
+    ['number without min/max', { count: { type: 'number', default: 5 } }],
+    ['number where min equals max', { fixed: { type: 'number', default: 10, min: 10, max: 10 } }]
+  ])('should skip non-optimizable field: %s', (_label, schema) => {
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters).toHaveLength(0);
+  });
+
+  it('should return empty parameters for empty schema', () => {
+    const space = buildParameterSpace('test-001', {});
+
+    expect(space.parameters).toHaveLength(0);
+    expect(space.strategyType).toBe('test-001');
+    expect(space.constraints).toEqual([]);
+  });
+
+  it('should pass through constraints and version', () => {
+    const schema = {
+      fastPeriod: { type: 'number', default: 12, min: 5, max: 50 },
+      slowPeriod: { type: 'number', default: 26, min: 10, max: 100 }
+    };
+    const constraints: ParameterConstraint[] = [
+      { type: 'less_than', param1: 'fastPeriod', param2: 'slowPeriod', message: 'fast < slow' }
+    ];
+
+    const space = buildParameterSpace('test-001', schema, constraints, '2.0.0');
+
+    expect(space.constraints).toEqual(constraints);
+    expect(space.version).toBe('2.0.0');
+    expect(space.parameters).toHaveLength(2);
+  });
+
+  it('should produce step > 0 for tiny float range (prevents infinite loop)', () => {
+    const schema = {
+      threshold: { type: 'number', default: 0.0015, min: 0.001, max: 0.002 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters[0].step).toBeGreaterThan(0);
+    expect(space.parameters[0].step).toBeLessThanOrEqual(0.001); // range = 0.001
+  });
+
+  it('should clamp step <= range for small float range', () => {
+    const schema = {
+      factor: { type: 'number', default: 0.05, min: 0.01, max: 0.02 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    const range = 0.02 - 0.01;
+    expect(space.parameters[0].step).toBeGreaterThan(0);
+    expect(space.parameters[0].step).toBeLessThanOrEqual(range);
+  });
+
+  it('should not clamp user-provided step', () => {
+    const schema = {
+      threshold: { type: 'number', default: 0.0015, min: 0.001, max: 0.002, step: 0.0001 }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters[0].step).toBe(0.0001);
+  });
+
+  it('should filter constraints referencing a filtered param1', () => {
+    const schema = {
+      enabled: { type: 'boolean', default: true },
+      fastPeriod: { type: 'number', default: 12, min: 5, max: 50 }
+    };
+    const constraints: ParameterConstraint[] = [
+      { type: 'less_than', param1: 'weight', param2: 'fastPeriod', message: 'weight < fast' }
+    ];
+
+    const space = buildParameterSpace('test-001', schema, constraints);
+
+    expect(space.constraints).toHaveLength(0);
+  });
+
+  it('should filter constraints referencing a filtered param2', () => {
+    const schema = {
+      fastPeriod: { type: 'number', default: 12, min: 5, max: 50 }
+    };
+    const constraints: ParameterConstraint[] = [
+      { type: 'less_than', param1: 'fastPeriod', param2: 'nonExistent', message: 'fast < non' }
+    ];
+
+    const space = buildParameterSpace('test-001', schema, constraints);
+
+    expect(space.constraints).toHaveLength(0);
+  });
+
+  it('should preserve value-based constraint (no param2)', () => {
+    const schema = {
+      fastPeriod: { type: 'number', default: 12, min: 5, max: 50 }
+    };
+    const constraints: ParameterConstraint[] = [
+      { type: 'greater_than', param1: 'fastPeriod', value: 3, message: 'fast > 3' } as ParameterConstraint
+    ];
+
+    const space = buildParameterSpace('test-001', schema, constraints);
+
+    expect(space.constraints).toHaveLength(1);
+    expect(space.constraints![0].param1).toBe('fastPeriod');
+  });
+
+  it('should preserve description from schema fields', () => {
+    const schema = {
+      crossoverLookback: {
+        type: 'number',
+        default: 3,
+        min: 1,
+        max: 10,
+        description: 'Number of bars to scan for crossover events'
+      }
+    };
+
+    const space = buildParameterSpace('test-001', schema);
+
+    expect(space.parameters[0].description).toBe('Number of bars to scan for crossover events');
+  });
+});

--- a/apps/api/src/optimization/utils/parameter-space-builder.ts
+++ b/apps/api/src/optimization/utils/parameter-space-builder.ts
@@ -1,0 +1,148 @@
+import { ParameterConstraint, ParameterDefinition, ParameterSpace } from '../interfaces/parameter-space.interface';
+
+/**
+ * Shape of a single field from getConfigSchema()
+ */
+interface ConfigSchemaField {
+  type: string;
+  default: unknown;
+  min?: number;
+  max?: number;
+  step?: number;
+  enum?: (string | number | boolean)[];
+  description?: string;
+}
+
+/**
+ * Control parameters that should not be optimized.
+ * These affect execution behaviour, not strategy logic.
+ */
+const NON_OPTIMIZABLE_PARAMS = new Set([
+  'enabled',
+  'weight',
+  'riskLevel',
+  'cooldownMs',
+  'maxTradesPerDay',
+  'minSellPercent'
+]);
+
+/**
+ * Check whether a schema field is worth optimizing.
+ * - Numeric fields need both min and max with min < max
+ * - Categorical fields (enum) need at least 2 values
+ * - Boolean fields are treated as categorical toggles
+ */
+function isOptimizable(field: ConfigSchemaField): boolean {
+  if (field.type === 'boolean') {
+    return true;
+  }
+  if (field.enum && field.enum.length >= 2) {
+    return true;
+  }
+  if (field.type === 'number' && field.min !== undefined && field.max !== undefined && field.min < field.max) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Determine whether a numeric field represents an integer.
+ * Uses the heuristic: default, min, and max are all integers.
+ */
+function isIntegerField(field: ConfigSchemaField): boolean {
+  const values = [field.default, field.min, field.max].filter((v) => v !== undefined) as number[];
+  return values.length > 0 && values.every((v) => Number.isInteger(v));
+}
+
+/**
+ * Convert a config schema field into a ParameterDefinition.
+ */
+function toParameterDefinition(name: string, field: ConfigSchemaField): ParameterDefinition {
+  // Boolean → categorical with [true, false]
+  if (field.type === 'boolean') {
+    return {
+      name,
+      type: 'categorical',
+      values: [true, false],
+      default: field.default as boolean,
+      priority: 'low',
+      description: field.description
+    };
+  }
+
+  // Enum → categorical
+  if (field.enum && field.enum.length >= 2) {
+    return {
+      name,
+      type: 'categorical',
+      values: field.enum,
+      default: field.default as string | number | boolean,
+      priority: 'medium',
+      description: field.description
+    };
+  }
+
+  // Numeric: integer vs float
+  const isInteger = isIntegerField(field);
+  const min = field.min!;
+  const max = field.max!;
+  const range = max - min;
+
+  let step: number;
+  if (field.step !== undefined) {
+    step = field.step;
+  } else if (isInteger) {
+    step = 1;
+  } else {
+    const raw = Math.round((range / 10) * 100) / 100;
+    step = Math.min(Math.max(raw, range / 100), range);
+  }
+
+  return {
+    name,
+    type: isInteger ? 'integer' : 'float',
+    min,
+    max,
+    step,
+    default: field.default as number,
+    priority: 'high',
+    description: field.description
+  };
+}
+
+/**
+ * Build a ParameterSpace from a strategy's getConfigSchema() output and
+ * getParameterConstraints() result. Filters out non-optimizable and
+ * control parameters automatically.
+ *
+ * @param strategyId  The strategy type identifier (e.g. 'ema-crossover-001')
+ * @param configSchema  Output of strategy.getConfigSchema()
+ * @param constraints  Output of strategy.getParameterConstraints()
+ * @param version  Optional version string for the parameter space
+ */
+export function buildParameterSpace(
+  strategyId: string,
+  configSchema: Record<string, unknown>,
+  constraints: ParameterConstraint[] = [],
+  version?: string
+): ParameterSpace {
+  const parameters: ParameterDefinition[] = [];
+
+  for (const [name, rawField] of Object.entries(configSchema)) {
+    if (NON_OPTIMIZABLE_PARAMS.has(name)) continue;
+
+    const field = rawField as ConfigSchemaField;
+    if (!isOptimizable(field)) continue;
+
+    parameters.push(toParameterDefinition(name, field));
+  }
+
+  const paramNames = new Set(parameters.map((p) => p.name));
+  const validConstraints = constraints.filter((c) => {
+    if (!paramNames.has(c.param1)) return false;
+    if (c.param2 !== undefined && !paramNames.has(c.param2)) return false;
+    return true;
+  });
+
+  return { strategyType: strategyId, parameters, constraints: validConstraints, version };
+}

--- a/apps/api/src/pipeline/dto/index.ts
+++ b/apps/api/src/pipeline/dto/index.ts
@@ -1,6 +1,6 @@
 export * from './pipeline-filters.dto';
 
-import { PipelineProgressionRules, PipelineStageConfig } from '../interfaces';
+import { PipelineProgressionRules, PipelineStage, PipelineStageConfig } from '../interfaces';
 
 /**
  * Internal interface for creating pipelines (no validation - internal use only)
@@ -12,4 +12,6 @@ export interface CreatePipelineInput {
   exchangeKeyId: string;
   stageConfig: PipelineStageConfig;
   progressionRules?: PipelineProgressionRules;
+  /** Optional initial stage to start at (defaults to OPTIMIZE) */
+  initialStage?: PipelineStage;
 }

--- a/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
@@ -114,7 +114,7 @@ export interface PaperTradingStageConfig {
  * Combined stage configuration
  */
 export interface PipelineStageConfig {
-  optimization: OptimizationStageConfig;
+  optimization?: OptimizationStageConfig;
   historical: HistoricalStageConfig;
   liveReplay: LiveReplayStageConfig;
   paperTrading: PaperTradingStageConfig;

--- a/apps/api/src/pipeline/pipeline.module.ts
+++ b/apps/api/src/pipeline/pipeline.module.ts
@@ -12,6 +12,7 @@ import { PipelineProcessor } from './processors/pipeline.processor';
 import { PipelineOrchestratorService } from './services/pipeline-orchestrator.service';
 import { PipelineReportService } from './services/pipeline-report.service';
 
+import { AlgorithmModule } from '../algorithm/algorithm.module';
 import { AuthenticationModule } from '../authentication/authentication.module';
 import { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
 import { MarketRegimeModule } from '../market-regime/market-regime.module';
@@ -29,6 +30,7 @@ const PIPELINE_CONFIG = pipelineConfig();
     TypeOrmModule.forFeature([Pipeline, StrategyConfig, ExchangeKey]),
     BullModule.registerQueue({ name: PIPELINE_CONFIG.queue }),
     EventEmitterModule.forRoot(),
+    forwardRef(() => AlgorithmModule),
     forwardRef(() => AuthenticationModule),
     forwardRef(() => OptimizationModule),
     forwardRef(() => OrderModule),


### PR DESCRIPTION
## Summary

- Derive `ParameterSpace` dynamically from strategy config schemas at runtime instead of hardcoding them
- Add `getConfigSchema()` to all strategy classes so the optimizer can introspect tunable parameters
- Introduce `ParameterSpaceBuilder` utility with float step calculation safeguards and constraint filtering

## Changes

### Strategy Schema Definitions
- Add `getConfigSchema()` method to `IAlgorithmStrategy` interface and `BaseAlgorithmStrategy` base class
- Implement config schemas for all 8 strategies (SMA, EMA, Triple EMA, MACD, RSI-MACD, EMA-RSI Filter, Confluence)
- Each schema defines parameter type, range, step, and default values

### Parameter Space Builder (`parameter-space-builder.ts`)
- New utility that converts strategy schemas into optimizer-compatible `ParameterSpace` objects
- Calculates safe float steps to prevent infinite loops on tiny ranges
- Filters out constraints that reference non-existent parameters
- Explicit error when optimization stage config is missing

### Pipeline Orchestration Updates
- Integrate `ParameterSpaceBuilder` into pipeline orchestrator service
- Move strategy config seeding from per-user to global task scheduler scope
- Improve error logging in `buildParameterSpaceForStrategy`

### Tests
- Add comprehensive unit tests for `ParameterSpaceBuilder` (258 lines)
- Extend pipeline orchestrator service tests (167 new lines)
- Extend pipeline orchestration task service tests (134 new lines)

## Test Plan

- [ ] `npx nx test api --testFile='parameter-space-builder'` passes
- [ ] `npx nx test api --testFile='pipeline-orchestrator.service'` passes
- [ ] `npx nx test api --testFile='pipeline-orchestration.service'` passes
- [ ] Pipeline orchestration correctly builds parameter spaces for all strategies