### PR TITLE
fix(api): tune optimization pipeline to prevent timeouts and wasted runs

### DIFF
--- a/apps/api/src/optimization/interfaces/optimization-config.interface.ts
+++ b/apps/api/src/optimization/interfaces/optimization-config.interface.ts
@@ -111,12 +111,13 @@ export interface OptimizationConfig {
  * Default optimization configuration
  */
 export const DEFAULT_OPTIMIZATION_CONFIG: OptimizationConfig = {
-  method: 'grid_search',
-  maxCombinations: 1000,
+  method: 'random_search',
+  maxIterations: 100,
+  maxCombinations: 100,
   walkForward: {
-    trainDays: 180,
-    testDays: 90,
-    stepDays: 30,
+    trainDays: 90,
+    testDays: 30,
+    stepDays: 14,
     method: 'rolling',
     minWindowsRequired: 3,
     maxAcceptableDegradation: 30
@@ -127,7 +128,7 @@ export const DEFAULT_OPTIMIZATION_CONFIG: OptimizationConfig = {
   },
   earlyStop: {
     enabled: true,
-    patience: 50,
+    patience: 20,
     minImprovement: 1
   },
   parallelism: {

--- a/apps/api/src/optimization/services/optimization-recovery.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-recovery.service.spec.ts
@@ -113,7 +113,7 @@ describe('OptimizationRecoveryService', () => {
   it('should skip RUNNING run with fresh heartbeat', async () => {
     const run = makeRun({
       status: OptimizationStatus.RUNNING,
-      lastHeartbeatAt: new Date(Date.now() - 30 * 60 * 1000) // 30 min ago — well within 120 min threshold
+      lastHeartbeatAt: new Date(Date.now() - 30 * 60 * 1000) // 30 min ago — well within 6-hour threshold
     });
     repo.find.mockResolvedValue([run]);
 
@@ -128,7 +128,7 @@ describe('OptimizationRecoveryService', () => {
       status: OptimizationStatus.RUNNING,
       combinationsTested: 10,
       totalCombinations: 100,
-      lastHeartbeatAt: new Date(Date.now() - 150 * 60 * 1000) // 150 min ago — beyond 120 min threshold
+      lastHeartbeatAt: new Date(Date.now() - 400 * 60 * 1000) // 400 min ago — beyond 6-hour threshold
     });
     repo.find.mockResolvedValue([run]);
 

--- a/apps/api/src/optimization/services/optimization-recovery.service.ts
+++ b/apps/api/src/optimization/services/optimization-recovery.service.ts
@@ -11,7 +11,7 @@ import { toErrorInfo } from '../../shared/error.util';
 import { OptimizationRun, OptimizationStatus } from '../entities/optimization-run.entity';
 
 /** Must match the watchdog threshold in BacktestOrchestrationTask */
-const STALE_HEARTBEAT_THRESHOLD_MS = 120 * 60 * 1000; // 120 min
+const STALE_HEARTBEAT_THRESHOLD_MS = 360 * 60 * 1000; // 6 hours
 
 @Injectable()
 export class OptimizationRecoveryService implements OnApplicationBootstrap {

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
@@ -942,7 +942,7 @@ describe('PipelineOrchestratorService', () => {
           ])
         }),
         expect.objectContaining({
-          method: 'grid_search',
+          method: 'random_search',
           objective: expect.objectContaining({ metric: runningPipeline.stageConfig.optimization!.objectiveMetric })
         })
       );

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -1050,7 +1050,8 @@ export class PipelineOrchestratorService {
 
     // Start optimization run
     const run = await this.optimizationService.startOptimization(pipeline.strategyConfigId, parameterSpace, {
-      method: 'grid_search',
+      method: 'random_search',
+      maxIterations: config.maxCombinations,
       maxCombinations: config.maxCombinations,
       objective: {
         metric: config.objectiveMetric,

--- a/apps/api/src/tasks/backtest-orchestration.task.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.ts
@@ -30,7 +30,7 @@ export class BacktestOrchestrationTask {
   private static readonly BOOT_GRACE_PERIOD_MS = 10 * 60 * 1000; // 10 min
   private static readonly HISTORICAL_THRESHOLD_MS = 90 * 60 * 1000;
   private static readonly LIVE_REPLAY_THRESHOLD_MS = 120 * 60 * 1000;
-  private static readonly OPTIMIZATION_THRESHOLD_MS = 120 * 60 * 1000; // 120 min
+  private static readonly OPTIMIZATION_THRESHOLD_MS = 360 * 60 * 1000; // 6 hours
 
   private readonly bootedAt = Date.now();
   private readonly logger = new Logger(BacktestOrchestrationTask.name);

--- a/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
+++ b/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
@@ -68,11 +68,11 @@ export const PAPER_TRADING_DURATION: Record<number, string> = {
  * Lower risk levels use longer training periods and more combinations.
  */
 export const OPTIMIZATION_CONFIG: Record<number, RiskOptimizationConfig> = {
-  1: { trainDays: 180, testDays: 60, stepDays: 30, maxCombinations: 1000, maxCoins: 20 }, // Conservative
-  2: { trainDays: 120, testDays: 45, stepDays: 21, maxCombinations: 750, maxCoins: 18 },
-  3: { trainDays: 90, testDays: 30, stepDays: 14, maxCombinations: 500, maxCoins: 15 }, // Default
-  4: { trainDays: 60, testDays: 21, stepDays: 10, maxCombinations: 300, maxCoins: 12 },
-  5: { trainDays: 30, testDays: 14, stepDays: 7, maxCombinations: 200, maxCoins: 10 } // Aggressive
+  1: { trainDays: 180, testDays: 60, stepDays: 30, maxCombinations: 150, maxCoins: 20 }, // Conservative
+  2: { trainDays: 120, testDays: 45, stepDays: 21, maxCombinations: 120, maxCoins: 18 },
+  3: { trainDays: 90, testDays: 30, stepDays: 14, maxCombinations: 100, maxCoins: 15 }, // Default
+  4: { trainDays: 60, testDays: 21, stepDays: 10, maxCombinations: 75, maxCoins: 12 },
+  5: { trainDays: 30, testDays: 14, stepDays: 7, maxCombinations: 50, maxCoins: 10 } // Aggressive
 };
 
 /**

--- a/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
@@ -378,21 +378,21 @@ describe('Pipeline Orchestration DTOs', () => {
     it('should return correct config for each risk level', () => {
       const config1 = getOptimizationConfig(1);
       expect(config1.trainDays).toBe(180);
-      expect(config1.maxCombinations).toBe(1000);
+      expect(config1.maxCombinations).toBe(150);
 
       const config3 = getOptimizationConfig(3);
       expect(config3.trainDays).toBe(90);
-      expect(config3.maxCombinations).toBe(500);
+      expect(config3.maxCombinations).toBe(100);
 
       const config5 = getOptimizationConfig(5);
       expect(config5.trainDays).toBe(30);
-      expect(config5.maxCombinations).toBe(200);
+      expect(config5.maxCombinations).toBe(50);
     });
 
     it('should return default config for invalid risk level', () => {
       const config = getOptimizationConfig(100);
       expect(config.trainDays).toBe(90);
-      expect(config.maxCombinations).toBe(500);
+      expect(config.maxCombinations).toBe(100);
     });
   });
 
@@ -404,7 +404,7 @@ describe('Pipeline Orchestration DTOs', () => {
       expect(config.optimization!.trainDays).toBe(90);
       expect(config.optimization!.testDays).toBe(30);
       expect(config.optimization!.objectiveMetric).toBe('sharpe_ratio');
-      expect(config.optimization!.maxCombinations).toBe(500);
+      expect(config.optimization!.maxCombinations).toBe(100);
       expect(config.optimization!.earlyStop).toBe(true);
 
       // Historical stage
@@ -425,7 +425,7 @@ describe('Pipeline Orchestration DTOs', () => {
       const config = buildStageConfigFromRisk(1);
 
       expect(config.optimization!.trainDays).toBe(180);
-      expect(config.optimization!.maxCombinations).toBe(1000);
+      expect(config.optimization!.maxCombinations).toBe(150);
       expect(config.paperTrading.duration).toBe('14d');
     });
 
@@ -433,7 +433,7 @@ describe('Pipeline Orchestration DTOs', () => {
       const config = buildStageConfigFromRisk(5);
 
       expect(config.optimization!.trainDays).toBe(30);
-      expect(config.optimization!.maxCombinations).toBe(200);
+      expect(config.optimization!.maxCombinations).toBe(50);
       expect(config.paperTrading.duration).toBe('3d');
     });
   });


### PR DESCRIPTION
## Summary

- Switch optimization from exhaustive grid search to random search with drastically reduced combination limits (200-1000 → 50-150) to prevent timeout-inducing parameter sweeps
- Increase stale heartbeat threshold from 2 hours to 6 hours so legitimate long-running optimization runs aren't prematurely killed
- Filter coins by minimum OHLC data span before optimization and fire heartbeats every window for better liveness tracking

## Changes

- **Optimization method**: `grid_search` → `random_search` across pipeline orchestrator and default config
- **maxCombinations**: Reduced per risk level (e.g., risk 3: 500 → 100) to keep runs fast
- **Walk-forward defaults**: Shortened default windows (train 180→90, test 90→30, step 30→14 days)
- **Early stop patience**: Reduced from 50 → 20 for faster convergence
- **Heartbeat threshold**: 120 min → 6 hours in both recovery service and watchdog task
- **OHLC data filter**: Coins must have enough historical data span to fill walk-forward windows; uses parameterized query
- **Heartbeat frequency**: Fire every window instead of every 5th window

## Test Plan

- [ ] Existing unit tests updated and passing for new maxCombinations values
- [ ] Recovery service spec updated for 6-hour threshold
- [ ] Pipeline orchestrator spec updated for `random_search` method
- [ ] Verify optimization runs complete within Railway timeout limits