### PR TITLE
feat(api): align backtest and optimization with live regime-aware trading

### DIFF
--- a/apps/api/src/algorithm/interfaces/algorithm-context.interface.ts
+++ b/apps/api/src/algorithm/interfaces/algorithm-context.interface.ts
@@ -1,3 +1,5 @@
+import { CompositeRegimeType, MarketRegimeType } from '@chansey/api-interfaces';
+
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { Order } from '../../order/order.entity';
 
@@ -60,4 +62,16 @@ export interface AlgorithmContext {
    * Used with `precomputedIndicators` to look up precomputed values.
    */
   currentTimestampIndex?: number;
+
+  /**
+   * Composite regime classification (trend + volatility) derived from BTC data.
+   * Available in both backtest and live trading contexts.
+   */
+  compositeRegime?: CompositeRegimeType;
+
+  /**
+   * Volatility regime derived from BTC realized volatility percentile.
+   * Available in both backtest and live trading contexts.
+   */
+  volatilityRegime?: MarketRegimeType;
 }

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
@@ -1144,7 +1144,7 @@ describe('OptimizationOrchestratorService', () => {
 
   describe('computeAdaptiveStepDays', () => {
     it('should not adjust when configured step fits comfortably', () => {
-      // 300 days, train=90, test=30, step=15, min=3 → maxStep=floor((300-120)/2)=90 → no change
+      // 300 days, train=90, test=30, step=15, min=3 → windowSize=121, maxStep=floor((300-121)/2)=89 → no change
       const result = service.computeAdaptiveStepDays(300, 90, 30, 15, 3);
       expect(result.stepDays).toBe(15);
       expect(result.adjusted).toBe(false);
@@ -1152,7 +1152,7 @@ describe('OptimizationOrchestratorService', () => {
 
     it('should reduce step for 108-day data with risk level 4 config', () => {
       // 108 days, train=60, test=21, step=21, min=3
-      // maxStep = floor((108-81)/2) = floor(27/2) = 13
+      // windowSize=82, maxStep = floor((108-82)/2) = floor(26/2) = 13
       const result = service.computeAdaptiveStepDays(108, 60, 21, 21, 3);
       expect(result.stepDays).toBe(13);
       expect(result.adjusted).toBe(true);
@@ -1160,14 +1160,14 @@ describe('OptimizationOrchestratorService', () => {
 
     it('should never increase beyond configured step', () => {
       // Even when data allows much larger steps, cap at configured value
-      // 500 days, train=30, test=14, step=5, min=3 → maxStep=floor((500-44)/2)=228 → stays 5
+      // 500 days, train=30, test=14, step=5, min=3 → windowSize=45, maxStep=floor((500-45)/2)=227 → stays 5
       const result = service.computeAdaptiveStepDays(500, 30, 14, 5, 3);
       expect(result.stepDays).toBe(5);
       expect(result.adjusted).toBe(false);
     });
 
     it('should floor at 1 day for very tight data', () => {
-      // 82 days, train=60, test=21, step=21, min=3 → maxStep=floor((82-81)/2)=0 → floors at 1
+      // 82 days, train=60, test=21, step=21, min=3 → windowSize=82, maxStep=floor((82-82)/2)=0 → floors at 1
       const result = service.computeAdaptiveStepDays(82, 60, 21, 21, 3);
       expect(result.stepDays).toBe(1);
       expect(result.adjusted).toBe(true);
@@ -1187,17 +1187,17 @@ describe('OptimizationOrchestratorService', () => {
       expect(result.adjusted).toBe(false);
     });
 
-    it('should handle exact fit scenario (123 days, step=21, 3 windows)', () => {
-      // 123 days, train=60, test=21, step=21, min=3
-      // maxStep = floor((123-81)/2) = floor(42/2) = 21 → exact fit, no adjustment
-      const result = service.computeAdaptiveStepDays(123, 60, 21, 21, 3);
+    it('should handle exact fit scenario (124 days, step=21, 3 windows)', () => {
+      // 124 days, train=60, test=21, step=21, min=3
+      // windowSize=60+1+21=82, maxStep=floor((124-82)/2)=floor(42/2)=21 → exact fit
+      const result = service.computeAdaptiveStepDays(124, 60, 21, 21, 3);
       expect(result.stepDays).toBe(21);
       expect(result.adjusted).toBe(false);
     });
 
     it('should work with risk level 5 config on 108 days of data', () => {
       // 108 days, train=30, test=14, step=14, min=3
-      // maxStep = floor((108-44)/2) = floor(64/2) = 32 → no adjustment needed
+      // windowSize=45, maxStep = floor((108-45)/2) = floor(63/2) = 31 → no adjustment needed
       const result = service.computeAdaptiveStepDays(108, 30, 14, 14, 3);
       expect(result.stepDays).toBe(14);
       expect(result.adjusted).toBe(false);

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.ts
@@ -693,7 +693,9 @@ export class OptimizationOrchestratorService {
       startDate,
       endDate,
       initialCapital: 10000,
-      tradingFee: 0.001
+      tradingFee: 0.001,
+      enableRegimeGate: true,
+      enableRegimeScaledSizing: true
     };
 
     try {
@@ -1167,7 +1169,10 @@ export class OptimizationOrchestratorService {
       return { stepDays: configuredStepDays, adjusted: false };
     }
 
-    const windowSize = trainDays + testDays;
+    // WalkForwardService.generateWindows() inserts a +1 day gap between
+    // trainEnd and testStart, so the effective window footprint is
+    // trainDays + 1 + testDays, not trainDays + testDays.
+    const windowSize = trainDays + 1 + testDays;
 
     // Not enough data for even one window — return configured value unchanged
     // (will fail at window generation with a clear error)

--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -146,7 +146,7 @@ interface ExecuteOptions {
    *  When enabled, BUY signals are blocked when BTC is below its 200-day SMA. */
   enableRegimeGate?: boolean;
 
-  /** Enable regime-scaled position sizing (default: false for backward compatibility) */
+  /** Enable regime-scaled position sizing (default: true to match live trading) */
   enableRegimeScaledSizing?: boolean;
   /** User risk level for regime multiplier lookup (1-5). Default: 3 */
   riskLevel?: number;
@@ -272,6 +272,10 @@ export interface OptimizationBacktestConfig {
   slippage?: SlippageConfig;
   /** Exit configuration for SL/TP/trailing stop simulation (overrides legacy hard stop-loss) */
   exitConfig?: ExitConfig;
+  /** Enable composite regime gate filtering (default: true) */
+  enableRegimeGate?: boolean;
+  /** Enable regime-scaled position sizing (default: true) */
+  enableRegimeScaledSizing?: boolean;
 }
 
 /**
@@ -330,6 +334,7 @@ export interface PrecomputedWindowData {
 
 interface CompositeRegimeResult {
   compositeRegime: CompositeRegimeType;
+  volatilityRegime: MarketRegimeType;
 }
 
 @Injectable()
@@ -430,14 +435,14 @@ export class BacktestEngine {
     }
 
     const compositeRegime = this.regimeGateService.classifyComposite(volatilityRegime, trendAboveSma);
-    return { compositeRegime };
+    return { compositeRegime, volatilityRegime };
   }
 
   private resolveRegimeConfig(
     options: { enableRegimeGate?: boolean; enableRegimeScaledSizing?: boolean; riskLevel?: number },
     coins: Coin[]
   ): { enableRegimeScaledSizing: boolean; riskLevel: number; regimeGateEnabled: boolean; btcCoin: Coin | undefined } {
-    const enableRegimeScaledSizing = options.enableRegimeScaledSizing === true;
+    const enableRegimeScaledSizing = options.enableRegimeScaledSizing !== false;
     const riskLevel = options.riskLevel ?? 3;
     const regimeGateEnabled = options.enableRegimeGate !== false;
     const btcCoin =
@@ -448,11 +453,25 @@ export class BacktestEngine {
     return { enableRegimeScaledSizing, riskLevel, regimeGateEnabled, btcCoin };
   }
 
+  private resolveRegimeConfigForOptimization(
+    config: { enableRegimeGate?: boolean; enableRegimeScaledSizing?: boolean; riskLevel?: number },
+    coins: Coin[],
+    priceCtx: PriceTrackingContext
+  ): { enableRegimeScaledSizing: boolean; riskLevel: number; regimeGateEnabled: boolean; btcCoin: Coin | undefined } {
+    const result = this.resolveRegimeConfig(config, coins);
+    if (result.btcCoin) {
+      priceCtx.btcRegimeSma = new IncrementalSma(BacktestEngine.REGIME_SMA_PERIOD);
+      priceCtx.btcCoinId = result.btcCoin.id;
+    }
+    return result;
+  }
+
   private applyBarRegime(
     strategySignals: TradingSignal[],
     priceCtx: PriceTrackingContext,
     regimeConfig: { btcCoin?: Coin; regimeGateEnabled: boolean; enableRegimeScaledSizing: boolean; riskLevel: number },
-    allocationLimits: { maxAllocation: number; minAllocation: number }
+    allocationLimits: { maxAllocation: number; minAllocation: number },
+    precomputedRegime?: CompositeRegimeResult | null
   ): { filteredSignals: TradingSignal[]; barMaxAllocation: number; barMinAllocation: number } {
     if (!regimeConfig.btcCoin || strategySignals.length === 0) {
       return {
@@ -462,7 +481,10 @@ export class BacktestEngine {
       };
     }
 
-    const regimeResult = this.computeCompositeRegime(regimeConfig.btcCoin.id, priceCtx);
+    const regimeResult =
+      precomputedRegime !== undefined
+        ? precomputedRegime
+        : this.computeCompositeRegime(regimeConfig.btcCoin.id, priceCtx);
     if (!regimeResult) {
       return {
         filteredSignals: strategySignals,
@@ -740,6 +762,7 @@ export class BacktestEngine {
 
       // During warmup: run algorithm to prime internal state but skip trading/recording
       if (isWarmup) {
+        const warmupRegime = btcCoin ? this.computeCompositeRegime(btcCoin.id, priceCtx) : null;
         const context = {
           coins,
           priceData,
@@ -753,7 +776,9 @@ export class BacktestEngine {
             datasetId: options.dataset.id,
             deterministicSeed: options.deterministicSeed,
             backtestId: backtest.id
-          }
+          },
+          compositeRegime: warmupRegime?.compositeRegime,
+          volatilityRegime: warmupRegime?.volatilityRegime
         };
         try {
           await this.algorithmRegistry.executeAlgorithm(backtest.algorithm.id, context);
@@ -786,6 +811,9 @@ export class BacktestEngine {
         });
       }
 
+      // Compute regime once per bar for context + filtering
+      const barRegimeResult = btcCoin ? this.computeCompositeRegime(btcCoin.id, priceCtx) : null;
+
       const context = {
         coins,
         priceData,
@@ -799,7 +827,9 @@ export class BacktestEngine {
           datasetId: options.dataset.id,
           deterministicSeed: options.deterministicSeed,
           backtestId: backtest.id
-        }
+        },
+        compositeRegime: barRegimeResult?.compositeRegime,
+        volatilityRegime: barRegimeResult?.volatilityRegime
       };
 
       let strategySignals: TradingSignal[] = [];
@@ -844,12 +874,13 @@ export class BacktestEngine {
         timestamp.getTime()
       );
 
-      // Regime gate + regime-scaled position sizing
+      // Regime gate + regime-scaled position sizing (pass precomputed to avoid double-computing)
       const { filteredSignals, barMaxAllocation, barMinAllocation } = this.applyBarRegime(
         strategySignals,
         priceCtx,
         { btcCoin, regimeGateEnabled, enableRegimeScaledSizing, riskLevel },
-        { maxAllocation, minAllocation }
+        { maxAllocation, minAllocation },
+        barRegimeResult
       );
       strategySignals = filteredSignals;
 
@@ -1551,6 +1582,9 @@ export class BacktestEngine {
         await this.delay(delayMs);
       }
 
+      // Compute regime once per bar for context + filtering
+      const barRegimeResult = btcCoin ? this.computeCompositeRegime(btcCoin.id, priceCtx) : null;
+
       const context = {
         coins,
         priceData,
@@ -1566,7 +1600,9 @@ export class BacktestEngine {
           backtestId: backtest.id,
           isLiveReplay: true,
           replaySpeed: replaySpeed
-        }
+        },
+        compositeRegime: barRegimeResult?.compositeRegime,
+        volatilityRegime: barRegimeResult?.volatilityRegime
       };
 
       let strategySignals: TradingSignal[] = [];
@@ -1602,12 +1638,13 @@ export class BacktestEngine {
         timestamp.getTime()
       );
 
-      // Regime gate + regime-scaled position sizing
+      // Regime gate + regime-scaled position sizing (pass precomputed to avoid double-computing)
       const { filteredSignals, barMaxAllocation, barMinAllocation } = this.applyBarRegime(
         strategySignals,
         priceCtx,
         { btcCoin, regimeGateEnabled, enableRegimeScaledSizing, riskLevel },
-        { maxAllocation, minAllocation }
+        { maxAllocation, minAllocation },
+        barRegimeResult
       );
       strategySignals = filteredSignals;
 
@@ -3134,8 +3171,15 @@ export class BacktestEngine {
       maxAllocation: config.maxAllocation,
       minAllocation: config.minAllocation
     });
-    const optMaxAllocation = optAllocLimits.maxAllocation;
-    const optMinAllocation = optAllocLimits.minAllocation;
+    let optMaxAllocation = optAllocLimits.maxAllocation;
+    let optMinAllocation = optAllocLimits.minAllocation;
+
+    // Regime gate + scaled sizing for optimization
+    const { enableRegimeScaledSizing, riskLevel, regimeGateEnabled, btcCoin } = this.resolveRegimeConfigForOptimization(
+      config,
+      coins,
+      priceCtx
+    );
 
     let peakValue = initialCapital;
     let maxDrawdown = 0;
@@ -3187,6 +3231,9 @@ export class BacktestEngine {
         });
       }
 
+      // Compute regime for context + filtering
+      const barRegimeResult = btcCoin ? this.computeCompositeRegime(btcCoin.id, priceCtx) : null;
+
       // Build algorithm context
       const positions =
         portfolio.positions.size > 0
@@ -3205,7 +3252,9 @@ export class BacktestEngine {
           algorithmId: config.algorithmId
         },
         precomputedIndicators,
-        currentTimestampIndex: i
+        currentTimestampIndex: i,
+        compositeRegime: barRegimeResult?.compositeRegime,
+        volatilityRegime: barRegimeResult?.volatilityRegime
       };
 
       let strategySignals: TradingSignal[] = [];
@@ -3229,6 +3278,20 @@ export class BacktestEngine {
         throttleConfig,
         timestamp.getTime()
       );
+
+      // Regime gate + regime-scaled position sizing
+      if (btcCoin) {
+        const { filteredSignals, barMaxAllocation, barMinAllocation } = this.applyBarRegime(
+          strategySignals,
+          priceCtx,
+          { btcCoin, regimeGateEnabled, enableRegimeScaledSizing, riskLevel },
+          { maxAllocation: optAllocLimits.maxAllocation, minAllocation: optAllocLimits.minAllocation },
+          barRegimeResult
+        );
+        strategySignals = filteredSignals;
+        optMaxAllocation = barMaxAllocation;
+        optMinAllocation = barMinAllocation;
+      }
 
       for (const strategySignal of strategySignals) {
         const dailyVolume = volumeMap.get(`${timestamps[i]}:${strategySignal.coinId}`);
@@ -3570,12 +3633,19 @@ export class BacktestEngine {
     }
 
     // Position sizing for OPTIMIZE stage
-    const coreOptAllocLimits = getAllocationLimits(PipelineStage.OPTIMIZE, config.riskLevel, {
+    const optAllocLimits = getAllocationLimits(PipelineStage.OPTIMIZE, config.riskLevel, {
       maxAllocation: config.maxAllocation,
       minAllocation: config.minAllocation
     });
-    const coreOptMaxAlloc = coreOptAllocLimits.maxAllocation;
-    const coreOptMinAlloc = coreOptAllocLimits.minAllocation;
+    let optMaxAllocation = optAllocLimits.maxAllocation;
+    let optMinAllocation = optAllocLimits.minAllocation;
+
+    // Regime gate + scaled sizing for optimization
+    const { enableRegimeScaledSizing, riskLevel, regimeGateEnabled, btcCoin } = this.resolveRegimeConfigForOptimization(
+      config,
+      coins,
+      priceCtx
+    );
 
     let peakValue = initialCapital;
     let maxDrawdown = 0;
@@ -3621,6 +3691,9 @@ export class BacktestEngine {
         });
       }
 
+      // Compute regime for context + filtering
+      const barRegimeResult = btcCoin ? this.computeCompositeRegime(btcCoin.id, priceCtx) : null;
+
       // Build algorithm context with optimization parameters
       // Lazy positions snapshot: only build when positions exist
       const positions =
@@ -3640,7 +3713,9 @@ export class BacktestEngine {
           algorithmId: config.algorithmId
         },
         precomputedIndicators,
-        currentTimestampIndex: i
+        currentTimestampIndex: i,
+        compositeRegime: barRegimeResult?.compositeRegime,
+        volatilityRegime: barRegimeResult?.volatilityRegime
       };
 
       let strategySignals: TradingSignal[] = [];
@@ -3665,6 +3740,20 @@ export class BacktestEngine {
         timestamp.getTime()
       );
 
+      // Regime gate + regime-scaled position sizing
+      if (btcCoin) {
+        const { filteredSignals, barMaxAllocation, barMinAllocation } = this.applyBarRegime(
+          strategySignals,
+          priceCtx,
+          { btcCoin, regimeGateEnabled, enableRegimeScaledSizing, riskLevel },
+          { maxAllocation: optAllocLimits.maxAllocation, minAllocation: optAllocLimits.minAllocation },
+          barRegimeResult
+        );
+        strategySignals = filteredSignals;
+        optMaxAllocation = barMaxAllocation;
+        optMinAllocation = barMinAllocation;
+      }
+
       for (const strategySignal of strategySignals) {
         // Use precomputed volume map instead of .find() per signal
         const dailyVolume = volumeMap.get(`${timestamps[i]}:${strategySignal.coinId}`);
@@ -3678,8 +3767,8 @@ export class BacktestEngine {
           slippageConfig,
           dailyVolume,
           BacktestEngine.DEFAULT_MIN_HOLD_MS,
-          coreOptMaxAlloc,
-          coreOptMinAlloc
+          optMaxAllocation,
+          optMinAllocation
         );
         if (tradeResult) {
           trades.push({ ...tradeResult.trade, executedAt: timestamp });

--- a/apps/api/src/order/backtest/backtest-pacing.interface.ts
+++ b/apps/api/src/order/backtest/backtest-pacing.interface.ts
@@ -103,7 +103,7 @@ export interface LiveReplayExecuteOptions {
   /** Pipeline stage for allocation limit lookup (default: LIVE_REPLAY) */
   pipelineStage?: PipelineStage;
 
-  /** Enable regime-scaled position sizing (default: false for backward compatibility) */
+  /** Enable regime-scaled position sizing (default: true to match live trading) */
   enableRegimeScaledSizing?: boolean;
   /** User risk level for regime multiplier lookup (1-5). Default: 3 */
   riskLevel?: number;

--- a/apps/api/src/order/backtest/backtest.processor.ts
+++ b/apps/api/src/order/backtest/backtest.processor.ts
@@ -200,6 +200,7 @@ export class BacktestProcessor extends WorkerHost implements OnModuleInit {
         });
       };
 
+      const regimeConfig = backtest.configSnapshot?.regime;
       const results = await this.backtestEngine.executeHistoricalBacktest(backtest, coins, {
         dataset,
         deterministicSeed,
@@ -208,7 +209,10 @@ export class BacktestProcessor extends WorkerHost implements OnModuleInit {
         onCheckpoint,
         onHeartbeat,
         resumeFrom,
-        exitConfig: backtest.configSnapshot?.exitConfig as ExitConfig | undefined
+        exitConfig: backtest.configSnapshot?.exitConfig as ExitConfig | undefined,
+        enableRegimeGate: regimeConfig?.enableRegimeGate,
+        enableRegimeScaledSizing: regimeConfig?.enableRegimeScaledSizing,
+        riskLevel: regimeConfig?.riskLevel
       });
 
       // Clear checkpoint on successful completion

--- a/apps/api/src/order/backtest/backtest.service.ts
+++ b/apps/api/src/order/backtest/backtest.service.ts
@@ -196,6 +196,11 @@ export class BacktestService implements OnModuleInit, OnModuleDestroy {
           baseBps: createBacktestDto.slippageBaseBps ?? 5,
           volumeImpactFactor: createBacktestDto.slippageVolumeImpactFactor ?? 100
         },
+        regime: {
+          enableRegimeGate: createBacktestDto.enableRegimeGate,
+          enableRegimeScaledSizing: createBacktestDto.enableRegimeScaledSizing,
+          riskLevel: createBacktestDto.riskLevel
+        },
         parameters: createBacktestDto.strategyParams ?? {},
         ...(createBacktestDto.exitConfig && { exitConfig: createBacktestDto.exitConfig })
       };

--- a/apps/api/src/order/backtest/dto/backtest.dto.ts
+++ b/apps/api/src/order/backtest/dto/backtest.dto.ts
@@ -6,6 +6,7 @@ import {
   IsBoolean,
   IsDateString,
   IsEnum,
+  IsInt,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -298,6 +299,39 @@ export class CreateBacktestDto {
     required: false
   })
   quoteCurrency?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    description:
+      'Enable composite regime gate filtering. When enabled, BUY signals are blocked in BEAR/EXTREME regimes.',
+    default: true,
+    required: false
+  })
+  enableRegimeGate?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Enable regime-scaled position sizing to match live trading behavior.',
+    default: true,
+    required: false
+  })
+  enableRegimeScaledSizing?: boolean;
+
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  @IsOptional()
+  @ApiProperty({
+    description: 'User risk level (1=conservative, 5=aggressive) for regime multiplier lookup.',
+    example: 3,
+    default: 3,
+    minimum: 1,
+    maximum: 5,
+    required: false
+  })
+  riskLevel?: number;
 
   @IsEnum(ReplaySpeed)
   @IsOptional()

--- a/apps/api/src/order/backtest/live-replay.processor.ts
+++ b/apps/api/src/order/backtest/live-replay.processor.ts
@@ -223,6 +223,7 @@ export class LiveReplayProcessor extends WorkerHost implements OnModuleInit {
       };
 
       // Execute live replay with pacing, pause support, and checkpoints
+      const regimeConfig = backtest.configSnapshot?.regime;
       const results = await this.backtestEngine.executeLiveReplayBacktest(backtest, coins, {
         dataset,
         deterministicSeed,
@@ -234,7 +235,10 @@ export class LiveReplayProcessor extends WorkerHost implements OnModuleInit {
         resumeFrom: backtest.checkpointState ?? undefined,
         shouldPause,
         onPaused,
-        exitConfig: backtest.configSnapshot?.exitConfig as ExitConfig | undefined
+        exitConfig: backtest.configSnapshot?.exitConfig as ExitConfig | undefined,
+        enableRegimeGate: regimeConfig?.enableRegimeGate,
+        enableRegimeScaledSizing: regimeConfig?.enableRegimeScaledSizing,
+        riskLevel: regimeConfig?.riskLevel
       });
 
       // Handle paused state (don't mark as completed)

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
@@ -1,4 +1,4 @@
-import { CompositeRegimeType } from '@chansey/api-interfaces';
+import { CompositeRegimeType, MarketRegimeType } from '@chansey/api-interfaces';
 
 import { PaperTradingOrderSide } from './entities';
 import { PaperTradingEngineService } from './paper-trading-engine.service';
@@ -56,7 +56,8 @@ const createService = (overrides: Partial<any> = {}) => {
   };
 
   const compositeRegimeService = {
-    getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BULL)
+    getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BULL),
+    getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
   };
 
   const signalFilterChain = {
@@ -1498,7 +1499,8 @@ describe('PaperTradingEngineService', () => {
   describe('regime gate filtering', () => {
     it('blocks BUY signals in BEAR regime', async () => {
       const compositeRegimeService = {
-        getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BEAR)
+        getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BEAR),
+        getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
       };
 
       const signalFilterChain = {
@@ -1557,7 +1559,8 @@ describe('PaperTradingEngineService', () => {
       const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
 
       const compositeRegimeService = {
-        getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BEAR)
+        getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BEAR),
+        getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
       };
 
       // Passthrough: STOP_LOSS mapped to SELL passes the gate

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
@@ -409,7 +409,9 @@ export class PaperTradingEngineService {
         metadata: {
           sessionId: session.id,
           isPaperTrading: true
-        }
+        },
+        compositeRegime: this.compositeRegimeService.getCompositeRegime(),
+        volatilityRegime: this.compositeRegimeService.getVolatilityRegime()
       };
 
       const result: AlgorithmResult = await this.algorithmRegistry.executeAlgorithm(

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -1091,6 +1091,15 @@ export class PipelineOrchestratorService {
     this.logger.log(`Started optimization run ${run.id} for pipeline ${pipeline.id}`);
   }
 
+  private getUserRiskLevel(pipeline: Pipeline): number {
+    const user = pipeline.user as User;
+    if (!user.risk) {
+      this.logger.warn(`Pipeline ${pipeline.id}: user.risk not loaded, falling back to default risk level 3`);
+      return 3;
+    }
+    return user.risk.level ?? 3;
+  }
+
   private async executeHistoricalStage(pipeline: Pipeline): Promise<void> {
     const config = pipeline.stageConfig.historical;
     const marketDataSetId = config.marketDataSetId ?? (await this.backtestService.getDefaultDatasetId());
@@ -1108,7 +1117,8 @@ export class PipelineOrchestratorService {
       endDate: config.endDate,
       initialCapital: config.initialCapital,
       tradingFee: config.tradingFee ?? 0.001,
-      strategyParams: pipeline.optimizedParameters as Record<string, any>
+      strategyParams: pipeline.optimizedParameters as Record<string, any>,
+      riskLevel: this.getUserRiskLevel(pipeline)
     });
 
     // Store backtest reference
@@ -1135,7 +1145,8 @@ export class PipelineOrchestratorService {
       endDate: config.endDate,
       initialCapital: config.initialCapital,
       tradingFee: config.tradingFee ?? 0.001,
-      strategyParams: pipeline.optimizedParameters as Record<string, any>
+      strategyParams: pipeline.optimizedParameters as Record<string, any>,
+      riskLevel: this.getUserRiskLevel(pipeline)
     });
 
     // Store backtest reference
@@ -1164,7 +1175,7 @@ export class PipelineOrchestratorService {
       stopConditions: config.stopConditions,
       userId: pipeline.user.id,
       name: `Pipeline ${pipeline.name} - Paper Trading`,
-      riskLevel: (pipeline.user as any).risk?.level ?? 3
+      riskLevel: this.getUserRiskLevel(pipeline)
     });
 
     // Store session reference

--- a/apps/api/src/scoring/walk-forward/walk-forward.service.ts
+++ b/apps/api/src/scoring/walk-forward/walk-forward.service.ts
@@ -150,15 +150,16 @@ export class WalkForwardService {
   }
 
   /**
-   * Calculate total data days required
+   * Calculate total data days required.
+   * Accounts for the +1 day gap between train and test windows in generateWindows().
    */
   calculateRequiredDays(config: WalkForwardConfig, numWindows: number): number {
     if (config.method === 'anchored') {
       // Anchored: train window grows, test windows stack
-      return config.trainDays + numWindows * config.testDays;
+      return config.trainDays + 1 + numWindows * config.testDays;
     } else {
-      // Rolling: windows move forward
-      return config.trainDays + config.testDays + (numWindows - 1) * config.stepDays;
+      // Rolling: windows move forward (each window spans trainDays + 1 gap + testDays)
+      return config.trainDays + 1 + config.testDays + (numWindows - 1) * config.stepDays;
     }
   }
 
@@ -167,7 +168,8 @@ export class WalkForwardService {
    */
   estimateWindowCount(startDate: Date, endDate: Date, config: WalkForwardConfig): number {
     const totalDays = this.daysBetween(startDate, endDate);
-    const windowSize = config.trainDays + config.testDays;
+    // generateWindows() inserts a +1 day gap between train and test windows
+    const windowSize = config.trainDays + 1 + config.testDays;
 
     if (totalDays < windowSize) {
       return 0;

--- a/apps/api/src/strategy/strategy-executor.service.spec.ts
+++ b/apps/api/src/strategy/strategy-executor.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { CompositeRegimeType, MarketRegimeType } from '@chansey/api-interfaces';
+
 import { MarketData, StrategyExecutorService } from './strategy-executor.service';
 
 import {
@@ -9,6 +11,7 @@ import {
 import { AlgorithmRegistry } from '../algorithm/registry/algorithm-registry.service';
 import { AlgorithmContextBuilder } from '../algorithm/services/algorithm-context-builder.service';
 import { Coin } from '../coin/coin.entity';
+import { CompositeRegimeService } from '../market-regime/composite-regime.service';
 import { SignalThrottleService } from '../order/backtest/shared/throttle';
 
 /**
@@ -42,7 +45,14 @@ describe('StrategyExecutorService – per-trade position cap', () => {
         StrategyExecutorService,
         { provide: AlgorithmRegistry, useValue: algorithmRegistry },
         { provide: AlgorithmContextBuilder, useValue: algorithmContextBuilder },
-        { provide: SignalThrottleService, useValue: { createState: jest.fn().mockReturnValue({}) } }
+        { provide: SignalThrottleService, useValue: { createState: jest.fn().mockReturnValue({}) } },
+        {
+          provide: CompositeRegimeService,
+          useValue: {
+            getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.NEUTRAL),
+            getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
+          }
+        }
       ]
     }).compile();
 

--- a/apps/api/src/strategy/strategy-executor.service.ts
+++ b/apps/api/src/strategy/strategy-executor.service.ts
@@ -9,6 +9,7 @@ import {
 } from '../algorithm/interfaces/algorithm-result.interface';
 import { AlgorithmRegistry } from '../algorithm/registry/algorithm-registry.service';
 import { AlgorithmContextBuilder } from '../algorithm/services/algorithm-context-builder.service';
+import { CompositeRegimeService } from '../market-regime/composite-regime.service';
 import { SignalThrottleService, ThrottleState } from '../order/backtest/shared/throttle';
 import { toErrorInfo } from '../shared/error.util';
 
@@ -48,7 +49,8 @@ export class StrategyExecutorService {
   constructor(
     private readonly algorithmRegistry: AlgorithmRegistry,
     private readonly algorithmContextBuilder: AlgorithmContextBuilder,
-    private readonly signalThrottle: SignalThrottleService
+    private readonly signalThrottle: SignalThrottleService,
+    private readonly compositeRegimeService: CompositeRegimeService
   ) {}
 
   /** Get or create throttle state for a strategy */
@@ -77,6 +79,8 @@ export class StrategyExecutorService {
       context.config = { ...context.config, ...strategy.parameters };
       context.availableBalance = availableCapital;
       context.positions = this.convertPositions(positions, context.coins);
+      context.compositeRegime = this.compositeRegimeService.getCompositeRegime();
+      context.volatilityRegime = this.compositeRegimeService.getVolatilityRegime();
 
       // Execute the algorithm
       const result = await this.algorithmRegistry.executeAlgorithm(strategy.algorithm.id, context);


### PR DESCRIPTION
## Summary

- Align backtest and optimization pipelines with live regime-aware trading behavior so backtests reflect real-world signal filtering and position sizing
- Default `enableRegimeScaledSizing` to true (opt-out) to match live trading, and expose regime config in backtest DTOs and config snapshots
- Fix off-by-one in walk-forward window sizing and clean up unsafe type casts in pipeline orchestrator

## Changes

**Regime alignment across pipelines**
- Add `compositeRegime` and `volatilityRegime` to `AlgorithmContext` interface
- Enable regime gate + scaled sizing in optimization backtest loops
- Pass precomputed regime into `applyBarRegime` to avoid double-computing
- Inject `CompositeRegimeService` into `StrategyExecutorService` for live context
- Update paper-trading and pipeline orchestrator to pass regime context

**Backtest configuration**
- Persist regime config (`gate`, `scaling`, `riskLevel`) in backtest `configSnapshot`
- Add `enableRegimeGate`, `enableRegimeScaledSizing`, `riskLevel` to backtest DTO
- Change `riskLevel` DTO validator from `@IsNumber` to `@IsInt` for stricter validation

**Code quality**
- Extract `resolveRegimeConfigForOptimization()` to deduplicate regime setup in optimization loops
- Extract `getUserRiskLevel()` in pipeline orchestrator to replace unsafe `as any` casts
- Fix off-by-one in walk-forward window size (+1 day gap between train/test)

## Test Plan

- [ ] Existing unit tests updated and pass (`strategy-executor`, `paper-trading-engine`, `optimization-orchestrator`)
- [ ] Backtest runs include regime config in `configSnapshot`
- [ ] Optimization loops apply regime gate and scaled sizing consistently
- [ ] Walk-forward windows no longer overlap by 1 day

Closes #230