### PR TITLE
feat: add signal activity feed to admin backtest monitoring

### DIFF
--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.controller.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.controller.ts
@@ -18,6 +18,8 @@ import {
   PaperTradingFiltersDto,
   PaperTradingMonitoringDto,
   PipelineStageCountsDto,
+  SignalActivityFeedDto,
+  SignalActivityFeedQueryDto,
   SignalAnalyticsDto,
   TradeAnalyticsDto
 } from './dto';
@@ -182,6 +184,27 @@ export class BacktestMonitoringController {
   @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Requires admin role' })
   async getPipelineStageCounts(): Promise<PipelineStageCountsDto> {
     return this.monitoringService.getPipelineStageCounts();
+  }
+
+  /**
+   * Get signal activity feed
+   */
+  @Get('signal-activity-feed')
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Get signal activity feed',
+    description:
+      'Returns a unified feed of recent signals from both backtests and paper trading sessions, ' +
+      'along with health indicators for signal generation activity.'
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Signal activity feed retrieved successfully',
+    type: SignalActivityFeedDto
+  })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Requires admin role' })
+  async getSignalActivityFeed(@Query() query: SignalActivityFeedQueryDto): Promise<SignalActivityFeedDto> {
+    return this.monitoringService.getSignalActivityFeed(query.limit ?? 100);
   }
 
   /**

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.spec.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.spec.ts
@@ -35,6 +35,7 @@ const createMockQueryBuilder = () => {
     andWhere: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
     innerJoin: jest.fn().mockReturnThis(),
+    innerJoinAndSelect: jest.fn().mockReturnThis(),
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     groupBy: jest.fn().mockReturnThis(),
     addGroupBy: jest.fn().mockReturnThis(),
@@ -173,11 +174,32 @@ describe('BacktestMonitoringService', () => {
         { provide: getRepositoryToken(BacktestTrade), useValue: tradeRepo },
         { provide: getRepositoryToken(BacktestSignal), useValue: signalRepo },
         { provide: getRepositoryToken(SimulatedOrderFill), useValue: fillRepo },
-        { provide: getRepositoryToken(OptimizationRun), useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder), count: jest.fn().mockResolvedValue(0) } },
-        { provide: getRepositoryToken(OptimizationResult), useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) } },
-        { provide: getRepositoryToken(PaperTradingSession), useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder), count: jest.fn().mockResolvedValue(0) } },
-        { provide: getRepositoryToken(PaperTradingOrder), useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) } },
-        { provide: getRepositoryToken(PaperTradingSignal), useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) } }
+        {
+          provide: getRepositoryToken(OptimizationRun),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+            count: jest.fn().mockResolvedValue(0)
+          }
+        },
+        {
+          provide: getRepositoryToken(OptimizationResult),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) }
+        },
+        {
+          provide: getRepositoryToken(PaperTradingSession),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+            count: jest.fn().mockResolvedValue(0)
+          }
+        },
+        {
+          provide: getRepositoryToken(PaperTradingOrder),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) }
+        },
+        {
+          provide: getRepositoryToken(PaperTradingSignal),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) }
+        }
       ]
     }).compile();
 
@@ -550,6 +572,170 @@ describe('BacktestMonitoringService', () => {
         relations: ['baseCoin', 'quoteCoin'],
         order: { executedAt: 'ASC' }
       });
+    });
+  });
+
+  describe('getSignalActivityFeed', () => {
+    it('returns combined feed with health summary when no signals exist', async () => {
+      // Mock backtest signals query (getMany returns empty)
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      // Mock paper signals query (getMany returns empty)
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      // Mock backtest stats (getRawOne for consolidated query)
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: '0',
+        dayCount: '0'
+      });
+      // Mock paper stats (getRawOne for consolidated query)
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: '0',
+        dayCount: '0'
+      });
+
+      const result = await service.getSignalActivityFeed(100);
+
+      expect(result).toMatchObject({
+        signals: [],
+        health: expect.objectContaining({
+          signalsLastHour: 0,
+          signalsLast24h: 0,
+          totalActiveSources: 0
+        })
+      });
+      expect(result).not.toHaveProperty('totalCount');
+    });
+
+    it('merges and sorts signals by timestamp DESC', async () => {
+      const now = new Date();
+      const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
+      const tenMinAgo = new Date(now.getTime() - 10 * 60 * 1000);
+
+      // Mock backtest signals
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([
+        createSignal({
+          id: 'bs-1',
+          timestamp: tenMinAgo,
+          backtest: {
+            id: 'bt-1',
+            name: 'Test BT',
+            algorithm: { name: 'Algo1' },
+            user: { email: 'user@test.com' }
+          } as any
+        })
+      ]);
+
+      // Mock paper signals
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 'ps-1',
+          createdAt: fiveMinAgo,
+          signalType: SignalType.EXIT,
+          direction: SignalDirection.LONG,
+          instrument: 'ETH/USDT',
+          quantity: 2,
+          price: 3000,
+          confidence: 0.8,
+          reason: 'Take profit',
+          processed: true,
+          session: {
+            id: 'sess-1',
+            name: 'Test Session',
+            algorithm: { name: 'Algo2' },
+            user: { email: 'user2@test.com' }
+          }
+        }
+      ]);
+
+      // Mock health queries
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: tenMinAgo.toISOString(),
+        hourCount: '1',
+        dayCount: '1'
+      });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: fiveMinAgo.toISOString(),
+        hourCount: '1',
+        dayCount: '1'
+      });
+
+      const result = await service.getSignalActivityFeed(10);
+
+      expect(result.signals).toHaveLength(2);
+      // Paper signal (5min ago) should come first (more recent)
+      expect(result.signals[0].id).toBe('ps-1');
+      expect(result.signals[0].source).toBe('PAPER_TRADING');
+      expect(result.signals[1].id).toBe('bs-1');
+      expect(result.signals[1].source).toBe('BACKTEST');
+    });
+
+    it('respects limit parameter', async () => {
+      const signals = Array.from({ length: 5 }, (_, i) =>
+        createSignal({
+          id: `bs-${i}`,
+          timestamp: new Date(Date.now() - i * 60000),
+          backtest: {
+            id: 'bt-1',
+            name: 'BT',
+            algorithm: { name: 'Algo' },
+            user: { email: 'u@t.com' }
+          } as any
+        })
+      );
+
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce(signals);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+
+      // Health queries
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+
+      const result = await service.getSignalActivityFeed(3);
+
+      expect(result.signals.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('getSignalHealth (via getSignalActivityFeed)', () => {
+    it('returns combined counts from both signal tables', async () => {
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+
+      const recentTime = new Date(Date.now() - 60000).toISOString();
+
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: recentTime,
+        hourCount: '5',
+        dayCount: '20'
+      });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: '3',
+        dayCount: '10'
+      });
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(2);
+
+      const result = await service.getSignalActivityFeed(100);
+
+      expect(result.health.signalsLastHour).toBe(8);
+      expect(result.health.signalsLast24h).toBe(30);
+      expect(result.health.lastSignalTime).toBe(recentTime);
+      expect(result.health.lastSignalAgoMs).toBeDefined();
+    });
+
+    it('handles no signals gracefully', async () => {
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+
+      const result = await service.getSignalActivityFeed(100);
+
+      expect(result.health.lastSignalTime).toBeUndefined();
+      expect(result.health.lastSignalAgoMs).toBeUndefined();
+      expect(result.health.signalsLastHour).toBe(0);
+      expect(result.health.signalsLast24h).toBe(0);
     });
   });
 });

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
@@ -26,6 +26,12 @@ import {
   PipelineStageCountsDto
 } from './dto/paper-trading-analytics.dto';
 import {
+  SignalActivityFeedDto,
+  SignalFeedItemDto,
+  SignalHealthSummaryDto,
+  SignalSource
+} from './dto/signal-activity-feed.dto';
+import {
   ConfidenceBucketDto,
   SignalAnalyticsDto,
   SignalDirectionMetricsDto,
@@ -466,6 +472,172 @@ export class BacktestMonitoringService {
   }
 
   // ===========================================================================
+  // Signal Activity Feed
+  // ===========================================================================
+
+  /**
+   * Get a unified signal activity feed combining backtest and paper trading signals
+   */
+  async getSignalActivityFeed(limit: number): Promise<SignalActivityFeedDto> {
+    const [signals, health] = await Promise.all([this.getRecentSignals(limit), this.getSignalHealth()]);
+
+    return {
+      health,
+      signals
+    };
+  }
+
+  private async getRecentSignals(limit: number): Promise<SignalFeedItemDto[]> {
+    const [backtestSignals, paperSignals] = await Promise.all([
+      this.signalRepo
+        .createQueryBuilder('s')
+        .innerJoinAndSelect('s.backtest', 'b')
+        .innerJoinAndSelect('b.algorithm', 'a')
+        .innerJoinAndSelect('b.user', 'u')
+        .select([
+          's.id',
+          's.timestamp',
+          's.signalType',
+          's.direction',
+          's.instrument',
+          's.quantity',
+          's.price',
+          's.confidence',
+          's.reason',
+          'b.id',
+          'b.name',
+          'a.name',
+          'u.email'
+        ])
+        .orderBy('s.timestamp', 'DESC')
+        .take(limit)
+        .getMany(),
+      this.paperSignalRepo
+        .createQueryBuilder('ps')
+        .innerJoinAndSelect('ps.session', 'sess')
+        .innerJoinAndSelect('sess.algorithm', 'a')
+        .innerJoinAndSelect('sess.user', 'u')
+        .select([
+          'ps.id',
+          'ps.createdAt',
+          'ps.signalType',
+          'ps.direction',
+          'ps.instrument',
+          'ps.quantity',
+          'ps.price',
+          'ps.confidence',
+          'ps.reason',
+          'ps.processed',
+          'sess.id',
+          'sess.name',
+          'a.name',
+          'u.email'
+        ])
+        .orderBy('ps.createdAt', 'DESC')
+        .take(limit)
+        .getMany()
+    ]);
+
+    const mapped: SignalFeedItemDto[] = [];
+
+    for (const s of backtestSignals) {
+      mapped.push({
+        id: s.id,
+        timestamp: s.timestamp.toISOString(),
+        signalType: s.signalType,
+        direction: s.direction,
+        instrument: s.instrument,
+        quantity: s.quantity,
+        price: s.price ?? undefined,
+        confidence: s.confidence ?? undefined,
+        reason: s.reason ?? undefined,
+        source: SignalSource.BACKTEST,
+        sourceId: s.backtest.id,
+        sourceName: s.backtest.name,
+        algorithmName: s.backtest.algorithm?.name || 'Unknown',
+        userEmail: s.backtest.user?.email
+      });
+    }
+
+    for (const ps of paperSignals) {
+      mapped.push({
+        id: ps.id,
+        timestamp: ps.createdAt.toISOString(),
+        signalType: ps.signalType as unknown as SignalType,
+        direction: ps.direction as unknown as SignalDirection,
+        instrument: ps.instrument,
+        quantity: ps.quantity,
+        price: ps.price ?? undefined,
+        confidence: ps.confidence ?? undefined,
+        reason: ps.reason ?? undefined,
+        source: SignalSource.PAPER_TRADING,
+        sourceId: ps.session.id,
+        sourceName: ps.session.name,
+        algorithmName: ps.session.algorithm?.name || 'Unknown',
+        userEmail: ps.session.user?.email,
+        processed: ps.processed
+      });
+    }
+
+    // Sort merged by timestamp DESC, take limit
+    mapped.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    return mapped.slice(0, limit);
+  }
+
+  private async getSignalHealth(): Promise<SignalHealthSummaryDto> {
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+    const [backtestStats, paperStats, activeBacktests, activePaperSessions] = await Promise.all([
+      this.signalRepo
+        .createQueryBuilder('s')
+        .select('MAX(s.timestamp)', 'maxTs')
+        .addSelect(`COUNT(*) FILTER (WHERE s.timestamp >= :oneHourAgo)`, 'hourCount')
+        .addSelect(`COUNT(*) FILTER (WHERE s.timestamp >= :oneDayAgo)`, 'dayCount')
+        .setParameter('oneHourAgo', oneHourAgo)
+        .setParameter('oneDayAgo', oneDayAgo)
+        .getRawOne(),
+      this.paperSignalRepo
+        .createQueryBuilder('ps')
+        .select('MAX(ps.createdAt)', 'maxTs')
+        .addSelect(`COUNT(*) FILTER (WHERE ps.createdAt >= :oneHourAgo)`, 'hourCount')
+        .addSelect(`COUNT(*) FILTER (WHERE ps.createdAt >= :oneDayAgo)`, 'dayCount')
+        .setParameter('oneHourAgo', oneHourAgo)
+        .setParameter('oneDayAgo', oneDayAgo)
+        .getRawOne(),
+      this.backtestRepo.count({ where: { status: BacktestStatus.RUNNING } }),
+      this.paperSessionRepo.count({ where: { status: PaperTradingStatus.ACTIVE } })
+    ]);
+
+    const backtestMax = backtestStats?.maxTs ? new Date(backtestStats.maxTs) : null;
+    const paperMax = paperStats?.maxTs ? new Date(paperStats.maxTs) : null;
+
+    let lastSignalTime: string | undefined;
+    let lastSignalAgoMs: number | undefined;
+
+    const latest =
+      backtestMax && paperMax ? (backtestMax > paperMax ? backtestMax : paperMax) : (backtestMax ?? paperMax);
+
+    if (latest) {
+      lastSignalTime = latest.toISOString();
+      lastSignalAgoMs = now.getTime() - latest.getTime();
+    }
+
+    const totalActiveSources = activeBacktests + activePaperSessions;
+
+    return {
+      lastSignalTime,
+      lastSignalAgoMs,
+      signalsLastHour: parseInt(backtestStats?.hourCount, 10) + parseInt(paperStats?.hourCount, 10) || 0,
+      signalsLast24h: parseInt(backtestStats?.dayCount, 10) + parseInt(paperStats?.dayCount, 10) || 0,
+      activeBacktestSources: activeBacktests,
+      activePaperTradingSources: activePaperSessions,
+      totalActiveSources
+    };
+  }
+
+  // ===========================================================================
   // Private Helper Methods
   // ===========================================================================
 
