### PR TITLE
feat: add paginated run/session tables to backtest monitoring

### DIFF
--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -9,6 +9,7 @@ import { TradingState } from './trading-state/trading-state.entity';
 import { TradingStateService } from './trading-state/trading-state.service';
 
 import { AuditModule } from '../audit/audit.module';
+import { Coin } from '../coin/coin.entity';
 import { OptimizationResult } from '../optimization/entities/optimization-result.entity';
 import { OptimizationRun } from '../optimization/entities/optimization-run.entity';
 import { Backtest, BacktestSignal, BacktestTrade, SimulatedOrderFill } from '../order/backtest/backtest.entity';
@@ -35,6 +36,7 @@ import { TasksModule } from '../tasks/tasks.module';
     TypeOrmModule.forFeature([
       TradingState,
       Order,
+      Coin,
       Backtest,
       BacktestTrade,
       BacktestSignal,

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.controller.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.controller.ts
@@ -12,11 +12,17 @@ import {
   BacktestListQueryDto,
   BacktestOverviewDto,
   ExportFormat,
+  LiveReplayRunListQueryDto,
   OptimizationAnalyticsDto,
   OptimizationFiltersDto,
+  OptimizationRunListQueryDto,
   PaginatedBacktestListDto,
+  PaginatedLiveReplayRunsDto,
+  PaginatedOptimizationRunsDto,
+  PaginatedPaperTradingSessionsDto,
   PaperTradingFiltersDto,
   PaperTradingMonitoringDto,
+  PaperTradingSessionListQueryDto,
   PipelineStageCountsDto,
   SignalActivityFeedDto,
   SignalActivityFeedQueryDto,
@@ -149,6 +155,25 @@ export class BacktestMonitoringController {
   }
 
   /**
+   * Get paginated list of optimization runs
+   */
+  @Get('optimization/runs')
+  @ApiOperation({
+    summary: 'Get paginated optimization runs',
+    description: 'Returns a paginated list of optimization runs with progress information.'
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Optimization runs retrieved successfully',
+    type: PaginatedOptimizationRunsDto
+  })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Requires admin role' })
+  async getOptimizationRuns(@Query() query: OptimizationRunListQueryDto): Promise<PaginatedOptimizationRunsDto> {
+    const { page, limit, ...filters } = query;
+    return this.monitoringService.listOptimizationRuns(filters, page, limit);
+  }
+
+  /**
    * Get paper trading monitoring analytics
    */
   @Get('paper-trading-analytics')
@@ -166,6 +191,46 @@ export class BacktestMonitoringController {
   @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Requires admin role' })
   async getPaperTradingAnalytics(@Query() filters: PaperTradingFiltersDto): Promise<PaperTradingMonitoringDto> {
     return this.monitoringService.getPaperTradingMonitoring(filters);
+  }
+
+  /**
+   * Get paginated list of paper trading sessions
+   */
+  @Get('paper-trading/sessions')
+  @ApiOperation({
+    summary: 'Get paginated paper trading sessions',
+    description: 'Returns a paginated list of paper trading sessions with progress information.'
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Paper trading sessions retrieved successfully',
+    type: PaginatedPaperTradingSessionsDto
+  })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Requires admin role' })
+  async getPaperTradingSessions(
+    @Query() query: PaperTradingSessionListQueryDto
+  ): Promise<PaginatedPaperTradingSessionsDto> {
+    const { page, limit, ...filters } = query;
+    return this.monitoringService.listPaperTradingSessions(filters, page, limit);
+  }
+
+  /**
+   * Get paginated list of live replay runs
+   */
+  @Get('live-replay/runs')
+  @ApiOperation({
+    summary: 'Get paginated live replay runs',
+    description: 'Returns a paginated list of live replay backtest runs with progress and replay state.'
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Live replay runs retrieved successfully',
+    type: PaginatedLiveReplayRunsDto
+  })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Requires admin role' })
+  async getLiveReplayRuns(@Query() query: LiveReplayRunListQueryDto): Promise<PaginatedLiveReplayRunsDto> {
+    const { page, limit, ...filters } = query;
+    return this.monitoringService.listLiveReplayRuns(filters, page, limit);
   }
 
   /**

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.spec.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.spec.ts
@@ -7,6 +7,7 @@ import { BacktestMonitoringService } from './backtest-monitoring.service';
 import { ExportFormat } from './dto/backtest-listing.dto';
 import { BacktestFiltersDto } from './dto/overview.dto';
 
+import { Coin } from '../../coin/coin.entity';
 import { OptimizationResult } from '../../optimization/entities/optimization-result.entity';
 import { OptimizationRun } from '../../optimization/entities/optimization-run.entity';
 import {
@@ -199,6 +200,10 @@ describe('BacktestMonitoringService', () => {
         {
           provide: getRepositoryToken(PaperTradingSignal),
           useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) }
+        },
+        {
+          provide: getRepositoryToken(Coin),
+          useValue: { find: jest.fn().mockResolvedValue([]) }
         }
       ]
     }).compile();

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
@@ -9,10 +9,17 @@ import {
   BacktestListQueryDto,
   BacktestSortField,
   ExportFormat,
+  LiveReplayRunListItemDto,
   PaginatedBacktestListDto,
+  PaginatedLiveReplayRunsDto,
   SortOrder
 } from './dto/backtest-listing.dto';
-import { OptimizationAnalyticsDto, OptimizationFiltersDto } from './dto/optimization-analytics.dto';
+import {
+  OptimizationAnalyticsDto,
+  OptimizationFiltersDto,
+  OptimizationRunListItemDto,
+  PaginatedOptimizationRunsDto
+} from './dto/optimization-analytics.dto';
 import {
   AverageMetricsDto,
   BacktestFiltersDto,
@@ -21,8 +28,10 @@ import {
   TopAlgorithmDto
 } from './dto/overview.dto';
 import {
+  PaginatedPaperTradingSessionsDto,
   PaperTradingFiltersDto,
   PaperTradingMonitoringDto,
+  PaperTradingSessionListItemDto,
   PipelineStageCountsDto
 } from './dto/paper-trading-analytics.dto';
 import {
@@ -48,6 +57,7 @@ import {
   TradeSummaryDto
 } from './dto/trade-analytics.dto';
 
+import { Coin } from '../../coin/coin.entity';
 import { OptimizationResult } from '../../optimization/entities/optimization-result.entity';
 import { OptimizationRun, OptimizationStatus } from '../../optimization/entities/optimization-run.entity';
 import {
@@ -118,7 +128,9 @@ export class BacktestMonitoringService {
     @InjectRepository(PaperTradingOrder)
     private readonly paperOrderRepo: Repository<PaperTradingOrder>,
     @InjectRepository(PaperTradingSignal)
-    private readonly paperSignalRepo: Repository<PaperTradingSignal>
+    private readonly paperSignalRepo: Repository<PaperTradingSignal>,
+    @InjectRepository(Coin)
+    private readonly coinRepo: Repository<Coin>
   ) {}
 
   /**
@@ -454,6 +466,141 @@ export class BacktestMonitoringService {
   }
 
   // ===========================================================================
+  // Optimization Run Listing
+  // ===========================================================================
+
+  /**
+   * Get paginated list of optimization runs with progress information
+   */
+  async listOptimizationRuns(
+    filters: OptimizationFiltersDto,
+    page = 1,
+    limit = 10
+  ): Promise<PaginatedOptimizationRunsDto> {
+    const dateRange = this.getOptDateRange(filters);
+    const skip = (page - 1) * limit;
+
+    const qb = this.optimizationRunRepo
+      .createQueryBuilder('r')
+      .innerJoinAndSelect('r.strategyConfig', 'sc')
+      .innerJoinAndSelect('sc.algorithm', 'a');
+
+    this.applyOptFilters(qb, filters, dateRange);
+
+    qb.orderBy('r.createdAt', 'DESC').skip(skip).take(limit);
+
+    const [runs, total] = await qb.getManyAndCount();
+
+    const data: OptimizationRunListItemDto[] = runs.map((r) => {
+      let progressPercent = 0;
+      if (r.status === OptimizationStatus.COMPLETED) {
+        progressPercent = 100;
+      } else if (r.status === OptimizationStatus.RUNNING && r.totalCombinations > 0) {
+        progressPercent = Math.round((r.combinationsTested / r.totalCombinations) * 100);
+      }
+
+      return {
+        id: r.id,
+        strategyName: r.strategyConfig?.name || 'Unknown',
+        algorithmName: r.strategyConfig?.algorithm?.name || 'Unknown',
+        status: r.status,
+        combinationsTested: r.combinationsTested,
+        totalCombinations: r.totalCombinations,
+        progressPercent,
+        improvement: r.improvement ?? null,
+        bestScore: r.bestScore ?? null,
+        createdAt: r.createdAt.toISOString()
+      };
+    });
+
+    const totalPages = Math.ceil(total / limit);
+    return { data, total, page, limit, totalPages, hasNextPage: page < totalPages, hasPreviousPage: page > 1 };
+  }
+
+  // ===========================================================================
+  // Paper Trading Session Listing
+  // ===========================================================================
+
+  /**
+   * Get paginated list of paper trading sessions with progress information
+   */
+  async listPaperTradingSessions(
+    filters: PaperTradingFiltersDto,
+    page = 1,
+    limit = 10
+  ): Promise<PaginatedPaperTradingSessionsDto> {
+    const dateRange = this.getPtDateRange(filters);
+    const skip = (page - 1) * limit;
+
+    const qb = this.paperSessionRepo.createQueryBuilder('s').innerJoinAndSelect('s.algorithm', 'a');
+
+    this.applyPtFilters(qb, filters, dateRange);
+
+    qb.orderBy('s.createdAt', 'DESC').skip(skip).take(limit);
+
+    const [sessions, total] = await qb.getManyAndCount();
+
+    const data: PaperTradingSessionListItemDto[] = sessions.map((s) => ({
+      id: s.id,
+      name: s.name,
+      algorithmName: s.algorithm?.name || 'Unknown',
+      status: s.status,
+      progressPercent: this.calculatePaperTradingProgress(s),
+      totalReturn: s.totalReturn ?? null,
+      sharpeRatio: s.sharpeRatio ?? null,
+      duration: s.duration || 'N/A',
+      startedAt: s.startedAt?.toISOString() ?? null,
+      createdAt: s.createdAt.toISOString()
+    }));
+
+    const totalPages = Math.ceil(total / limit);
+    return { data, total, page, limit, totalPages, hasNextPage: page < totalPages, hasPreviousPage: page > 1 };
+  }
+
+  // ===========================================================================
+  // Live Replay Run Listing
+  // ===========================================================================
+
+  /**
+   * Get paginated list of live replay runs with progress and replay state
+   */
+  async listLiveReplayRuns(filters: BacktestFiltersDto, page = 1, limit = 10): Promise<PaginatedLiveReplayRunsDto> {
+    const dateRange = this.getDateRange(filters);
+    const skip = (page - 1) * limit;
+
+    const qb = this.backtestRepo
+      .createQueryBuilder('b')
+      .innerJoinAndSelect('b.algorithm', 'a')
+      .where('b.type = :type', { type: BacktestType.LIVE_REPLAY });
+
+    // Apply shared filters (date, status, algorithm) but skip type since we hardcode it
+    this.applyBacktestFilters(qb, { ...filters, type: undefined }, dateRange);
+
+    qb.orderBy('b.createdAt', 'DESC').skip(skip).take(limit);
+
+    const [backtests, total] = await qb.getManyAndCount();
+
+    const data: LiveReplayRunListItemDto[] = backtests.map((b) => ({
+      id: b.id,
+      name: b.name,
+      algorithmName: b.algorithm?.name || 'Unknown',
+      status: b.status,
+      progressPercent: this.calculateProgress(b),
+      processedTimestamps: b.processedTimestampCount,
+      totalTimestamps: b.totalTimestampCount,
+      totalReturn: b.totalReturn ?? null,
+      sharpeRatio: b.sharpeRatio ?? null,
+      maxDrawdown: b.maxDrawdown ?? null,
+      replaySpeed: b.liveReplayState?.replaySpeed ?? null,
+      isPaused: b.liveReplayState?.isPaused ?? null,
+      createdAt: b.createdAt.toISOString()
+    }));
+
+    const totalPages = Math.ceil(total / limit);
+    return { data, total, page, limit, totalPages, hasNextPage: page < totalPages, hasPreviousPage: page > 1 };
+  }
+
+  // ===========================================================================
   // Pipeline Stage Counts
   // ===========================================================================
 
@@ -538,6 +685,22 @@ export class BacktestMonitoringService {
         .getMany()
     ]);
 
+    // Collect all unique instrument UUIDs and resolve to coin symbols
+    const instrumentIds = new Set<string>();
+    for (const s of backtestSignals) instrumentIds.add(s.instrument);
+    for (const ps of paperSignals) instrumentIds.add(ps.instrument);
+
+    const coinMap = new Map<string, string>();
+    if (instrumentIds.size > 0) {
+      const coins = await this.coinRepo.find({
+        where: { id: In([...instrumentIds]) },
+        select: ['id', 'symbol']
+      });
+      for (const coin of coins) {
+        coinMap.set(coin.id, coin.symbol.toUpperCase());
+      }
+    }
+
     const mapped: SignalFeedItemDto[] = [];
 
     for (const s of backtestSignals) {
@@ -546,7 +709,7 @@ export class BacktestMonitoringService {
         timestamp: s.timestamp.toISOString(),
         signalType: s.signalType,
         direction: s.direction,
-        instrument: s.instrument,
+        instrument: coinMap.get(s.instrument) ?? s.instrument,
         quantity: s.quantity,
         price: s.price ?? undefined,
         confidence: s.confidence ?? undefined,
@@ -565,7 +728,7 @@ export class BacktestMonitoringService {
         timestamp: ps.createdAt.toISOString(),
         signalType: ps.signalType as unknown as SignalType,
         direction: ps.direction as unknown as SignalDirection,
-        instrument: ps.instrument,
+        instrument: coinMap.get(ps.instrument) ?? ps.instrument,
         quantity: ps.quantity,
         price: ps.price ?? undefined,
         confidence: ps.confidence ?? undefined,
@@ -1361,6 +1524,39 @@ export class BacktestMonitoringService {
     if (hours > 0) return `${hours}h ${minutes % 60}m`;
     if (minutes > 0) return `${minutes}m`;
     return `${seconds}s`;
+  }
+
+  private calculatePaperTradingProgress(session: PaperTradingSession): number {
+    if (session.status === PaperTradingStatus.COMPLETED) return 100;
+    if (session.status === PaperTradingStatus.FAILED || session.status === PaperTradingStatus.STOPPED) return 0;
+    if (session.status !== PaperTradingStatus.ACTIVE) return 0;
+    if (!session.startedAt || !session.duration) return 0;
+
+    const durationMs = this.parseDuration(session.duration);
+    if (durationMs <= 0) return 0;
+
+    const elapsedMs = Date.now() - session.startedAt.getTime();
+    return Math.min(100, Math.max(0, Math.round((elapsedMs / durationMs) * 100)));
+  }
+
+  private parseDuration(duration: string): number {
+    const match = duration.match(/^(\d+)([smhdwMy])$/);
+    if (!match) return 0;
+
+    const value = parseInt(match[1], 10);
+    const unit = match[2];
+
+    const multipliers: Record<string, number> = {
+      s: 1000,
+      m: 60 * 1000,
+      h: 60 * 60 * 1000,
+      d: 24 * 60 * 60 * 1000,
+      w: 7 * 24 * 60 * 60 * 1000,
+      M: 30 * 24 * 60 * 60 * 1000,
+      y: 365 * 24 * 60 * 60 * 1000
+    };
+
+    return value * (multipliers[unit] ?? 0);
   }
 
   private convertToCsv(data: object[]): Buffer {

--- a/apps/api/src/admin/backtest-monitoring/dto/backtest-listing.dto.ts
+++ b/apps/api/src/admin/backtest-monitoring/dto/backtest-listing.dto.ts
@@ -5,6 +5,7 @@ import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-
 
 import { BacktestFiltersDto } from './overview.dto';
 
+import { ReplaySpeed } from '../../../order/backtest/backtest-pacing.interface';
 import { BacktestStatus, BacktestType } from '../../../order/backtest/backtest.entity';
 
 /**
@@ -169,4 +170,54 @@ export class PaginatedBacktestListDto {
 export enum ExportFormat {
   CSV = 'csv',
   JSON = 'json'
+}
+
+// ===========================================================================
+// Live Replay Run Listing DTOs
+// ===========================================================================
+
+/**
+ * Query parameters for paginated live replay run list
+ */
+export class LiveReplayRunListQueryDto extends BacktestFiltersDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 10, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class LiveReplayRunListItemDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() algorithmName: string;
+  @ApiProperty({ enum: BacktestStatus }) status: BacktestStatus;
+  @ApiProperty({ description: 'Progress 0-100' }) progressPercent: number;
+  @ApiProperty() processedTimestamps: number;
+  @ApiProperty() totalTimestamps: number;
+  @ApiProperty({ nullable: true }) totalReturn: number | null;
+  @ApiProperty({ nullable: true }) sharpeRatio: number | null;
+  @ApiProperty({ nullable: true }) maxDrawdown: number | null;
+  @ApiProperty({ nullable: true, description: 'Replay speed multiplier' }) replaySpeed: ReplaySpeed | null;
+  @ApiProperty({ nullable: true, description: 'Whether the run is currently paused' }) isPaused: boolean | null;
+  @ApiProperty() createdAt: string;
+}
+
+export class PaginatedLiveReplayRunsDto {
+  @ApiProperty({ type: [LiveReplayRunListItemDto] }) data: LiveReplayRunListItemDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+  @ApiProperty({ description: 'Total number of pages' }) totalPages: number;
+  @ApiProperty({ description: 'Whether there is a next page' }) hasNextPage: boolean;
+  @ApiProperty({ description: 'Whether there is a previous page' }) hasPreviousPage: boolean;
 }

--- a/apps/api/src/admin/backtest-monitoring/dto/optimization-analytics.dto.ts
+++ b/apps/api/src/admin/backtest-monitoring/dto/optimization-analytics.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsDateString, IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 
 import { OptimizationStatus } from '../../../optimization/entities/optimization-run.entity';
 
@@ -85,4 +86,47 @@ export class OptimizationAnalyticsDto {
 
   @ApiProperty({ description: 'Summary of optimization result quality' })
   resultSummary: OptimizationResultSummaryDto;
+}
+
+/**
+ * Query DTO for paginated optimization run listing
+ */
+export class OptimizationRunListQueryDto extends OptimizationFiltersDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 10, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class OptimizationRunListItemDto {
+  @ApiProperty() id: string;
+  @ApiProperty() strategyName: string;
+  @ApiProperty() algorithmName: string;
+  @ApiProperty({ enum: OptimizationStatus }) status: OptimizationStatus;
+  @ApiProperty() combinationsTested: number;
+  @ApiProperty() totalCombinations: number;
+  @ApiProperty({ description: 'Progress 0-100' }) progressPercent: number;
+  @ApiProperty({ nullable: true }) improvement: number | null;
+  @ApiProperty({ nullable: true }) bestScore: number | null;
+  @ApiProperty() createdAt: string;
+}
+
+export class PaginatedOptimizationRunsDto {
+  @ApiProperty({ type: [OptimizationRunListItemDto] }) data: OptimizationRunListItemDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+  @ApiProperty({ description: 'Total number of pages' }) totalPages: number;
+  @ApiProperty({ description: 'Whether there is a next page' }) hasNextPage: boolean;
+  @ApiProperty({ description: 'Whether there is a previous page' }) hasPreviousPage: boolean;
 }

--- a/apps/api/src/admin/backtest-monitoring/dto/paper-trading-analytics.dto.ts
+++ b/apps/api/src/admin/backtest-monitoring/dto/paper-trading-analytics.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-import { IsDateString, IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsDateString, IsEnum, IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
 
 import { PaperTradingStatus } from '../../../order/paper-trading/entities/paper-trading-session.entity';
 
@@ -141,4 +142,47 @@ export class PipelineStageCountsDto {
 
   @ApiProperty({ description: 'Total paper trading sessions' })
   paperTradingSessions: number;
+}
+
+/**
+ * Query DTO for paginated paper trading session listing
+ */
+export class PaperTradingSessionListQueryDto extends PaperTradingFiltersDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 10, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class PaperTradingSessionListItemDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() algorithmName: string;
+  @ApiProperty({ enum: PaperTradingStatus }) status: PaperTradingStatus;
+  @ApiProperty({ description: 'Progress 0-100' }) progressPercent: number;
+  @ApiProperty({ nullable: true }) totalReturn: number | null;
+  @ApiProperty({ nullable: true }) sharpeRatio: number | null;
+  @ApiProperty() duration: string;
+  @ApiProperty({ nullable: true }) startedAt: string | null;
+  @ApiProperty() createdAt: string;
+}
+
+export class PaginatedPaperTradingSessionsDto {
+  @ApiProperty({ type: [PaperTradingSessionListItemDto] }) data: PaperTradingSessionListItemDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+  @ApiProperty({ description: 'Total number of pages' }) totalPages: number;
+  @ApiProperty({ description: 'Whether there is a next page' }) hasNextPage: boolean;
+  @ApiProperty({ description: 'Whether there is a previous page' }) hasPreviousPage: boolean;
 }

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.component.ts
@@ -21,6 +21,9 @@ import {
   OptimizationFiltersDto,
   OptimizationStatus,
   PaginatedBacktestListDto,
+  PaginatedLiveReplayRunsDto,
+  PaginatedOptimizationRunsDto,
+  PaginatedPaperTradingSessionsDto,
   PaperTradingFiltersDto,
   PaperTradingMonitoringDto,
   PaperTradingStatus,
@@ -33,6 +36,7 @@ import {
 import { BacktestMonitoringService } from './backtest-monitoring.service';
 import { BacktestsTableComponent } from './components/backtests-table/backtests-table.component';
 import { ExportPanelComponent } from './components/export-panel/export-panel.component';
+import { LiveReplayPanelComponent } from './components/live-replay-panel/live-replay-panel.component';
 import { OptimizationPanelComponent } from './components/optimization-panel/optimization-panel.component';
 import { OverviewCardsComponent } from './components/overview-cards/overview-cards.component';
 import { PaperTradingPanelComponent } from './components/paper-trading-panel/paper-trading-panel.component';
@@ -61,6 +65,7 @@ type PipelineView = 'optimization' | 'historical' | 'live-replay' | 'paper-tradi
     TopAlgorithmsComponent,
     SignalQualityPanelComponent,
     TradeAnalyticsPanelComponent,
+    LiveReplayPanelComponent,
     OptimizationPanelComponent,
     PaperTradingPanelComponent,
     SignalActivityFeedComponent,
@@ -151,7 +156,11 @@ type PipelineView = 'optimization' | 'historical' | 'live-replay' | 'paper-tradi
               <p-progress-spinner strokeWidth="4" />
             </div>
           } @else {
-            <app-optimization-panel [analytics]="optimizationAnalytics()" />
+            <app-optimization-panel
+              [analytics]="optimizationAnalytics()"
+              [runs]="optimizationRuns()"
+              (pageChange)="onOptimizationRunsPageChange($event)"
+            />
           }
         } @else if (selectedView === 'paper-trading') {
           @if (paperTradingQuery.isPending()) {
@@ -159,7 +168,23 @@ type PipelineView = 'optimization' | 'historical' | 'live-replay' | 'paper-tradi
               <p-progress-spinner strokeWidth="4" />
             </div>
           } @else {
-            <app-paper-trading-panel [analytics]="paperTradingAnalytics()" />
+            <app-paper-trading-panel
+              [analytics]="paperTradingAnalytics()"
+              [sessions]="paperTradingSessions()"
+              (pageChange)="onPaperTradingSessionsPageChange($event)"
+            />
+          }
+        } @else if (selectedView === 'live-replay') {
+          @if (liveReplayRunsQuery.isPending()) {
+            <div class="flex items-center justify-center py-8">
+              <p-progress-spinner strokeWidth="4" />
+            </div>
+          } @else {
+            <app-live-replay-panel
+              [overview]="overview()"
+              [runs]="liveReplayRuns()"
+              (pageChange)="onLiveReplayRunsPageChange($event)"
+            />
           }
         } @else {
           <!-- Backtest tabs (overview, signals, trades, export) -->
@@ -231,6 +256,9 @@ export class BacktestMonitoringComponent {
   optimizationFiltersSignal = signal<OptimizationFiltersDto>({});
   paperTradingFiltersSignal = signal<PaperTradingFiltersDto>({});
   currentPage = signal(1);
+  optimizationRunsPage = signal(1);
+  liveReplayRunsPage = signal(1);
+  paperTradingSessionsPage = signal(1);
 
   // Computed filters
   currentFilters = computed(() => this.filtersSignal());
@@ -247,7 +275,28 @@ export class BacktestMonitoringComponent {
   signalAnalyticsQuery = this.monitoringService.useSignalAnalytics(this.filtersSignal);
   tradeAnalyticsQuery = this.monitoringService.useTradeAnalytics(this.filtersSignal);
   optimizationQuery = this.monitoringService.useOptimizationAnalytics(this.optimizationFiltersSignal);
+  optimizationRunsQuery = this.monitoringService.useOptimizationRuns(
+    computed(() => ({
+      ...this.optimizationFiltersSignal(),
+      page: this.optimizationRunsPage(),
+      limit: 10
+    }))
+  );
+  liveReplayRunsQuery = this.monitoringService.useLiveReplayRuns(
+    computed(() => ({
+      ...this.filtersSignal(),
+      page: this.liveReplayRunsPage(),
+      limit: 10
+    }))
+  );
   paperTradingQuery = this.monitoringService.usePaperTradingAnalytics(this.paperTradingFiltersSignal);
+  paperTradingSessionsQuery = this.monitoringService.usePaperTradingSessions(
+    computed(() => ({
+      ...this.paperTradingFiltersSignal(),
+      page: this.paperTradingSessionsPage(),
+      limit: 10
+    }))
+  );
   signalFeedEnabled = computed(() => this.activeTab() === 'signal-feed');
   signalFeedQuery = this.monitoringService.useSignalActivityFeed(undefined, this.signalFeedEnabled);
   pipelineStageCountsQuery = this.monitoringService.usePipelineStageCounts();
@@ -260,7 +309,12 @@ export class BacktestMonitoringComponent {
   signalAnalytics = computed(() => this.signalAnalyticsQuery.data() as SignalAnalyticsDto | undefined);
   tradeAnalytics = computed(() => this.tradeAnalyticsQuery.data() as TradeAnalyticsDto | undefined);
   optimizationAnalytics = computed(() => this.optimizationQuery.data() as OptimizationAnalyticsDto | undefined);
+  optimizationRuns = computed(() => this.optimizationRunsQuery.data() as PaginatedOptimizationRunsDto | undefined);
+  liveReplayRuns = computed(() => this.liveReplayRunsQuery.data() as PaginatedLiveReplayRunsDto | undefined);
   paperTradingAnalytics = computed(() => this.paperTradingQuery.data() as PaperTradingMonitoringDto | undefined);
+  paperTradingSessions = computed(
+    () => this.paperTradingSessionsQuery.data() as PaginatedPaperTradingSessionsDto | undefined
+  );
   signalFeed = computed(() => this.signalFeedQuery.data() as SignalActivityFeedDto | undefined);
   pipelineStageCounts = computed(() => this.pipelineStageCountsQuery.data() as PipelineStageCountsDto | undefined);
 
@@ -320,10 +374,25 @@ export class BacktestMonitoringComponent {
     this.paperTradingFiltersSignal.set(ptFilters);
 
     this.currentPage.set(1);
+    this.optimizationRunsPage.set(1);
+    this.liveReplayRunsPage.set(1);
+    this.paperTradingSessionsPage.set(1);
   }
 
   onPageChange(page: number): void {
     this.currentPage.set(page);
+  }
+
+  onOptimizationRunsPageChange(page: number): void {
+    this.optimizationRunsPage.set(page);
+  }
+
+  onLiveReplayRunsPageChange(page: number): void {
+    this.liveReplayRunsPage.set(page);
+  }
+
+  onPaperTradingSessionsPageChange(page: number): void {
+    this.paperTradingSessionsPage.set(page);
   }
 
   toggleSignalFeed(): void {
@@ -341,8 +410,13 @@ export class BacktestMonitoringComponent {
       this.signalFeedQuery.refetch();
     } else if (this.selectedView === 'optimization') {
       this.optimizationQuery.refetch();
+      this.optimizationRunsQuery.refetch();
+    } else if (this.selectedView === 'live-replay') {
+      this.overviewQuery.refetch();
+      this.liveReplayRunsQuery.refetch();
     } else if (this.selectedView === 'paper-trading') {
       this.paperTradingQuery.refetch();
+      this.paperTradingSessionsQuery.refetch();
     } else {
       this.overviewQuery.refetch();
       this.backtestsQuery.refetch();

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.service.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/backtest-monitoring.service.ts
@@ -10,6 +10,9 @@ import {
   OptimizationAnalyticsDto,
   OptimizationFiltersDto,
   PaginatedBacktestListDto,
+  PaginatedLiveReplayRunsDto,
+  PaginatedOptimizationRunsDto,
+  PaginatedPaperTradingSessionsDto,
   PaperTradingFiltersDto,
   PaperTradingMonitoringDto,
   PipelineStageCountsDto,
@@ -145,6 +148,53 @@ export class BacktestMonitoringService {
         queryFn: () =>
           authenticatedFetch<PaperTradingMonitoringDto>(
             buildUrl(`${this.apiUrl}/paper-trading-analytics`, currentFilters as Record<string, unknown>)
+          ),
+        ...FREQUENT_POLICY
+      };
+    });
+  }
+
+  /**
+   * Query paginated optimization runs with progress
+   */
+  useOptimizationRuns(query?: Signal<Record<string, unknown>>) {
+    return injectQuery(() => {
+      const currentQuery = query?.() ?? {};
+      return {
+        queryKey: queryKeys.admin.backtestMonitoring.optimizationRuns(currentQuery),
+        queryFn: () =>
+          authenticatedFetch<PaginatedOptimizationRunsDto>(buildUrl(`${this.apiUrl}/optimization/runs`, currentQuery)),
+        ...FREQUENT_POLICY
+      };
+    });
+  }
+
+  /**
+   * Query paginated live replay runs with progress
+   */
+  useLiveReplayRuns(query?: Signal<Record<string, unknown>>) {
+    return injectQuery(() => {
+      const currentQuery = query?.() ?? {};
+      return {
+        queryKey: queryKeys.admin.backtestMonitoring.liveReplayRuns(currentQuery),
+        queryFn: () =>
+          authenticatedFetch<PaginatedLiveReplayRunsDto>(buildUrl(`${this.apiUrl}/live-replay/runs`, currentQuery)),
+        ...FREQUENT_POLICY
+      };
+    });
+  }
+
+  /**
+   * Query paginated paper trading sessions with progress
+   */
+  usePaperTradingSessions(query?: Signal<Record<string, unknown>>) {
+    return injectQuery(() => {
+      const currentQuery = query?.() ?? {};
+      return {
+        queryKey: queryKeys.admin.backtestMonitoring.paperTradingSessions(currentQuery),
+        queryFn: () =>
+          authenticatedFetch<PaginatedPaperTradingSessionsDto>(
+            buildUrl(`${this.apiUrl}/paper-trading/sessions`, currentQuery)
           ),
         ...FREQUENT_POLICY
       };

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/components/live-replay-panel/live-replay-panel.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/components/live-replay-panel/live-replay-panel.component.ts
@@ -1,0 +1,216 @@
+import { CommonModule, DatePipe, DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+import { CardModule } from 'primeng/card';
+import { ProgressBarModule } from 'primeng/progressbar';
+import type { TableLazyLoadEvent } from 'primeng/table';
+import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
+
+import { BacktestOverviewDto, BacktestStatus, PaginatedLiveReplayRunsDto, ReplaySpeed } from '@chansey/api-interfaces';
+
+@Component({
+  selector: 'app-live-replay-panel',
+  standalone: true,
+  imports: [CommonModule, CardModule, DatePipe, DecimalPipe, ProgressBarModule, TableModule, TagModule, TooltipModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <!-- Status Counts -->
+      <p-card header="Status Counts">
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
+          <div class="text-center">
+            <div class="text-2xl font-bold text-blue-500">{{ overview()?.statusCounts?.RUNNING || 0 }}</div>
+            <div class="text-sm text-gray-500">Running</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-yellow-500">{{ overview()?.statusCounts?.PAUSED || 0 }}</div>
+            <div class="text-sm text-gray-500">Paused</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-green-500">{{ overview()?.statusCounts?.COMPLETED || 0 }}</div>
+            <div class="text-sm text-gray-500">Completed</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-red-500">{{ overview()?.statusCounts?.FAILED || 0 }}</div>
+            <div class="text-sm text-gray-500">Failed</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-gray-500">{{ overview()?.statusCounts?.PENDING || 0 }}</div>
+            <div class="text-sm text-gray-500">Pending</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-gray-400">{{ overview()?.statusCounts?.CANCELLED || 0 }}</div>
+            <div class="text-sm text-gray-500">Cancelled</div>
+          </div>
+        </div>
+      </p-card>
+
+      <!-- Average Performance -->
+      <p-card header="Average Performance">
+        <div class="grid grid-cols-2 gap-4">
+          <div class="text-center">
+            <div class="text-2xl font-bold" [class]="getReturnClass()">
+              {{ overview()?.averageMetrics?.totalReturn | number: '1.1-1' }}%
+            </div>
+            <div class="text-sm text-gray-500">Avg Return</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-red-400">
+              {{ overview()?.averageMetrics?.maxDrawdown | number: '1.1-1' }}%
+            </div>
+            <div class="text-sm text-gray-500">Avg Drawdown</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-purple-500">
+              {{ overview()?.averageMetrics?.sharpeRatio | number: '1.2-2' }}
+            </div>
+            <div class="text-sm text-gray-500">Avg Sharpe</div>
+          </div>
+          <div class="text-center">
+            <div class="text-2xl font-bold text-blue-500">
+              {{ (overview()?.averageMetrics?.winRate || 0) * 100 | number: '1.0-0' }}%
+            </div>
+            <div class="text-sm text-gray-500">Avg Win Rate</div>
+          </div>
+        </div>
+      </p-card>
+    </div>
+
+    <!-- Recent Live Replay Runs -->
+    <div class="mt-4">
+      <p-card header="Recent Live Replay Runs">
+        <p-table
+          [value]="runs()?.data || []"
+          [rows]="10"
+          [totalRecords]="runs()?.total || 0"
+          [lazy]="true"
+          (onLazyLoad)="onLazyLoad($event)"
+          [paginator]="true"
+          [showCurrentPageReport]="true"
+          currentPageReportTemplate="{first} to {last} of {totalRecords}"
+          styleClass="p-datatable-sm"
+        >
+          <ng-template pTemplate="header">
+            <tr>
+              <th>Name</th>
+              <th>Algorithm</th>
+              <th>Status</th>
+              <th class="text-right">Speed</th>
+              <th class="text-right">Progress</th>
+              <th class="text-right">Return</th>
+              <th class="text-right">Sharpe</th>
+              <th>Created</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-run>
+            <tr>
+              <td>{{ run.name }}</td>
+              <td>{{ run.algorithmName }}</td>
+              <td>
+                <p-tag [severity]="getRunStatusSeverity(run.status)" [value]="getStatusLabel(run)" />
+                @if (run.status === BacktestStatus.RUNNING) {
+                  <p-progressBar [value]="run.progressPercent" [showValue]="false" styleClass="h-1 mt-1" />
+                }
+              </td>
+              <td class="text-right">
+                @if (run.replaySpeed !== null) {
+                  {{ getSpeedLabel(run.replaySpeed) }}
+                } @else {
+                  <span class="text-gray-400">-</span>
+                }
+              </td>
+              <td class="text-right">
+                <span [pTooltip]="run.processedTimestamps + ' / ' + run.totalTimestamps" tooltipPosition="top">
+                  {{ run.progressPercent }}%
+                </span>
+              </td>
+              <td class="text-right">
+                @if (run.totalReturn !== null) {
+                  <span [class]="run.totalReturn >= 0 ? 'text-green-500' : 'text-red-500'">
+                    {{ run.totalReturn | number: '1.1-1' }}%
+                  </span>
+                } @else {
+                  <span class="text-gray-400">-</span>
+                }
+              </td>
+              <td class="text-right">
+                @if (run.sharpeRatio !== null) {
+                  {{ run.sharpeRatio | number: '1.2-2' }}
+                } @else {
+                  <span class="text-gray-400">-</span>
+                }
+              </td>
+              <td>{{ run.createdAt | date: 'short' }}</td>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="emptymessage">
+            <tr>
+              <td colspan="8" class="py-4 text-center text-gray-500">No live replay runs found</td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </p-card>
+    </div>
+  `
+})
+export class LiveReplayPanelComponent {
+  overview = input<BacktestOverviewDto>();
+  runs = input<PaginatedLiveReplayRunsDto>();
+  pageChange = output<number>();
+
+  protected readonly BacktestStatus = BacktestStatus;
+
+  getReturnClass(): string {
+    return (this.overview()?.averageMetrics?.totalReturn || 0) >= 0 ? 'text-green-500' : 'text-red-500';
+  }
+
+  getStatusLabel(run: { status: BacktestStatus; isPaused: boolean | null }): string {
+    if (run.status === BacktestStatus.RUNNING && run.isPaused) {
+      return 'PAUSED';
+    }
+    return run.status;
+  }
+
+  getSpeedLabel(speed: ReplaySpeed): string {
+    switch (speed) {
+      case ReplaySpeed.REAL_TIME:
+        return '1x';
+      case ReplaySpeed.FAST_2X:
+        return '2x';
+      case ReplaySpeed.FAST_5X:
+        return '5x';
+      case ReplaySpeed.FAST_10X:
+        return '10x';
+      case ReplaySpeed.MAX_SPEED:
+        return 'Max';
+      default:
+        return `${speed}x`;
+    }
+  }
+
+  onLazyLoad(event: TableLazyLoadEvent): void {
+    const page = Math.floor((event.first ?? 0) / (event.rows ?? 10)) + 1;
+    this.pageChange.emit(page);
+  }
+
+  getRunStatusSeverity(status: BacktestStatus): 'success' | 'info' | 'warn' | 'danger' | 'secondary' | 'contrast' {
+    switch (status) {
+      case BacktestStatus.COMPLETED:
+        return 'success';
+      case BacktestStatus.RUNNING:
+        return 'info';
+      case BacktestStatus.PENDING:
+        return 'warn';
+      case BacktestStatus.PAUSED:
+        return 'warn';
+      case BacktestStatus.FAILED:
+        return 'danger';
+      case BacktestStatus.CANCELLED:
+        return 'secondary';
+      default:
+        return 'secondary';
+    }
+  }
+}

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/components/optimization-panel/optimization-panel.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/components/optimization-panel/optimization-panel.component.ts
@@ -1,64 +1,38 @@
-import { CommonModule, DecimalPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule, DatePipe, DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
 import { CardModule } from 'primeng/card';
+import { ProgressBarModule } from 'primeng/progressbar';
+import type { TableLazyLoadEvent } from 'primeng/table';
 import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
 
-import { OptimizationAnalyticsDto, OptimizationStatus } from '@chansey/api-interfaces';
+import { OptimizationAnalyticsDto, OptimizationStatus, PaginatedOptimizationRunsDto } from '@chansey/api-interfaces';
 
 @Component({
   selector: 'app-optimization-panel',
   standalone: true,
-  imports: [CommonModule, CardModule, DecimalPipe, TableModule],
+  imports: [CommonModule, CardModule, DatePipe, DecimalPipe, ProgressBarModule, TableModule, TagModule, TooltipModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <!-- Status Counts -->
-      <p-card header="Optimization Status">
-        <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
-          <div class="text-center">
-            <div class="text-2xl font-bold text-blue-500">{{ getStatusCount(OptimizationStatus.RUNNING) }}</div>
-            <div class="text-sm text-gray-500">Running</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-green-500">{{ getStatusCount(OptimizationStatus.COMPLETED) }}</div>
-            <div class="text-sm text-gray-500">Completed</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-red-500">{{ getStatusCount(OptimizationStatus.FAILED) }}</div>
-            <div class="text-sm text-gray-500">Failed</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-yellow-500">{{ getStatusCount(OptimizationStatus.PENDING) }}</div>
-            <div class="text-sm text-gray-500">Pending</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-gray-500">{{ getStatusCount(OptimizationStatus.CANCELLED) }}</div>
-            <div class="text-sm text-gray-500">Cancelled</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold">{{ analytics?.totalRuns || 0 }}</div>
-            <div class="text-sm text-gray-500">Total Runs</div>
-          </div>
-        </div>
-      </p-card>
-
       <!-- Average Metrics -->
       <p-card header="Performance Metrics">
         <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
           <div class="text-center">
-            <div class="text-2xl font-bold text-green-500">{{ analytics?.avgImprovement | number: '1.1-1' }}%</div>
+            <div class="text-2xl font-bold text-green-500">{{ analytics()?.avgImprovement | number: '1.1-1' }}%</div>
             <div class="text-sm text-gray-500">Avg Improvement</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-purple-500">
-              {{ analytics?.avgBestScore | number: '1.2-2' }}
+              {{ analytics()?.avgBestScore | number: '1.2-2' }}
             </div>
             <div class="text-sm text-gray-500">Avg Best Score</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-blue-500">
-              {{ analytics?.avgCombinationsTested | number: '1.0-0' }}
+              {{ analytics()?.avgCombinationsTested | number: '1.0-0' }}
             </div>
             <div class="text-sm text-gray-500">Avg Combos Tested</div>
           </div>
@@ -70,31 +44,31 @@ import { OptimizationAnalyticsDto, OptimizationStatus } from '@chansey/api-inter
         <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
           <div class="text-center">
             <div class="text-2xl font-bold">
-              {{ analytics?.resultSummary?.avgTrainScore | number: '1.2-2' }}
+              {{ analytics()?.resultSummary?.avgTrainScore | number: '1.2-2' }}
             </div>
             <div class="text-sm text-gray-500">Avg Train Score</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold">
-              {{ analytics?.resultSummary?.avgTestScore | number: '1.2-2' }}
+              {{ analytics()?.resultSummary?.avgTestScore | number: '1.2-2' }}
             </div>
             <div class="text-sm text-gray-500">Avg Test Score</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold" [class]="getDegradationClass()">
-              {{ analytics?.resultSummary?.avgDegradation | number: '1.2-2' }}
+              {{ analytics()?.resultSummary?.avgDegradation | number: '1.2-2' }}
             </div>
             <div class="text-sm text-gray-500">Avg Degradation</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-blue-500">
-              {{ analytics?.resultSummary?.avgConsistency | number: '1.0-0' }}
+              {{ analytics()?.resultSummary?.avgConsistency | number: '1.0-0' }}
             </div>
             <div class="text-sm text-gray-500">Avg Consistency</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold" [class]="getOverfittingClass()">
-              {{ (analytics?.resultSummary?.overfittingRate || 0) * 100 | number: '1.0-0' }}%
+              {{ (analytics()?.resultSummary?.overfittingRate || 0) * 100 | number: '1.0-0' }}%
             </div>
             <div class="text-sm text-gray-500">Overfitting Rate</div>
           </div>
@@ -103,7 +77,7 @@ import { OptimizationAnalyticsDto, OptimizationStatus } from '@chansey/api-inter
 
       <!-- Top Strategies -->
       <p-card header="Top Strategies">
-        <p-table [value]="analytics?.topStrategies || []" styleClass="p-datatable-sm">
+        <p-table [value]="analytics()?.topStrategies || []" styleClass="p-datatable-sm">
           <ng-template pTemplate="header">
             <tr>
               <th>Algorithm</th>
@@ -132,25 +106,108 @@ import { OptimizationAnalyticsDto, OptimizationStatus } from '@chansey/api-inter
         </p-table>
       </p-card>
     </div>
+
+    <!-- Recent Runs -->
+    <div class="mt-4">
+      <p-card header="Recent Runs">
+        <p-table
+          [value]="runs()?.data || []"
+          [rows]="10"
+          [totalRecords]="runs()?.total || 0"
+          [lazy]="true"
+          (onLazyLoad)="onLazyLoad($event)"
+          [paginator]="true"
+          [showCurrentPageReport]="true"
+          currentPageReportTemplate="{first} to {last} of {totalRecords}"
+          styleClass="p-datatable-sm"
+        >
+          <ng-template pTemplate="header">
+            <tr>
+              <th>Strategy</th>
+              <th>Status</th>
+              <th class="text-right">Combos Tested</th>
+              <th class="text-right">Improvement</th>
+              <th class="text-right">Best Score</th>
+              <th>Created</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-run>
+            <tr>
+              <td>
+                <span [pTooltip]="run.algorithmName" tooltipPosition="top">{{ run.strategyName }}</span>
+              </td>
+              <td>
+                <p-tag [severity]="getRunStatusSeverity(run.status)" [value]="run.status" />
+                @if (run.status === OptimizationStatus.RUNNING) {
+                  <p-progressBar [value]="run.progressPercent" [showValue]="false" styleClass="h-1 mt-1" />
+                }
+              </td>
+              <td class="text-right">{{ run.combinationsTested }} / {{ run.totalCombinations }}</td>
+              <td class="text-right">
+                @if (run.improvement !== null) {
+                  <span [class]="run.improvement >= 0 ? 'text-green-500' : 'text-red-500'">
+                    {{ run.improvement | number: '1.1-1' }}%
+                  </span>
+                } @else {
+                  <span class="text-gray-400">-</span>
+                }
+              </td>
+              <td class="text-right">
+                @if (run.bestScore !== null) {
+                  {{ run.bestScore | number: '1.2-2' }}
+                } @else {
+                  <span class="text-gray-400">-</span>
+                }
+              </td>
+              <td>{{ run.createdAt | date: 'short' }}</td>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="emptymessage">
+            <tr>
+              <td colspan="6" class="py-4 text-center text-gray-500">No optimization runs found</td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </p-card>
+    </div>
   `
 })
 export class OptimizationPanelComponent {
-  @Input() analytics: OptimizationAnalyticsDto | undefined;
+  analytics = input<OptimizationAnalyticsDto>();
+  runs = input<PaginatedOptimizationRunsDto>();
+  pageChange = output<number>();
 
   protected readonly OptimizationStatus = OptimizationStatus;
 
-  getStatusCount(status: OptimizationStatus): number {
-    if (!this.analytics?.statusCounts) return 0;
-    return this.analytics.statusCounts[status] || 0;
-  }
-
   getDegradationClass(): string {
-    const deg = this.analytics?.resultSummary?.avgDegradation || 0;
+    const deg = this.analytics()?.resultSummary?.avgDegradation || 0;
     return deg > 0.3 ? 'text-red-500' : deg > 0.15 ? 'text-yellow-500' : 'text-green-500';
   }
 
   getOverfittingClass(): string {
-    const rate = this.analytics?.resultSummary?.overfittingRate || 0;
+    const rate = this.analytics()?.resultSummary?.overfittingRate || 0;
     return rate > 0.3 ? 'text-red-500' : rate > 0.15 ? 'text-yellow-500' : 'text-green-500';
+  }
+
+  onLazyLoad(event: TableLazyLoadEvent): void {
+    const page = Math.floor((event.first ?? 0) / (event.rows ?? 10)) + 1;
+    this.pageChange.emit(page);
+  }
+
+  getRunStatusSeverity(status: OptimizationStatus): 'success' | 'info' | 'warn' | 'danger' | 'secondary' | 'contrast' {
+    switch (status) {
+      case OptimizationStatus.COMPLETED:
+        return 'success';
+      case OptimizationStatus.RUNNING:
+        return 'info';
+      case OptimizationStatus.PENDING:
+        return 'warn';
+      case OptimizationStatus.FAILED:
+        return 'danger';
+      case OptimizationStatus.CANCELLED:
+        return 'secondary';
+      default:
+        return 'secondary';
+    }
   }
 }

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/components/paper-trading-panel/paper-trading-panel.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/components/paper-trading-panel/paper-trading-panel.component.ts
@@ -1,72 +1,50 @@
-import { CommonModule, DecimalPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule, DatePipe, DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
 import { CardModule } from 'primeng/card';
+import { ProgressBarModule } from 'primeng/progressbar';
+import type { TableLazyLoadEvent } from 'primeng/table';
 import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
 
-import { PaperTradingMonitoringDto, PaperTradingStatus } from '@chansey/api-interfaces';
+import {
+  PaginatedPaperTradingSessionsDto,
+  PaperTradingMonitoringDto,
+  PaperTradingStatus
+} from '@chansey/api-interfaces';
 
 @Component({
   selector: 'app-paper-trading-panel',
   standalone: true,
-  imports: [CommonModule, CardModule, DecimalPipe, TableModule],
+  imports: [CommonModule, CardModule, DatePipe, DecimalPipe, ProgressBarModule, TableModule, TagModule, TooltipModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <!-- Status Counts -->
-      <p-card header="Session Status">
-        <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
-          <div class="text-center">
-            <div class="text-2xl font-bold text-green-500">{{ getStatusCount(PaperTradingStatus.ACTIVE) }}</div>
-            <div class="text-sm text-gray-500">Active</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-yellow-500">{{ getStatusCount(PaperTradingStatus.PAUSED) }}</div>
-            <div class="text-sm text-gray-500">Paused</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-blue-500">{{ getStatusCount(PaperTradingStatus.COMPLETED) }}</div>
-            <div class="text-sm text-gray-500">Completed</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-red-500">{{ getStatusCount(PaperTradingStatus.FAILED) }}</div>
-            <div class="text-sm text-gray-500">Failed</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-gray-500">{{ getStatusCount(PaperTradingStatus.STOPPED) }}</div>
-            <div class="text-sm text-gray-500">Stopped</div>
-          </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold">{{ analytics?.totalSessions || 0 }}</div>
-            <div class="text-sm text-gray-500">Total Sessions</div>
-          </div>
-        </div>
-      </p-card>
-
       <!-- Average Metrics -->
       <p-card header="Average Performance">
         <div class="grid grid-cols-2 gap-4">
           <div class="text-center">
             <div class="text-2xl font-bold" [class]="getReturnClass()">
-              {{ analytics?.avgMetrics?.totalReturn | number: '1.1-1' }}%
+              {{ analytics()?.avgMetrics?.totalReturn | number: '1.1-1' }}%
             </div>
             <div class="text-sm text-gray-500">Avg Return</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-red-400">
-              {{ analytics?.avgMetrics?.maxDrawdown | number: '1.1-1' }}%
+              {{ analytics()?.avgMetrics?.maxDrawdown | number: '1.1-1' }}%
             </div>
             <div class="text-sm text-gray-500">Avg Drawdown</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-purple-500">
-              {{ analytics?.avgMetrics?.sharpeRatio | number: '1.2-2' }}
+              {{ analytics()?.avgMetrics?.sharpeRatio | number: '1.2-2' }}
             </div>
             <div class="text-sm text-gray-500">Avg Sharpe</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-blue-500">
-              {{ (analytics?.avgMetrics?.winRate || 0) * 100 | number: '1.0-0' }}%
+              {{ (analytics()?.avgMetrics?.winRate || 0) * 100 | number: '1.0-0' }}%
             </div>
             <div class="text-sm text-gray-500">Avg Win Rate</div>
           </div>
@@ -77,36 +55,36 @@ import { PaperTradingMonitoringDto, PaperTradingStatus } from '@chansey/api-inte
       <p-card header="Order Analytics">
         <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
           <div class="text-center">
-            <div class="text-2xl font-bold">{{ analytics?.orderAnalytics?.totalOrders || 0 }}</div>
+            <div class="text-2xl font-bold">{{ analytics()?.orderAnalytics?.totalOrders || 0 }}</div>
             <div class="text-sm text-gray-500">Total Orders</div>
           </div>
           <div class="text-center">
-            <div class="text-2xl font-bold text-green-500">{{ analytics?.orderAnalytics?.buyCount || 0 }}</div>
+            <div class="text-2xl font-bold text-green-500">{{ analytics()?.orderAnalytics?.buyCount || 0 }}</div>
             <div class="text-sm text-gray-500">Buys</div>
           </div>
           <div class="text-center">
-            <div class="text-2xl font-bold text-red-500">{{ analytics?.orderAnalytics?.sellCount || 0 }}</div>
+            <div class="text-2xl font-bold text-red-500">{{ analytics()?.orderAnalytics?.sellCount || 0 }}</div>
             <div class="text-sm text-gray-500">Sells</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold" [class]="getPnLClass()">
-              {{ analytics?.orderAnalytics?.totalPnL | number: '1.2-2' }}
+              {{ analytics()?.orderAnalytics?.totalPnL | number: '1.2-2' }}
             </div>
             <div class="text-sm text-gray-500">Total P&L</div>
           </div>
         </div>
         <div class="mt-4 grid grid-cols-3 gap-4">
           <div class="text-center">
-            <div class="text-lg font-semibold">{{ analytics?.orderAnalytics?.totalVolume | number: '1.0-0' }}</div>
+            <div class="text-lg font-semibold">{{ analytics()?.orderAnalytics?.totalVolume | number: '1.0-0' }}</div>
             <div class="text-xs text-gray-500">Total Volume</div>
           </div>
           <div class="text-center">
-            <div class="text-lg font-semibold">{{ analytics?.orderAnalytics?.totalFees | number: '1.2-2' }}</div>
+            <div class="text-lg font-semibold">{{ analytics()?.orderAnalytics?.totalFees | number: '1.2-2' }}</div>
             <div class="text-xs text-gray-500">Total Fees</div>
           </div>
           <div class="text-center">
             <div class="text-lg font-semibold">
-              {{ analytics?.orderAnalytics?.avgSlippageBps | number: '1.1-1' }} bps
+              {{ analytics()?.orderAnalytics?.avgSlippageBps | number: '1.1-1' }} bps
             </div>
             <div class="text-xs text-gray-500">Avg Slippage</div>
           </div>
@@ -117,18 +95,18 @@ import { PaperTradingMonitoringDto, PaperTradingStatus } from '@chansey/api-inte
       <p-card header="Signal Analytics">
         <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
           <div class="text-center">
-            <div class="text-2xl font-bold">{{ analytics?.signalAnalytics?.totalSignals || 0 }}</div>
+            <div class="text-2xl font-bold">{{ analytics()?.signalAnalytics?.totalSignals || 0 }}</div>
             <div class="text-sm text-gray-500">Total Signals</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-green-500">
-              {{ (analytics?.signalAnalytics?.processedRate || 0) * 100 | number: '1.0-0' }}%
+              {{ (analytics()?.signalAnalytics?.processedRate || 0) * 100 | number: '1.0-0' }}%
             </div>
             <div class="text-sm text-gray-500">Processed Rate</div>
           </div>
           <div class="text-center">
             <div class="text-2xl font-bold text-purple-500">
-              {{ (analytics?.signalAnalytics?.avgConfidence || 0) * 100 | number: '1.0-0' }}%
+              {{ (analytics()?.signalAnalytics?.avgConfidence || 0) * 100 | number: '1.0-0' }}%
             </div>
             <div class="text-sm text-gray-500">Avg Confidence</div>
           </div>
@@ -137,7 +115,7 @@ import { PaperTradingMonitoringDto, PaperTradingStatus } from '@chansey/api-inte
 
       <!-- Top Algorithms -->
       <p-card header="Top Algorithms">
-        <p-table [value]="analytics?.topAlgorithms || []" styleClass="p-datatable-sm">
+        <p-table [value]="analytics()?.topAlgorithms || []" styleClass="p-datatable-sm">
           <ng-template pTemplate="header">
             <tr>
               <th>Algorithm</th>
@@ -168,7 +146,7 @@ import { PaperTradingMonitoringDto, PaperTradingStatus } from '@chansey/api-inte
 
       <!-- By Symbol Breakdown -->
       <p-card header="Volume by Symbol">
-        <p-table [value]="analytics?.orderAnalytics?.bySymbol || []" styleClass="p-datatable-sm">
+        <p-table [value]="analytics()?.orderAnalytics?.bySymbol || []" styleClass="p-datatable-sm">
           <ng-template pTemplate="header">
             <tr>
               <th>Symbol</th>
@@ -197,23 +175,106 @@ import { PaperTradingMonitoringDto, PaperTradingStatus } from '@chansey/api-inte
         </p-table>
       </p-card>
     </div>
+
+    <!-- Recent Sessions -->
+    <div class="mt-4">
+      <p-card header="Recent Sessions">
+        <p-table
+          [value]="sessions()?.data || []"
+          [rows]="10"
+          [totalRecords]="sessions()?.total || 0"
+          [lazy]="true"
+          (onLazyLoad)="onLazyLoad($event)"
+          [paginator]="true"
+          [showCurrentPageReport]="true"
+          currentPageReportTemplate="{first} to {last} of {totalRecords}"
+          styleClass="p-datatable-sm"
+        >
+          <ng-template pTemplate="header">
+            <tr>
+              <th>Name</th>
+              <th>Algorithm</th>
+              <th>Status</th>
+              <th class="text-right">Return</th>
+              <th class="text-right">Sharpe</th>
+              <th>Created</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-session>
+            <tr>
+              <td>{{ session.name }}</td>
+              <td>{{ session.algorithmName }}</td>
+              <td>
+                <p-tag [severity]="getSessionStatusSeverity(session.status)" [value]="session.status" />
+                @if (session.status === PaperTradingStatus.ACTIVE) {
+                  <p-progressBar [value]="session.progressPercent" [showValue]="false" styleClass="h-1 mt-1" />
+                }
+              </td>
+              <td class="text-right">
+                @if (session.totalReturn !== null) {
+                  <span [class]="session.totalReturn >= 0 ? 'text-green-500' : 'text-red-500'">
+                    {{ session.totalReturn | number: '1.1-1' }}%
+                  </span>
+                } @else {
+                  <span class="text-gray-400">-</span>
+                }
+              </td>
+              <td class="text-right">
+                @if (session.sharpeRatio !== null) {
+                  {{ session.sharpeRatio | number: '1.2-2' }}
+                } @else {
+                  <span class="text-gray-400">-</span>
+                }
+              </td>
+              <td>{{ session.createdAt | date: 'short' }}</td>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="emptymessage">
+            <tr>
+              <td colspan="6" class="py-4 text-center text-gray-500">No paper trading sessions found</td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </p-card>
+    </div>
   `
 })
 export class PaperTradingPanelComponent {
-  @Input() analytics: PaperTradingMonitoringDto | undefined;
+  analytics = input<PaperTradingMonitoringDto>();
+  sessions = input<PaginatedPaperTradingSessionsDto>();
+  pageChange = output<number>();
 
   protected readonly PaperTradingStatus = PaperTradingStatus;
 
-  getStatusCount(status: PaperTradingStatus): number {
-    if (!this.analytics?.statusCounts) return 0;
-    return this.analytics.statusCounts[status] || 0;
-  }
-
   getReturnClass(): string {
-    return (this.analytics?.avgMetrics?.totalReturn || 0) >= 0 ? 'text-green-500' : 'text-red-500';
+    return (this.analytics()?.avgMetrics?.totalReturn || 0) >= 0 ? 'text-green-500' : 'text-red-500';
   }
 
   getPnLClass(): string {
-    return (this.analytics?.orderAnalytics?.totalPnL || 0) >= 0 ? 'text-green-500' : 'text-red-500';
+    return (this.analytics()?.orderAnalytics?.totalPnL || 0) >= 0 ? 'text-green-500' : 'text-red-500';
+  }
+
+  onLazyLoad(event: TableLazyLoadEvent): void {
+    const page = Math.floor((event.first ?? 0) / (event.rows ?? 10)) + 1;
+    this.pageChange.emit(page);
+  }
+
+  getSessionStatusSeverity(
+    status: PaperTradingStatus
+  ): 'success' | 'info' | 'warn' | 'danger' | 'secondary' | 'contrast' {
+    switch (status) {
+      case PaperTradingStatus.ACTIVE:
+        return 'info';
+      case PaperTradingStatus.COMPLETED:
+        return 'success';
+      case PaperTradingStatus.PAUSED:
+        return 'warn';
+      case PaperTradingStatus.FAILED:
+        return 'danger';
+      case PaperTradingStatus.STOPPED:
+        return 'secondary';
+      default:
+        return 'secondary';
+    }
   }
 }

--- a/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
+++ b/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
@@ -4,7 +4,13 @@
  * Shared types for the admin backtest monitoring dashboard.
  */
 
-import { BacktestStatus, BacktestType, SignalDirection, SignalType } from '../backtesting/backtesting.interface';
+import {
+  BacktestStatus,
+  BacktestType,
+  ReplaySpeed,
+  SignalDirection,
+  SignalType
+} from '../backtesting/backtesting.interface';
 import { PaperTradingSignalDirection, PaperTradingSignalType, PaperTradingStatus } from '../paper-trading';
 
 // ===========================================================================
@@ -338,6 +344,90 @@ export interface PaperTradingMonitoringDto {
   topAlgorithms: PaperTradingTopAlgorithmDto[];
   orderAnalytics: PaperTradingOrderAnalyticsDto;
   signalAnalytics: PaperTradingSignalAnalyticsDto;
+}
+
+// ===========================================================================
+// Optimization Run Listing DTOs
+// ===========================================================================
+
+export interface OptimizationRunListItemDto {
+  id: string;
+  strategyName: string;
+  algorithmName: string;
+  status: OptimizationStatus;
+  combinationsTested: number;
+  totalCombinations: number;
+  progressPercent: number;
+  improvement: number | null;
+  bestScore: number | null;
+  createdAt: string;
+}
+
+export interface PaginatedOptimizationRunsDto {
+  data: OptimizationRunListItemDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+// ===========================================================================
+// Paper Trading Session Listing DTOs
+// ===========================================================================
+
+export interface PaperTradingSessionListItemDto {
+  id: string;
+  name: string;
+  algorithmName: string;
+  status: PaperTradingStatus;
+  progressPercent: number;
+  totalReturn: number | null;
+  sharpeRatio: number | null;
+  duration: string;
+  startedAt: string | null;
+  createdAt: string;
+}
+
+export interface PaginatedPaperTradingSessionsDto {
+  data: PaperTradingSessionListItemDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+// ===========================================================================
+// Live Replay Run Listing DTOs
+// ===========================================================================
+
+export interface LiveReplayRunListItemDto {
+  id: string;
+  name: string;
+  algorithmName: string;
+  status: BacktestStatus;
+  progressPercent: number;
+  processedTimestamps: number;
+  totalTimestamps: number;
+  totalReturn: number | null;
+  sharpeRatio: number | null;
+  maxDrawdown: number | null;
+  replaySpeed: ReplaySpeed | null;
+  isPaused: boolean | null;
+  createdAt: string;
+}
+
+export interface PaginatedLiveReplayRunsDto {
+  data: LiveReplayRunListItemDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
 }
 
 // ===========================================================================

--- a/libs/shared/src/lib/query/query-keys.ts
+++ b/libs/shared/src/lib/query/query-keys.ts
@@ -221,7 +221,19 @@ export const queryKeys = {
       signalActivityFeed: (limit?: number) =>
         limit
           ? ([...queryKeys.admin.backtestMonitoring.all(), 'signal-activity-feed', limit] as const)
-          : ([...queryKeys.admin.backtestMonitoring.all(), 'signal-activity-feed'] as const)
+          : ([...queryKeys.admin.backtestMonitoring.all(), 'signal-activity-feed'] as const),
+      optimizationRuns: (query?: Record<string, unknown>) =>
+        query
+          ? ([...queryKeys.admin.backtestMonitoring.all(), 'optimization-runs', query] as const)
+          : ([...queryKeys.admin.backtestMonitoring.all(), 'optimization-runs'] as const),
+      paperTradingSessions: (query?: Record<string, unknown>) =>
+        query
+          ? ([...queryKeys.admin.backtestMonitoring.all(), 'paper-trading-sessions', query] as const)
+          : ([...queryKeys.admin.backtestMonitoring.all(), 'paper-trading-sessions'] as const),
+      liveReplayRuns: (query?: Record<string, unknown>) =>
+        query
+          ? ([...queryKeys.admin.backtestMonitoring.all(), 'live-replay-runs', query] as const)
+          : ([...queryKeys.admin.backtestMonitoring.all(), 'live-replay-runs'] as const)
     },
     liveTradeMonitoring: {
       all: () => [...queryKeys.admin.all, 'live-trade-monitoring'] as const,


### PR DESCRIPTION
## Summary

- Add paginated API endpoints and lazy-loaded data tables for optimization runs, paper trading sessions, and live replay runs in the admin backtest monitoring dashboard
- Replace static status count cards with interactive PrimeNG tables featuring status tags, progress bars, and server-side pagination
- Modernize panel components with Angular signals and fix coin symbol resolution in the signal activity feed

## Changes

### API (Backend)
- **`backtest-monitoring.controller.ts`** — Add three new paginated endpoints: optimization runs, paper trading sessions, and live replay runs
- **`backtest-monitoring.service.ts`** — Implement paginated query methods with sorting, filtering, and metadata (totalPages, hasNextPage, hasPreviousPage)
- **`backtest-listing.dto.ts`** — New shared pagination DTO with `@Max(100)` validation on limit
- **`optimization-analytics.dto.ts` / `paper-trading-analytics.dto.ts`** — Extend response DTOs with pagination metadata fields

### Frontend
- **`live-replay-panel.component.ts`** — New standalone component with lazy-loaded table for live replay runs
- **`optimization-panel.component.ts`** — Replace status cards with paginated runs table
- **`paper-trading-panel.component.ts`** — Replace status cards with paginated sessions table
- **`backtest-monitoring.component.ts`** — Wire up new live replay panel and data flow
- **`backtest-monitoring.service.ts`** — Add TanStack Query hooks for all three run listing endpoints

### Shared
- **`backtest-monitoring.interface.ts`** — Add interfaces for run/session listing responses and pagination
- **`query-keys.ts`** — Add query key factories for optimization runs, paper trading sessions, and live replay runs

### Other
- Migrate panel components from `@Input()`/`@Output()` to signal-based `input()`/`output()`
- Replace `any` with `TableLazyLoadEvent` in lazy-load handlers
- Fix loading spinner in live replay to gate on correct query
- Fix test to include `CoinRepository` dependency

## Test Plan

- [ ] `nx test api` — unit tests pass (including updated spec)
- [ ] Verify `/api/admin/backtest-monitoring/optimization/runs?page=1&limit=10` returns paginated results
- [ ] Verify `/api/admin/backtest-monitoring/paper-trading/sessions?page=1&limit=10` returns paginated results
- [ ] Verify `/api/admin/backtest-monitoring/live-replay/runs?page=1&limit=10` returns paginated results
- [ ] Verify pagination controls work in all three panel tables
- [ ] Verify status tags and progress bars render correctly
- [ ] Verify signal activity feed shows coin symbols instead of UUIDs