### PR TITLE
fix(api): detect and fail pipelines with failed optimization runs

### DIFF
--- a/apps/api/src/optimization/services/optimization-orchestrator.service.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.ts
@@ -404,6 +404,12 @@ export class OptimizationOrchestratorService {
       run.errorMessage = err.message;
       run.completedAt = new Date();
       await this.optimizationRunRepository.save(run);
+
+      this.eventEmitter.emit(PIPELINE_EVENTS.OPTIMIZATION_FAILED, {
+        runId: run.id,
+        reason: err.message
+      });
+
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

- Emit `OPTIMIZATION_FAILED` event when an optimization run errors out, enabling the pipeline event listener to propagate the failure
- Add a new watchdog cron (`detectFailedOptimizationPipelines`) that marks RUNNING pipelines as FAILED when their linked optimization run has already FAILED or been deleted
- Detect stale PENDING optimization runs stuck for 30+ minutes without being picked up by a worker

## Changes

- **`optimization-orchestrator.service.ts`** — Emit `OPTIMIZATION_FAILED` event in the catch block after marking a run as FAILED, so the pipeline listener can react immediately
- **`backtest-orchestration.task.ts`** — Add `PENDING_OPTIMIZATION_THRESHOLD_MS` (30 min) constant and extend `detectStaleOptimizationRuns` to catch stuck PENDING runs with type-aware failure messages
- **`backtest-orchestration.task.ts`** — Add new `detectFailedOptimizationPipelines` watchdog (runs every 15 min) that finds RUNNING pipelines in OPTIMIZE stage whose optimization run is FAILED or missing, and marks them FAILED with CAS guard

## Test Plan

- [ ] Verify optimization run failure emits `OPTIMIZATION_FAILED` event (trigger an optimization error)
- [ ] Verify `detectFailedOptimizationPipelines` marks pipelines with failed optimization runs as FAILED
- [ ] Verify `detectStaleOptimizationRuns` catches PENDING runs stuck > 30 min
- [ ] Verify CAS guards prevent double-marking when both event path and watchdog fire
- [ ] Existing pipeline orchestration tests pass (`nx test api`)