@@ -854,13 +1026,14 @@ export class BacktestMonitoringService {
   private async getSignalsByInstrument(backtestIds: string[]): Promise<SignalInstrumentMetricsDto[]> {
     const qb = this.signalRepo
       .createQueryBuilder('s')
-      .select('s.instrument', 'instrument')
+      .select('COALESCE(UPPER(c.symbol), s.instrument)', 'instrument')
       .addSelect('COUNT(*)', 'count')
       .addSelect(
         `AVG(CASE WHEN t."realizedPnL" > 0 THEN 1.0 WHEN t."realizedPnL" < 0 THEN 0.0 ELSE NULL END)`,
         'successRate'
       )
       .addSelect('AVG(t."realizedPnLPercent")', 'avgReturn')
+      .leftJoin('coins', 'c', 'CAST(c.id AS text) = s.instrument')
       .leftJoin(
         (subQuery) =>
           subQuery
@@ -878,6 +1051,7 @@ export class BacktestMonitoringService {
       )
       .where('s.backtestId IN (:...backtestIds)', { backtestIds })
       .groupBy('s.instrument')
+      .addGroupBy('c.symbol')
       .orderBy('COUNT(*)', 'DESC')
       .limit(10);
 

--- a/apps/api/src/admin/backtest-monitoring/dto/index.ts
+++ b/apps/api/src/admin/backtest-monitoring/dto/index.ts
@@ -2,5 +2,6 @@ export * from './backtest-listing.dto';
 export * from './optimization-analytics.dto';
 export * from './overview.dto';
 export * from './paper-trading-analytics.dto';
+export * from './signal-activity-feed.dto';
 export * from './signal-analytics.dto';
 export * from './trade-analytics.dto';

--- a/apps/api/src/admin/backtest-monitoring/dto/signal-activity-feed.dto.ts
+++ b/apps/api/src/admin/backtest-monitoring/dto/signal-activity-feed.dto.ts
@@ -1,0 +1,111 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+import { SignalDirection, SignalType } from '../../../order/backtest/backtest.entity';
+
+export enum SignalSource {
+  BACKTEST = 'BACKTEST',
+  PAPER_TRADING = 'PAPER_TRADING'
+}
+
+/**
+ * A single signal in the activity feed
+ */
+export class SignalFeedItemDto {
+  @ApiProperty({ description: 'Signal ID' })
+  id: string;
+
+  @ApiProperty({ description: 'When the signal was generated' })
+  timestamp: string;
+
+  @ApiProperty({ description: 'Signal type', enum: SignalType })
+  signalType: SignalType;
+
+  @ApiProperty({ description: 'Signal direction', enum: SignalDirection })
+  direction: SignalDirection;
+
+  @ApiProperty({ description: 'Target instrument/symbol' })
+  instrument: string;
+
+  @ApiProperty({ description: 'Quantity or exposure' })
+  quantity: number;
+
+  @ApiPropertyOptional({ description: 'Reference price' })
+  price?: number;
+
+  @ApiPropertyOptional({ description: 'Confidence score 0-1' })
+  confidence?: number;
+
+  @ApiPropertyOptional({ description: 'Human-readable reason' })
+  reason?: string;
+
+  @ApiProperty({ description: 'Signal source', enum: SignalSource })
+  source: SignalSource;
+
+  @ApiProperty({ description: 'Source entity ID (backtest or session ID)' })
+  sourceId: string;
+
+  @ApiProperty({ description: 'Source entity name (backtest name or session name)' })
+  sourceName: string;
+
+  @ApiProperty({ description: 'Algorithm name' })
+  algorithmName: string;
+
+  @ApiPropertyOptional({ description: 'User email' })
+  userEmail?: string;
+
+  @ApiPropertyOptional({ description: 'Whether signal was processed (paper trading only)' })
+  processed?: boolean;
+}
+
+/**
+ * Health summary for signal generation activity
+ */
+export class SignalHealthSummaryDto {
+  @ApiPropertyOptional({ description: 'Timestamp of the most recent signal' })
+  lastSignalTime?: string;
+
+  @ApiPropertyOptional({ description: 'Milliseconds since the last signal' })
+  lastSignalAgoMs?: number;
+
+  @ApiProperty({ description: 'Number of signals in the last hour' })
+  signalsLastHour: number;
+
+  @ApiProperty({ description: 'Number of signals in the last 24 hours' })
+  signalsLast24h: number;
+
+  @ApiProperty({ description: 'Number of active backtest sources (RUNNING backtests)' })
+  activeBacktestSources: number;
+
+  @ApiProperty({ description: 'Number of active paper trading sources (ACTIVE sessions)' })
+  activePaperTradingSources: number;
+
+  @ApiProperty({ description: 'Total active sources' })
+  totalActiveSources: number;
+}
+
+/**
+ * Complete signal activity feed response
+ */
+export class SignalActivityFeedDto {
+  @ApiProperty({ description: 'Health summary', type: SignalHealthSummaryDto })
+  health: SignalHealthSummaryDto;
+
+  @ApiProperty({ description: 'Recent signals', type: [SignalFeedItemDto] })
+  signals: SignalFeedItemDto[];
+}
+
+/**
+ * Query parameters for the signal activity feed
+ */
+export class SignalActivityFeedQueryDto {
+  @ApiPropertyOptional({ description: 'Maximum number of signals to return (default 100, max 500)', default: 100 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  @Type(() => Number)
+  limit?: number = 100;
+}

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.component.ts
@@ -25,6 +25,7 @@ import {
   PaperTradingMonitoringDto,
   PaperTradingStatus,
   PipelineStageCountsDto,
+  SignalActivityFeedDto,
   SignalAnalyticsDto,
   TradeAnalyticsDto
 } from '@chansey/api-interfaces';
@@ -35,6 +36,7 @@ import { ExportPanelComponent } from './components/export-panel/export-panel.com
 import { OptimizationPanelComponent } from './components/optimization-panel/optimization-panel.component';
 import { OverviewCardsComponent } from './components/overview-cards/overview-cards.component';
 import { PaperTradingPanelComponent } from './components/paper-trading-panel/paper-trading-panel.component';
+import { SignalActivityFeedComponent } from './components/signal-activity-feed/signal-activity-feed.component';
 import { SignalQualityPanelComponent } from './components/signal-quality-panel/signal-quality-panel.component';
 import { TopAlgorithmsComponent } from './components/top-algorithms/top-algorithms.component';
 import { TradeAnalyticsPanelComponent } from './components/trade-analytics-panel/trade-analytics-panel.component';
@@ -61,6 +63,7 @@ type PipelineView = 'optimization' | 'historical' | 'live-replay' | 'paper-tradi
     TradeAnalyticsPanelComponent,
     OptimizationPanelComponent,
     PaperTradingPanelComponent,
+    SignalActivityFeedComponent,
     ExportPanelComponent
   ],
   providers: [MessageService],
@@ -105,6 +108,15 @@ type PipelineView = 'optimization' | 'historical' | 'live-replay' | 'paper-tradi
             />
 
             <p-button
+              icon="pi pi-bolt"
+              [rounded]="true"
+              [text]="activeTab() !== 'signal-feed'"
+              [severity]="activeTab() === 'signal-feed' ? 'warn' : 'secondary'"
+              (onClick)="toggleSignalFeed()"
+              pTooltip="Signal Activity Feed"
+            />
+
+            <p-button
               icon="pi pi-refresh"
               [rounded]="true"
               [text]="true"
@@ -124,7 +136,16 @@ type PipelineView = 'optimization' | 'historical' | 'live-replay' | 'paper-tradi
         <!-- Overview Cards -->
         <app-overview-cards [overview]="overview()" [pipelineStageCounts]="pipelineStageCounts()" class="mb-4" />
 
-        @if (selectedView === 'optimization') {
+        <!-- Global Signal Activity Feed (all pipeline stages) -->
+        @if (activeTab() === 'signal-feed') {
+          @if (signalFeedQuery.isPending()) {
+            <div class="flex items-center justify-center py-8">
+              <p-progress-spinner strokeWidth="4" />
+            </div>
+          } @else {
+            <app-signal-activity-feed [feed]="signalFeed()" />
+          }
+        } @else if (selectedView === 'optimization') {
           @if (optimizationQuery.isPending()) {
             <div class="flex items-center justify-center py-8">
               <p-progress-spinner strokeWidth="4" />
@@ -142,7 +163,7 @@ type PipelineView = 'optimization' | 'historical' | 'live-replay' | 'paper-tradi
           }
         } @else {
           <!-- Backtest tabs (overview, signals, trades, export) -->
-          <p-tabs [(value)]="activeTab">
+          <p-tabs [value]="activeTab()" (valueChange)="activeTab.set($any($event))">
             <p-tablist>
               <p-tab value="overview">Overview</p-tab>
               <p-tab value="signals">Signal Quality</p-tab>
@@ -192,7 +213,7 @@ export class BacktestMonitoringComponent {
   dateRange: Date[] | null = null;
   selectedStatus: string | null = null;
   selectedView: PipelineView | null = null;
-  activeTab = 'overview';
+  activeTab = signal('overview');
 
   // View options for pipeline stages
   viewOptions: { label: string; value: PipelineView }[] = [
@@ -227,6 +248,8 @@ export class BacktestMonitoringComponent {
   tradeAnalyticsQuery = this.monitoringService.useTradeAnalytics(this.filtersSignal);
   optimizationQuery = this.monitoringService.useOptimizationAnalytics(this.optimizationFiltersSignal);
   paperTradingQuery = this.monitoringService.usePaperTradingAnalytics(this.paperTradingFiltersSignal);
+  signalFeedEnabled = computed(() => this.activeTab() === 'signal-feed');
+  signalFeedQuery = this.monitoringService.useSignalActivityFeed(undefined, this.signalFeedEnabled);
   pipelineStageCountsQuery = this.monitoringService.usePipelineStageCounts();
 
   // Computed data
@@ -238,6 +261,7 @@ export class BacktestMonitoringComponent {
   tradeAnalytics = computed(() => this.tradeAnalyticsQuery.data() as TradeAnalyticsDto | undefined);
   optimizationAnalytics = computed(() => this.optimizationQuery.data() as OptimizationAnalyticsDto | undefined);
   paperTradingAnalytics = computed(() => this.paperTradingQuery.data() as PaperTradingMonitoringDto | undefined);
+  signalFeed = computed(() => this.signalFeedQuery.data() as SignalActivityFeedDto | undefined);
   pipelineStageCounts = computed(() => this.pipelineStageCountsQuery.data() as PipelineStageCountsDto | undefined);
 
   onDateRangeChange(): void {
@@ -302,10 +326,20 @@ export class BacktestMonitoringComponent {
     this.currentPage.set(page);
   }
 
+  toggleSignalFeed(): void {
+    if (this.activeTab() === 'signal-feed') {
+      this.activeTab.set('overview');
+    } else {
+      this.activeTab.set('signal-feed');
+    }
+  }
+
   refresh(): void {
     this.pipelineStageCountsQuery.refetch();
 
-    if (this.selectedView === 'optimization') {
+    if (this.activeTab() === 'signal-feed') {
+      this.signalFeedQuery.refetch();
+    } else if (this.selectedView === 'optimization') {
       this.optimizationQuery.refetch();
     } else if (this.selectedView === 'paper-trading') {
       this.paperTradingQuery.refetch();
@@ -313,11 +347,11 @@ export class BacktestMonitoringComponent {
       this.overviewQuery.refetch();
       this.backtestsQuery.refetch();
 
-      if (this.activeTab === 'signals') {
+      if (this.activeTab() === 'signals') {
         this.signalAnalyticsQuery.refetch();
       }
 
-      if (this.activeTab === 'trades') {
+      if (this.activeTab() === 'trades') {
         this.tradeAnalyticsQuery.refetch();
       }
     }

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.service.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.service.ts
@@ -13,10 +13,11 @@ import {
   PaperTradingFiltersDto,
   PaperTradingMonitoringDto,
   PipelineStageCountsDto,
+  SignalActivityFeedDto,
   SignalAnalyticsDto,
   TradeAnalyticsDto
 } from '@chansey/api-interfaces';
-import { FREQUENT_POLICY, authenticatedFetch, queryKeys } from '@chansey/shared';
+import { FREQUENT_POLICY, REALTIME_POLICY, authenticatedFetch, queryKeys } from '@chansey/shared';
 
 /**
  * Builds URL with query parameters
@@ -159,6 +160,26 @@ export class BacktestMonitoringService {
       queryFn: () => authenticatedFetch<PipelineStageCountsDto>(`${this.apiUrl}/pipeline-stage-counts`),
       ...FREQUENT_POLICY
     }));
+  }
+
+  /**
+   * Query signal activity feed with auto-refresh
+   *
+   * Uses REALTIME policy for ~45s auto-refresh
+   */
+  useSignalActivityFeed(limit?: Signal<number>, enabled?: Signal<boolean>) {
+    return injectQuery(() => {
+      const currentLimit = limit?.() ?? 100;
+      return {
+        queryKey: queryKeys.admin.backtestMonitoring.signalActivityFeed(currentLimit),
+        queryFn: () =>
+          authenticatedFetch<SignalActivityFeedDto>(
+            buildUrl(`${this.apiUrl}/signal-activity-feed`, { limit: currentLimit })
+          ),
+        enabled: enabled?.() ?? true,
+        ...REALTIME_POLICY
+      };
+    });
   }
 
   /**

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/components/signal-activity-feed/signal-activity-feed.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/components/signal-activity-feed/signal-activity-feed.component.ts
@@ -1,0 +1,184 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+import { CardModule } from 'primeng/card';
+import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
+
+import { SignalActivityFeedDto } from '@chansey/api-interfaces';
+
+@Component({
+  selector: 'app-signal-activity-feed',
+  standalone: true,
+  imports: [CommonModule, CardModule, TableModule, TagModule, TooltipModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <!-- Health Cards -->
+    <div class="mb-4 grid grid-cols-2 gap-4 md:grid-cols-4">
+      <p-card>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">Last Signal</div>
+          @if (feed?.health?.lastSignalTime) {
+            <div class="text-xl font-bold" [class]="lastSignalColorClass">
+              {{ formatTimeAgo(feed?.health?.lastSignalTime) }}
+            </div>
+            <div class="mt-1 text-xs text-gray-400">{{ feed?.health?.lastSignalTime | date: 'short' }}</div>
+          } @else {
+            <div class="text-xl font-bold text-gray-400">No signals</div>
+          }
+        </div>
+      </p-card>
+
+      <p-card>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">Signals / Hour</div>
+          <div class="text-2xl font-bold">{{ feed?.health?.signalsLastHour ?? 0 }}</div>
+        </div>
+      </p-card>
+
+      <p-card>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">Signals / 24h</div>
+          <div class="text-2xl font-bold">{{ feed?.health?.signalsLast24h ?? 0 }}</div>
+        </div>
+      </p-card>
+
+      <p-card>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">Active Sources</div>
+          <div class="text-2xl font-bold">{{ feed?.health?.totalActiveSources ?? 0 }}</div>
+          <div class="mt-1 text-xs text-gray-400">
+            {{ feed?.health?.activeBacktestSources ?? 0 }} backtest ·
+            {{ feed?.health?.activePaperTradingSources ?? 0 }} paper
+          </div>
+        </div>
+      </p-card>
+    </div>
+
+    <!-- Signal Feed Table -->
+    <p-card header="Recent Signals">
+      <p-table
+        [value]="feed?.signals ?? []"
+        [rows]="20"
+        [paginator]="(feed?.signals?.length ?? 0) > 20"
+        [rowsPerPageOptions]="[20, 50, 100]"
+        [scrollable]="true"
+        scrollHeight="500px"
+        styleClass="p-datatable-sm p-datatable-striped"
+      >
+        <ng-template #header>
+          <tr>
+            <th style="width: 140px">Time</th>
+            <th style="width: 90px">Type</th>
+            <th style="width: 80px">Direction</th>
+            <th>Instrument</th>
+            <th style="width: 100px" class="text-right">Price</th>
+            <th style="width: 80px" class="text-right">Confidence</th>
+            <th style="width: 100px">Source</th>
+            <th>Algorithm</th>
+            <th>User</th>
+            <th>Reason</th>
+          </tr>
+        </ng-template>
+        <ng-template #body let-signal>
+          <tr>
+            <td>{{ signal.timestamp | date: 'short' }}</td>
+            <td>
+              <p-tag [value]="signal.signalType" [severity]="getSignalTypeSeverity(signal.signalType)" />
+            </td>
+            <td>
+              <p-tag [value]="signal.direction" [severity]="getDirectionSeverity(signal.direction)" />
+            </td>
+            <td class="font-mono text-sm">{{ signal.instrument }}</td>
+            <td class="text-right font-mono">
+              @if (signal.price !== null && signal.price !== undefined) {
+                {{ signal.price | number: '1.2-8' }}
+              } @else {
+                <span class="text-gray-400">-</span>
+              }
+            </td>
+            <td class="text-right">
+              @if (signal.confidence !== null && signal.confidence !== undefined) {
+                {{ signal.confidence | percent: '1.0-0' }}
+              } @else {
+                <span class="text-gray-400">-</span>
+              }
+            </td>
+            <td>
+              <p-tag
+                [value]="signal.source === 'BACKTEST' ? 'Backtest' : 'Paper'"
+                [severity]="signal.source === 'BACKTEST' ? 'info' : 'warn'"
+              />
+            </td>
+            <td class="max-w-[120px] truncate" [pTooltip]="signal.algorithmName">
+              {{ signal.algorithmName }}
+            </td>
+            <td class="max-w-[120px] truncate" [pTooltip]="signal.userEmail || ''">
+              {{ signal.userEmail || '-' }}
+            </td>
+            <td class="max-w-[200px] truncate" [pTooltip]="signal.reason || ''">
+              {{ signal.reason || '-' }}
+            </td>
+          </tr>
+        </ng-template>
+        <ng-template #emptymessage>
+          <tr>
+            <td colspan="10" class="py-8 text-center text-gray-500">No signals found</td>
+          </tr>
+        </ng-template>
+      </p-table>
+    </p-card>
+  `
+})
+export class SignalActivityFeedComponent {
+  @Input() feed?: SignalActivityFeedDto;
+
+  get lastSignalColorClass(): string {
+    const lastSignalTime = this.feed?.health?.lastSignalTime;
+    if (lastSignalTime == null) return 'text-gray-400';
+    const ms = Date.now() - new Date(lastSignalTime).getTime();
+    if (ms < 5 * 60 * 1000) return 'text-green-500'; // < 5 min
+    if (ms < 30 * 60 * 1000) return 'text-yellow-500'; // < 30 min
+    return 'text-red-500'; // > 30 min
+  }
+
+  formatTimeAgo(lastSignalTime?: string): string {
+    if (lastSignalTime == null) return 'Never';
+    const ms = Date.now() - new Date(lastSignalTime).getTime();
+    const seconds = Math.floor(ms / 1000);
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ${minutes % 60}m ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }
+
+  getSignalTypeSeverity(type: string): 'success' | 'info' | 'warn' | 'danger' | 'secondary' {
+    switch (type) {
+      case 'ENTRY':
+        return 'success';
+      case 'EXIT':
+        return 'info';
+      case 'ADJUSTMENT':
+        return 'warn';
+      case 'RISK_CONTROL':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+
+  getDirectionSeverity(direction: string): 'success' | 'danger' | 'secondary' {
+    switch (direction) {
+      case 'LONG':
+        return 'success';
+      case 'SHORT':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+}

--- a/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
+++ b/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
@@ -350,3 +350,45 @@ export interface PipelineStageCountsDto {
   liveReplayBacktests: number;
   paperTradingSessions: number;
 }
+
+// ===========================================================================
+// Signal Activity Feed DTOs
+// ===========================================================================
+
+export enum SignalSource {
+  BACKTEST = 'BACKTEST',
+  PAPER_TRADING = 'PAPER_TRADING'
+}
+
+export interface SignalFeedItemDto {
+  id: string;
+  timestamp: string;
+  signalType: SignalType;
+  direction: SignalDirection;
+  instrument: string;
+  quantity: number;
+  price?: number;
+  confidence?: number;
+  reason?: string;
+  source: SignalSource;
+  sourceId: string;
+  sourceName: string;
+  algorithmName: string;
+  userEmail?: string;
+  processed?: boolean;
+}
+
+export interface SignalHealthSummaryDto {
+  lastSignalTime?: string;
+  lastSignalAgoMs?: number;
+  signalsLastHour: number;
+  signalsLast24h: number;
+  activeBacktestSources: number;
+  activePaperTradingSources: number;
+  totalActiveSources: number;
+}
+
+export interface SignalActivityFeedDto {
+  health: SignalHealthSummaryDto;
+  signals: SignalFeedItemDto[];
+}

--- a/libs/shared/src/lib/query/query-keys.ts
+++ b/libs/shared/src/lib/query/query-keys.ts
@@ -217,7 +217,11 @@ export const queryKeys = {
         filters
           ? ([...queryKeys.admin.backtestMonitoring.all(), 'paper-trading-analytics', filters] as const)
           : ([...queryKeys.admin.backtestMonitoring.all(), 'paper-trading-analytics'] as const),
-      pipelineStageCounts: () => [...queryKeys.admin.backtestMonitoring.all(), 'pipeline-stage-counts'] as const
+      pipelineStageCounts: () => [...queryKeys.admin.backtestMonitoring.all(), 'pipeline-stage-counts'] as const,
+      signalActivityFeed: (limit?: number) =>
+        limit
+          ? ([...queryKeys.admin.backtestMonitoring.all(), 'signal-activity-feed', limit] as const)
+          : ([...queryKeys.admin.backtestMonitoring.all(), 'signal-activity-feed'] as const)
     },
     liveTradeMonitoring: {
       all: () => [...queryKeys.admin.all, 'live-trade-monitoring'] as const,


### PR DESCRIPTION
## Summary

- Add a unified signal activity feed combining BacktestSignal and PaperTradingSignal data into a single paginated endpoint
- Add health summary dashboard with last signal time, hourly/daily signal counts, and active source tracking
- Create frontend component with health cards, paginated signal table, and ~45s auto-refresh polling

## Changes

### Backend
- **`backtest-monitoring.controller.ts`** — New `GET /signal-activity-feed` endpoint with `@Throttle(30/min)` rate limit
- **`backtest-monitoring.service.ts`** — `getSignalActivityFeed()` and `getSignalHealth()` methods querying both signal tables, consolidated health queries using `COUNT(*) FILTER`
- **`dto/signal-activity-feed.dto.ts`** — DTOs with typed `SignalType`/`SignalDirection` enums for feed and health responses
- **`backtest-monitoring.service.spec.ts`** — Test coverage for feed and health methods

### Frontend
- **`signal-activity-feed.component.ts`** — Standalone component with health stat cards, paginated signal table, time-ago display, and conditional polling via `enabled` signal
- **`backtest-monitoring.component.ts`** — Bolt icon toggle to show/hide signal feed from any pipeline stage, `activeTab` converted to signal
- **`backtest-monitoring.service.ts`** — `useSignalActivityFeed` TanStack Query hook with `REALTIME_POLICY`

### Shared
- **`backtest-monitoring.interface.ts`** — `ISignalActivityFeed`, `ISignalHealth`, and related interfaces
- **`query-keys.ts`** — New `signalActivityFeed` query key

## Test Plan

- [ ] `npx nx test api --testFile='backtest-monitoring.service'` passes
- [ ] Signal feed endpoint returns merged, time-sorted signals from both tables
- [ ] Health summary shows correct hourly/daily counts and last signal time
- [ ] Frontend bolt icon toggles signal feed panel visibility
- [ ] Auto-refresh polls every ~45s when feed is visible, stops when hidden
- [ ] Pagination works correctly across merged signal sources