### PR TITLE
fix(api): filter optimization coins by OHLC data availability

### DIFF
--- a/apps/api/src/optimization/interfaces/optimization-config.interface.ts
+++ b/apps/api/src/optimization/interfaces/optimization-config.interface.ts
@@ -102,6 +102,9 @@ export interface OptimizationConfig {
     startDate: Date;
     endDate: Date;
   };
+
+  /** Maximum number of coins to include in optimization (only coins with OHLC data) */
+  maxCoins?: number;
 }
 
 /**

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
@@ -116,7 +116,12 @@ describe('OptimizationOrchestratorService', () => {
     } as unknown as jest.Mocked<BacktestEngine>;
 
     ohlcService = {
-      getCandlesByDateRange: jest.fn().mockResolvedValue([])
+      getCandlesByDateRange: jest.fn().mockResolvedValue([]),
+      getCoinsWithCandleData: jest.fn().mockResolvedValue(['btc', 'eth']),
+      getCandleDataDateRange: jest.fn().mockResolvedValue({
+        start: new Date('2025-11-10'),
+        end: new Date('2026-02-20')
+      })
     } as unknown as jest.Mocked<OHLCService>;
 
     dataSource = {
@@ -519,6 +524,7 @@ describe('OptimizationOrchestratorService', () => {
 
     const mockCoinQueryBuilder = () => ({
       where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       take: jest.fn().mockReturnThis(),
       getMany: jest.fn().mockResolvedValue(mockCoins)

--- a/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
@@ -51,6 +51,8 @@ export interface OptimizationStageConfig {
   earlyStop?: boolean;
   /** Patience for early stopping */
   patience?: number;
+  /** Maximum number of coins to include in optimization */
+  maxCoins?: number;
 }
 
 /**

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -1073,7 +1073,8 @@ export class PipelineOrchestratorService {
       parallelism: {
         maxConcurrentBacktests: 2,
         maxConcurrentWindows: 2
-      }
+      },
+      maxCoins: config.maxCoins
     });
 
     // Store optimization run reference

--- a/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
+++ b/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
@@ -25,6 +25,8 @@ export interface RiskOptimizationConfig {
   stepDays: number;
   /** Maximum parameter combinations to test */
   maxCombinations: number;
+  /** Maximum number of coins to include in optimization */
+  maxCoins: number;
 }
 
 /**
@@ -66,11 +68,11 @@ export const PAPER_TRADING_DURATION: Record<number, string> = {
  * Lower risk levels use longer training periods and more combinations.
  */
 export const OPTIMIZATION_CONFIG: Record<number, RiskOptimizationConfig> = {
-  1: { trainDays: 180, testDays: 60, stepDays: 30, maxCombinations: 1000 }, // Conservative
-  2: { trainDays: 120, testDays: 45, stepDays: 21, maxCombinations: 750 },
-  3: { trainDays: 90, testDays: 30, stepDays: 14, maxCombinations: 500 }, // Default
-  4: { trainDays: 60, testDays: 21, stepDays: 10, maxCombinations: 300 },
-  5: { trainDays: 30, testDays: 14, stepDays: 7, maxCombinations: 200 } // Aggressive
+  1: { trainDays: 180, testDays: 60, stepDays: 30, maxCombinations: 1000, maxCoins: 20 }, // Conservative
+  2: { trainDays: 120, testDays: 45, stepDays: 21, maxCombinations: 750, maxCoins: 18 },
+  3: { trainDays: 90, testDays: 30, stepDays: 14, maxCombinations: 500, maxCoins: 15 }, // Default
+  4: { trainDays: 60, testDays: 21, stepDays: 10, maxCombinations: 300, maxCoins: 12 },
+  5: { trainDays: 30, testDays: 14, stepDays: 7, maxCombinations: 200, maxCoins: 10 } // Aggressive
 };
 
 /**
@@ -196,7 +198,8 @@ export function buildStageConfigFromRisk(riskLevel: number): PipelineStageConfig
     objectiveMetric: 'sharpe_ratio',
     maxCombinations: optimizationConfig.maxCombinations,
     earlyStop: true,
-    patience: 20
+    patience: 20,
+    maxCoins: optimizationConfig.maxCoins
   };
 
   const historical: HistoricalStageConfig = {


### PR DESCRIPTION
## Summary

- Filter optimization coin selection to only include coins with actual OHLC candle data, preventing wasted compute on coins without historical data
- Derive backtest date ranges from real data bounds instead of assuming a hardcoded 3-year window
- Add configurable `maxCoins` parameter per risk level (10-20 coins) and reduce the default from 50 to 20

## Changes

- **`optimization-orchestrator.service.ts`** - Query OHLC repository to verify data availability before including coins; compute date ranges from actual data bounds with a 3-month fallback
- **`optimization-config.interface.ts`** - Add `maxCoins` to the optimization config interface
- **`pipeline-config.interface.ts`** - Add `maxCoins` to the pipeline config interface
- **`pipeline-orchestrator.service.ts`** - Pass `maxCoins` through to optimization config
- **`pipeline-orchestration.dto.ts`** - Add `maxCoins` DTO field with per-risk-level defaults (10/12/15/18/20)
- **`optimization-orchestrator.service.spec.ts`** - Update test setup for new config

## Test Plan

- [ ] Optimization runs only process coins that have OHLC data in the database
- [ ] Date ranges reflect actual data bounds rather than hardcoded 3-year window
- [ ] `maxCoins` respects risk-level defaults and can be overridden
- [ ] Coins without any OHLC data are excluded from optimization
- [ ] Fallback to 3-month range works when no OHLC data exists