### PR TITLE
feat(api): harden backtest resilience with data guards, adaptive windows, and queue-aware watchdog

### DIFF
--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -9,6 +9,7 @@ import { TradingState } from './trading-state/trading-state.entity';
 import { TradingStateService } from './trading-state/trading-state.service';
 
 import { AuditModule } from '../audit/audit.module';
+import { Coin } from '../coin/coin.entity';
 import { OptimizationResult } from '../optimization/entities/optimization-result.entity';
 import { OptimizationRun } from '../optimization/entities/optimization-run.entity';
 import { Backtest, BacktestSignal, BacktestTrade, SimulatedOrderFill } from '../order/backtest/backtest.entity';
@@ -35,6 +36,7 @@ import { TasksModule } from '../tasks/tasks.module';
     TypeOrmModule.forFeature([
       TradingState,
       Order,
+      Coin,
       Backtest,
       BacktestTrade,
       BacktestSignal,

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
@@ -57,6 +57,7 @@ import {
   TradeSummaryDto
 } from './dto/trade-analytics.dto';
 
+import { Coin } from '../../coin/coin.entity';
 import { OptimizationResult } from '../../optimization/entities/optimization-result.entity';
 import { OptimizationRun, OptimizationStatus } from '../../optimization/entities/optimization-run.entity';
 import {
@@ -110,6 +111,8 @@ export class BacktestMonitoringService {
   private readonly logger = new Logger(BacktestMonitoringService.name);
 
   constructor(
+    @InjectRepository(Coin)
+    private readonly coinRepo: Repository<Coin>,
     @InjectRepository(Backtest)
     private readonly backtestRepo: Repository<Backtest>,
     @InjectRepository(BacktestTrade)
@@ -352,6 +355,15 @@ export class BacktestMonitoringService {
       confidence: s.confidence,
       reason: s.reason
     }));
+
+    // Resolve instrument UUIDs to coin symbols
+    const instrumentSet = new Set(data.map((d) => d.instrument).filter(Boolean) as string[]);
+    const symbolMap = await this.resolveInstrumentSymbols(instrumentSet);
+    for (const item of data) {
+      if (item.instrument) {
+        item.instrument = symbolMap.get(item.instrument.toLowerCase()) ?? item.instrument;
+      }
+    }
 
     if (format === ExportFormat.JSON) {
       return data;
@@ -721,6 +733,15 @@ export class BacktestMonitoringService {
         userEmail: ps.session.user?.email,
         processed: ps.processed
       });
+    }
+
+    // Resolve instrument UUIDs to coin symbols
+    const instrumentSet = new Set(mapped.map((m) => m.instrument).filter(Boolean) as string[]);
+    const symbolMap = await this.resolveInstrumentSymbols(instrumentSet);
+    for (const item of mapped) {
+      if (item.instrument) {
+        item.instrument = symbolMap.get(item.instrument.toLowerCase()) ?? item.instrument;
+      }
     }
 
     // Sort merged by timestamp DESC, take limit
@@ -1199,8 +1220,12 @@ export class BacktestMonitoringService {
 
     const results = await qb.getRawMany();
 
+    // Resolve instrument UUIDs to coin symbols
+    const instrumentSet = new Set(results.map((r) => r.instrument as string).filter(Boolean));
+    const symbolMap = await this.resolveInstrumentSymbols(instrumentSet);
+
     return results.map((r) => ({
-      instrument: r.instrument,
+      instrument: symbolMap.get((r.instrument as string)?.toLowerCase()) ?? r.instrument,
       count: parseInt(r.count, 10) || 0,
       successRate: parseFloat(r.successRate) || 0,
       avgReturn: parseFloat(r.avgReturn) || 0
@@ -1470,6 +1495,34 @@ export class BacktestMonitoringService {
       },
       byInstrument: []
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Instrument Resolution Helper
+  // ---------------------------------------------------------------------------
+
+  /** UUID v4 pattern (case-insensitive) */
+  private static readonly UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  /**
+   * Batch-resolve instrument UUIDs to coin symbols.
+   * Non-UUID values (already symbols) are skipped.
+   */
+  private async resolveInstrumentSymbols(instruments: Set<string>): Promise<Map<string, string>> {
+    const uuids = [...instruments].filter((v) => BacktestMonitoringService.UUID_RE.test(v));
+    if (uuids.length === 0) return new Map();
+
+    const coins = await this.coinRepo
+      .createQueryBuilder('c')
+      .select(['c.id', 'c.symbol'])
+      .where('c.id IN (:...ids)', { ids: uuids })
+      .getMany();
+
+    const map = new Map<string, string>();
+    for (const coin of coins) {
+      map.set(coin.id.toLowerCase(), coin.symbol.toUpperCase());
+    }
+    return map;
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/api/src/algorithm/base/base-algorithm-strategy.ts
+++ b/apps/api/src/algorithm/base/base-algorithm-strategy.ts
@@ -102,6 +102,14 @@ export abstract class BaseAlgorithmStrategy implements AlgorithmStrategy {
   }
 
   /**
+   * Return the minimum number of price data points required for signal generation.
+   * Override in concrete strategies; default 0 means "no minimum".
+   */
+  getMinDataPoints(_config: Record<string, unknown>): number {
+    return 0;
+  }
+
+  /**
    * Get default configuration schema
    */
   getConfigSchema(): Record<string, unknown> {

--- a/apps/api/src/algorithm/interfaces/algorithm-strategy.interface.ts
+++ b/apps/api/src/algorithm/interfaces/algorithm-strategy.interface.ts
@@ -70,6 +70,13 @@ export interface AlgorithmStrategy {
   getIndicatorRequirements?(config: Record<string, unknown>): IndicatorRequirement[];
 
   /**
+   * Return the minimum number of price data points (candles) this strategy
+   * needs before it can produce meaningful signals.  Used by the backtest
+   * engine to pre-filter coins and avoid per-timestamp "insufficient data" noise.
+   */
+  getMinDataPoints?(config: Record<string, unknown>): number;
+
+  /**
    * Health check for the algorithm
    */
   healthCheck?(): Promise<boolean>;

--- a/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
+++ b/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
@@ -74,7 +74,7 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -604,6 +604,11 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
         }
       };
     });
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const atrPeriod = (config.atrPeriod as number) ?? 14;
+    return atrPeriod + 5;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
@@ -464,6 +464,12 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
   /**
    * Declare indicator requirements for precomputation during optimization.
    */
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const period = (config.period as number) ?? 20;
+    const minSqueezeBars = (config.minSqueezeBars as number) ?? 6;
+    return period + minSqueezeBars + 5;
+  }
+
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {
     return [{ type: 'BOLLINGER_BANDS', paramKeys: ['period', 'stdDev'], defaultParams: { period: 20, stdDev: 2 } }];
   }

--- a/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
@@ -65,7 +65,7 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -348,6 +348,13 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
   /**
    * Declare indicator requirements for precomputation during optimization.
    */
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const period = (config.period as number) ?? 20;
+    const requireConfirmation = (config.requireConfirmation as boolean) ?? false;
+    const confirmationBars = (config.confirmationBars as number) ?? 2;
+    return period + (requireConfirmation ? confirmationBars : 1);
+  }
+
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {
     return [{ type: 'BOLLINGER_BANDS', paramKeys: ['period', 'stdDev'], defaultParams: { period: 20, stdDev: 2 } }];
   }

--- a/apps/api/src/algorithm/strategies/confluence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/confluence.strategy.ts
@@ -72,7 +72,7 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -115,7 +115,7 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
   /**
    * Get configuration with defaults
    */
-  private getConfigWithDefaults(config: Record<string, unknown>): ConfluenceConfig {
+  protected getConfigWithDefaults(config: Record<string, unknown>): ConfluenceConfig {
     const minConfluence = (config.minConfluence as number) ?? 2;
     return {
       minConfluence,
@@ -1010,6 +1010,17 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
   /**
    * Declare indicator requirements for precomputation during optimization.
    */
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const c = this.getConfigWithDefaults(config);
+    const requirements: number[] = [];
+    if (c.ema.enabled) requirements.push(c.ema.slowPeriod + 1);
+    if (c.rsi.enabled) requirements.push(c.rsi.period + 1);
+    if (c.macd.enabled) requirements.push(c.macd.slowPeriod + c.macd.signalPeriod - 1);
+    if (c.atr.enabled) requirements.push(c.atr.period + 1);
+    if (c.bollingerBands.enabled) requirements.push(c.bollingerBands.period + 1);
+    return requirements.length > 0 ? Math.max(...requirements) : 1;
+  }
+
   getIndicatorRequirements(config: Record<string, unknown>): IndicatorRequirement[] {
     const reqs: IndicatorRequirement[] = [];
     if (config.emaEnabled !== false) {

--- a/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
+++ b/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
@@ -67,7 +67,7 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -383,6 +383,12 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
         low: price.low
       }
     }));
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const slowEmaPeriod = (config.slowEmaPeriod as number) ?? 26;
+    const rsiPeriod = (config.rsiPeriod as number) ?? 14;
+    return Math.max(slowEmaPeriod, rsiPeriod) + 5;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
+++ b/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
@@ -60,7 +60,7 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, slowPeriod)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -245,6 +245,12 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
         low: price.low
       }
     }));
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const slowPeriod = (config.slowPeriod as number) ?? 26;
+    const crossoverLookback = (config.crossoverLookback as number) ?? 3;
+    return slowPeriod + crossoverLookback;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/macd.strategy.ts
+++ b/apps/api/src/algorithm/strategies/macd.strategy.ts
@@ -64,7 +64,7 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -320,6 +320,12 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
         low: price.low
       }
     }));
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const slowPeriod = (config.slowPeriod as number) ?? 26;
+    const signalPeriod = (config.signalPeriod as number) ?? 9;
+    return slowPeriod + signalPeriod - 1;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
@@ -65,7 +65,7 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, period)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -240,6 +240,11 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
   /**
    * Declare indicator requirements for precomputation during optimization.
    */
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const period = (config.period as number) ?? 20;
+    return period + 1;
+  }
+
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {
     return [
       { type: 'BOLLINGER_BANDS', paramKeys: ['period', 'threshold'], defaultParams: { period: 20, threshold: 2 } }

--- a/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
@@ -80,7 +80,7 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -410,6 +410,13 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
         low: price.low
       }
     }));
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const rsiPeriod = (config.rsiPeriod as number) ?? 14;
+    const lookbackPeriod = (config.lookbackPeriod as number) ?? 14;
+    const pivotStrength = (config.pivotStrength as number) ?? 2;
+    return rsiPeriod + lookbackPeriod + pivotStrength * 2;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
@@ -76,7 +76,7 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -392,6 +392,14 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
         low: price.low
       }
     }));
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const rsiPeriod = (config.rsiPeriod as number) ?? 14;
+    const macdSlow = (config.macdSlow as number) ?? 26;
+    const macdSignal = (config.macdSignal as number) ?? 9;
+    const confirmationWindow = (config.confirmationWindow as number) ?? 3;
+    return Math.max(rsiPeriod, macdSlow + macdSignal - 1) + confirmationWindow;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/rsi.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.ts
@@ -61,7 +61,7 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -238,6 +238,11 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
         low: price.low
       }
     }));
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const period = (config.period as number) ?? 14;
+    return period + 1;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
@@ -60,7 +60,7 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, slowPeriod)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -189,6 +189,11 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         low: price.low
       }
     }));
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const slowPeriod = (config.slowPeriod as number) ?? 20;
+    return slowPeriod + 1;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
@@ -78,7 +78,7 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         const priceHistory = context.priceData[coin.id];
 
         if (!this.hasEnoughData(priceHistory, config)) {
-          this.logger.warn(`Insufficient price data for ${coin.symbol}`);
+          this.logger.debug(`Insufficient price data for ${coin.symbol}`);
           continue;
         }
 
