### PR TITLE
fix(api): resolve stuck optimization runs and eliminate redundant OHLC queries

### DIFF
--- a/apps/api/src/migrations/1739100000000-AddOptimizationHeartbeat.ts
+++ b/apps/api/src/migrations/1739100000000-AddOptimizationHeartbeat.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOptimizationHeartbeat1739100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "optimization_runs" ADD "lastHeartbeatAt" TIMESTAMPTZ`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "optimization_runs" DROP COLUMN "lastHeartbeatAt"`);
+  }
+}

--- a/apps/api/src/optimization/entities/optimization-run.entity.ts
+++ b/apps/api/src/optimization/entities/optimization-run.entity.ts
@@ -137,6 +137,9 @@ export class OptimizationRun {
   @Column({ type: 'timestamptz', nullable: true })
   completedAt: Date;
 
+  @Column({ type: 'timestamptz', nullable: true })
+  lastHeartbeatAt: Date;
+
   @OneToMany('OptimizationResult', 'optimizationRun')
   results: Relation<OptimizationResult[]>;
 }

--- a/apps/api/src/optimization/optimization.module.ts
+++ b/apps/api/src/optimization/optimization.module.ts
@@ -8,8 +8,10 @@ import { OptimizationController } from './optimization.controller';
 import { OptimizationProcessor } from './processors/optimization.processor';
 import { GridSearchService } from './services/grid-search.service';
 import { OptimizationOrchestratorService } from './services/optimization-orchestrator.service';
+import { OptimizationRecoveryService } from './services/optimization-recovery.service';
 
 import { Coin } from '../coin/coin.entity';
+import { OHLCModule } from '../ohlc/ohlc.module';
 import { OrderModule } from '../order/order.module';
 import { ScoringModule } from '../scoring/scoring.module';
 import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
@@ -19,10 +21,11 @@ import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
     TypeOrmModule.forFeature([OptimizationRun, OptimizationResult, StrategyConfig, Coin]),
     BullModule.registerQueue({ name: 'optimization' }),
     ScoringModule,
-    forwardRef(() => OrderModule)
+    forwardRef(() => OrderModule),
+    forwardRef(() => OHLCModule)
   ],
   controllers: [OptimizationController],
-  providers: [GridSearchService, OptimizationOrchestratorService, OptimizationProcessor],
+  providers: [GridSearchService, OptimizationOrchestratorService, OptimizationProcessor, OptimizationRecoveryService],
   exports: [GridSearchService, OptimizationOrchestratorService]
 })
 export class OptimizationModule {}

--- a/apps/api/src/optimization/processors/optimization.processor.ts
+++ b/apps/api/src/optimization/processors/optimization.processor.ts
@@ -15,10 +15,17 @@ interface OptimizationJobData {
   }>;
 }
 
+/** Lock renewal interval: 30 minutes */
+const LOCK_RENEWAL_MS = 30 * 60 * 1000;
+
 /**
  * BullMQ processor for optimization jobs
  */
