### PR TITLE
feat(api): add resumable optimization runs with stored combinations

### DIFF
--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
@@ -1033,7 +1033,7 @@ export class BacktestMonitoringService {
         'successRate'
       )
       .addSelect('AVG(t."realizedPnLPercent")', 'avgReturn')
-      .leftJoin('coins', 'c', 'CAST(c.id AS text) = s.instrument')
+      .leftJoin('coin', 'c', 'CAST(c.id AS text) = s.instrument')
       .leftJoin(
         (subQuery) =>
           subQuery

--- a/apps/api/src/migrations/1739400000000-AddOptimizationCombinations.ts
+++ b/apps/api/src/migrations/1739400000000-AddOptimizationCombinations.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add `combinations` JSONB column to optimization_runs.
+ *
+ * Stores the generated parameter combinations at run creation time so that
+ * interrupted optimization runs can resume from their last completed batch.
+ * Critical for random_search where combinations are non-deterministic and
+ * cannot be regenerated.
+ */
+export class AddOptimizationCombinations1739400000000 implements MigrationInterface {
+  name = 'AddOptimizationCombinations1739400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "optimization_runs" ADD COLUMN IF NOT EXISTS "combinations" jsonb`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "optimization_runs" DROP COLUMN IF EXISTS "combinations"`);
+  }
+}