@@ -135,7 +135,7 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
   /**
    * Get configuration with defaults
    */
-  private getConfigWithDefaults(config: Record<string, unknown>): TripleEMAConfig {
+  protected getConfigWithDefaults(config: Record<string, unknown>): TripleEMAConfig {
     return {
       fastPeriod: (config.fastPeriod as number) ?? 8,
       mediumPeriod: (config.mediumPeriod as number) ?? 21,
@@ -428,6 +428,11 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         }
       };
     });
+  }
+
+  getMinDataPoints(config: Record<string, unknown>): number {
+    const slowPeriod = (config.slowPeriod as number) ?? 55;
+    return slowPeriod + 5;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {

--- a/apps/api/src/ohlc/tasks/ohlc-sync.task.spec.ts
+++ b/apps/api/src/ohlc/tasks/ohlc-sync.task.spec.ts
@@ -7,6 +7,7 @@ import { ExchangeService } from '../../exchange/exchange.service';
 import { ExchangeSymbolMap } from '../exchange-symbol-map.entity';
 import { OHLCService } from '../ohlc.service';
 import { ExchangeOHLCService } from '../services/exchange-ohlc.service';
+import { OHLCBackfillService } from '../services/ohlc-backfill.service';
 
 describe('OHLCSyncTask', () => {
   let task: OHLCSyncTask;
@@ -17,6 +18,7 @@ describe('OHLCSyncTask', () => {
   let exchangeService: jest.Mocked<ExchangeService>;
   let configService: { get: jest.Mock };
   let lockService: { acquire: jest.Mock; release: jest.Mock };
+  let backfillService: jest.Mocked<Pick<OHLCBackfillService, 'startBackfill'>>;
 
   const originalEnv = process.env;
 
@@ -30,6 +32,7 @@ describe('OHLCSyncTask', () => {
 
     ohlcService = {
       getActiveSymbolMaps: jest.fn(),
+      upsertSymbolMap: jest.fn().mockResolvedValue({}),
       upsertCandles: jest.fn(),
       incrementFailureCount: jest.fn(),
       markSyncSuccess: jest.fn(),
@@ -59,6 +62,10 @@ describe('OHLCSyncTask', () => {
       release: jest.fn().mockResolvedValue(undefined)
     };
 
+    backfillService = {
+      startBackfill: jest.fn().mockResolvedValue('job-id')
+    };
+
     task = new OHLCSyncTask(
       queue as any,
       ohlcService,
@@ -66,7 +73,8 @@ describe('OHLCSyncTask', () => {
       coinService,
       exchangeService,
       configService as any,
-      lockService as any
+      lockService as any,
+      backfillService as any
     );
   });
 
@@ -103,7 +111,6 @@ describe('OHLCSyncTask', () => {
     ohlcService.getActiveSymbolMaps.mockResolvedValue([]);
     exchangeService.getExchanges.mockResolvedValue([{ id: 'ex-1', slug: 'binance_us', name: 'Binance US' }] as any);
     coinService.getPopularCoins.mockResolvedValue([{ id: 'btc', symbol: 'btc' }] as any);
-    ohlcService.upsertSymbolMap = jest.fn().mockResolvedValue({});
     // getAvailableSymbols returns a valid pair for BTC on binance_us
     exchangeOHLC.getAvailableSymbols.mockResolvedValue(['BTC/USD']);
     jest.spyOn(task as any, 'scheduleOHLCSyncJob').mockResolvedValue(undefined);

--- a/apps/api/src/ohlc/tasks/ohlc-sync.task.ts
+++ b/apps/api/src/ohlc/tasks/ohlc-sync.task.ts
@@ -13,6 +13,7 @@ import { toErrorInfo } from '../../shared/error.util';
 import { ExchangeSymbolMap } from '../exchange-symbol-map.entity';
 import { OHLCService } from '../ohlc.service';
 import { ExchangeOHLCService } from '../services/exchange-ohlc.service';
+import { OHLCBackfillService } from '../services/ohlc-backfill.service';
 
 @Processor('ohlc-sync-queue')
 @Injectable()
@@ -28,7 +29,8 @@ export class OHLCSyncTask extends WorkerHost implements OnModuleInit {
     private readonly coinService: CoinService,
     private readonly exchangeService: ExchangeService,
     private readonly configService: ConfigService,
-    private readonly lockService: DistributedLockService
+    private readonly lockService: DistributedLockService,
+    private readonly backfillService: OHLCBackfillService
   ) {
     super();
   }
@@ -144,8 +146,13 @@ export class OHLCSyncTask extends WorkerHost implements OnModuleInit {
         return;
       }
 
+      // Track which coins already have symbol maps so we can detect newly mapped ones
+      const existingMaps = await this.ohlcService.getActiveSymbolMaps();
+      const existingCoinIds = new Set(existingMaps.map((m) => m.coinId));
+
       let created = 0;
       let skipped = 0;
+      const newlyMappedCoinIds: string[] = [];
 
       for (const coin of coins) {
         try {
@@ -167,6 +174,12 @@ export class OHLCSyncTask extends WorkerHost implements OnModuleInit {
               });
               created++;
               mapped = true;
+
+              // Track newly mapped coins for backfill
+              if (!existingCoinIds.has(coin.id)) {
+                newlyMappedCoinIds.push(coin.id);
+              }
+
               break;
             }
           }
@@ -182,6 +195,17 @@ export class OHLCSyncTask extends WorkerHost implements OnModuleInit {
       }
 
       this.logger.log(`Seeded ${created} symbol mappings, skipped ${skipped} coins with no valid pairs`);
+
+      // Trigger backfill for newly mapped coins (runs in background, non-blocking)
+      if (newlyMappedCoinIds.length > 0) {
+        this.logger.log(`Triggering backfill for ${newlyMappedCoinIds.length} newly mapped coin(s)`);
+        for (const coinId of newlyMappedCoinIds) {
+          this.backfillService.startBackfill(coinId).catch((error: unknown) => {
+            const err = toErrorInfo(error);
+            this.logger.warn(`Failed to trigger backfill for coin ${coinId}: ${err.message}`);
+          });
+        }
+      }
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Failed to seed symbol maps: ${err.message}`);

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
@@ -546,6 +546,7 @@ describe('OptimizationOrchestratorService', () => {
 
       expect(run.status).toBe(OptimizationStatus.FAILED);
       expect(run.errorMessage).toContain('Insufficient windows');
+      expect(run.errorMessage).toContain('Data span');
       expect(optimizationRunRepo.save).toHaveBeenCalledWith(run);
     });
 
@@ -1138,6 +1139,68 @@ describe('OptimizationOrchestratorService', () => {
       });
       // default=50, no compound, * 1.2 = 60
       expect(service.computeWarmupDays(space)).toBe(60);
+    });
+  });
+
+  describe('computeAdaptiveStepDays', () => {
+    it('should not adjust when configured step fits comfortably', () => {
+      // 300 days, train=90, test=30, step=15, min=3 → maxStep=floor((300-120)/2)=90 → no change
+      const result = service.computeAdaptiveStepDays(300, 90, 30, 15, 3);
+      expect(result.stepDays).toBe(15);
+      expect(result.adjusted).toBe(false);
+    });
+
+    it('should reduce step for 108-day data with risk level 4 config', () => {
+      // 108 days, train=60, test=21, step=21, min=3
+      // maxStep = floor((108-81)/2) = floor(27/2) = 13
+      const result = service.computeAdaptiveStepDays(108, 60, 21, 21, 3);
+      expect(result.stepDays).toBe(13);
+      expect(result.adjusted).toBe(true);
+    });
+
+    it('should never increase beyond configured step', () => {
+      // Even when data allows much larger steps, cap at configured value
+      // 500 days, train=30, test=14, step=5, min=3 → maxStep=floor((500-44)/2)=228 → stays 5
+      const result = service.computeAdaptiveStepDays(500, 30, 14, 5, 3);
+      expect(result.stepDays).toBe(5);
+      expect(result.adjusted).toBe(false);
+    });
+
+    it('should floor at 1 day for very tight data', () => {
+      // 82 days, train=60, test=21, step=21, min=3 → maxStep=floor((82-81)/2)=0 → floors at 1
+      const result = service.computeAdaptiveStepDays(82, 60, 21, 21, 3);
+      expect(result.stepDays).toBe(1);
+      expect(result.adjusted).toBe(true);
+    });
+
+    it('should not adjust when data is less than one window (will fail at window gen)', () => {
+      // 50 days, train=60, test=21, step=21, min=3 → totalDays < windowSize → no adjustment
+      const result = service.computeAdaptiveStepDays(50, 60, 21, 21, 3);
+      expect(result.stepDays).toBe(21);
+      expect(result.adjusted).toBe(false);
+    });
+
+    it('should not adjust when minWindows is 1', () => {
+      // Any data with minWindows=1 never needs stepping
+      const result = service.computeAdaptiveStepDays(100, 60, 21, 21, 1);
+      expect(result.stepDays).toBe(21);
+      expect(result.adjusted).toBe(false);
+    });
+
+    it('should handle exact fit scenario (123 days, step=21, 3 windows)', () => {
+      // 123 days, train=60, test=21, step=21, min=3
+      // maxStep = floor((123-81)/2) = floor(42/2) = 21 → exact fit, no adjustment
+      const result = service.computeAdaptiveStepDays(123, 60, 21, 21, 3);
+      expect(result.stepDays).toBe(21);
+      expect(result.adjusted).toBe(false);
+    });
+
+    it('should work with risk level 5 config on 108 days of data', () => {
+      // 108 days, train=30, test=14, step=14, min=3
+      // maxStep = floor((108-44)/2) = floor(64/2) = 32 → no adjustment needed
+      const result = service.computeAdaptiveStepDays(108, 30, 14, 14, 3);
+      expect(result.stepDays).toBe(14);
+      expect(result.adjusted).toBe(false);
     });
   });
 

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.ts
@@ -229,18 +229,39 @@ export class OptimizationOrchestratorService {
     try {
       // Generate walk-forward windows
       const { startDate, endDate } = await this.getDateRange(run.config);
+      const totalDays = this.daysBetween(startDate, endDate);
+
+      // Adaptively reduce stepDays if the data span can't produce enough windows
+      const { stepDays: adaptiveStepDays, adjusted: stepAdjusted } = this.computeAdaptiveStepDays(
+        totalDays,
+        run.config.walkForward.trainDays,
+        run.config.walkForward.testDays,
+        run.config.walkForward.stepDays,
+        run.config.walkForward.minWindowsRequired
+      );
+
+      if (stepAdjusted) {
+        this.logger.warn(
+          `Adaptive step adjustment for run ${runId}: stepDays reduced from ` +
+            `${run.config.walkForward.stepDays} to ${adaptiveStepDays} ` +
+            `(data span: ${totalDays} days, need ${run.config.walkForward.minWindowsRequired} windows)`
+        );
+      }
+
       const windows = this.walkForwardService.generateWindows({
         startDate,
         endDate,
         trainDays: run.config.walkForward.trainDays,
         testDays: run.config.walkForward.testDays,
-        stepDays: run.config.walkForward.stepDays,
+        stepDays: adaptiveStepDays,
         method: run.config.walkForward.method
       });
 
       if (windows.length < run.config.walkForward.minWindowsRequired) {
         throw new Error(
-          `Insufficient windows: ${windows.length} generated, ${run.config.walkForward.minWindowsRequired} required`
+          `Insufficient windows: ${windows.length} generated, ${run.config.walkForward.minWindowsRequired} required. ` +
+            `Data span: ${totalDays} days (${startDate.toISOString().split('T')[0]} to ${endDate.toISOString().split('T')[0]}), ` +
+            `trainDays=${run.config.walkForward.trainDays}, testDays=${run.config.walkForward.testDays}, stepDays=${adaptiveStepDays}`
         );
       }
 
@@ -1113,6 +1134,54 @@ export class OptimizationOrchestratorService {
 
     // Convert periods to days (1 period = 1 day for daily OHLC data)
     return Math.max(MIN_WARMUP_DAYS, Math.ceil(warmupPeriods));
+  }
+
+  /**
+   * Compute the number of days between two dates (rounded to nearest integer).
+   */
+  private daysBetween(date1: Date, date2: Date): number {
+    const oneDay = 24 * 60 * 60 * 1000;
+    return Math.round(Math.abs((date2.getTime() - date1.getTime()) / oneDay));
+  }
+
+  /**
+   * Compute an adaptive stepDays that guarantees at least `minWindows` walk-forward windows
+   * given the available data span. Uses the inverse of WalkForwardService.estimateWindowCount():
+   *
+   *   maxStepDays = floor((totalDays - trainDays - testDays) / (minWindows - 1))
+   *
+   * Returns min(configuredStepDays, maxStepDays) — never increases, only reduces.
+   * Floors at 1 day minimum.
+   *
+   * @returns Object with `stepDays` (possibly reduced) and `adjusted` flag
+   */
+  computeAdaptiveStepDays(
+    totalDays: number,
+    trainDays: number,
+    testDays: number,
+    configuredStepDays: number,
+    minWindows: number
+  ): { stepDays: number; adjusted: boolean } {
+    // When minWindows <= 1, a single window needs no stepping at all
+    if (minWindows <= 1) {
+      return { stepDays: configuredStepDays, adjusted: false };
+    }
+
+    const windowSize = trainDays + testDays;
+
+    // Not enough data for even one window — return configured value unchanged
+    // (will fail at window generation with a clear error)
+    if (totalDays < windowSize) {
+      return { stepDays: configuredStepDays, adjusted: false };
+    }
+
+    const maxStepDays = Math.floor((totalDays - windowSize) / (minWindows - 1));
+    const adaptiveStep = Math.max(1, Math.min(configuredStepDays, maxStepDays));
+
+    return {
+      stepDays: adaptiveStep,
+      adjusted: adaptiveStep < configuredStepDays
+    };
   }
 
   /**

--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -1925,6 +1925,47 @@ export class BacktestEngine {
   }
 
   /**
+   * Filter out coins that don't have enough OHLC bars for the strategy's minimum
+   * data requirement. Logs a single summary warning for excluded coins instead of
+   * per-timestamp warnings inside the strategy loop.
+   */
+  private async filterCoinsWithSufficientData(
+    algorithmId: string,
+    coins: Coin[],
+    parameters: Record<string, unknown>,
+    summariesByCoin: Map<string, PriceSummary[]>
+  ): Promise<Coin[]> {
+    const strategy = await this.algorithmRegistry.getStrategyForAlgorithm(algorithmId);
+
+    if (!strategy?.getMinDataPoints) {
+      return coins;
+    }
+
+    const minRequired = strategy.getMinDataPoints(parameters);
+    if (minRequired <= 0) {
+      return coins;
+    }
+
+    const excluded: string[] = [];
+    const filtered = coins.filter((coin) => {
+      const totalBars = summariesByCoin.get(coin.id)?.length ?? 0;
+      if (totalBars < minRequired) {
+        excluded.push(`${coin.symbol}(${totalBars}/${minRequired})`);
+        return false;
+      }
+      return true;
+    });
+
+    if (excluded.length > 0) {
+      this.logger.warn(
+        `Excluded ${excluded.length} coin(s) with insufficient data for optimization: ${excluded.join(', ')}`
+      );
+    }
+
+    return filtered;
+  }
+
+  /**
    * Advance per-coin price windows up to and including the given timestamp.
    *
    * Returns a snapshot of each coin's price window as a plain `PriceSummary[]`
@@ -3037,8 +3078,16 @@ export class BacktestEngine {
     // Create fresh mutable state from cached immutable data
     const priceCtx = this.initPriceTrackingFromPrecomputed(immutablePriceData);
 
-    // Precompute indicators (depends on per-combo config.parameters — must be per-combo)
-    const precomputedIndicators = await this.precomputeIndicatorsForOptimization(config, coins, priceCtx);
+    // Pre-filter coins whose total bar count is below the strategy's minimum requirement
+    const coinsWithData = await this.filterCoinsWithSufficientData(
+      config.algorithmId,
+      coins,
+      config.parameters,
+      priceCtx.summariesByCoin
+    );
+
+    // Precompute indicators only for coins that passed the filter
+    const precomputedIndicators = await this.precomputeIndicatorsForOptimization(config, coinsWithData, priceCtx);
 
     // Position sizing for OPTIMIZE stage
     const optAllocLimits = getAllocationLimits(PipelineStage.OPTIMIZE, config.riskLevel, {
@@ -3075,7 +3124,7 @@ export class BacktestEngine {
       // Always update portfolio values and price windows (needed for indicator warm-up)
       portfolio = this.portfolioState.updateValues(portfolio, marketData.prices);
 
-      const priceData = this.advancePriceWindows(priceCtx, coins, timestamp);
+      const priceData = this.advancePriceWindows(priceCtx, coinsWithData, timestamp);
 
       // Skip trading logic during warm-up period — indicators need history to produce
       // valid values, but no trades should execute before the original window start date
@@ -3105,7 +3154,7 @@ export class BacktestEngine {
           : {};
 
       const context = {
-        coins,
+        coins: coinsWithData,
         priceData,
         timestamp,
         config: config.parameters,

--- a/apps/api/src/tasks/backtest-orchestration.task.spec.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.spec.ts
@@ -9,11 +9,14 @@ import { BacktestOrchestrationService } from './backtest-orchestration.service';
 import { BacktestOrchestrationTask } from './backtest-orchestration.task';
 import { STAGGER_INTERVAL_MS } from './dto/backtest-orchestration.dto';
 
-import { OptimizationRun } from '../optimization/entities/optimization-run.entity';
+import { OptimizationRun, OptimizationStatus } from '../optimization/entities/optimization-run.entity';
 import { BacktestResultService } from '../order/backtest/backtest-result.service';
+import { backtestConfig } from '../order/backtest/backtest.config';
 import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
 import { BacktestService } from '../order/backtest/backtest.service';
 import { Pipeline } from '../pipeline/entities/pipeline.entity';
+
+const BACKTEST_QUEUE_NAMES = backtestConfig();
 
 describe('BacktestOrchestrationTask', () => {
   let task: BacktestOrchestrationTask;
@@ -28,6 +31,10 @@ describe('BacktestOrchestrationTask', () => {
     getFailedCount: jest.fn(),
     getDelayedCount: jest.fn()
   };
+
+  const mockHistoricalQueue = { getJob: jest.fn() };
+  const mockReplayQueue = { getJob: jest.fn() };
+  const mockOptimizationQueue = { getJob: jest.fn() };
 
   const mockService = {
     getEligibleUsers: jest.fn()
@@ -64,6 +71,9 @@ describe('BacktestOrchestrationTask', () => {
       providers: [
         BacktestOrchestrationTask,
         { provide: getQueueToken('backtest-orchestration'), useValue: mockQueue },
+        { provide: getQueueToken(BACKTEST_QUEUE_NAMES.historicalQueue), useValue: mockHistoricalQueue },
+        { provide: getQueueToken(BACKTEST_QUEUE_NAMES.replayQueue), useValue: mockReplayQueue },
+        { provide: getQueueToken('optimization'), useValue: mockOptimizationQueue },
         { provide: BacktestOrchestrationService, useValue: mockService },
         { provide: BacktestService, useValue: mockBacktestService },
         { provide: BacktestResultService, useValue: mockBacktestResultService },
@@ -268,21 +278,6 @@ describe('BacktestOrchestrationTask', () => {
       );
     });
 
-    it('should NOT mark LIVE_REPLAY as stale within 120 min', async () => {
-      // The 90-min-old replay should NOT appear in query results (threshold is 120 min)
-      mockBacktestRepository.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-
-      await task.detectStaleBacktests();
-
-      expect(mockBacktestResultService.markFailed).not.toHaveBeenCalled();
-
-      // Verify the LIVE_REPLAY query uses a ~120-min cutoff (second find call)
-      const liveReplayCall = mockBacktestRepository.find.mock.calls[1][0];
-      const liveReplayWhere = liveReplayCall.where[0];
-      expect(liveReplayWhere.type).toBe(BacktestType.LIVE_REPLAY);
-      expect(liveReplayWhere.lastCheckpointAt).toBeDefined();
-    });
-
     it('should continue loop when markFailed throws for one backtest', async () => {
       const stale1 = {
         id: 'stale-1',
@@ -334,6 +329,8 @@ describe('BacktestOrchestrationTask', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([stuckPending]);
+      // BullMQ job is missing — truly lost
+      mockHistoricalQueue.getJob.mockResolvedValue(null);
 
       await task.detectStaleBacktests();
 
@@ -343,34 +340,178 @@ describe('BacktestOrchestrationTask', () => {
       );
     });
 
-    it('should query HISTORICAL with 90-min cutoff', async () => {
-      mockBacktestRepository.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-      const before = Date.now();
+    it('should skip PENDING backtest when BullMQ job is in waiting state', async () => {
+      const stuckPending = {
+        id: 'pending-bt-2',
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.PENDING,
+        updatedAt: new Date(Date.now() - 45 * 60 * 1000),
+        processedTimestampCount: 0,
+        totalTimestampCount: 0,
+        checkpointState: null
+      };
+      mockBacktestRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([stuckPending]);
+      mockHistoricalQueue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue('waiting') });
 
       await task.detectStaleBacktests();
 
-      const after = Date.now();
-      const historicalCall = mockBacktestRepository.find.mock.calls[0][0];
-      const cutoffDate: Date = historicalCall.where[0].lastCheckpointAt.value;
-      const expectedCutoff = 90 * 60 * 1000;
-      // Verify cutoff is within 5 seconds of expected 90-min threshold (1ms tolerance for clock jitter)
-      expect(before - cutoffDate.getTime()).toBeGreaterThanOrEqual(expectedCutoff - 1);
-      expect(after - cutoffDate.getTime()).toBeLessThanOrEqual(expectedCutoff + 5000);
+      expect(mockBacktestResultService.markFailed).not.toHaveBeenCalled();
     });
 
-    it('should query LIVE_REPLAY with 120-min cutoff', async () => {
-      mockBacktestRepository.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-      const before = Date.now();
+    it('should skip PENDING backtest when BullMQ job is in active state', async () => {
+      const stuckPending = {
+        id: 'pending-bt-active',
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.PENDING,
+        updatedAt: new Date(Date.now() - 45 * 60 * 1000),
+        processedTimestampCount: 0,
+        totalTimestampCount: 0,
+        checkpointState: null
+      };
+      mockBacktestRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([stuckPending]);
+      mockHistoricalQueue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue('active') });
 
       await task.detectStaleBacktests();
 
-      const after = Date.now();
-      const liveReplayCall = mockBacktestRepository.find.mock.calls[1][0];
-      const cutoffDate: Date = liveReplayCall.where[0].lastCheckpointAt.value;
-      const expectedCutoff = 120 * 60 * 1000;
-      // Verify cutoff is within 5 seconds of expected 120-min threshold (1ms tolerance for clock jitter)
-      expect(before - cutoffDate.getTime()).toBeGreaterThanOrEqual(expectedCutoff - 1);
-      expect(after - cutoffDate.getTime()).toBeLessThanOrEqual(expectedCutoff + 5000);
+      expect(mockBacktestResultService.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('should skip PENDING LIVE_REPLAY backtest when BullMQ job is in delayed state', async () => {
+      const stuckPending = {
+        id: 'pending-replay-1',
+        type: BacktestType.LIVE_REPLAY,
+        status: BacktestStatus.PENDING,
+        updatedAt: new Date(Date.now() - 45 * 60 * 1000),
+        processedTimestampCount: 0,
+        totalTimestampCount: 0,
+        checkpointState: null
+      };
+      mockBacktestRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([stuckPending]);
+      mockReplayQueue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue('delayed') });
+
+      await task.detectStaleBacktests();
+
+      expect(mockBacktestResultService.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('should still mark PENDING backtest as FAILED when BullMQ job is missing', async () => {
+      const stuckPending = {
+        id: 'pending-bt-3',
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.PENDING,
+        updatedAt: new Date(Date.now() - 45 * 60 * 1000),
+        processedTimestampCount: 0,
+        totalTimestampCount: 0,
+        checkpointState: null
+      };
+      mockBacktestRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([stuckPending]);
+      mockHistoricalQueue.getJob.mockResolvedValue(null);
+
+      await task.detectStaleBacktests();
+
+      expect(mockBacktestResultService.markFailed).toHaveBeenCalledWith(
+        'pending-bt-3',
+        expect.stringContaining('Stuck PENDING for 30 min')
+      );
+    });
+
+    it('should still mark PENDING backtest as FAILED when queue check errors', async () => {
+      const stuckPending = {
+        id: 'pending-bt-4',
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.PENDING,
+        updatedAt: new Date(Date.now() - 45 * 60 * 1000),
+        processedTimestampCount: 0,
+        totalTimestampCount: 0,
+        checkpointState: null
+      };
+      mockBacktestRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([stuckPending]);
+      mockHistoricalQueue.getJob.mockRejectedValue(new Error('Redis connection lost'));
+
+      await task.detectStaleBacktests();
+
+      expect(mockBacktestResultService.markFailed).toHaveBeenCalledWith(
+        'pending-bt-4',
+        expect.stringContaining('Stuck PENDING for 30 min')
+      );
+    });
+  });
+
+  describe('detectStaleOptimizationRuns — queue-aware PENDING check', () => {
+    it('should skip PENDING optimization run when BullMQ job is in waiting state', async () => {
+      const pendingRun = {
+        id: 'opt-run-1',
+        status: OptimizationStatus.PENDING,
+        createdAt: new Date(Date.now() - 400 * 60 * 1000),
+        combinationsTested: 0,
+        totalCombinations: 100
+      };
+      mockOptimizationRunRepository.find.mockResolvedValue([pendingRun]);
+      mockOptimizationQueue.getJob.mockResolvedValue({ getState: jest.fn().mockResolvedValue('waiting') });
+
+      await task.detectStaleOptimizationRuns();
+
+      expect(mockOptimizationRunRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should still mark PENDING optimization run as FAILED when BullMQ job is missing', async () => {
+      const pendingRun = {
+        id: 'opt-run-2',
+        status: OptimizationStatus.PENDING,
+        createdAt: new Date(Date.now() - 400 * 60 * 1000),
+        combinationsTested: 0,
+        totalCombinations: 100
+      };
+      mockOptimizationRunRepository.find.mockResolvedValue([pendingRun]);
+      mockOptimizationQueue.getJob.mockResolvedValue(null);
+      mockOptimizationRunRepository.update.mockResolvedValue({ affected: 1 });
+
+      await task.detectStaleOptimizationRuns();
+
+      expect(mockOptimizationRunRepository.update).toHaveBeenCalledWith(
+        { id: 'opt-run-2', status: expect.anything() },
+        expect.objectContaining({
+          status: OptimizationStatus.FAILED,
+          errorMessage: expect.stringContaining('PENDING')
+        })
+      );
+    });
+
+    it('should still mark PENDING optimization run as FAILED when queue check errors', async () => {
+      const pendingRun = {
+        id: 'opt-run-3',
+        status: OptimizationStatus.PENDING,
+        createdAt: new Date(Date.now() - 400 * 60 * 1000),
+        combinationsTested: 0,
+        totalCombinations: 100
+      };
+      mockOptimizationRunRepository.find.mockResolvedValue([pendingRun]);
+      mockOptimizationQueue.getJob.mockRejectedValue(new Error('Redis timeout'));
+      mockOptimizationRunRepository.update.mockResolvedValue({ affected: 1 });
+
+      await task.detectStaleOptimizationRuns();
+
+      expect(mockOptimizationRunRepository.update).toHaveBeenCalledWith(
+        { id: 'opt-run-3', status: expect.anything() },
+        expect.objectContaining({
+          status: OptimizationStatus.FAILED
+        })
+      );
     });
   });
 });

--- a/apps/api/src/tasks/backtest-orchestration.task.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.ts
@@ -19,11 +19,14 @@ import { OrchestrationJobData, STAGGER_INTERVAL_MS } from './dto/backtest-orches
 
 import { OptimizationRun, OptimizationStatus } from '../optimization/entities/optimization-run.entity';
 import { BacktestResultService } from '../order/backtest/backtest-result.service';
+import { backtestConfig } from '../order/backtest/backtest.config';
 import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
 import { BacktestService } from '../order/backtest/backtest.service';
 import { Pipeline } from '../pipeline/entities/pipeline.entity';
 import { PIPELINE_EVENTS, PipelineStage, PipelineStatus } from '../pipeline/interfaces';
 import { toErrorInfo } from '../shared/error.util';
+
+const BACKTEST_QUEUE_NAMES = backtestConfig();
 
 @Injectable()
 export class BacktestOrchestrationTask {
@@ -40,6 +43,12 @@ export class BacktestOrchestrationTask {
   constructor(
     @InjectQueue('backtest-orchestration')
     private readonly orchestrationQueue: Queue<OrchestrationJobData>,
+    @InjectQueue(BACKTEST_QUEUE_NAMES.historicalQueue)
+    private readonly historicalQueue: Queue,
+    @InjectQueue(BACKTEST_QUEUE_NAMES.replayQueue)
+    private readonly replayQueue: Queue,
+    @InjectQueue('optimization')
+    private readonly optimizationQueue: Queue,
     private readonly orchestrationService: BacktestOrchestrationService,
     private readonly backtestService: BacktestService,
     private readonly backtestResultService: BacktestResultService,
@@ -235,9 +244,20 @@ export class BacktestOrchestrationTask {
       }))
     ];
 
+    let marked = 0;
     for (const { backtest, thresholdMs } of staleBacktests) {
       try {
         const isPending = backtest.status === BacktestStatus.PENDING;
+
+        // For PENDING backtests, check if the BullMQ job is legitimately queued
+        if (isPending) {
+          const queue = this.getQueueForBacktestType(backtest.type);
+          if (queue && (await this.isJobLegitimatelyQueued(queue, backtest.id))) {
+            this.logger.debug(`Skipping PENDING backtest ${backtest.id} — BullMQ job still legitimately queued`);
+            continue;
+          }
+        }
+
         const reason = isPending
           ? `Stuck PENDING for ${Math.round(thresholdMs / 60000)} min — BullMQ job likely lost`
           : `Stale: no heartbeat progress for ${Math.round(thresholdMs / 60000)} min. ` +
@@ -251,14 +271,15 @@ export class BacktestOrchestrationTask {
                 `progress: ${backtest.processedTimestampCount}/${backtest.totalTimestampCount})`)
         );
         await this.backtestResultService.markFailed(backtest.id, reason);
+        marked++;
       } catch (error: unknown) {
         const err = toErrorInfo(error);
         this.logger.error(`Failed to mark stale backtest ${backtest.id} as FAILED: ${err.message}`);
       }
     }
 
-    if (staleBacktests.length > 0) {
-      this.logger.log(`Stale watchdog marked ${staleBacktests.length} backtest(s) as FAILED`);
+    if (marked > 0) {
+      this.logger.log(`Stale watchdog marked ${marked} backtest(s) as FAILED`);
     }
   }
 
@@ -285,9 +306,17 @@ export class BacktestOrchestrationTask {
       ]
     });
 
+    let marked = 0;
     for (const run of staleRuns) {
       try {
         const isPending = run.status === OptimizationStatus.PENDING;
+
+        // For PENDING optimization runs, check if the BullMQ job is legitimately queued
+        if (isPending && (await this.isJobLegitimatelyQueued(this.optimizationQueue, run.id))) {
+          this.logger.debug(`Skipping PENDING optimization run ${run.id} — BullMQ job still legitimately queued`);
+          continue;
+        }
+
         const thresholdMin = Math.round(
           (isPending
             ? BacktestOrchestrationTask.PENDING_OPTIMIZATION_THRESHOLD_MS
@@ -315,6 +344,7 @@ export class BacktestOrchestrationTask {
           continue;
         }
 
+        marked++;
         this.eventEmitter.emit(PIPELINE_EVENTS.OPTIMIZATION_FAILED, {
           runId: run.id,
           reason
@@ -325,8 +355,8 @@ export class BacktestOrchestrationTask {
       }
     }
 
-    if (staleRuns.length > 0) {
-      this.logger.log(`Stale optimization watchdog marked ${staleRuns.length} run(s) as FAILED`);
+    if (marked > 0) {
+      this.logger.log(`Stale optimization watchdog marked ${marked} run(s) as FAILED`);
     }
   }
 
@@ -445,6 +475,35 @@ export class BacktestOrchestrationTask {
 
     if (marked > 0) {
       this.logger.log(`Failed-optimization pipeline watchdog marked ${marked} pipeline(s) as FAILED`);
+    }
+  }
+
+  /**
+   * Check if a BullMQ job is legitimately queued (waiting or delayed).
+   * Returns false on missing job or any error (lets watchdog proceed on failure).
+   */
+  private async isJobLegitimatelyQueued(queue: Queue, jobId: string): Promise<boolean> {
+    try {
+      const job = await queue.getJob(jobId);
+      if (!job) return false;
+      const state = await job.getState();
+      return state === 'waiting' || state === 'delayed' || state === 'active';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Map a backtest type to its corresponding BullMQ queue.
+   */
+  private getQueueForBacktestType(type: BacktestType): Queue | null {
+    switch (type) {
+      case BacktestType.HISTORICAL:
+        return this.historicalQueue;
+      case BacktestType.LIVE_REPLAY:
+        return this.replayQueue;
+      default:
+        return null;
     }
   }
 }

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -28,6 +28,7 @@ import { MarketRegimeModule } from '../market-regime/market-regime.module';
 import { MonitoringModule } from '../monitoring/monitoring.module';
 import { OHLCModule } from '../ohlc/ohlc.module';
 import { OptimizationRun } from '../optimization/entities/optimization-run.entity';
+import { backtestConfig } from '../order/backtest/backtest.config';
 import { Backtest } from '../order/backtest/backtest.entity';
 import { MarketDataSet } from '../order/backtest/market-data-set.entity';
 import { OrderModule } from '../order/order.module';
@@ -61,6 +62,8 @@ import { UsersModule } from '../users/users.module';
  * - PipelineOrchestrationTask: Daily at 2 AM - Orchestrate full validation pipelines for algo-enabled users
  * - BacktestOrchestrationTask: Twice daily at 3 AM/3 PM UTC - Orchestrate automatic backtests for algo-enabled users
  */
+const BACKTEST_QUEUE_NAMES = backtestConfig();
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -82,7 +85,10 @@ import { UsersModule } from '../users/users.module';
       { name: 'drift-detection-queue' },
       { name: 'regime-check-queue' },
       { name: 'backtest-orchestration' },
-      { name: 'pipeline-orchestration' }
+      { name: 'pipeline-orchestration' },
+      { name: BACKTEST_QUEUE_NAMES.historicalQueue },
+      { name: BACKTEST_QUEUE_NAMES.replayQueue },
+      { name: 'optimization' }
     ),
     forwardRef(() => AlgorithmModule),
     forwardRef(() => CoinModule),


### PR DESCRIPTION
## Summary

- Add `getMinDataPoints()` to all strategies and pre-filter coins with insufficient OHLC data before backtesting
- Make stale-detection watchdog queue-aware — skip jobs that are legitimately `PENDING` or `active` in BullMQ
- Add adaptive walk-forward step reduction when data span is tight during optimization

## Changes

### Strategy Data Guards
- Add `getMinDataPoints()` to the `AlgorithmStrategy` interface and `BaseAlgorithmStrategy`
- Implement minimum data point calculations for all 13 strategies (RSI, MACD, EMA, Bollinger, Confluence, etc.)
- Pre-filter coins with insufficient OHLC data in the backtest engine before running

### Watchdog Improvements
- Query BullMQ for actual job state before marking backtests as stale/failed
- Treat `active` and `waiting` states as legitimate — only mark truly orphaned jobs
- Track actual marked-failed count in watchdog logs instead of total candidates

### Optimization Resilience
- Adaptive walk-forward step reduction when data span < 2× window size
- Move indicator precomputation after coin data filter to avoid wasted work

### Monitoring & Data Pipeline
- Resolve instrument UUIDs to coin symbols in backtest monitoring exports/analytics
- Auto-trigger OHLC backfill for newly mapped coins during symbol map seeding
- Downgrade "Insufficient price data" logs from `warn` to `debug` (noise reduction)

## Test Plan

- [x] Watchdog correctly skips PENDING backtests when BullMQ job is active
- [x] Optimization orchestrator reduces walk-forward steps for short data spans
- [x] Backtest engine filters coins below strategy's minimum data point threshold
- [x] All existing tests pass with updated assertions