-@Processor('optimization')
+@Processor('optimization', {
+  lockDuration: 14_400_000, // 4 hours
+  stalledInterval: 14_400_000, // 4 hours
+  maxStalledCount: 2
+})
 export class OptimizationProcessor extends WorkerHost {
   private readonly logger = new Logger(OptimizationProcessor.name);
 
@@ -31,6 +38,16 @@ export class OptimizationProcessor extends WorkerHost {
 
     this.logger.log(`Starting optimization job ${job.id} for run ${runId} with ${combinations.length} combinations`);
 
+    // Periodically extend the lock so BullMQ doesn't mark this job as stalled
+    const lockRenewal = setInterval(async () => {
+      try {
+        await job.extendLock(job.token!, 14_400_000);
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        this.logger.warn(`Failed to extend lock for job ${job.id}: ${err.message}`);
+      }
+    }, LOCK_RENEWAL_MS);
+
     try {
       await this.orchestratorService.executeOptimization(runId, combinations);
       this.logger.log(`Optimization job ${job.id} completed successfully`);
@@ -38,6 +55,8 @@ export class OptimizationProcessor extends WorkerHost {
       const err = toErrorInfo(error);
       this.logger.error(`Optimization job ${job.id} failed: ${err.message}`, err.stack);
       throw error;
+    } finally {
+      clearInterval(lockRenewal);
     }
   }
 }

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
@@ -10,6 +10,7 @@ import { GridSearchService } from './grid-search.service';
 import { OptimizationOrchestratorService } from './optimization-orchestrator.service';
 
 import { Coin } from '../../coin/coin.entity';
+import { OHLCService } from '../../ohlc/ohlc.service';
 import { BacktestEngine } from '../../order/backtest/backtest-engine.service';
 import { WalkForwardService } from '../../scoring/walk-forward/walk-forward.service';
 import { WindowProcessor } from '../../scoring/walk-forward/window-processor';
@@ -62,6 +63,7 @@ describe('OptimizationOrchestratorService', () => {
   let walkForwardService: jest.Mocked<WalkForwardService>;
   let windowProcessor: jest.Mocked<WindowProcessor>;
   let backtestEngine: jest.Mocked<BacktestEngine>;
+  let ohlcService: jest.Mocked<OHLCService>;
   let dataSource: jest.Mocked<DataSource>;
 
   beforeEach(() => {
@@ -109,8 +111,13 @@ describe('OptimizationOrchestratorService', () => {
     } as unknown as jest.Mocked<WindowProcessor>;
 
     backtestEngine = {
-      executeOptimizationBacktest: jest.fn()
+      executeOptimizationBacktest: jest.fn(),
+      executeOptimizationBacktestWithData: jest.fn()
     } as unknown as jest.Mocked<BacktestEngine>;
+
+    ohlcService = {
+      getCandlesByDateRange: jest.fn().mockResolvedValue([])
+    } as unknown as jest.Mocked<OHLCService>;
 
     dataSource = {
       transaction: jest.fn()
@@ -130,6 +137,7 @@ describe('OptimizationOrchestratorService', () => {
       walkForwardService,
       windowProcessor,
       backtestEngine,
+      ohlcService,
       dataSource,
       eventEmitter
     );

--- a/apps/api/src/optimization/services/optimization-recovery.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-recovery.service.spec.ts
@@ -1,0 +1,238 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+import { Queue } from 'bullmq';
+import { In, Repository } from 'typeorm';
+
+import { OptimizationRecoveryService } from './optimization-recovery.service';
+
+import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
+import { OptimizationRun, OptimizationStatus } from '../entities/optimization-run.entity';
+
+type MockRepo = jest.Mocked<Pick<Repository<OptimizationRun>, 'find' | 'update'>>;
+
+const makeRun = (overrides: Partial<OptimizationRun> = {}): OptimizationRun =>
+  ({
+    id: 'run-1',
+    status: OptimizationStatus.RUNNING,
+    combinationsTested: 0,
+    totalCombinations: 100,
+    ...overrides
+  }) as OptimizationRun;
+
+describe('OptimizationRecoveryService', () => {
+  let service: OptimizationRecoveryService;
+  let repo: MockRepo;
+  let queue: jest.Mocked<Pick<Queue, 'getJob'>>;
+  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
+
+  beforeEach(() => {
+    repo = {
+      find: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue({ affected: 1 })
+    };
+
+    queue = {
+      getJob: jest.fn().mockResolvedValue(undefined)
+    };
+
+    eventEmitter = {
+      emit: jest.fn()
+    };
+
+    // Direct constructor instantiation to avoid onApplicationBootstrap firing
+    service = new OptimizationRecoveryService(
+      repo as unknown as Repository<OptimizationRun>,
+      queue as unknown as Queue,
+      eventEmitter as unknown as EventEmitter2
+    );
+  });
+
+  // Access private method for testing
+  const recover = (svc: OptimizationRecoveryService) =>
+    (svc as unknown as { recoverOrphanedOptimizationRuns: () => Promise<void> }).recoverOrphanedOptimizationRuns();
+
+  it('should do nothing when no orphaned runs exist', async () => {
+    repo.find.mockResolvedValue([]);
+
+    await recover(service);
+
+    expect(repo.update).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+  });
+
+  it.each(['waiting', 'delayed'] as const)('should skip PENDING run with valid %s job', async (jobState) => {
+    const run = makeRun({ status: OptimizationStatus.PENDING });
+    repo.find.mockResolvedValue([run]);
+    queue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue(jobState) } as never);
+
+    await recover(service);
+
+    expect(queue.getJob).toHaveBeenCalledWith(run.id);
+    expect(repo.update).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('should mark PENDING run with no job as FAILED and emit event', async () => {
+    const run = makeRun({ status: OptimizationStatus.PENDING });
+    repo.find.mockResolvedValue([run]);
+    queue.getJob.mockResolvedValue(undefined);
+
+    await recover(service);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({
+        status: OptimizationStatus.FAILED,
+        errorMessage: expect.stringContaining('job lost from queue'),
+        completedAt: expect.any(Date)
+      })
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
+      expect.objectContaining({ runId: run.id })
+    );
+  });
+
+  it('should mark PENDING run with stuck active job as FAILED and emit event', async () => {
+    const run = makeRun({ status: OptimizationStatus.PENDING });
+    repo.find.mockResolvedValue([run]);
+    queue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue('active') } as never);
+
+    await recover(service);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({ status: OptimizationStatus.FAILED })
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
+      expect.objectContaining({ runId: run.id })
+    );
+  });
+
+  it('should skip RUNNING run with fresh heartbeat', async () => {
+    const run = makeRun({
+      status: OptimizationStatus.RUNNING,
+      lastHeartbeatAt: new Date(Date.now() - 30 * 60 * 1000) // 30 min ago — well within 120 min threshold
+    });
+    repo.find.mockResolvedValue([run]);
+
+    await recover(service);
+
+    expect(repo.update).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('should fail RUNNING run with stale heartbeat', async () => {
+    const run = makeRun({
+      status: OptimizationStatus.RUNNING,
+      combinationsTested: 10,
+      totalCombinations: 100,
+      lastHeartbeatAt: new Date(Date.now() - 150 * 60 * 1000) // 150 min ago — beyond 120 min threshold
+    });
+    repo.find.mockResolvedValue([run]);
+
+    await recover(service);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({
+        status: OptimizationStatus.FAILED,
+        errorMessage: expect.stringContaining('partial progress'),
+        completedAt: expect.any(Date)
+      })
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
+      expect.objectContaining({ runId: run.id })
+    );
+  });
+
+  it('should include "no progress" in reason for RUNNING run with 0 progress', async () => {
+    const run = makeRun({ status: OptimizationStatus.RUNNING, combinationsTested: 0 });
+    repo.find.mockResolvedValue([run]);
+
+    await recover(service);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({
+        status: OptimizationStatus.FAILED,
+        errorMessage: expect.stringContaining('no progress'),
+        completedAt: expect.any(Date)
+      })
+    );
+  });
+
+  it('should include combination counts in reason for RUNNING run with partial progress', async () => {
+    const run = makeRun({ status: OptimizationStatus.RUNNING, combinationsTested: 42, totalCombinations: 100 });
+    repo.find.mockResolvedValue([run]);
+
+    await recover(service);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({
+        status: OptimizationStatus.FAILED,
+        errorMessage: expect.stringContaining('42/100'),
+        completedAt: expect.any(Date)
+      })
+    );
+  });
+
+  it('should NOT emit event when affected === 0 (race guard)', async () => {
+    const run = makeRun({ status: OptimizationStatus.RUNNING });
+    repo.find.mockResolvedValue([run]);
+    repo.update.mockResolvedValue({ affected: 0, raw: [], generatedMaps: [] });
+
+    await recover(service);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({ status: OptimizationStatus.FAILED })
+    );
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('should continue to next run when recovery error occurs on one run', async () => {
+    const run1 = makeRun({ id: 'run-1', status: OptimizationStatus.RUNNING });
+    const run2 = makeRun({ id: 'run-2', status: OptimizationStatus.RUNNING });
+    repo.find.mockResolvedValue([run1, run2]);
+
+    // First update (recoverSingleRun) throws, inner catch update succeeds
+    let callCount = 0;
+    repo.update.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error('simulated failure');
+      return { affected: 1, raw: [], generatedMaps: [] };
+    });
+
+    await recover(service);
+
+    // Inner catch should have tried to mark run1 as FAILED (call 2)
+    // run2 should have been processed normally (call 3)
+    expect(repo.update).toHaveBeenCalledTimes(3);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
+      expect.objectContaining({ runId: 'run-2' })
+    );
+  });
+
+  it('should not crash when inner catch also throws', async () => {
+    const run = makeRun({ status: OptimizationStatus.RUNNING });
+    repo.find.mockResolvedValue([run]);
+
+    // Both the recoverSingleRun and the inner catch update throw
+    repo.update.mockRejectedValue(new Error('all updates fail'));
+
+    // Should not throw
+    await expect(recover(service)).resolves.toBeUndefined();
+  });
+
+  it('should not crash when top-level find throws', async () => {
+    repo.find.mockRejectedValue(new Error('database unavailable'));
+
+    // Should not throw — top-level catch handles it
+    await expect(recover(service)).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/optimization/services/optimization-recovery.service.ts
+++ b/apps/api/src/optimization/services/optimization-recovery.service.ts
@@ -1,0 +1,138 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Queue } from 'bullmq';
+import { In, Repository } from 'typeorm';
+
+import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
+import { toErrorInfo } from '../../shared/error.util';
+import { OptimizationRun, OptimizationStatus } from '../entities/optimization-run.entity';
+
+/** Must match the watchdog threshold in BacktestOrchestrationTask */
+const STALE_HEARTBEAT_THRESHOLD_MS = 120 * 60 * 1000; // 120 min
+
+@Injectable()
+export class OptimizationRecoveryService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(OptimizationRecoveryService.name);
+
+  constructor(
+    @InjectRepository(OptimizationRun) private readonly optimizationRunRepository: Repository<OptimizationRun>,
+    @InjectQueue('optimization') private readonly optimizationQueue: Queue,
+    private readonly eventEmitter: EventEmitter2
+  ) {}
+
+  onApplicationBootstrap(): void {
+    this.recoverOrphanedOptimizationRuns().catch((error: unknown) => {
+      const err = toErrorInfo(error);
+      this.logger.error(`Background optimization recovery failed: ${err.message}`, err.stack);
+    });
+  }
+
+  /**
+   * Find orphaned RUNNING/PENDING optimization runs after a restart and mark them FAILED.
+   * Unlike backtests, optimization runs do not support checkpoint-resume,
+   * so any interrupted run must be failed and retried from scratch.
+   */
+  private async recoverOrphanedOptimizationRuns(): Promise<void> {
+    this.logger.log('Checking for orphaned optimization runs to recover...');
+
+    try {
+      const orphaned = await this.optimizationRunRepository.find({
+        where: {
+          status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING])
+        }
+      });
+
+      if (orphaned.length === 0) {
+        this.logger.log('No orphaned optimization runs found');
+        return;
+      }
+
+      this.logger.log(`Found ${orphaned.length} orphaned optimization run(s) to recover`);
+
+      for (const run of orphaned) {
+        try {
+          await this.recoverSingleRun(run);
+        } catch (error: unknown) {
+          const err = toErrorInfo(error);
+          this.logger.error(`Failed to recover optimization run ${run.id}: ${err.message}`, err.stack);
+          try {
+            await this.optimizationRunRepository.update(
+              { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+              {
+                status: OptimizationStatus.FAILED,
+                errorMessage: `Recovery failed: ${err.message}`,
+                completedAt: new Date()
+              }
+            );
+          } catch (markError: unknown) {
+            const markErr = toErrorInfo(markError);
+            this.logger.error(`Failed to mark optimization run ${run.id} as failed: ${markErr.message}`);
+          }
+        }
+      }
+
+      this.logger.log('Optimization recovery check complete');
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Optimization recovery check failed: ${err.message}`, err.stack);
+    }
+  }
+
+  private async recoverSingleRun(run: OptimizationRun): Promise<void> {
+    // For PENDING runs, check if a valid job still exists in the queue
+    if (run.status === OptimizationStatus.PENDING) {
+      const existingJob = await this.optimizationQueue.getJob(run.id);
+      if (existingJob) {
+        const jobState = await existingJob.getState();
+        if (jobState === 'waiting' || jobState === 'delayed') {
+          this.logger.log(`Skipping PENDING optimization run ${run.id} — valid job exists (state: ${jobState})`);
+          return;
+        }
+      }
+    }
+
+    // For RUNNING runs, check heartbeat freshness — another node may still be processing this run
+    if (run.status === OptimizationStatus.RUNNING && run.lastHeartbeatAt) {
+      const msSinceHeartbeat = Date.now() - run.lastHeartbeatAt.getTime();
+      if (msSinceHeartbeat < STALE_HEARTBEAT_THRESHOLD_MS) {
+        this.logger.log(
+          `Skipping RUNNING optimization run ${run.id} — heartbeat is fresh ` +
+            `(${Math.round(msSinceHeartbeat / 60000)} min ago, threshold: ${Math.round(STALE_HEARTBEAT_THRESHOLD_MS / 60000)} min)`
+        );
+        return;
+      }
+    }
+
+    const reason =
+      run.status === OptimizationStatus.PENDING
+        ? 'Container restart: job lost from queue before execution started'
+        : run.combinationsTested === 0
+          ? 'Container restart: no progress was made'
+          : `Container restart: partial progress (${run.combinationsTested}/${run.totalCombinations} combinations)`;
+
+    this.logger.warn(`Marking orphaned optimization run ${run.id} as FAILED: ${reason}`);
+
+    const result = await this.optimizationRunRepository.update(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      {
+        status: OptimizationStatus.FAILED,
+        errorMessage: reason,
+        completedAt: new Date()
+      }
+    );
+
+    if (result.affected === 0) {
+      this.logger.log(`Optimization run ${run.id} already transitioned — skipping event emission`);
+      return;
+    }
+
+    // Emit failure event so pipeline listener can clean up
+    this.eventEmitter.emit(PIPELINE_EVENTS.OPTIMIZATION_FAILED, {
+      runId: run.id,
+      reason
+    });
+  }
+}

--- a/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
@@ -12,6 +12,14 @@ export interface OptimizationCompletedEvent {
 }
 
 /**
+ * Event payload for optimization failure (stale watchdog or error)
+ */
+export interface OptimizationFailedEvent {
+  runId: string;
+  reason: string;
+}
+
+/**
  * Event payload for backtest completion
  */
 export interface BacktestCompletedEvent {
@@ -109,6 +117,7 @@ export interface PipelineWebSocketPayload {
  */
 export const PIPELINE_EVENTS = {
   OPTIMIZATION_COMPLETED: 'optimization.completed',
+  OPTIMIZATION_FAILED: 'optimization.failed',
   BACKTEST_COMPLETED: 'backtest.completed',
   PAPER_TRADING_COMPLETED: 'paper-trading.completed',
   PIPELINE_STAGE_TRANSITION: 'pipeline.stage-transition',

--- a/apps/api/src/pipeline/listeners/pipeline-event.listener.ts
+++ b/apps/api/src/pipeline/listeners/pipeline-event.listener.ts
@@ -5,6 +5,7 @@ import { toErrorInfo } from '../../shared/error.util';
 import {
   BacktestCompletedEvent,
   OptimizationCompletedEvent,
+  OptimizationFailedEvent,
   PIPELINE_EVENTS,
   PaperTradingCompletedEvent
 } from '../interfaces';
@@ -36,6 +37,21 @@ export class PipelineEventListener {
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Failed to handle optimization completion for run ${payload.runId}: ${err.message}`, err.stack);
+    }
+  }
+
+  /**
+   * Handle optimization failure event (stale watchdog or error)
+   */
+  @OnEvent(PIPELINE_EVENTS.OPTIMIZATION_FAILED, { async: true })
+  async handleOptimizationFailed(payload: OptimizationFailedEvent): Promise<void> {
+    this.logger.log(`Received optimization.failed event for run ${payload.runId}: ${payload.reason}`);
+
+    try {
+      await this.orchestratorService.handleOptimizationFailed(payload.runId, payload.reason);
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Failed to handle optimization failure for run ${payload.runId}: ${err.message}`, err.stack);
     }
   }
 

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -27,6 +27,7 @@ import { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
 import { MarketRegimeModule } from '../market-regime/market-regime.module';
 import { MonitoringModule } from '../monitoring/monitoring.module';
 import { OHLCModule } from '../ohlc/ohlc.module';
+import { OptimizationRun } from '../optimization/entities/optimization-run.entity';
 import { Backtest } from '../order/backtest/backtest.entity';
 import { MarketDataSet } from '../order/backtest/market-data-set.entity';
 import { OrderModule } from '../order/order.module';
@@ -73,7 +74,8 @@ import { UsersModule } from '../users/users.module';
       Backtest,
       MarketDataSet,
       Pipeline,
-      ExchangeKey
+      ExchangeKey,
+      OptimizationRun
     ]),
     BullModule.registerQueue(
       { name: 'strategy-evaluation-queue' },


### PR DESCRIPTION
## Summary

- Fix optimization runs getting permanently stuck by adding heartbeat monitoring, stale run detection, and startup recovery
- Eliminate redundant OHLC database queries by pre-loading all candles once per optimization run with O(log N) binary-search extraction
- Add race-condition guards on all status transitions to prevent duplicate event emissions

## Changes

### Stuck Run Detection & Recovery
- `optimization-run.entity.ts` - Add `lastHeartbeatAt` column with migration
- `optimization-recovery.service.ts` - New service that fails orphaned RUNNING/PENDING runs on container restart (OnApplicationBootstrap)
- `backtest-orchestration.task.ts` - Add stale optimization watchdog (120-min threshold) and orphaned pipeline detector as @Cron jobs
- `optimization.processor.ts` - Configure BullMQ with 4-hour lock/stalled intervals, 30-min lock renewal, maxStalledCount of 2

### OHLC Query Optimization
- `backtest-engine.service.ts` - Pre-load all OHLC candles once per run, indexed by coin in a Map for binary-search range extraction instead of per-window linear filter
- `optimization-orchestrator.service.ts` - Pass pre-loaded candle map through to backtest engine

### Pipeline Event Handling
- `pipeline-events.interface.ts` - Add OPTIMIZATION_FAILED event type
- `pipeline-event.listener.ts` - Handle OPTIMIZATION_FAILED with cleanup
- `pipeline-orchestrator.service.ts` - Add race-condition guards using conditional update with affected-row check

### Tests
- `optimization-recovery.service.spec.ts` - Comprehensive test suite for recovery service
- `backtest-orchestration.task.spec.ts` - Tests for stale run watchdog and orphaned pipeline detection

## Test Plan

- [ ] Existing optimization tests pass (`nx test api --testFile='optimization'`)
- [ ] Backtest orchestration tests pass (`nx test api --testFile='backtest-orchestration'`)
- [ ] Recovery service tests pass (`nx test api --testFile='optimization-recovery'`)
- [ ] Verify stale optimization runs are detected and failed after 120-min threshold
- [ ] Verify orphaned runs are cleaned up on container restart
- [ ] Verify OHLC pre-loading reduces database query count during optimization