--- a/apps/api/src/optimization/entities/optimization-run.entity.ts
+++ b/apps/api/src/optimization/entities/optimization-run.entity.ts
@@ -37,6 +37,7 @@ export interface OptimizationProgressDetails {
   lastUpdated: Date;
   currentBestScore?: number;
   currentBestParams?: Record<string, unknown>;
+  autoResumeCount?: number;
 }
 
 /**
@@ -124,6 +125,9 @@ export class OptimizationRun {
 
   @Column({ type: 'jsonb', nullable: true })
   progressDetails: OptimizationProgressDetails;
+
+  @Column({ type: 'jsonb', nullable: true, select: false })
+  combinations: Array<{ index: number; values: Record<string, unknown>; isBaseline: boolean }>;
 
   @Column({ type: 'text', nullable: true })
   errorMessage: string;

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
@@ -78,8 +78,15 @@ describe('OptimizationOrchestratorService', () => {
       findOne: jest.fn(),
       save: jest.fn(),
       create: jest.fn(),
-      find: jest.fn(),
-      update: jest.fn()
+      find: jest.fn().mockResolvedValue([]),
+      update: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 1 })
+      })
     } as unknown as MockRepo<OptimizationResult>;
 
     strategyConfigRepo = {
@@ -552,6 +559,137 @@ describe('OptimizationOrchestratorService', () => {
       expect(optimizationRunRepo.save).toHaveBeenCalledWith(run);
     });
 
+    it('should preserve startedAt on resume', async () => {
+      const originalStartedAt = new Date('2025-01-01T00:00:00Z');
+      const run = buildRun({
+        combinationsTested: 5,
+        startedAt: originalStartedAt,
+        config: createValidConfig({ walkForward: { minWindowsRequired: 1 } as any })
+      });
+      optimizationRunRepo.findOne.mockResolvedValue(run);
+      optimizationRunRepo.save.mockImplementation(async (r: any) => r);
+      optimizationRunRepo.update.mockResolvedValue({ affected: 1, raw: [], generatedMaps: [] });
+      coinRepo.createQueryBuilder.mockReturnValue(mockCoinQueryBuilder() as any);
+
+      // Return existing results for the already-processed combinations
+      optimizationResultRepo.find.mockResolvedValue([
+        { combinationIndex: 0, avgTestScore: 1.5, parameters: { period: 14 }, isBaseline: true } as any
+      ]);
+
+      walkForwardService.generateWindows.mockReturnValue([
+        {
+          windowIndex: 0,
+          trainStartDate: new Date('2024-01-01'),
+          trainEndDate: new Date('2024-04-01'),
+          testStartDate: new Date('2024-04-01'),
+          testEndDate: new Date('2024-05-01')
+        }
+      ]);
+
+      // Empty combinations (all filtered out on resume)
+      await service.executeOptimization(run.id, [{ index: 0, values: { period: 14 }, isBaseline: true }]);
+
+      // startedAt should still be the original value (not overwritten)
+      expect(run.startedAt).toEqual(originalStartedAt);
+    });
+
+    it('should skip already-processed combinations on resume', async () => {
+      const run = buildRun({
+        combinationsTested: 1,
+        startedAt: new Date('2025-01-01T00:00:00Z'),
+        config: createValidConfig({ walkForward: { minWindowsRequired: 1 } as any })
+      });
+      optimizationRunRepo.findOne
+        .mockResolvedValueOnce(run) // initial load
+        .mockResolvedValueOnce(run); // cancellation check
+      optimizationRunRepo.save.mockImplementation(async (r: any) => r);
+      optimizationRunRepo.update.mockResolvedValue({ affected: 1, raw: [], generatedMaps: [] });
+      coinRepo.createQueryBuilder.mockReturnValue(mockCoinQueryBuilder() as any);
+
+      // One combination already processed
+      optimizationResultRepo.find.mockResolvedValue([
+        { combinationIndex: 0, avgTestScore: 1.5, parameters: { period: 14 }, isBaseline: true } as any
+      ]);
+
+      walkForwardService.generateWindows.mockReturnValue([
+        {
+          windowIndex: 0,
+          trainStartDate: new Date('2024-01-01'),
+          trainEndDate: new Date('2024-04-01'),
+          testStartDate: new Date('2024-04-01'),
+          testEndDate: new Date('2024-05-01')
+        }
+      ]);
+
+      const mockMetrics = {
+        sharpeRatio: 2.0,
+        totalReturn: 0.15,
+        maxDrawdown: -0.1,
+        winRate: 0.65,
+        tradeCount: 60,
+        profitFactor: 2.5,
+        volatility: 0.18,
+        downsideDeviation: 0.12
+      };
+
+      backtestEngine.executeOptimizationBacktestWithData.mockResolvedValue(mockMetrics);
+      windowProcessor.processWindow.mockResolvedValue({ degradation: 0.05, overfittingDetected: false } as any);
+
+      const managerSave = jest.fn().mockResolvedValue({});
+      const managerCreate = jest.fn().mockReturnValue({});
+      dataSource.transaction.mockImplementation(async (cb: any) => {
+        await cb({ save: managerSave, create: managerCreate });
+      });
+
+      // Pass two combinations: index 0 (already done) and index 1 (new)
+      await service.executeOptimization(run.id, [
+        { index: 0, values: { period: 14 }, isBaseline: true },
+        { index: 1, values: { period: 20 }, isBaseline: false }
+      ]);
+
+      // Only index 1 should be evaluated (index 0 was filtered out)
+      expect(backtestEngine.executeOptimizationBacktestWithData).toHaveBeenCalledTimes(2); // train + test for 1 combo
+    });
+
+    it('should reconstruct bestScore and baselineScore from existing results on resume', async () => {
+      const run = buildRun({
+        combinationsTested: 2,
+        startedAt: new Date('2025-01-01T00:00:00Z'),
+        config: createValidConfig({ walkForward: { minWindowsRequired: 1 } as any })
+      });
+      optimizationRunRepo.findOne.mockResolvedValue(run);
+      optimizationRunRepo.save.mockImplementation(async (r: any) => r);
+      optimizationRunRepo.update.mockResolvedValue({ affected: 1, raw: [], generatedMaps: [] });
+      coinRepo.createQueryBuilder.mockReturnValue(mockCoinQueryBuilder() as any);
+
+      // Two results already processed
+      optimizationResultRepo.find.mockResolvedValue([
+        { combinationIndex: 0, avgTestScore: 1.2, parameters: { period: 14 }, isBaseline: true } as any,
+        { combinationIndex: 1, avgTestScore: 1.8, parameters: { period: 20 }, isBaseline: false } as any
+      ]);
+
+      walkForwardService.generateWindows.mockReturnValue([
+        {
+          windowIndex: 0,
+          trainStartDate: new Date('2024-01-01'),
+          trainEndDate: new Date('2024-04-01'),
+          testStartDate: new Date('2024-04-01'),
+          testEndDate: new Date('2024-05-01')
+        }
+      ]);
+
+      // All combinations already processed, so no new evaluations
+      await service.executeOptimization(run.id, [
+        { index: 0, values: { period: 14 }, isBaseline: true },
+        { index: 1, values: { period: 20 }, isBaseline: false }
+      ]);
+
+      // Finalization should use reconstructed scores
+      // The run should be COMPLETED with best score from results
+      expect(run.status).toBe(OptimizationStatus.COMPLETED);
+      expect(run.bestScore).toBeDefined();
+    });
+
     it('should exit early when run is cancelled before processing batch', async () => {
       const run = buildRun({
         config: createValidConfig({ walkForward: { minWindowsRequired: 1 } as any })
@@ -642,6 +780,57 @@ describe('OptimizationOrchestratorService', () => {
       expect(callOrder[0]).toContain('start');
       expect(callOrder[1]).toContain('start');
       expect(backtestEngine.executeOptimizationBacktestWithData).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('updateProgress', () => {
+    it('should preserve autoResumeCount in progress details', async () => {
+      const run = {
+        id: 'run-1',
+        startedAt: new Date(Date.now() - 60000),
+        totalCombinations: 10,
+        progressDetails: { autoResumeCount: 2 }
+      } as unknown as OptimizationRun;
+
+      optimizationRunRepo.update.mockResolvedValue({ affected: 1, raw: [], generatedMaps: [] });
+
+      // Call private method
+      await (service as any).updateProgress(run, 5, 3, 1.5, { period: 14 });
+
+      expect(optimizationRunRepo.update).toHaveBeenCalledWith(
+        run.id,
+        expect.objectContaining({
+          combinationsTested: 5,
+          progressDetails: expect.objectContaining({
+            autoResumeCount: 2,
+            currentCombination: 5,
+            currentBestScore: 1.5
+          })
+        })
+      );
+    });
+
+    it('should set autoResumeCount to undefined when not previously set', async () => {
+      const run = {
+        id: 'run-1',
+        startedAt: new Date(Date.now() - 60000),
+        totalCombinations: 10,
+        progressDetails: null
+      } as unknown as OptimizationRun;
+
+      optimizationRunRepo.update.mockResolvedValue({ affected: 1, raw: [], generatedMaps: [] });
+
+      await (service as any).updateProgress(run, 3, 2, 0.8, null);
+
+      expect(optimizationRunRepo.update).toHaveBeenCalledWith(
+        run.id,
+        expect.objectContaining({
+          progressDetails: expect.objectContaining({
+            autoResumeCount: undefined,
+            currentCombination: 3
+          })
+        })
+      );
     });
   });
 

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.ts
@@ -152,7 +152,7 @@ export class OptimizationOrchestratorService {
     const baselineCombination = combinations.find((c) => c.isBaseline);
     const baselineParameters = baselineCombination?.values || this.getDefaultParameters(parameterSpace);
 
-    // Create optimization run
+    // Create optimization run (persist combinations for checkpoint-resume)
     const run = this.optimizationRunRepository.create({
       strategyConfigId,
       status: OptimizationStatus.PENDING,
@@ -160,7 +160,8 @@ export class OptimizationOrchestratorService {
       parameterSpace,
       baselineParameters,
       totalCombinations: combinations.length,
-      combinationsTested: 0
+      combinationsTested: 0,
+      combinations
     });
 
     const savedRun = await this.optimizationRunRepository.save(run);
@@ -202,9 +203,12 @@ export class OptimizationOrchestratorService {
       throw new NotFoundException(`Optimization run ${runId} not found`);
     }
 
-    // Update status to running
+    // Detect resume: preserve original startedAt if this is a resumed run
+    const isResume = run.combinationsTested > 0;
     run.status = OptimizationStatus.RUNNING;
-    run.startedAt = new Date();
+    if (!isResume) {
+      run.startedAt = new Date();
+    }
     run.lastHeartbeatAt = new Date();
     await this.optimizationRunRepository.save(run);
 
@@ -267,6 +271,34 @@ export class OptimizationOrchestratorService {
       let baselineScore = 0;
       let noImprovementCount = 0;
       let combinationsProcessed = 0;
+
+      // Resume: reconstruct state from already-persisted results
+      if (isResume) {
+        const existingResults = await this.optimizationResultRepository.find({
+          where: { optimizationRunId: runId },
+          select: ['combinationIndex', 'avgTestScore', 'parameters', 'isBaseline']
+        });
+
+        const processedIndices = new Set(existingResults.map((r) => r.combinationIndex));
+        combinations = combinations.filter((c) => !processedIndices.has(c.index));
+        combinationsProcessed = existingResults.length;
+
+        // Reconstruct best score/parameters from persisted results
+        for (const result of existingResults) {
+          if (result.isBaseline) {
+            baselineScore = result.avgTestScore;
+          }
+          if (result.avgTestScore > bestScore) {
+            bestScore = result.avgTestScore;
+            bestParameters = result.parameters;
+          }
+        }
+
+        this.logger.log(
+          `Resumed optimization run ${runId}: ${combinationsProcessed} already processed, ` +
+            `${combinations.length} remaining, best score: ${bestScore === -Infinity ? 'none' : bestScore.toFixed(4)}`
+        );
+      }
 
       // Heartbeat callback updates lastHeartbeatAt on the run entity
       const heartbeatFn = async () => {
@@ -431,8 +463,6 @@ export class OptimizationOrchestratorService {
     let totalTestScore = 0;
     let totalDegradation = 0;
     let overfittingWindows = 0;
-    let windowCount = 0;
-
     for (const window of windows) {
       // Execute train and test backtests in parallel (independent date ranges, no shared state)
       const [trainMetrics, testMetrics] = await Promise.all([
@@ -481,7 +511,6 @@ export class OptimizationOrchestratorService {
         overfittingWindows++;
       }
 
-      windowCount++;
       if (heartbeatFn) {
         await heartbeatFn();
       }
@@ -744,7 +773,8 @@ export class OptimizationOrchestratorService {
       estimatedTimeRemaining,
       lastUpdated: new Date(),
       currentBestScore,
-      currentBestParams: currentBestParams || undefined
+      currentBestParams: currentBestParams || undefined,
+      autoResumeCount: run.progressDetails?.autoResumeCount
     };
 
     await this.optimizationRunRepository.update(run.id, {

--- a/apps/api/src/optimization/services/optimization-recovery.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-recovery.service.spec.ts
@@ -1,14 +1,12 @@
-import { EventEmitter2 } from '@nestjs/event-emitter';
-
 import { Queue } from 'bullmq';
 import { In, Repository } from 'typeorm';
 
+import { GridSearchService } from './grid-search.service';
 import { OptimizationRecoveryService } from './optimization-recovery.service';
 
-import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
 import { OptimizationRun, OptimizationStatus } from '../entities/optimization-run.entity';
 
-type MockRepo = jest.Mocked<Pick<Repository<OptimizationRun>, 'find' | 'update'>>;
+type MockRepo = jest.Mocked<Pick<Repository<OptimizationRun>, 'find' | 'update' | 'createQueryBuilder'>>;
 
 const makeRun = (overrides: Partial<OptimizationRun> = {}): OptimizationRun =>
   ({
@@ -16,190 +14,329 @@ const makeRun = (overrides: Partial<OptimizationRun> = {}): OptimizationRun =>
     status: OptimizationStatus.RUNNING,
     combinationsTested: 0,
     totalCombinations: 100,
+    config: { method: 'grid_search' },
+    parameterSpace: { strategyType: 'test', parameters: [] },
+    combinations: [{ index: 0, values: { period: 14 }, isBaseline: true }],
+    progressDetails: null,
     ...overrides
-  }) as OptimizationRun;
+  }) as unknown as OptimizationRun;
 
 describe('OptimizationRecoveryService', () => {
   let service: OptimizationRecoveryService;
   let repo: MockRepo;
-  let queue: jest.Mocked<Pick<Queue, 'getJob'>>;
-  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
+  let queue: jest.Mocked<Pick<Queue, 'getJob' | 'add' | 'client' | 'opts' | 'name'>>;
+  let gridSearchService: jest.Mocked<Pick<GridSearchService, 'generateCombinations'>>;
 
   beforeEach(() => {
     repo = {
       find: jest.fn().mockResolvedValue([]),
-      update: jest.fn().mockResolvedValue({ affected: 1 })
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([])
+      })
     };
 
     queue = {
-      getJob: jest.fn().mockResolvedValue(undefined)
+      getJob: jest.fn().mockResolvedValue(undefined),
+      add: jest.fn().mockResolvedValue(undefined),
+      client: Promise.resolve({ del: jest.fn().mockResolvedValue(1) }),
+      opts: { prefix: 'bull' },
+      name: 'optimization'
+    } as any;
+
+    gridSearchService = {
+      generateCombinations: jest.fn().mockReturnValue([{ index: 0, values: {}, isBaseline: true }])
     };
 
-    eventEmitter = {
-      emit: jest.fn()
-    };
-
-    // Direct constructor instantiation to avoid onApplicationBootstrap firing
     service = new OptimizationRecoveryService(
       repo as unknown as Repository<OptimizationRun>,
       queue as unknown as Queue,
-      eventEmitter as unknown as EventEmitter2
+      gridSearchService as unknown as GridSearchService
     );
   });
 
-  // Access private method for testing
   const recover = (svc: OptimizationRecoveryService) =>
     (svc as unknown as { recoverOrphanedOptimizationRuns: () => Promise<void> }).recoverOrphanedOptimizationRuns();
 
+  /** Helper: configure createQueryBuilder mock to return given runs */
+  const mockOrphanedRuns = (runs: OptimizationRun[]) => {
+    repo.createQueryBuilder.mockReturnValue({
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(runs)
+    } as any);
+  };
+
+  /** Helper: configure createQueryBuilder mock to reject */
+  const mockOrphanedRunsRejected = (error: Error) => {
+    repo.createQueryBuilder.mockReturnValue({
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockRejectedValue(error)
+    } as any);
+  };
+
   it('should do nothing when no orphaned runs exist', async () => {
-    repo.find.mockResolvedValue([]);
+    mockOrphanedRuns([]);
 
     await recover(service);
 
     expect(repo.update).not.toHaveBeenCalled();
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
   });
 
   it.each(['waiting', 'delayed'] as const)('should skip PENDING run with valid %s job', async (jobState) => {
     const run = makeRun({ status: OptimizationStatus.PENDING });
-    repo.find.mockResolvedValue([run]);
+    mockOrphanedRuns([run]);
     queue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue(jobState) } as never);
 
     await recover(service);
 
     expect(queue.getJob).toHaveBeenCalledWith(run.id);
     expect(repo.update).not.toHaveBeenCalled();
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
   });
 
-  it('should mark PENDING run with no job as FAILED and emit event', async () => {
+  it('should skip RUNNING run with fresh heartbeat', async () => {
+    const run = makeRun({
+      status: OptimizationStatus.RUNNING,
+      lastHeartbeatAt: new Date(Date.now() - 30 * 60 * 1000) // 30 min ago
+    });
+    mockOrphanedRuns([run]);
+
+    await recover(service);
+
+    expect(repo.update).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('should re-queue RUNNING run with stale heartbeat', async () => {
+    const run = makeRun({
+      status: OptimizationStatus.RUNNING,
+      combinationsTested: 10,
+      totalCombinations: 100,
+      lastHeartbeatAt: new Date(Date.now() - 400 * 60 * 1000) // 400 min ago
+    });
+    mockOrphanedRuns([run]);
+
+    await recover(service);
+
+    // Should update to PENDING first
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({
+        status: OptimizationStatus.PENDING,
+        progressDetails: expect.objectContaining({ autoResumeCount: 1 })
+      })
+    );
+    // Then enqueue
+    expect(queue.add).toHaveBeenCalledWith(
+      'run-optimization',
+      expect.objectContaining({ runId: run.id, combinations: run.combinations }),
+      expect.objectContaining({ jobId: run.id })
+    );
+  });
+
+  it('should re-queue PENDING run with no job', async () => {
     const run = makeRun({ status: OptimizationStatus.PENDING });
-    repo.find.mockResolvedValue([run]);
+    mockOrphanedRuns([run]);
     queue.getJob.mockResolvedValue(undefined);
 
     await recover(service);
 
     expect(repo.update).toHaveBeenCalledWith(
       { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
-      expect.objectContaining({
-        status: OptimizationStatus.FAILED,
-        errorMessage: expect.stringContaining('job lost from queue'),
-        completedAt: expect.any(Date)
-      })
+      expect.objectContaining({ status: OptimizationStatus.PENDING })
     );
-    expect(eventEmitter.emit).toHaveBeenCalledWith(
-      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
-      expect.objectContaining({ runId: run.id })
+    expect(queue.add).toHaveBeenCalledWith(
+      'run-optimization',
+      expect.objectContaining({ runId: run.id }),
+      expect.objectContaining({ jobId: run.id })
     );
   });
 
-  it('should mark PENDING run with stuck active job as FAILED and emit event', async () => {
+  it('should re-queue PENDING run with stuck active job after force-removing', async () => {
     const run = makeRun({ status: OptimizationStatus.PENDING });
-    repo.find.mockResolvedValue([run]);
-    queue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue('active') } as never);
+    mockOrphanedRuns([run]);
+
+    // First getJob returns active job (for skip check), second returns stale job (for force-remove)
+    const mockJob = { getState: jest.fn().mockResolvedValue('active'), remove: jest.fn().mockResolvedValue(undefined) };
+    queue.getJob.mockResolvedValue(mockJob as never);
 
     await recover(service);
 
-    expect(repo.update).toHaveBeenCalledWith(
-      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
-      expect.objectContaining({ status: OptimizationStatus.FAILED })
-    );
-    expect(eventEmitter.emit).toHaveBeenCalledWith(
-      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
-      expect.objectContaining({ runId: run.id })
+    expect(mockJob.remove).toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledWith(
+      'run-optimization',
+      expect.objectContaining({ runId: run.id }),
+      expect.objectContaining({ jobId: run.id })
     );
   });
 
-  it('should skip RUNNING run with fresh heartbeat', async () => {
+  it('should mark FAILED when auto-resume count exceeds limit', async () => {
     const run = makeRun({
       status: OptimizationStatus.RUNNING,
-      lastHeartbeatAt: new Date(Date.now() - 30 * 60 * 1000) // 30 min ago — well within 6-hour threshold
+      progressDetails: { autoResumeCount: 3 } as any
     });
-    repo.find.mockResolvedValue([run]);
+    mockOrphanedRuns([run]);
 
     await recover(service);
 
-    expect(repo.update).not.toHaveBeenCalled();
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({
+        status: OptimizationStatus.FAILED,
+        errorMessage: expect.stringContaining('maximum automatic recovery attempts')
+      })
+    );
+    expect(queue.add).not.toHaveBeenCalled();
   });
 
-  it('should fail RUNNING run with stale heartbeat', async () => {
+  it('should regenerate combinations for grid_search when not stored', async () => {
     const run = makeRun({
       status: OptimizationStatus.RUNNING,
-      combinationsTested: 10,
-      totalCombinations: 100,
-      lastHeartbeatAt: new Date(Date.now() - 400 * 60 * 1000) // 400 min ago — beyond 6-hour threshold
+      combinations: undefined as any
     });
-    repo.find.mockResolvedValue([run]);
+    mockOrphanedRuns([run]);
+
+    const regenerated = [{ index: 0, values: { period: 14 }, isBaseline: true }];
+    gridSearchService.generateCombinations.mockReturnValue(regenerated);
 
     await recover(service);
 
+    expect(gridSearchService.generateCombinations).toHaveBeenCalledWith(run.parameterSpace, run.config.maxCombinations);
+    expect(queue.add).toHaveBeenCalledWith(
+      'run-optimization',
+      expect.objectContaining({ combinations: regenerated }),
+      expect.any(Object)
+    );
+  });
+
+  it('should fail random_search without stored combinations', async () => {
+    const run = makeRun({
+      status: OptimizationStatus.RUNNING,
+      config: { method: 'random_search' } as any,
+      combinations: undefined as any
+    });
+    mockOrphanedRuns([run]);
+
+    await recover(service);
+
+    // Recovery error should cause the inner catch to mark it FAILED
     expect(repo.update).toHaveBeenCalledWith(
       { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
       expect.objectContaining({
         status: OptimizationStatus.FAILED,
-        errorMessage: expect.stringContaining('partial progress'),
-        completedAt: expect.any(Date)
+        errorMessage: expect.stringContaining('random_search')
       })
     );
-    expect(eventEmitter.emit).toHaveBeenCalledWith(
-      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
-      expect.objectContaining({ runId: run.id })
-    );
+    expect(queue.add).not.toHaveBeenCalled();
   });
 
-  it('should include "no progress" in reason for RUNNING run with 0 progress', async () => {
-    const run = makeRun({ status: OptimizationStatus.RUNNING, combinationsTested: 0 });
-    repo.find.mockResolvedValue([run]);
-
-    await recover(service);
-
-    expect(repo.update).toHaveBeenCalledWith(
-      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
-      expect.objectContaining({
-        status: OptimizationStatus.FAILED,
-        errorMessage: expect.stringContaining('no progress'),
-        completedAt: expect.any(Date)
-      })
-    );
-  });
-
-  it('should include combination counts in reason for RUNNING run with partial progress', async () => {
-    const run = makeRun({ status: OptimizationStatus.RUNNING, combinationsTested: 42, totalCombinations: 100 });
-    repo.find.mockResolvedValue([run]);
-
-    await recover(service);
-
-    expect(repo.update).toHaveBeenCalledWith(
-      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
-      expect.objectContaining({
-        status: OptimizationStatus.FAILED,
-        errorMessage: expect.stringContaining('42/100'),
-        completedAt: expect.any(Date)
-      })
-    );
-  });
-
-  it('should NOT emit event when affected === 0 (race guard)', async () => {
+  it('should update DB to PENDING before enqueuing (ordering)', async () => {
     const run = makeRun({ status: OptimizationStatus.RUNNING });
-    repo.find.mockResolvedValue([run]);
+    mockOrphanedRuns([run]);
+
+    const callOrder: string[] = [];
+    repo.update.mockImplementation(async () => {
+      callOrder.push('db-update');
+      return { affected: 1, raw: [], generatedMaps: [] };
+    });
+    queue.add.mockImplementation(async () => {
+      callOrder.push('queue-add');
+      return {} as any;
+    });
+
+    await recover(service);
+
+    expect(callOrder).toEqual(['db-update', 'queue-add']);
+  });
+
+  it('should increment autoResumeCount from existing value', async () => {
+    const run = makeRun({
+      status: OptimizationStatus.RUNNING,
+      progressDetails: { autoResumeCount: 2 } as any
+    });
+    mockOrphanedRuns([run]);
+
+    await recover(service);
+
+    // autoResumeCount = 2 < 3 (MAX), so should re-queue with count = 3
+    expect(repo.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: OptimizationStatus.PENDING,
+        progressDetails: expect.objectContaining({ autoResumeCount: 3 })
+      })
+    );
+  });
+
+  it('should force-remove stale Redis lock when initial remove fails', async () => {
+    const run = makeRun({ status: OptimizationStatus.RUNNING });
+    mockOrphanedRuns([run]);
+
+    const mockDel = jest.fn().mockResolvedValue(1);
+    (queue as any).client = Promise.resolve({ del: mockDel });
+
+    const mockJob = {
+      getState: jest.fn().mockResolvedValue('active'),
+      remove: jest.fn().mockRejectedValueOnce(new Error('Could not remove lock')).mockResolvedValueOnce(undefined)
+    };
+    queue.getJob.mockResolvedValue(mockJob as never);
+
+    await recover(service);
+
+    expect(mockDel).toHaveBeenCalledWith('bull:optimization:run-1:lock');
+    expect(mockJob.remove).toHaveBeenCalledTimes(2);
+    expect(queue.add).toHaveBeenCalled();
+  });
+
+  it('should mark FAILED when both job remove attempts fail', async () => {
+    const run = makeRun({ status: OptimizationStatus.RUNNING });
+    mockOrphanedRuns([run]);
+
+    const mockDel = jest.fn().mockResolvedValue(0);
+    (queue as any).client = Promise.resolve({ del: mockDel });
+
+    const mockJob = {
+      getState: jest.fn().mockResolvedValue('active'),
+      remove: jest.fn().mockRejectedValue(new Error('locked'))
+    };
+    queue.getJob.mockResolvedValue(mockJob as never);
+
+    await recover(service);
+
+    // Run should be marked FAILED (not re-queued)
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      expect.objectContaining({
+        status: OptimizationStatus.FAILED,
+        errorMessage: expect.stringContaining('Cannot remove stale job')
+      })
+    );
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('should skip re-queue when another node already claimed the run', async () => {
+    const run = makeRun({ status: OptimizationStatus.RUNNING });
+    mockOrphanedRuns([run]);
+
     repo.update.mockResolvedValue({ affected: 0, raw: [], generatedMaps: [] });
 
     await recover(service);
 
-    expect(repo.update).toHaveBeenCalledWith(
-      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
-      expect.objectContaining({ status: OptimizationStatus.FAILED })
-    );
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(repo.update).toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
   });
 
   it('should continue to next run when recovery error occurs on one run', async () => {
     const run1 = makeRun({ id: 'run-1', status: OptimizationStatus.RUNNING });
     const run2 = makeRun({ id: 'run-2', status: OptimizationStatus.RUNNING });
-    repo.find.mockResolvedValue([run1, run2]);
+    mockOrphanedRuns([run1, run2]);
 
-    // First update (recoverSingleRun) throws, inner catch update succeeds
+    // First update (recoverSingleRun for run1) throws, inner catch succeeds
     let callCount = 0;
     repo.update.mockImplementation(async () => {
       callCount++;
@@ -209,30 +346,27 @@ describe('OptimizationRecoveryService', () => {
 
     await recover(service);
 
-    // Inner catch should have tried to mark run1 as FAILED (call 2)
-    // run2 should have been processed normally (call 3)
+    // Inner catch marks run1 as FAILED (call 2), then run2 is recovered (call 3)
     expect(repo.update).toHaveBeenCalledTimes(3);
-    expect(eventEmitter.emit).toHaveBeenCalledWith(
-      PIPELINE_EVENTS.OPTIMIZATION_FAILED,
-      expect.objectContaining({ runId: 'run-2' })
+    expect(queue.add).toHaveBeenCalledWith(
+      'run-optimization',
+      expect.objectContaining({ runId: 'run-2' }),
+      expect.any(Object)
     );
   });
 
   it('should not crash when inner catch also throws', async () => {
     const run = makeRun({ status: OptimizationStatus.RUNNING });
-    repo.find.mockResolvedValue([run]);
+    mockOrphanedRuns([run]);
 
-    // Both the recoverSingleRun and the inner catch update throw
     repo.update.mockRejectedValue(new Error('all updates fail'));
 
-    // Should not throw
     await expect(recover(service)).resolves.toBeUndefined();
   });
 
   it('should not crash when top-level find throws', async () => {
-    repo.find.mockRejectedValue(new Error('database unavailable'));
+    mockOrphanedRunsRejected(new Error('database unavailable'));
 
-    // Should not throw — top-level catch handles it
     await expect(recover(service)).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/optimization/services/optimization-recovery.service.ts
+++ b/apps/api/src/optimization/services/optimization-recovery.service.ts
@@ -1,17 +1,20 @@
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Queue } from 'bullmq';
-import { In, Repository } from 'typeorm';
+import { In, type QueryDeepPartialEntity, Repository } from 'typeorm';
 
-import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
+import { GridSearchService } from './grid-search.service';
+
 import { toErrorInfo } from '../../shared/error.util';
 import { OptimizationRun, OptimizationStatus } from '../entities/optimization-run.entity';
 
 /** Must match the watchdog threshold in BacktestOrchestrationTask */
 const STALE_HEARTBEAT_THRESHOLD_MS = 360 * 60 * 1000; // 6 hours
+
+/** Maximum number of automatic recovery attempts before permanently failing */
+const MAX_AUTO_RESUME_COUNT = 3;
 
 @Injectable()
 export class OptimizationRecoveryService implements OnApplicationBootstrap {
@@ -20,7 +23,7 @@ export class OptimizationRecoveryService implements OnApplicationBootstrap {
   constructor(
     @InjectRepository(OptimizationRun) private readonly optimizationRunRepository: Repository<OptimizationRun>,
     @InjectQueue('optimization') private readonly optimizationQueue: Queue,
-    private readonly eventEmitter: EventEmitter2
+    private readonly gridSearchService: GridSearchService
   ) {}
 
   onApplicationBootstrap(): void {
@@ -31,19 +34,18 @@ export class OptimizationRecoveryService implements OnApplicationBootstrap {
   }
 
   /**
-   * Find orphaned RUNNING/PENDING optimization runs after a restart and mark them FAILED.
-   * Unlike backtests, optimization runs do not support checkpoint-resume,
-   * so any interrupted run must be failed and retried from scratch.
+   * Find orphaned RUNNING/PENDING optimization runs after a restart and re-queue them.
+   * Runs resume from their last completed batch via persisted optimization_results.
    */
   private async recoverOrphanedOptimizationRuns(): Promise<void> {
     this.logger.log('Checking for orphaned optimization runs to recover...');
 
     try {
-      const orphaned = await this.optimizationRunRepository.find({
-        where: {
-          status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING])
-        }
-      });
+      const orphaned = await this.optimizationRunRepository
+        .createQueryBuilder('run')
+        .addSelect('run.combinations')
+        .where({ status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) })
+        .getMany();
 
       if (orphaned.length === 0) {
         this.logger.log('No orphaned optimization runs found');
@@ -106,33 +108,112 @@ export class OptimizationRecoveryService implements OnApplicationBootstrap {
       }
     }
 
-    const reason =
-      run.status === OptimizationStatus.PENDING
-        ? 'Container restart: job lost from queue before execution started'
-        : run.combinationsTested === 0
-          ? 'Container restart: no progress was made'
-          : `Container restart: partial progress (${run.combinationsTested}/${run.totalCombinations} combinations)`;
-
-    this.logger.warn(`Marking orphaned optimization run ${run.id} as FAILED: ${reason}`);
-
-    const result = await this.optimizationRunRepository.update(
-      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
-      {
-        status: OptimizationStatus.FAILED,
-        errorMessage: reason,
-        completedAt: new Date()
-      }
-    );
-
-    if (result.affected === 0) {
-      this.logger.log(`Optimization run ${run.id} already transitioned — skipping event emission`);
+    // Guard against infinite recovery loops
+    const autoResumeCount = run.progressDetails?.autoResumeCount ?? 0;
+    if (autoResumeCount >= MAX_AUTO_RESUME_COUNT) {
+      this.logger.warn(
+        `Optimization run ${run.id} has reached max auto-resume count ` +
+          `(${autoResumeCount}/${MAX_AUTO_RESUME_COUNT}), marking FAILED`
+      );
+      await this.optimizationRunRepository.update(
+        { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+        {
+          status: OptimizationStatus.FAILED,
+          errorMessage: `Exceeded maximum automatic recovery attempts (${MAX_AUTO_RESUME_COUNT})`,
+          completedAt: new Date()
+        }
+      );
       return;
     }
 
-    // Emit failure event so pipeline listener can clean up
-    this.eventEmitter.emit(PIPELINE_EVENTS.OPTIMIZATION_FAILED, {
-      runId: run.id,
-      reason
-    });
+    // Resolve combinations: prefer stored, fallback to regeneration for grid_search
+    let combinations = run.combinations;
+    if (!combinations) {
+      if (run.config.method === 'random_search') {
+        throw new Error(
+          'Cannot resume random_search optimization without stored combinations (created before checkpoint-resume support)'
+        );
+      }
+      // Grid search is deterministic — regenerate from parameter space
+      combinations = this.gridSearchService.generateCombinations(run.parameterSpace, run.config.maxCombinations);
+      this.logger.log(`Regenerated ${combinations.length} grid_search combinations for optimization run ${run.id}`);
+    }
+
+    // Remove any existing job with the same ID to prevent BullMQ jobId collision
+    await this.forceRemoveJob(run.id);
+
+    // Increment autoResumeCount in progressDetails
+    const updatedProgressDetails = {
+      ...(run.progressDetails ?? {}),
+      autoResumeCount: autoResumeCount + 1
+    };
+
+    // Update DB to PENDING BEFORE enqueuing the job.
+    // BullMQ workers are already active (started in onModuleInit, before onApplicationBootstrap),
+    // so if we enqueue first, the worker can pick up the job before the DB update executes.
+    const result = await this.optimizationRunRepository.update(
+      { id: run.id, status: In([OptimizationStatus.RUNNING, OptimizationStatus.PENDING]) },
+      {
+        status: OptimizationStatus.PENDING,
+        progressDetails: updatedProgressDetails
+      } as QueryDeepPartialEntity<OptimizationRun>
+    );
+
+    if (result.affected === 0) {
+      this.logger.log(`Optimization run ${run.id} already claimed by another node, skipping`);
+      return;
+    }
+
+    await this.optimizationQueue.add(
+      'run-optimization',
+      { runId: run.id, combinations },
+      {
+        jobId: run.id,
+        removeOnComplete: true,
+        attempts: 1
+      }
+    );
+
+    this.logger.log(
+      `Re-queued optimization run ${run.id} for recovery ` +
+        `(attempt ${autoResumeCount + 1}/${MAX_AUTO_RESUME_COUNT}, ` +
+        `progress: ${run.combinationsTested}/${run.totalCombinations})`
+    );
+  }
+
+  /**
+   * Force-remove a job from the queue, clearing stale locks from dead workers if needed.
+   * After a deployment, the old worker process is gone but its Redis lock on active jobs
+   * persists until lockDuration expires. job.remove() fails on locked jobs, so we delete
+   * the lock key directly and retry.
+   */
+  private async forceRemoveJob(jobId: string): Promise<void> {
+    const existingJob = await this.optimizationQueue.getJob(jobId);
+    if (!existingJob) return;
+
+    try {
+      await existingJob.remove();
+      this.logger.log(`Removed existing job ${jobId} from queue before re-queuing`);
+      return;
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.log(`Initial remove for job ${jobId} failed (${err.message}), attempting force-remove`);
+    }
+
+    // Force-remove the stale lock via Redis and retry
+    try {
+      const client = await this.optimizationQueue.client;
+      const prefix = this.optimizationQueue.opts?.prefix ?? 'bull';
+      const lockKey = `${prefix}:${this.optimizationQueue.name}:${jobId}:lock`;
+      const deleted = await client.del(lockKey);
+      this.logger.log(`Force-deleted stale lock for job ${jobId} (keys removed: ${deleted})`);
+
+      await existingJob.remove();
+      this.logger.log(`Removed previously-locked job ${jobId} after clearing stale lock`);
+    } catch (forceError: unknown) {
+      const err = toErrorInfo(forceError);
+      this.logger.warn(`Could not force-remove job ${jobId}: ${err.message}`);
+      throw new Error(`Cannot remove stale job ${jobId} from queue: ${err.message}`);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Enable interrupted optimization runs to resume from their last completed batch instead of failing and requiring a full restart
- Persist generated parameter combinations in a JSONB column so non-deterministic random_search runs can be faithfully restored
- Replace fail-on-recovery behavior with automatic re-queuing with a 3-attempt guard against infinite loops

## Changes

### Database & Entity
- Add `combinations` JSONB column to `optimization_runs` via migration
- Add `autoResumeCount` to `OptimizationProgressDetails` interface
- Use `select: false` to exclude large combinations payload from default queries

### Orchestrator (checkpoint-resume logic)
- Persist combinations at run creation time
- On resume: reconstruct best score, baseline, and remaining combinations from existing `optimization_results`
- Preserve `startedAt` timestamp on resumed runs
- Preserve `autoResumeCount` through `updateProgress` calls
- Remove unused `windowCount` variable

### Recovery Service (re-queue instead of fail)
- Re-queue orphaned RUNNING/PENDING runs as PENDING with original combinations
- For grid_search: regenerate deterministic combinations if stored payload is missing (pre-migration runs)
- For random_search: fail gracefully if no stored combinations exist
- Add `forceRemoveJob` to handle stale BullMQ locks from dead workers
- Guard against infinite recovery with `MAX_AUTO_RESUME_COUNT = 3`
- Replace `EventEmitter2` dependency with `GridSearchService` for combination regeneration

### Bug Fix
- Fix table name typo in backtest monitoring SQL join (`coins` → `coin`)

## Test Plan

- [x] Unit tests for `updateProgress` autoResumeCount preservation
- [x] Unit tests for double-fail job removal marking run as FAILED
- [x] Recovery service tests for re-queue behavior, max retry guard, and combination regeneration
- [x] All existing optimization orchestrator tests pass