### PR TITLE
feat(api): add trade cooldown and signal throttle to prevent double-trading

### DIFF
--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -382,6 +382,57 @@ import { MetricsService } from './metrics.service';
       labelNames: ['strategy', 'shadow_status']
     }),
 
+    // ===================
+    // Live Trading & Throttle Metrics
+    // ===================
+
+    makeCounterProvider({
+      name: 'chansey_trade_cooldown_blocks_total',
+      help: 'Total trade signals blocked by cooldown',
+      labelNames: ['direction', 'symbol']
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_trade_cooldown_claims_total',
+      help: 'Total trade signals that claimed a cooldown slot and proceeded',
+      labelNames: ['direction', 'symbol']
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_trade_cooldown_cleared_total',
+      help: 'Total cooldown slots cleared after order failure',
+      labelNames: ['reason']
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_signal_throttle_suppressed_total',
+      help: 'Total signals suppressed by the signal throttle',
+      labelNames: ['strategy']
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_signal_throttle_passed_total',
+      help: 'Total signals that survived the signal throttle',
+      labelNames: ['strategy', 'action']
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_regime_gate_blocks_total',
+      help: 'Total signals blocked by the regime gate',
+      labelNames: ['regime']
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_drawdown_gate_blocks_total',
+      help: 'Total signals blocked by the drawdown gate'
+    }),
+
+    makeCounterProvider({
+      name: 'chansey_live_orders_placed_total',
+      help: 'Total live orders placed successfully',
+      labelNames: ['market_type', 'side']
+    }),
+
     MetricsService
   ],
   exports: [PrometheusModule, MetricsService]

--- a/apps/api/src/metrics/metrics.service.spec.ts
+++ b/apps/api/src/metrics/metrics.service.spec.ts
@@ -97,7 +97,17 @@ const buildService = () => {
     strategyHeartbeatAge: createGaugeMock(),
     strategyHeartbeatTotal: createCounterMock(),
     strategyHeartbeatFailures: createGaugeMock(),
-    strategyHealthScore: createGaugeMock()
+    strategyHealthScore: createGaugeMock(),
+
+    // Live Trading & Throttle Metrics
+    tradeCooldownBlocksTotal: createCounterMock(),
+    tradeCooldownClaimsTotal: createCounterMock(),
+    tradeCooldownClearedTotal: createCounterMock(),
+    signalThrottleSuppressedTotal: createCounterMock(),
+    signalThrottlePassedTotal: createCounterMock(),
+    regimeGateBlocksTotal: createCounterMock(),
+    drawdownGateBlocksTotal: createCounterMock(),
+    liveOrdersPlacedTotal: createCounterMock()
   };
 
   const service = new MetricsService(
@@ -170,7 +180,16 @@ const buildService = () => {
     mocks.strategyHeartbeatAge,
     mocks.strategyHeartbeatTotal,
     mocks.strategyHeartbeatFailures,
-    mocks.strategyHealthScore
+    mocks.strategyHealthScore,
+    // Live Trading & Throttle Metrics
+    mocks.tradeCooldownBlocksTotal,
+    mocks.tradeCooldownClaimsTotal,
+    mocks.tradeCooldownClearedTotal,
+    mocks.signalThrottleSuppressedTotal,
+    mocks.signalThrottlePassedTotal,
+    mocks.regimeGateBlocksTotal,
+    mocks.drawdownGateBlocksTotal,
+    mocks.liveOrdersPlacedTotal
   );
 
   return { service, mocks };

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -166,7 +166,25 @@ export class MetricsService {
     @InjectMetric('chansey_strategy_heartbeat_failures')
     private readonly strategyHeartbeatFailures: Gauge<string>,
     @InjectMetric('chansey_strategy_health_score')
-    private readonly strategyHealthScore: Gauge<string>
+    private readonly strategyHealthScore: Gauge<string>,
+
+    // Live Trading & Throttle Metrics
+    @InjectMetric('chansey_trade_cooldown_blocks_total')
+    private readonly tradeCooldownBlocksTotal: Counter<string>,
+    @InjectMetric('chansey_trade_cooldown_claims_total')
+    private readonly tradeCooldownClaimsTotal: Counter<string>,
+    @InjectMetric('chansey_trade_cooldown_cleared_total')
+    private readonly tradeCooldownClearedTotal: Counter<string>,
+    @InjectMetric('chansey_signal_throttle_suppressed_total')
+    private readonly signalThrottleSuppressedTotal: Counter<string>,
+    @InjectMetric('chansey_signal_throttle_passed_total')
+    private readonly signalThrottlePassedTotal: Counter<string>,
+    @InjectMetric('chansey_regime_gate_blocks_total')
+    private readonly regimeGateBlocksTotal: Counter<string>,
+    @InjectMetric('chansey_drawdown_gate_blocks_total')
+    private readonly drawdownGateBlocksTotal: Counter<string>,
+    @InjectMetric('chansey_live_orders_placed_total')
+    private readonly liveOrdersPlacedTotal: Counter<string>
   ) {}
 
   // ===================
@@ -622,6 +640,42 @@ export class MetricsService {
    */
   setStrategyHealthScore(strategy: string, shadowStatus: string, score: number): void {
     this.strategyHealthScore.set({ strategy, shadow_status: shadowStatus }, Math.max(0, Math.min(100, score)));
+  }
+
+  // ===================
+  // Live Trading & Throttle Metrics
+  // ===================
+
+  recordTradeCooldownBlock(direction: string, symbol: string): void {
+    this.tradeCooldownBlocksTotal.inc({ direction, symbol });
+  }
+
+  recordTradeCooldownClaim(direction: string, symbol: string): void {
+    this.tradeCooldownClaimsTotal.inc({ direction, symbol });
+  }
+
+  recordTradeCooldownCleared(reason: string): void {
+    this.tradeCooldownClearedTotal.inc({ reason });
+  }
+
+  recordSignalThrottleSuppressed(strategy: string, count: number): void {
+    this.signalThrottleSuppressedTotal.inc({ strategy }, count);
+  }
+
+  recordSignalThrottlePassed(strategy: string, action: string): void {
+    this.signalThrottlePassedTotal.inc({ strategy, action });
+  }
+
+  recordRegimeGateBlock(regime: string): void {
+    this.regimeGateBlocksTotal.inc({ regime });
+  }
+
+  recordDrawdownGateBlock(): void {
+    this.drawdownGateBlocksTotal.inc();
+  }
+
+  recordLiveOrderPlaced(marketType: 'futures' | 'spot', side: string): void {
+    this.liveOrdersPlacedTotal.inc({ market_type: marketType, side });
   }
 
   /**

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.interface.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.interface.ts
@@ -1,4 +1,5 @@
 import { SignalType as AlgoSignalType } from '../../../../algorithm/interfaces';
+import type { TradingSignal } from '../../backtest-engine.service';
 
 /**
  * Configuration for signal throttling.
@@ -52,3 +53,14 @@ export const THROTTLE_BYPASS_TYPES: ReadonlySet<AlgoSignalType> = new Set([
   AlgoSignalType.STOP_LOSS,
   AlgoSignalType.TAKE_PROFIT
 ]);
+
+/** Maps each algorithm signal type to the backtest TradingSignal action. */
+export const SIGNAL_TYPE_TO_ACTION: Record<AlgoSignalType, TradingSignal['action']> = {
+  [AlgoSignalType.BUY]: 'BUY',
+  [AlgoSignalType.SELL]: 'SELL',
+  [AlgoSignalType.STOP_LOSS]: 'SELL',
+  [AlgoSignalType.TAKE_PROFIT]: 'SELL',
+  [AlgoSignalType.SHORT_ENTRY]: 'OPEN_SHORT',
+  [AlgoSignalType.SHORT_EXIT]: 'CLOSE_SHORT',
+  [AlgoSignalType.HOLD]: 'HOLD'
+};

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.ts
@@ -3,12 +3,14 @@ import { Injectable } from '@nestjs/common';
 import {
   CooldownKey,
   DEFAULT_THROTTLE_CONFIG,
+  SIGNAL_TYPE_TO_ACTION,
   SerializableThrottleState,
   SignalThrottleConfig,
   THROTTLE_BYPASS_TYPES,
   ThrottleState
 } from './signal-throttle.interface';
 
+import { TradingSignal as AlgorithmTradingSignal } from '../../../../algorithm/interfaces/algorithm-result.interface';
 import { TradingSignal } from '../../backtest-engine.service';
 
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
@@ -141,6 +143,18 @@ export class SignalThrottleService {
     return {
       lastSignalTime: { ...serialized.lastSignalTime } as Record<CooldownKey, number>,
       tradeTimestamps: [...serialized.tradeTimestamps]
+    };
+  }
+
+  /** Convert an algorithm signal to the backtest TradingSignal format expected by filterSignals() */
+  toThrottleSignal(signal: AlgorithmTradingSignal): TradingSignal {
+    return {
+      action: SIGNAL_TYPE_TO_ACTION[signal.type] ?? 'HOLD',
+      coinId: signal.coinId,
+      quantity: signal.quantity,
+      reason: signal.reason,
+      confidence: signal.confidence,
+      originalType: signal.type
     };
   }
 }

--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -53,6 +53,7 @@ import { OrderSyncTask } from './tasks/order-sync.task';
 import { PositionMonitorTask } from './tasks/position-monitor.task';
 import { TradeExecutionTask } from './tasks/trade-execution.task';
 
+import { AdminModule } from '../admin/admin.module';
 import { AlgorithmActivation } from '../algorithm/algorithm-activation.entity';
 import { AlgorithmPerformance } from '../algorithm/algorithm-performance.entity';
 import { Algorithm } from '../algorithm/algorithm.entity';
@@ -128,6 +129,7 @@ const BACKTEST_DEFAULTS = backtestConfig();
     BullModule.registerQueue({ name: 'position-monitor' }),
     BullModule.registerQueue({ name: 'liquidation-monitor' }),
     SharedCacheModule,
+    forwardRef(() => AdminModule),
     forwardRef(() => AlgorithmModule),
     forwardRef(() => BalanceModule),
     forwardRef(() => ExchangeModule),

--- a/apps/api/src/order/tasks/trade-execution.task.spec.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.spec.ts
@@ -3,22 +3,29 @@ import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
+import { MarketType } from '@chansey/api-interfaces';
+
 import { TradeExecutionTask } from './trade-execution.task';
 
+import { TradingStateService } from '../../admin/trading-state/trading-state.service';
 import { SignalType } from '../../algorithm/interfaces';
 import { AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
 import { AlgorithmActivationService } from '../../algorithm/services/algorithm-activation.service';
 import { AlgorithmContextBuilder } from '../../algorithm/services/algorithm-context-builder.service';
 import { BalanceService } from '../../balance/balance.service';
 import { CoinService } from '../../coin/coin.service';
+import { TradeCooldownService } from '../../shared/trade-cooldown.service';
 import { StrategyConfig } from '../../strategy/entities/strategy-config.entity';
+import { User } from '../../users/users.entity';
 import { UsersService } from '../../users/users.service';
+import { SignalThrottleService } from '../backtest/shared/throttle';
 import { TradeExecutionService } from '../services/trade-execution.service';
 
 describe('TradeExecutionTask', () => {
   let task: TradeExecutionTask;
   let mockQueue: any;
   let mockStrategyConfigRepo: any;
+  let mockUserRepo: any;
   let mockTradeExecutionService: any;
   let mockActivationService: any;
   let mockAlgorithmRegistry: any;
@@ -26,6 +33,9 @@ describe('TradeExecutionTask', () => {
   let mockBalanceService: any;
   let mockCoinService: any;
   let mockUsersService: any;
+  let mockTradingStateService: any;
+  let mockTradeCooldownService: any;
+  let mockSignalThrottle: any;
 
   const mockJob = {
     id: 'job-1',
@@ -83,6 +93,44 @@ describe('TradeExecutionTask', () => {
       findOne: jest.fn().mockResolvedValue(null)
     };
 
+    mockUserRepo = {
+      find: jest.fn().mockResolvedValue([])
+    };
+
+    mockTradingStateService = {
+      isTradingEnabled: jest.fn().mockReturnValue(true)
+    };
+
+    mockTradeCooldownService = {
+      checkAndClaim: jest.fn().mockResolvedValue({ allowed: true }),
+      clearCooldown: jest.fn().mockResolvedValue(undefined)
+    };
+
+    mockSignalThrottle = {
+      createState: jest.fn().mockReturnValue({ lastSignalTime: {}, tradeTimestamps: [] }),
+      resolveConfig: jest.fn().mockReturnValue({ cooldownMs: 86_400_000, maxTradesPerDay: 6, minSellPercent: 0.5 }),
+      filterSignals: jest.fn().mockImplementation((signals: any[]) => signals),
+      toThrottleSignal: jest.fn().mockImplementation((s: any) => {
+        const map: Record<string, string> = {
+          BUY: 'BUY',
+          SELL: 'SELL',
+          HOLD: 'HOLD',
+          SHORT_ENTRY: 'OPEN_SHORT',
+          SHORT_EXIT: 'CLOSE_SHORT',
+          STOP_LOSS: 'SELL',
+          TAKE_PROFIT: 'SELL'
+        };
+        return {
+          action: map[s.type] ?? 'HOLD',
+          coinId: s.coinId,
+          quantity: s.quantity,
+          reason: s.reason,
+          confidence: s.confidence,
+          originalType: s.type
+        };
+      })
+    };
+
     mockTradeExecutionService = {
       executeTradeSignal: jest.fn().mockResolvedValue({ id: 'order-1' })
     };
@@ -122,13 +170,17 @@ describe('TradeExecutionTask', () => {
         TradeExecutionTask,
         { provide: getQueueToken('trade-execution'), useValue: mockQueue },
         { provide: getRepositoryToken(StrategyConfig), useValue: mockStrategyConfigRepo },
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
         { provide: TradeExecutionService, useValue: mockTradeExecutionService },
         { provide: AlgorithmActivationService, useValue: mockActivationService },
         { provide: AlgorithmRegistry, useValue: mockAlgorithmRegistry },
         { provide: AlgorithmContextBuilder, useValue: mockContextBuilder },
         { provide: BalanceService, useValue: mockBalanceService },
         { provide: CoinService, useValue: mockCoinService },
-        { provide: UsersService, useValue: mockUsersService }
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: TradingStateService, useValue: mockTradingStateService },
+        { provide: TradeCooldownService, useValue: mockTradeCooldownService },
+        { provide: SignalThrottleService, useValue: mockSignalThrottle }
       ]
     }).compile();
 
@@ -180,20 +232,6 @@ describe('TradeExecutionTask', () => {
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
       mockAlgorithmRegistry.executeAlgorithm.mockResolvedValue({
         success: false,
-        signals: [],
-        timestamp: new Date()
-      });
-
-      const result: any = await task.process(mockJob);
-
-      expect(result.skippedCount).toBe(1);
-    });
-
-    it('should skip when algorithm returns no signals', async () => {
-      const activation = buildActivation();
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-      mockAlgorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
         signals: [],
         timestamp: new Date()
       });
@@ -266,7 +304,7 @@ describe('TradeExecutionTask', () => {
       expect(signalArg.symbol).toBe('ETH/USDT');
     });
 
-    it('should pass autoSize, portfolioValue, and allocationPercentage in the signal', async () => {
+    it('should pass complete trade signal with auto-sizing and market context fields', async () => {
       const activation = buildActivation({ allocationPercentage: 5 });
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
       mockBalanceService.getUserBalances.mockResolvedValue({ totalUsdValue: 25000 });
@@ -286,9 +324,12 @@ describe('TradeExecutionTask', () => {
           quantity: 0,
           autoSize: true,
           portfolioValue: 25000,
-          allocationPercentage: 5
+          allocationPercentage: 5,
+          marketType: 'spot',
+          leverage: 1
         })
       );
+      expect(signalArg.positionSide).toBeUndefined();
     });
 
     it('should map BUY and SELL signal types correctly', async () => {
@@ -348,54 +389,20 @@ describe('TradeExecutionTask', () => {
   });
 
   describe('symbol resolution (via process)', () => {
-    it('should return "BTC/USDT" for binance_us', async () => {
-      const activation = buildActivation({ exchangeKey: { exchange: { slug: 'binance_us' } } });
+    it.each([
+      ['binance_us', 'BTC/USDT'],
+      ['coinbase', 'BTC/USD'],
+      ['gdax', 'BTC/USD'],
+      ['kraken', 'BTC/USD'],
+      ['unknown_exchange', 'BTC/USDT']
+    ])('should resolve quote currency for %s → %s', async (slug, expectedSymbol) => {
+      const activation = buildActivation({ exchangeKey: { exchange: { slug } } });
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
       configureActionableSignal();
 
       await task.process(mockJob);
 
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe('BTC/USDT');
-    });
-
-    it('should return "BTC/USD" for coinbase', async () => {
-      const activation = buildActivation({ exchangeKey: { exchange: { slug: 'coinbase' } } });
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-      configureActionableSignal();
-
-      await task.process(mockJob);
-
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe('BTC/USD');
-    });
-
-    it('should return "BTC/USD" for gdax (Coinbase Pro)', async () => {
-      const activation = buildActivation({ exchangeKey: { exchange: { slug: 'gdax' } } });
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-      configureActionableSignal();
-
-      await task.process(mockJob);
-
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe('BTC/USD');
-    });
-
-    it('should return "BTC/USD" for kraken', async () => {
-      const activation = buildActivation({ exchangeKey: { exchange: { slug: 'kraken' } } });
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-      configureActionableSignal();
-
-      await task.process(mockJob);
-
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe('BTC/USD');
-    });
-
-    it('should default to USDT for unknown exchange slugs', async () => {
-      const activation = buildActivation({ exchangeKey: { exchange: { slug: 'unknown_exchange' } } });
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-      configureActionableSignal();
-
-      await task.process(mockJob);
-
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe('BTC/USDT');
+      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe(expectedSymbol);
     });
 
     it('should uppercase the coin symbol', async () => {
@@ -459,7 +466,7 @@ describe('TradeExecutionTask', () => {
       expect(result.totalActivations).toBe(2);
     });
 
-    it('should return counts: successCount, failCount, skippedCount', async () => {
+    it('should return counts: successCount, failCount, skippedCount, blockedCount', async () => {
       const activation1 = buildActivation({ id: 'act-1', algorithmId: 'algo-buy' });
       const activation2 = buildActivation({ id: 'act-2', algorithmId: 'algo-fail' });
       const activation3 = buildActivation({ id: 'act-3', algorithmId: 'algo-skip' });
@@ -482,6 +489,7 @@ describe('TradeExecutionTask', () => {
       expect(result.successCount).toBe(1);
       expect(result.failCount).toBe(1);
       expect(result.skippedCount).toBe(1);
+      expect(result.blockedCount).toBe(0);
       expect(result.totalActivations).toBe(3);
     });
 
@@ -495,39 +503,89 @@ describe('TradeExecutionTask', () => {
         successCount: 0,
         failCount: 0,
         skippedCount: 0,
+        blockedCount: 0,
         timestamp: expect.any(String)
       });
     });
+  });
 
-    it('should process 12 activations across 3 users with only 3 balance fetches', async () => {
-      const activations = [];
-      const userIds = ['user-1', 'user-2', 'user-3'];
-      for (let i = 0; i < 12; i++) {
-        activations.push(
-          buildActivation({
-            id: `act-${i}`,
-            userId: userIds[i % 3],
-            algorithmId: `algo-${i}`
-          })
-        );
-      }
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue(activations);
+  describe('kill switch', () => {
+    it('should return early when trading is globally halted', async () => {
+      mockTradingStateService.isTradingEnabled.mockReturnValue(false);
 
-      // All return no actionable signals
+      const result: any = await task.process(mockJob);
+
+      expect(result).toEqual({ success: false, message: 'Trading globally halted' });
+      expect(mockActivationService.findAllActiveAlgorithms).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mutual exclusion — filterRoboAdvisorUsers', () => {
+    it('should filter out activations for users with algoTradingEnabled=true', async () => {
+      const activation1 = buildActivation({ id: 'act-1', userId: 'robo-user' });
+      const activation2 = buildActivation({ id: 'act-2', userId: 'manual-user' });
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation1, activation2]);
+      mockUserRepo.find.mockResolvedValue([{ id: 'robo-user' }]);
+
+      // manual-user has no signal
       mockAlgorithmRegistry.executeAlgorithm.mockResolvedValue({
         success: true,
         signals: [],
         timestamp: new Date()
       });
 
-      await task.process(mockJob);
+      const result: any = await task.process(mockJob);
 
-      // Only 3 unique users → 3 balance fetches
-      expect(mockUsersService.getById).toHaveBeenCalledTimes(3);
-      expect(mockBalanceService.getUserBalances).toHaveBeenCalledTimes(3);
+      // Only manual-user's activation should be processed (1 total, 1 skipped due to no signal)
+      expect(result.totalActivations).toBe(1);
+    });
 
-      // All 12 activations processed (as skipped, since no signals)
-      expect(mockAlgorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(12);
+    it('should process all activations when no robo-advisor users found', async () => {
+      const activation1 = buildActivation({ id: 'act-1', userId: 'user-1' });
+      const activation2 = buildActivation({ id: 'act-2', userId: 'user-2' });
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation1, activation2]);
+      mockUserRepo.find.mockResolvedValue([]); // No robo-advisor users
+
+      mockAlgorithmRegistry.executeAlgorithm.mockResolvedValue({
+        success: true,
+        signals: [],
+        timestamp: new Date()
+      });
+
+      const result: any = await task.process(mockJob);
+
+      expect(result.totalActivations).toBe(2);
+    });
+  });
+
+  describe('trade cooldown', () => {
+    it('should block activation when cooldown rejects the trade', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+      mockTradeCooldownService.checkAndClaim.mockResolvedValue({
+        allowed: false,
+        existingClaim: { pipeline: 'strategy:config-1', claimedAt: Date.now() }
+      });
+
+      const result: any = await task.process(mockJob);
+
+      expect(result.blockedCount).toBe(1);
+      expect(result.skippedCount).toBe(0);
+      expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+    });
+
+    it('should clear cooldown on trade execution failure', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+      mockTradeCooldownService.checkAndClaim.mockResolvedValue({ allowed: true });
+      mockTradeExecutionService.executeTradeSignal.mockRejectedValue(new Error('Exchange error'));
+
+      const result: any = await task.process(mockJob);
+
+      expect(result.failCount).toBe(1);
+      expect(mockTradeCooldownService.clearCooldown).toHaveBeenCalledWith('user-1', 'BTC/USDT', 'BUY');
     });
   });
 
@@ -569,6 +627,136 @@ describe('TradeExecutionTask', () => {
 
       expect(result.skippedCount).toBe(1);
       expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('signal throttle integration', () => {
+    it('should call filterSignals with converted signals for actionable activations', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal('coin-1', SignalType.BUY, 0.8, 0.8);
+
+      await task.process(mockJob);
+
+      expect(mockSignalThrottle.filterSignals).toHaveBeenCalledTimes(1);
+      const [signals] = mockSignalThrottle.filterSignals.mock.calls[0];
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).toEqual(
+        expect.objectContaining({
+          action: 'BUY',
+          coinId: 'coin-1',
+          originalType: SignalType.BUY
+        })
+      );
+    });
+
+    it('should skip activation when all signals are throttled', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+      mockSignalThrottle.filterSignals.mockReturnValue([]);
+
+      const result: any = await task.process(mockJob);
+
+      expect(result.skippedCount).toBe(1);
+      expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+    });
+
+    it('should resolve throttle config from activation.config', async () => {
+      const activation = buildActivation({ config: { cooldownMs: 3600_000 } });
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+
+      await task.process(mockJob);
+
+      expect(mockSignalThrottle.resolveConfig).toHaveBeenCalledWith({ cooldownMs: 3600_000 });
+    });
+
+    it('should apply throttle before TradeCooldownService dedup', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+      mockSignalThrottle.filterSignals.mockReturnValue([]);
+
+      await task.process(mockJob);
+
+      // Signal was throttled before reaching cooldown service
+      expect(mockTradeCooldownService.checkAndClaim).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('futures / market context resolution', () => {
+    it('should use activation config metadata for futures market type', async () => {
+      const activation = buildActivation({
+        config: { metadata: { marketType: MarketType.FUTURES, leverage: 5 } }
+      });
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+
+      await task.process(mockJob);
+
+      const signalArg = mockTradeExecutionService.executeTradeSignal.mock.calls[0][0];
+      expect(signalArg.marketType).toBe('futures');
+      expect(signalArg.leverage).toBe(5);
+      expect(signalArg.positionSide).toBe('long');
+    });
+
+    it('should fall back to StrategyConfig for futures market type', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockStrategyConfigRepo.findOne.mockResolvedValue({
+        marketType: MarketType.FUTURES,
+        defaultLeverage: 3
+      });
+      configureActionableSignal();
+
+      await task.process(mockJob);
+
+      const signalArg = mockTradeExecutionService.executeTradeSignal.mock.calls[0][0];
+      expect(signalArg.marketType).toBe('futures');
+      expect(signalArg.leverage).toBe(3);
+    });
+
+    it('should default to spot with leverage 1 when no futures config exists', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockStrategyConfigRepo.findOne.mockResolvedValue(null);
+      configureActionableSignal();
+
+      await task.process(mockJob);
+
+      const signalArg = mockTradeExecutionService.executeTradeSignal.mock.calls[0][0];
+      expect(signalArg.marketType).toBe('spot');
+      expect(signalArg.leverage).toBe(1);
+      expect(signalArg.positionSide).toBeUndefined();
+    });
+
+    it('should map SHORT_ENTRY to SELL with positionSide short', async () => {
+      const activation = buildActivation({
+        config: { metadata: { marketType: MarketType.FUTURES, leverage: 2 } }
+      });
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal('coin-1', SignalType.SHORT_ENTRY);
+
+      await task.process(mockJob);
+
+      const signalArg = mockTradeExecutionService.executeTradeSignal.mock.calls[0][0];
+      expect(signalArg.action).toBe('SELL');
+      expect(signalArg.positionSide).toBe('short');
+    });
+
+    it('should map SHORT_EXIT to BUY with positionSide short', async () => {
+      const activation = buildActivation({
+        config: { metadata: { marketType: MarketType.FUTURES, leverage: 2 } }
+      });
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal('coin-1', SignalType.SHORT_EXIT);
+
+      await task.process(mockJob);
+
+      const signalArg = mockTradeExecutionService.executeTradeSignal.mock.calls[0][0];
+      expect(signalArg.action).toBe('BUY');
+      expect(signalArg.positionSide).toBe('short');
     });
   });
 });

--- a/apps/api/src/order/tasks/trade-execution.task.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.ts
@@ -4,10 +4,11 @@ import { CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Job, Queue } from 'bullmq';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 
 import { MarketType } from '@chansey/api-interfaces';
 
+import { TradingStateService } from '../../admin/trading-state/trading-state.service';
 import { AlgorithmActivation } from '../../algorithm/algorithm-activation.entity';
 import { SignalType, TradingSignal } from '../../algorithm/interfaces';
 import { AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
@@ -17,8 +18,11 @@ import { BalanceService } from '../../balance/balance.service';
 import { CoinService } from '../../coin/coin.service';
 import { DEFAULT_QUOTE_CURRENCY, EXCHANGE_QUOTE_CURRENCY } from '../../exchange/constants';
 import { toErrorInfo } from '../../shared/error.util';
+import { TradeCooldownService } from '../../shared/trade-cooldown.service';
 import { StrategyConfig } from '../../strategy/entities/strategy-config.entity';
+import { User } from '../../users/users.entity';
 import { UsersService } from '../../users/users.service';
+import { SignalThrottleService, ThrottleState } from '../backtest/shared/throttle';
 import { TradeExecutionService, TradeSignalWithExit } from '../services/trade-execution.service';
 
 const MIN_CONFIDENCE_THRESHOLD = 0.6;
@@ -41,17 +45,25 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
   private readonly logger = new Logger(TradeExecutionTask.name);
   private jobScheduled = false;
 
+  /** Per-activation throttle state persisted across cron cycles (keyed by activation ID) */
+  private readonly throttleStates = new Map<string, ThrottleState>();
+
   constructor(
     @InjectQueue('trade-execution') private readonly tradeExecutionQueue: Queue,
     @InjectRepository(StrategyConfig)
     private readonly strategyConfigRepo: Repository<StrategyConfig>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
     private readonly tradeExecutionService: TradeExecutionService,
     private readonly algorithmActivationService: AlgorithmActivationService,
     private readonly algorithmRegistry: AlgorithmRegistry,
     private readonly contextBuilder: AlgorithmContextBuilder,
     private readonly balanceService: BalanceService,
     private readonly coinService: CoinService,
-    private readonly usersService: UsersService
+    private readonly usersService: UsersService,
+    private readonly tradingStateService: TradingStateService,
+    private readonly tradeCooldownService: TradeCooldownService,
+    private readonly signalThrottle: SignalThrottleService
   ) {
     super();
   }
@@ -115,6 +127,12 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
   async process(job: Job) {
     this.logger.log(`Processing job ${job.id} of type ${job.name}`);
 
+    // Kill switch check — must be first before any trading activity
+    if (!this.tradingStateService.isTradingEnabled()) {
+      this.logger.warn('Trading is globally halted — skipping trade execution job');
+      return { success: false, message: 'Trading globally halted' };
+    }
+
     try {
       if (job.name === 'execute-trades') {
         return await this.handleExecuteTrades(job);
@@ -138,9 +156,16 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     try {
       await job.updateProgress(10);
 
-      const activeActivations = await this.algorithmActivationService.findAllActiveAlgorithms();
+      const allActivations = await this.algorithmActivationService.findAllActiveAlgorithms();
 
-      this.logger.log(`Found ${activeActivations.length} active algorithm activations`);
+      // Mutual exclusion: filter out users who have algoTradingEnabled=true
+      // Those users are handled exclusively by Pipeline 1 (LiveTradingService)
+      const activeActivations = await this.filterRoboAdvisorUsers(allActivations);
+
+      this.logger.log(
+        `Found ${allActivations.length} active activations, ${allActivations.length - activeActivations.length} ` +
+          `skipped (robo-advisor users), ${activeActivations.length} to process`
+      );
 
       if (activeActivations.length === 0) {
         return {
@@ -148,6 +173,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
           successCount: 0,
           failCount: 0,
           skippedCount: 0,
+          blockedCount: 0,
           timestamp: new Date().toISOString()
         };
       }
@@ -171,6 +197,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       let successCount = 0;
       let failCount = 0;
       let skippedCount = 0;
+      let blockedCount = 0;
       let processedActivations = 0;
 
       const groups = this.groupByExchangeKey(activeActivations);
@@ -179,11 +206,12 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       for (const chunk of chunks) {
         const results = await Promise.allSettled(
           chunk.map(async (group) => {
-            const groupCounts = { success: 0, fail: 0, skipped: 0 };
+            const groupCounts = { success: 0, fail: 0, skipped: 0, blocked: 0 };
             for (const activation of group) {
               try {
                 const outcome = await this.processActivation(activation, portfolioCache.get(activation.userId) ?? 0);
                 if (outcome === 'executed') groupCounts.success++;
+                else if (outcome === 'blocked') groupCounts.blocked++;
                 else groupCounts.skipped++;
               } catch (error: unknown) {
                 const err = toErrorInfo(error);
@@ -200,6 +228,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
             successCount += result.value.success;
             failCount += result.value.fail;
             skippedCount += result.value.skipped;
+            blockedCount += result.value.blocked;
           } else {
             const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
             this.logger.error(`Activation group processing failed: ${reason}`, result.reason?.stack);
@@ -213,9 +242,15 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
         await job.updateProgress(progressPercentage);
       }
 
+      // Prune throttle states for deactivated activations to prevent unbounded growth
+      const activeIds = new Set(activeActivations.map((a) => a.id));
+      for (const key of this.throttleStates.keys()) {
+        if (!activeIds.has(key)) this.throttleStates.delete(key);
+      }
+
       await job.updateProgress(100);
       this.logger.log(
-        `Trade execution complete: ${totalActivations} activations — ${successCount} executed, ${skippedCount} skipped, ${failCount} failed`
+        `Trade execution complete: ${totalActivations} activations — ${successCount} executed, ${skippedCount} skipped, ${blockedCount} blocked, ${failCount} failed`
       );
 
       return {
@@ -223,6 +258,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
         successCount,
         failCount,
         skippedCount,
+        blockedCount,
         timestamp: new Date().toISOString()
       };
     } catch (error: unknown) {
@@ -234,12 +270,12 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
 
   /**
    * Process a single activation: generate signal and execute trade
-   * @returns 'executed' if a trade was placed, 'skipped' otherwise
+   * @returns 'executed' if a trade was placed, 'skipped' if no signal, 'blocked' if cooldown rejected
    */
   private async processActivation(
     activation: AlgorithmActivation,
     portfolioValue: number
-  ): Promise<'executed' | 'skipped'> {
+  ): Promise<'executed' | 'skipped' | 'blocked'> {
     if (portfolioValue <= 0) {
       this.logger.warn(
         `Skipping activation ${activation.id}: portfolio value is $${portfolioValue} (cannot auto-size)`
@@ -250,11 +286,33 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     const signal = await this.generateTradeSignal(activation, portfolioValue);
 
     if (signal) {
-      await this.tradeExecutionService.executeTradeSignal(signal);
-      this.logger.log(
-        `Executed trade for activation ${activation.id} (${activation.algorithm.name}): ${signal.action} ${signal.symbol}`
+      // Trade cooldown: prevent double-trading if Pipeline 1 already placed this trade
+      const cooldownCheck = await this.tradeCooldownService.checkAndClaim(
+        signal.userId,
+        signal.symbol,
+        signal.action,
+        `activation:${activation.id}`
       );
-      return 'executed';
+
+      if (!cooldownCheck.allowed) {
+        this.logger.warn(
+          `Trade cooldown blocked activation ${activation.id}: ${signal.action} ${signal.symbol} ` +
+            `already claimed by ${cooldownCheck.existingClaim?.pipeline}`
+        );
+        return 'blocked';
+      }
+
+      try {
+        await this.tradeExecutionService.executeTradeSignal(signal);
+        this.logger.log(
+          `Executed trade for activation ${activation.id} (${activation.algorithm.name}): ${signal.action} ${signal.symbol}`
+        );
+        return 'executed';
+      } catch (error: unknown) {
+        // Clear cooldown on failure so next cycle can retry
+        await this.tradeCooldownService.clearCooldown(signal.userId, signal.symbol, signal.action);
+        throw error;
+      }
     }
 
     this.logger.debug(`No actionable signal for activation ${activation.id} (${activation.algorithm.name})`);
@@ -301,8 +359,25 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       return null;
     }
 
+    // Apply signal throttle: cooldowns, daily cap, min sell %
+    const throttleState = this.getThrottleState(activation.id);
+    const throttleConfig = this.signalThrottle.resolveConfig(activation.config as Record<string, unknown> | undefined);
+    const throttleInput = actionableSignals.map((s) => this.signalThrottle.toThrottleSignal(s));
+    const throttleOutput = this.signalThrottle.filterSignals(throttleInput, throttleState, throttleConfig, Date.now());
+
+    if (throttleOutput.length === 0) {
+      return null;
+    }
+
+    // Map accepted throttle signals back to original algorithm signals
+    const acceptedKeys = new Set(throttleOutput.map((s) => `${s.coinId}:${s.action}`));
+    const surviving = actionableSignals.filter((s) => {
+      const t = this.signalThrottle.toThrottleSignal(s);
+      return acceptedKeys.has(`${t.coinId}:${t.action}`);
+    });
+
     // Pick the strongest signal by strength × confidence
-    const bestSignal = actionableSignals.reduce((best: TradingSignal, current: TradingSignal) =>
+    const bestSignal = surviving.reduce((best: TradingSignal, current: TradingSignal) =>
       current.strength * current.confidence > best.strength * best.confidence ? current : best
     );
 
@@ -425,6 +500,31 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     }
   }
 
+  /**
+   * Filter out activations belonging to robo-advisor users (algoTradingEnabled=true).
+   * Those users are handled exclusively by Pipeline 1 (LiveTradingService).
+   */
+  private async filterRoboAdvisorUsers(activations: AlgorithmActivation[]): Promise<AlgorithmActivation[]> {
+    if (activations.length === 0) return activations;
+
+    const uniqueUserIds = [...new Set(activations.map((a) => a.userId))];
+
+    const roboAdvisorUsers = await this.userRepo.find({
+      where: { id: In(uniqueUserIds), algoTradingEnabled: true },
+      select: ['id']
+    });
+
+    if (roboAdvisorUsers.length === 0) return activations;
+
+    const roboUserIds = new Set(roboAdvisorUsers.map((u) => u.id));
+
+    this.logger.log(
+      `Filtering ${roboAdvisorUsers.length} robo-advisor user(s) from activation pipeline (handled by LiveTradingService)`
+    );
+
+    return activations.filter((a) => !roboUserIds.has(a.userId));
+  }
+
   private chunkArray<T>(array: T[], size: number): T[][] {
     const chunks: T[][] = [];
     for (let i = 0; i < array.length; i += size) {
@@ -442,5 +542,15 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       groups.set(key, group);
     }
     return [...groups.values()];
+  }
+
+  /** Get or create throttle state for an activation */
+  private getThrottleState(activationId: string): ThrottleState {
+    let state = this.throttleStates.get(activationId);
+    if (!state) {
+      state = this.signalThrottle.createState();
+      this.throttleStates.set(activationId, state);
+    }
+    return state;
   }
 }

--- a/apps/api/src/shared/distributed-lock.service.spec.ts
+++ b/apps/api/src/shared/distributed-lock.service.spec.ts
@@ -1,9 +1,7 @@
 import { Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 
 import { DistributedLockService } from './distributed-lock.service';
 
-// Mock Redis
 const createRedisMock = () => ({
   set: jest.fn(),
   get: jest.fn(),
@@ -13,40 +11,15 @@ const createRedisMock = () => ({
   disconnect: jest.fn()
 });
 
-jest.mock('ioredis', () => {
-  const RedisMockConstructor = jest.fn().mockImplementation(() => createRedisMock());
-  return {
-    __esModule: true,
-    default: RedisMockConstructor
-  };
-});
-
-// Create mock ConfigService
-const createMockConfigService = (): jest.Mocked<ConfigService> =>
-  ({
-    get: jest.fn((key: string, defaultValue?: unknown) => {
-      const config: Record<string, unknown> = {
-        REDIS_HOST: 'localhost',
-        REDIS_PORT: 6379,
-        REDIS_USER: undefined,
-        REDIS_PASSWORD: undefined,
-        REDIS_TLS: 'false'
-      };
-      return config[key] ?? defaultValue;
-    })
-  }) as unknown as jest.Mocked<ConfigService>;
-
 describe('DistributedLockService', () => {
   let service: DistributedLockService;
   let redisMock: ReturnType<typeof createRedisMock>;
-  let mockConfigService: jest.Mocked<ConfigService>;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockConfigService = createMockConfigService();
-    service = new DistributedLockService(mockConfigService);
-    redisMock = (service as any).redis;
+    redisMock = createRedisMock();
+    service = new DistributedLockService(redisMock as any);
   });
 
   describe('acquire', () => {
@@ -233,27 +206,6 @@ describe('DistributedLockService', () => {
 
       expect(result).toBe(false);
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to extend lock test-lock'));
-    });
-  });
-
-  describe('onModuleDestroy', () => {
-    it('closes Redis connection gracefully', async () => {
-      const logSpy = jest.spyOn(service['logger'] as Logger, 'log');
-
-      await service.onModuleDestroy();
-
-      expect(redisMock.quit).toHaveBeenCalled();
-      expect(logSpy).toHaveBeenCalledWith('Distributed lock Redis connection closed');
-    });
-
-    it('disconnects forcefully if quit fails', async () => {
-      redisMock.quit.mockRejectedValue(new Error('Timeout'));
-      const warnSpy = jest.spyOn(service['logger'] as Logger, 'warn');
-
-      await service.onModuleDestroy();
-
-      expect(redisMock.disconnect).toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Error closing Redis connection'));
     });
   });
 });

--- a/apps/api/src/shared/distributed-lock.service.ts
+++ b/apps/api/src/shared/distributed-lock.service.ts
@@ -1,12 +1,12 @@
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 import Redis from 'ioredis';
 
 import { randomUUID } from 'crypto';
 
-import { LOCK_DEFAULTS, LOCK_REDIS_DB } from './distributed-lock.constants';
+import { LOCK_DEFAULTS } from './distributed-lock.constants';
 import { toErrorInfo } from './error.util';
+import { LOCK_REDIS } from './lock-redis.provider';
 
 export interface LockOptions {
   key: string;
@@ -27,9 +27,8 @@ export interface LockInfo {
 }
 
 @Injectable()
-export class DistributedLockService implements OnModuleDestroy {
+export class DistributedLockService {
   private readonly logger = new Logger(DistributedLockService.name);
-  private readonly redis: Redis;
 
   // Lua script for safe release (only delete if we own the lock)
   private readonly RELEASE_SCRIPT = `
@@ -49,18 +48,7 @@ export class DistributedLockService implements OnModuleDestroy {
     end
   `;
 
-  constructor(private readonly configService: ConfigService) {
-    this.redis = new Redis({
-      host: this.configService.get<string>('REDIS_HOST'),
-      port: this.configService.get<number>('REDIS_PORT', 6379),
-      db: LOCK_REDIS_DB,
-      username: this.configService.get<string>('REDIS_USER') || undefined,
-      password: this.configService.get<string>('REDIS_PASSWORD') || undefined,
-      tls: this.configService.get<string>('REDIS_TLS') === 'true' ? {} : undefined,
-      maxRetriesPerRequest: null,
-      enableReadyCheck: false
-    });
-  }
+  constructor(@Inject(LOCK_REDIS) private readonly redis: Redis) {}
 
   /**
    * Attempts to acquire a distributed lock.
@@ -163,16 +151,5 @@ export class DistributedLockService implements OnModuleDestroy {
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  async onModuleDestroy(): Promise<void> {
-    try {
-      await this.redis.quit();
-      this.logger.log('Distributed lock Redis connection closed');
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.warn(`Error closing Redis connection: ${err.message}`);
-      this.redis.disconnect();
-    }
   }
 }

--- a/apps/api/src/shared/index.ts
+++ b/apps/api/src/shared/index.ts
@@ -1,8 +1,10 @@
 export { LOCK_DEFAULTS, LOCK_KEYS, LOCK_REDIS_DB } from './distributed-lock.constants';
 export { DistributedLockService, LockInfo, LockOptions, LockResult } from './distributed-lock.service';
 export { isUniqueConstraintViolation, toErrorInfo } from './error.util';
+export { LOCK_REDIS, lockRedisProvider } from './lock-redis.provider';
 export { forceRemoveJob } from './queue.util';
 export { SharedLockModule } from './shared-lock.module';
+export { CooldownCheckResult, CooldownClaim, TradeCooldownService } from './trade-cooldown.service';
 
 // Resilience patterns
 export {

--- a/apps/api/src/shared/lock-redis.provider.ts
+++ b/apps/api/src/shared/lock-redis.provider.ts
@@ -1,0 +1,24 @@
+import { FactoryProvider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import Redis from 'ioredis';
+
+import { LOCK_REDIS_DB } from './distributed-lock.constants';
+
+export const LOCK_REDIS = Symbol('LOCK_REDIS');
+
+export const lockRedisProvider: FactoryProvider<Redis> = {
+  provide: LOCK_REDIS,
+  inject: [ConfigService],
+  useFactory: (configService: ConfigService): Redis =>
+    new Redis({
+      host: configService.get<string>('REDIS_HOST'),
+      port: configService.get<number>('REDIS_PORT', 6379),
+      db: LOCK_REDIS_DB,
+      username: configService.get<string>('REDIS_USER') || undefined,
+      password: configService.get<string>('REDIS_PASSWORD') || undefined,
+      tls: configService.get<string>('REDIS_TLS') === 'true' ? {} : undefined,
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false
+    })
+};

--- a/apps/api/src/shared/shared-lock.module.ts
+++ b/apps/api/src/shared/shared-lock.module.ts
@@ -1,10 +1,30 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, Inject, Logger, Module, OnModuleDestroy } from '@nestjs/common';
+
+import Redis from 'ioredis';
 
 import { DistributedLockService } from './distributed-lock.service';
+import { toErrorInfo } from './error.util';
+import { LOCK_REDIS, lockRedisProvider } from './lock-redis.provider';
+import { TradeCooldownService } from './trade-cooldown.service';
 
 @Global()
 @Module({
-  providers: [DistributedLockService],
-  exports: [DistributedLockService]
+  providers: [lockRedisProvider, DistributedLockService, TradeCooldownService],
+  exports: [LOCK_REDIS, DistributedLockService, TradeCooldownService]
 })
-export class SharedLockModule {}
+export class SharedLockModule implements OnModuleDestroy {
+  private readonly logger = new Logger(SharedLockModule.name);
+
+  constructor(@Inject(LOCK_REDIS) private readonly redis: Redis) {}
+
+  async onModuleDestroy(): Promise<void> {
+    try {
+      await this.redis.quit();
+      this.logger.log('Lock Redis connection closed');
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Error closing lock Redis connection: ${err.message}`);
+      this.redis.disconnect();
+    }
+  }
+}

--- a/apps/api/src/shared/trade-cooldown.service.spec.ts
+++ b/apps/api/src/shared/trade-cooldown.service.spec.ts
@@ -1,0 +1,115 @@
+import { Logger } from '@nestjs/common';
+
+import { TradeCooldownService } from './trade-cooldown.service';
+
+const createRedisMock = () => ({
+  eval: jest.fn(),
+  del: jest.fn(),
+  quit: jest.fn().mockResolvedValue(undefined),
+  disconnect: jest.fn()
+});
+
+describe('TradeCooldownService', () => {
+  let service: TradeCooldownService;
+  let redisMock: ReturnType<typeof createRedisMock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    redisMock = createRedisMock();
+    service = new TradeCooldownService(redisMock as any);
+  });
+
+  describe('checkAndClaim', () => {
+    it('returns allowed: true when key is not yet claimed', async () => {
+      redisMock.eval.mockResolvedValue([1]);
+
+      const result = await service.checkAndClaim('user-1', 'BTC/USDT', 'BUY', 'strategy:s1');
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it('returns allowed: false with existingClaim when key is already held', async () => {
+      const existingClaim = { pipeline: 'activation:a1', claimedAt: 1700000000000 };
+      redisMock.eval.mockResolvedValue([0, JSON.stringify(existingClaim)]);
+
+      const result = await service.checkAndClaim('user-1', 'BTC/USDT', 'BUY', 'strategy:s1');
+
+      expect(result.allowed).toBe(false);
+      expect(result.existingClaim).toEqual(existingClaim);
+    });
+
+    it('fails open on Redis error (allows trade through)', async () => {
+      redisMock.eval.mockRejectedValue(new Error('Connection refused'));
+      const warnSpy = jest.spyOn(service['logger'] as Logger, 'warn');
+
+      const result = await service.checkAndClaim('user-1', 'BTC/USDT', 'BUY', 'strategy:s1');
+
+      expect(result).toEqual({ allowed: true });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('fail-open'));
+    });
+
+    it('builds correct key from userId, symbol, and direction', async () => {
+      redisMock.eval.mockResolvedValue([1]);
+
+      await service.checkAndClaim('user-42', 'ETH/USDT', 'SELL', 'activation:a1');
+
+      expect(redisMock.eval).toHaveBeenCalledWith(
+        expect.any(String),
+        1,
+        'trade-cd:user-42:ETH/USDT:SELL',
+        expect.any(String),
+        expect.any(Number)
+      );
+    });
+
+    it('passes 11-minute TTL to Lua script', async () => {
+      redisMock.eval.mockResolvedValue([1]);
+
+      await service.checkAndClaim('user-1', 'BTC/USDT', 'BUY', 'strategy:s1');
+
+      const ttlArg = redisMock.eval.mock.calls[0][4];
+      expect(ttlArg).toBe(11 * 60 * 1000);
+    });
+
+    it('returns fallback existingClaim when existing value is missing', async () => {
+      redisMock.eval.mockResolvedValue([0, undefined]);
+
+      const result = await service.checkAndClaim('user-1', 'BTC/USDT', 'BUY', 'strategy:s1');
+
+      expect(result.allowed).toBe(false);
+      expect(result.existingClaim).toEqual({ pipeline: 'unknown', claimedAt: 0 });
+    });
+
+    it('passes claim payload with pipeline and claimedAt to Redis', async () => {
+      redisMock.eval.mockResolvedValue([1]);
+      const before = Date.now();
+
+      await service.checkAndClaim('user-1', 'BTC/USDT', 'BUY', 'strategy:s1');
+
+      const claimJson = redisMock.eval.mock.calls[0][3] as string;
+      const claim = JSON.parse(claimJson);
+      expect(claim.pipeline).toBe('strategy:s1');
+      expect(claim.claimedAt).toBeGreaterThanOrEqual(before);
+      expect(claim.claimedAt).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  describe('clearCooldown', () => {
+    it('calls redis.del with the correct key', async () => {
+      redisMock.del.mockResolvedValue(1);
+
+      await service.clearCooldown('user-1', 'BTC/USDT', 'BUY');
+
+      expect(redisMock.del).toHaveBeenCalledWith('trade-cd:user-1:BTC/USDT:BUY');
+    });
+
+    it('swallows Redis errors with a warn-level log', async () => {
+      redisMock.del.mockRejectedValue(new Error('Connection refused'));
+      const warnSpy = jest.spyOn(service['logger'] as Logger, 'warn');
+
+      await expect(service.clearCooldown('user-1', 'BTC/USDT', 'BUY')).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to clear trade cooldown'));
+    });
+  });
+});

--- a/apps/api/src/shared/trade-cooldown.service.ts
+++ b/apps/api/src/shared/trade-cooldown.service.ts
@@ -1,0 +1,120 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import Redis from 'ioredis';
+
+import { toErrorInfo } from './error.util';
+import { LOCK_REDIS } from './lock-redis.provider';
+
+export interface CooldownClaim {
+  pipeline: string;
+  claimedAt: number;
+}
+
+export interface CooldownCheckResult {
+  allowed: boolean;
+  existingClaim?: CooldownClaim;
+}
+
+/**
+ * Cooldown TTL: 11 minutes.
+ * Pipeline 1 runs every 2 min, Pipeline 2 every 5 min.
+ * 11 min = 2 full Pipeline 2 cycles (5+5) + 1 min safety margin.
+ */
+const COOLDOWN_TTL_MS = 11 * 60 * 1000;
+
+/**
+ * TradeCooldownService
+ *
+ * Redis-based per-(userId, symbol, direction) trade cooldown.
+ * Uses an atomic Lua check-and-set script to prevent two pipelines
+ * from placing the same trade within a short window.
+ *
+ * Fail-open: if Redis is unreachable the trade is allowed through,
+ * because blocking all trading due to a safety-check outage is worse
+ * than a rare duplicate in an edge case.
+ */
+@Injectable()
+export class TradeCooldownService {
+  private readonly logger = new Logger(TradeCooldownService.name);
+
+  /**
+   * Lua script: atomically check if key exists, if not set it with value and TTL.
+   * Returns 1 if claimed (key was set), or 0 + existing value if already held.
+   *
+   * KEYS[1] = cooldown key
+   * ARGV[1] = JSON claim value
+   * ARGV[2] = TTL in milliseconds
+   *
+   * Returns: [1] on success, [0, existingValue] if already claimed.
+   */
+  private readonly CHECK_AND_CLAIM_SCRIPT = `
+    local existing = redis.call("GET", KEYS[1])
+    if existing then
+      return {0, existing}
+    end
+    redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
+    return {1}
+  `;
+
+  constructor(@Inject(LOCK_REDIS) private readonly redis: Redis) {}
+
+  /**
+   * Atomically check whether a trade cooldown exists and claim it if not.
+   *
+   * @param userId   - User placing the trade
+   * @param symbol   - Trading pair (e.g. "BTC/USDT")
+   * @param direction - "BUY" or "SELL" (opposite directions are independent)
+   * @param pipeline - Identifier for the claiming pipeline (for debugging)
+   * @returns `{ allowed: true }` when the caller may proceed,
+   *          `{ allowed: false, existingClaim }` when another pipeline already claimed this trade
+   */
+  async checkAndClaim(
+    userId: string,
+    symbol: string,
+    direction: string,
+    pipeline: string
+  ): Promise<CooldownCheckResult> {
+    const key = this.buildKey(userId, symbol, direction);
+    const claim: CooldownClaim = { pipeline, claimedAt: Date.now() };
+
+    try {
+      const result = (await this.redis.eval(
+        this.CHECK_AND_CLAIM_SCRIPT,
+        1,
+        key,
+        JSON.stringify(claim),
+        COOLDOWN_TTL_MS
+      )) as [number, string?];
+
+      if (result[0] === 1) {
+        return { allowed: true };
+      }
+
+      const existingClaim: CooldownClaim = result[1] ? JSON.parse(result[1]) : { pipeline: 'unknown', claimedAt: 0 };
+      return { allowed: false, existingClaim };
+    } catch (error: unknown) {
+      // Fail-open: allow trade through if Redis is unreachable
+      const err = toErrorInfo(error);
+      this.logger.warn(`Trade cooldown check failed (fail-open, allowing trade): ${err.message}`);
+      return { allowed: true };
+    }
+  }
+
+  /**
+   * Clear a cooldown key so the next cycle can retry.
+   * Called when a trade execution fails.
+   */
+  async clearCooldown(userId: string, symbol: string, direction: string): Promise<void> {
+    const key = this.buildKey(userId, symbol, direction);
+    try {
+      await this.redis.del(key);
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Failed to clear trade cooldown ${key}: ${err.message}`);
+    }
+  }
+
+  private buildKey(userId: string, symbol: string, direction: string): string {
+    return `trade-cd:${userId}:${symbol}:${direction}`;
+  }
+}

--- a/apps/api/src/strategy/live-trading.service.spec.ts
+++ b/apps/api/src/strategy/live-trading.service.spec.ts
@@ -15,10 +15,12 @@ import { BalanceService } from '../balance/balance.service';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
 import { CompositeRegimeService } from '../market-regime/composite-regime.service';
 import { RegimeGateService } from '../market-regime/regime-gate.service';
+import { MetricsService } from '../metrics/metrics.service';
 import { OrderService } from '../order/order.service';
 import { TradeExecutionService } from '../order/services/trade-execution.service';
 import { LOCK_KEYS } from '../shared/distributed-lock.constants';
 import { DistributedLockService } from '../shared/distributed-lock.service';
+import { TradeCooldownService } from '../shared/trade-cooldown.service';
 import { User } from '../users/users.entity';
 
 type MockRepo<T extends ObjectLiteral> = jest.Mocked<Repository<T>>;
@@ -44,6 +46,10 @@ describe('LiveTradingService', () => {
   let orderService: jest.Mocked<OrderService>;
   let balanceService: jest.Mocked<BalanceService>;
   let tradingStateService: jest.Mocked<TradingStateService>;
+  let regimeGateService: jest.Mocked<RegimeGateService>;
+  let preTradeRiskGate: jest.Mocked<PreTradeRiskGateService>;
+  let tradeExecutionService: jest.Mocked<TradeExecutionService>;
+  let tradeCooldownService: jest.Mocked<TradeCooldownService>;
 
   beforeEach(async () => {
     userRepo = {
@@ -88,6 +94,23 @@ describe('LiveTradingService', () => {
       isTradingEnabled: jest.fn().mockReturnValue(true)
     } as unknown as jest.Mocked<TradingStateService>;
 
+    regimeGateService = {
+      filterLiveSignal: jest.fn().mockReturnValue({ allowed: true })
+    } as unknown as jest.Mocked<RegimeGateService>;
+
+    preTradeRiskGate = {
+      checkDrawdown: jest.fn().mockResolvedValue({ allowed: true })
+    } as unknown as jest.Mocked<PreTradeRiskGateService>;
+
+    tradeExecutionService = {
+      executeTradeSignal: jest.fn().mockResolvedValue({ id: 'order-1' })
+    } as unknown as jest.Mocked<TradeExecutionService>;
+
+    tradeCooldownService = {
+      checkAndClaim: jest.fn().mockResolvedValue({ allowed: true }),
+      clearCooldown: jest.fn().mockResolvedValue(undefined)
+    } as unknown as jest.Mocked<TradeCooldownService>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LiveTradingService,
@@ -110,20 +133,41 @@ describe('LiveTradingService', () => {
             isOverrideActive: jest.fn().mockReturnValue(false)
           }
         },
-        { provide: RegimeGateService, useValue: { filterLiveSignal: jest.fn().mockReturnValue({ allowed: true }) } },
+        { provide: RegimeGateService, useValue: regimeGateService },
+        { provide: PreTradeRiskGateService, useValue: preTradeRiskGate },
+        { provide: TradeExecutionService, useValue: tradeExecutionService },
+        { provide: TradeCooldownService, useValue: tradeCooldownService },
         {
-          provide: PreTradeRiskGateService,
-          useValue: { checkDrawdown: jest.fn().mockResolvedValue({ allowed: true }) }
-        },
-        {
-          provide: TradeExecutionService,
-          useValue: { executeTradeSignal: jest.fn().mockResolvedValue({ id: 'order-1' }) }
+          provide: MetricsService,
+          useValue: {
+            recordTradeCooldownBlock: jest.fn(),
+            recordTradeCooldownClaim: jest.fn(),
+            recordTradeCooldownCleared: jest.fn(),
+            recordRegimeGateBlock: jest.fn(),
+            recordDrawdownGateBlock: jest.fn(),
+            recordLiveOrderPlaced: jest.fn()
+          }
         }
       ]
     }).compile();
 
     service = module.get(LiveTradingService);
   });
+
+  /** Mocks the common setup for tests that reach the signal execution path */
+  const setupSignalPath = (opts?: { user?: Partial<User>; strategies?: any[] }): User => {
+    lockService.acquire.mockResolvedValue({ acquired: true, lockId: 'lock-1' });
+    const user = createUser(opts?.user);
+    userRepo.find.mockResolvedValue([user]);
+    balanceService.getUserBalances.mockResolvedValue({
+      current: [{ balances: [{ free: '100', locked: '0', usdValue: 100 }] }]
+    } as any);
+    riskPoolMapping.getActiveStrategiesForUser.mockResolvedValue(opts?.strategies ?? [{ id: 'strategy-1' } as any]);
+    capitalAllocation.allocateCapitalByKelly.mockResolvedValue(new Map([['strategy-1', 50]]));
+    positionTracking.getPositions.mockResolvedValue([]);
+    jest.spyOn<any, any>(service as any, 'fetchMarketData').mockResolvedValue([]);
+    return user;
+  };
 
   it('returns early when trading is globally disabled', async () => {
     tradingStateService.isTradingEnabled.mockReturnValue(false);
@@ -142,22 +186,15 @@ describe('LiveTradingService', () => {
     expect(lockService.release).not.toHaveBeenCalled();
   });
 
-  it('places orders for valid signals on preferred exchange', async () => {
-    lockService.acquire.mockResolvedValue({ acquired: true, lockId: 'lock-1' });
-    const user = createUser({
-      exchanges: [
-        { id: 'ex-1', name: 'Coinbase', slug: 'coinbase', isActive: true },
-        { id: 'ex-2', name: 'Binance US', slug: 'binance_us', isActive: true }
-      ] as any
+  it('places spot order on preferred exchange and tracks buy as long', async () => {
+    const user = setupSignalPath({
+      user: {
+        exchanges: [
+          { id: 'ex-1', name: 'Coinbase', slug: 'coinbase', isActive: true },
+          { id: 'ex-2', name: 'Binance US', slug: 'binance_us', isActive: true }
+        ] as any
+      }
     });
-    userRepo.find.mockResolvedValue([user]);
-    balanceService.getUserBalances.mockResolvedValue({
-      current: [{ balances: [{ free: '100', locked: '0', usdValue: 100 }] }]
-    } as any);
-    riskPoolMapping.getActiveStrategiesForUser.mockResolvedValue([{ id: 'strategy-1' } as any]);
-    capitalAllocation.allocateCapitalByKelly.mockResolvedValue(new Map([['strategy-1', 50]]));
-    positionTracking.getPositions.mockResolvedValue([]);
-    jest.spyOn<any, any>(service as any, 'fetchMarketData').mockResolvedValue([]);
 
     const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
     strategyExecutor.executeStrategy.mockResolvedValue(signal);
@@ -167,21 +204,20 @@ describe('LiveTradingService', () => {
     await service.executeLiveTrading();
 
     expect(orderService.placeAlgorithmicOrder).toHaveBeenCalledWith(user.id, 'strategy-1', signal, 'ex-2');
-    expect(positionTracking.updatePosition).toHaveBeenCalled();
+    expect(positionTracking.updatePosition).toHaveBeenCalledWith(
+      user.id,
+      'strategy-1',
+      'BTC/USDT',
+      0.01,
+      30000,
+      'buy',
+      'long'
+    );
     expect(lockService.release).toHaveBeenCalledWith(LOCK_KEYS.LIVE_TRADING, 'lock-1');
   });
 
-  it('skips invalid signals', async () => {
-    lockService.acquire.mockResolvedValue({ acquired: true, lockId: 'lock-1' });
-    const user = createUser();
-    userRepo.find.mockResolvedValue([user]);
-    balanceService.getUserBalances.mockResolvedValue({
-      current: [{ balances: [{ free: '100', locked: '0', usdValue: 100 }] }]
-    } as any);
-    riskPoolMapping.getActiveStrategiesForUser.mockResolvedValue([{ id: 'strategy-1' } as any]);
-    capitalAllocation.allocateCapitalByKelly.mockResolvedValue(new Map([['strategy-1', 50]]));
-    positionTracking.getPositions.mockResolvedValue([]);
-    jest.spyOn<any, any>(service as any, 'fetchMarketData').mockResolvedValue([]);
+  it('skips invalid signals without placing orders', async () => {
+    setupSignalPath();
 
     const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
     strategyExecutor.executeStrategy.mockResolvedValue(signal);
@@ -215,34 +251,151 @@ describe('LiveTradingService', () => {
     expect(result).toEqual({ running: true, enrolledUsers: 5, instanceId: 'instance-1' });
   });
 
-  it('caps oversized buy signal quantity before placing order', async () => {
-    lockService.acquire.mockResolvedValue({ acquired: true, lockId: 'lock-1' });
-    const user = createUser();
-    userRepo.find.mockResolvedValue([user]);
-    balanceService.getUserBalances.mockResolvedValue({
-      current: [{ balances: [{ free: '10000', locked: '0', usdValue: 10000 }] }]
-    } as any);
-    riskPoolMapping.getActiveStrategiesForUser.mockResolvedValue([{ id: 'strategy-1' } as any]);
-    capitalAllocation.allocateCapitalByKelly.mockResolvedValue(new Map([['strategy-1', 5000]]));
-    positionTracking.getPositions.mockResolvedValue([]);
-    jest.spyOn<any, any>(service as any, 'fetchMarketData').mockResolvedValue([]);
+  it('tracks sell signal as side=sell positionSide=long via spot path', async () => {
+    const user = setupSignalPath();
 
-    // Signal with quantity far exceeding 20% cap (0.5 BTC @ 50000 = $25000, capital = $5000)
-    // StrategyExecutorService.mapAlgorithmSignal would cap to 20% → 0.02 BTC
-    const cappedSignal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.02, price: 50000 };
-    strategyExecutor.executeStrategy.mockResolvedValue(cappedSignal);
+    const signal: TradingSignal = { action: 'sell', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+    strategyExecutor.executeStrategy.mockResolvedValue(signal);
     strategyExecutor.validateSignal.mockReturnValue({ valid: true });
     orderService.placeAlgorithmicOrder.mockResolvedValue({ id: 'order-1' } as any);
 
     await service.executeLiveTrading();
 
-    // Verify the order was placed with the capped quantity, not the original oversized one
-    expect(orderService.placeAlgorithmicOrder).toHaveBeenCalledWith(
+    expect(orderService.placeAlgorithmicOrder).toHaveBeenCalled();
+    expect(positionTracking.updatePosition).toHaveBeenCalledWith(
       user.id,
       'strategy-1',
-      expect.objectContaining({ quantity: 0.02 }),
-      expect.any(String)
+      'BTC/USDT',
+      0.01,
+      30000,
+      'sell',
+      'long'
     );
+  });
+
+  it('routes short_entry through futures path and tracks as buy/short', async () => {
+    const user = setupSignalPath({
+      strategies: [{ id: 'strategy-1', marketType: 'futures', defaultLeverage: 1 } as any]
+    });
+
+    const signal: TradingSignal = { action: 'short_entry', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+    strategyExecutor.executeStrategy.mockResolvedValue(signal);
+    strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+
+    await service.executeLiveTrading();
+
+    expect(tradeExecutionService.executeTradeSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'SELL',
+        symbol: 'BTC/USDT',
+        quantity: 0.01,
+        marketType: 'futures',
+        positionSide: 'short',
+        leverage: 1
+      })
+    );
+    expect(orderService.placeAlgorithmicOrder).not.toHaveBeenCalled();
+    expect(positionTracking.updatePosition).toHaveBeenCalledWith(
+      user.id,
+      'strategy-1',
+      'BTC/USDT',
+      0.01,
+      30000,
+      'buy',
+      'short'
+    );
+  });
+
+  it('routes short_exit through futures path and tracks as sell/short', async () => {
+    const user = setupSignalPath({
+      strategies: [{ id: 'strategy-1', marketType: 'futures', defaultLeverage: 1 } as any]
+    });
+
+    const signal: TradingSignal = { action: 'short_exit', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+    strategyExecutor.executeStrategy.mockResolvedValue(signal);
+    strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+
+    await service.executeLiveTrading();
+
+    expect(tradeExecutionService.executeTradeSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'BUY',
+        symbol: 'BTC/USDT',
+        quantity: 0.01,
+        marketType: 'futures',
+        positionSide: 'short',
+        leverage: 1
+      })
+    );
+    expect(orderService.placeAlgorithmicOrder).not.toHaveBeenCalled();
+    expect(positionTracking.updatePosition).toHaveBeenCalledWith(
+      user.id,
+      'strategy-1',
+      'BTC/USDT',
+      0.01,
+      30000,
+      'sell',
+      'short'
+    );
+  });
+
+  it('blocks signal when regime gate rejects', async () => {
+    setupSignalPath();
+    regimeGateService.filterLiveSignal.mockReturnValue({
+      allowed: false,
+      reason: 'BEAR regime — BUY signals blocked'
+    } as any);
+
+    const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+    strategyExecutor.executeStrategy.mockResolvedValue(signal);
+    strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+
+    await service.executeLiveTrading();
+
+    expect(orderService.placeAlgorithmicOrder).not.toHaveBeenCalled();
+    expect(tradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+  });
+
+  it('blocks signal when drawdown gate rejects', async () => {
+    setupSignalPath();
+    preTradeRiskGate.checkDrawdown.mockResolvedValue({ allowed: false, reason: 'drawdown breach' } as any);
+
+    const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+    strategyExecutor.executeStrategy.mockResolvedValue(signal);
+    strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+
+    await service.executeLiveTrading();
+
+    expect(orderService.placeAlgorithmicOrder).not.toHaveBeenCalled();
+  });
+
+  it('blocks signal when trade cooldown rejects', async () => {
+    setupSignalPath();
+    tradeCooldownService.checkAndClaim.mockResolvedValue({
+      allowed: false,
+      existingClaim: { pipeline: 'pipeline:abc' }
+    } as any);
+
+    const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+    strategyExecutor.executeStrategy.mockResolvedValue(signal);
+    strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+
+    await service.executeLiveTrading();
+
+    expect(orderService.placeAlgorithmicOrder).not.toHaveBeenCalled();
+  });
+
+  it('clears cooldown when order placement fails', async () => {
+    setupSignalPath();
+
+    const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+    strategyExecutor.executeStrategy.mockResolvedValue(signal);
+    strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+    orderService.placeAlgorithmicOrder.mockRejectedValue(new Error('Exchange error'));
+
+    await service.executeLiveTrading();
+
+    expect(tradeCooldownService.clearCooldown).toHaveBeenCalledWith('user-1', 'BTC/USDT', 'BUY');
   });
 
   it('releases lock on shutdown when held', async () => {
@@ -251,5 +404,11 @@ describe('LiveTradingService', () => {
     await service.onApplicationShutdown('SIGTERM');
 
     expect(lockService.release).toHaveBeenCalledWith(LOCK_KEYS.LIVE_TRADING, 'shutdown-lock');
+  });
+
+  it('does not release lock on shutdown when none is held', async () => {
+    await service.onApplicationShutdown('SIGTERM');
+
+    expect(lockService.release).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/strategy/live-trading.service.ts
+++ b/apps/api/src/strategy/live-trading.service.ts
@@ -21,11 +21,13 @@ import { SupportedExchangeKeyDto } from '../exchange/exchange-key/dto';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
 import { CompositeRegimeService } from '../market-regime/composite-regime.service';
 import { RegimeGateService } from '../market-regime/regime-gate.service';
+import { MetricsService } from '../metrics/metrics.service';
 import { OrderService } from '../order/order.service';
 import { TradeExecutionService, TradeSignalWithExit } from '../order/services/trade-execution.service';
 import { LOCK_DEFAULTS, LOCK_KEYS } from '../shared/distributed-lock.constants';
 import { DistributedLockService } from '../shared/distributed-lock.service';
 import { toErrorInfo } from '../shared/error.util';
+import { TradeCooldownService } from '../shared/trade-cooldown.service';
 import { User } from '../users/users.entity';
 
 /** Maximum consecutive errors before disabling algo trading for a user */
@@ -57,7 +59,9 @@ export class LiveTradingService implements OnApplicationShutdown {
     private readonly compositeRegimeService: CompositeRegimeService,
     private readonly regimeGateService: RegimeGateService,
     private readonly preTradeRiskGate: PreTradeRiskGateService,
-    private readonly tradeExecutionService: TradeExecutionService
+    private readonly tradeExecutionService: TradeExecutionService,
+    private readonly tradeCooldownService: TradeCooldownService,
+    private readonly metricsService: MetricsService
   ) {}
 
   @Cron('*/2 * * * *')
@@ -196,6 +200,7 @@ export class LiveTradingService implements OnApplicationShutdown {
             trendAboveSma
           );
           if (!gateDecision.allowed) {
+            this.metricsService.recordRegimeGateBlock(compositeRegime);
             gateBlockedCount++;
             continue;
           }
@@ -203,6 +208,7 @@ export class LiveTradingService implements OnApplicationShutdown {
           // Drawdown gate: block BUY signals when deployment is in drawdown breach
           const drawdownCheck = await this.preTradeRiskGate.checkDrawdown(strategy.id, action);
           if (!drawdownCheck.allowed) {
+            this.metricsService.recordDrawdownGateBlock();
             drawdownBlockedCount++;
             continue;
           }
@@ -239,64 +245,118 @@ export class LiveTradingService implements OnApplicationShutdown {
         return;
       }
 
-      const isFutures =
-        signal.action === 'short_entry' || signal.action === 'short_exit' || strategy.marketType === MarketType.FUTURES;
+      // Trade cooldown: prevent double-trading if Pipeline 2 already placed this trade
+      const direction = this.mapSignalActionToDirection(signal.action);
+      const cooldownCheck = await this.tradeCooldownService.checkAndClaim(
+        user.id,
+        signal.symbol,
+        direction,
+        `strategy:${strategyConfigId}`
+      );
 
-      if (isFutures) {
-        // Route futures signals through TradeExecutionService which has full futures support
-        const { action, positionSide } = this.mapLiveSignalToTradeAction(signal.action, strategy.marketType);
-        const tradeSignal: TradeSignalWithExit = {
-          algorithmActivationId: strategyConfigId,
-          userId: user.id,
-          exchangeKeyId: exchangeKey.id,
-          action,
-          symbol: signal.symbol,
-          quantity: signal.quantity,
-          marketType: 'futures',
-          positionSide,
-          leverage: Number(strategy.defaultLeverage) || 1
-        };
-
-        await this.tradeExecutionService.executeTradeSignal(tradeSignal);
-
-        this.logger.log(
-          `Futures order placed for user ${user.id}: ${action} ${signal.quantity} ${signal.symbol} ` +
-            `positionSide=${positionSide} leverage=${tradeSignal.leverage}x on ${exchangeKey.name}`
+      if (!cooldownCheck.allowed) {
+        this.metricsService.recordTradeCooldownBlock(direction, signal.symbol);
+        this.logger.warn(
+          `Trade cooldown blocked strategy ${strategyConfigId} for user ${user.id}: ` +
+            `${direction} ${signal.symbol} already claimed by ${cooldownCheck.existingClaim?.pipeline}`
         );
-      } else {
-        // Spot path — unchanged
-        const orderSignal = {
-          action: signal.action as 'buy' | 'sell',
-          symbol: signal.symbol,
-          quantity: signal.quantity,
-          price: signal.price
-        };
-
-        const order = await this.orderService.placeAlgorithmicOrder(
-          user.id,
-          strategyConfigId,
-          orderSignal,
-          exchangeKey.id
-        );
-
-        this.logger.log(
-          `Order placed for user ${user.id}: ${signal.action} ${signal.quantity} ${signal.symbol} ` +
-            `on ${exchangeKey.name} (Order ID: ${order.id})`
-        );
+        return;
       }
 
-      await this.positionTracking.updatePosition(
-        user.id,
-        strategyConfigId,
-        signal.symbol,
-        signal.quantity,
-        signal.price,
-        signal.action === 'buy' ? 'buy' : 'sell'
-      );
+      this.metricsService.recordTradeCooldownClaim(direction, signal.symbol);
+
+      try {
+        const isFutures =
+          signal.action === 'short_entry' ||
+          signal.action === 'short_exit' ||
+          strategy.marketType === MarketType.FUTURES;
+
+        if (isFutures) {
+          // Route futures signals through TradeExecutionService which has full futures support
+          const { action, positionSide } = this.mapLiveSignalToTradeAction(signal.action, strategy.marketType);
+          const tradeSignal: TradeSignalWithExit = {
+            algorithmActivationId: strategyConfigId,
+            userId: user.id,
+            exchangeKeyId: exchangeKey.id,
+            action,
+            symbol: signal.symbol,
+            quantity: signal.quantity,
+            marketType: 'futures',
+            positionSide,
+            leverage: Number(strategy.defaultLeverage) || 1
+          };
+
+          await this.tradeExecutionService.executeTradeSignal(tradeSignal);
+          this.metricsService.recordLiveOrderPlaced('futures', action);
+
+          this.logger.log(
+            `Futures order placed for user ${user.id}: ${action} ${signal.quantity} ${signal.symbol} ` +
+              `positionSide=${positionSide} leverage=${tradeSignal.leverage}x on ${exchangeKey.name}`
+          );
+        } else {
+          // Spot path — unchanged
+          const orderSignal = {
+            action: signal.action as 'buy' | 'sell',
+            symbol: signal.symbol,
+            quantity: signal.quantity,
+            price: signal.price
+          };
+
+          const order = await this.orderService.placeAlgorithmicOrder(
+            user.id,
+            strategyConfigId,
+            orderSignal,
+            exchangeKey.id
+          );
+          this.metricsService.recordLiveOrderPlaced('spot', signal.action);
+
+          this.logger.log(
+            `Order placed for user ${user.id}: ${signal.action} ${signal.quantity} ${signal.symbol} ` +
+              `on ${exchangeKey.name} (Order ID: ${order.id})`
+          );
+        }
+
+        const { side: trackingSide, positionSide: trackingPositionSide } = this.mapSignalToPositionTracking(
+          signal.action
+        );
+        await this.positionTracking.updatePosition(
+          user.id,
+          strategyConfigId,
+          signal.symbol,
+          signal.quantity,
+          signal.price,
+          trackingSide,
+          trackingPositionSide
+        );
+      } catch (error: unknown) {
+        // Clear cooldown on failure so next cycle can retry
+        await this.tradeCooldownService.clearCooldown(user.id, signal.symbol, direction);
+        this.metricsService.recordTradeCooldownCleared('order_failure');
+        throw error;
+      }
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Failed to place order for user ${user.id}: ${err.message}`);
       throw error;
+    }
+  }
+
+  /**
+   * Map a signal action string to a BUY/SELL direction for cooldown keys.
+   */
+  private mapSignalActionToDirection(action: string): string {
+    switch (action) {
+      case 'buy':
+      case 'short_exit':
+        return 'BUY';
+      case 'sell':
+      case 'short_entry':
+        return 'SELL';
+      default:
+        this.logger.warn(
+          `Unexpected signal action "${action}" — using "${action.toUpperCase()}" as cooldown direction`
+        );
+        return action.toUpperCase();
     }
   }
 
@@ -318,6 +378,32 @@ export class LiveTradingService implements OnApplicationShutdown {
         return { action: 'SELL', positionSide: marketType === MarketType.FUTURES ? PositionSide.LONG : undefined };
       default:
         throw new Error(`Unknown signal action: ${action}`);
+    }
+  }
+
+  /**
+   * Map a signal action to the side + positionSide used by PositionTrackingService.
+   *
+   * | signal.action | side   | positionSide |
+   * |---------------|--------|--------------|
+   * | buy           | buy    | long         |
+   * | sell          | sell   | long         |
+   * | short_entry   | buy    | short        |  (opening a short = "buying" into a short position)
+   * | short_exit    | sell   | short        |  (closing a short = "selling" the short position)
+   */
+  private mapSignalToPositionTracking(action: string): { side: 'buy' | 'sell'; positionSide: 'long' | 'short' } {
+    switch (action) {
+      case 'buy':
+        return { side: 'buy', positionSide: 'long' };
+      case 'sell':
+        return { side: 'sell', positionSide: 'long' };
+      case 'short_entry':
+        return { side: 'buy', positionSide: 'short' };
+      case 'short_exit':
+        return { side: 'sell', positionSide: 'short' };
+      default:
+        this.logger.error(`Unknown signal action "${action}" for position tracking`);
+        throw new Error(`Unknown signal action for position tracking: ${action}`);
     }
   }
 

--- a/apps/api/src/strategy/position-tracking.service.spec.ts
+++ b/apps/api/src/strategy/position-tracking.service.spec.ts
@@ -1,0 +1,365 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ObjectLiteral, Repository } from 'typeorm';
+
+import { UserStrategyPosition } from './entities/user-strategy-position.entity';
+import { PositionTrackingService } from './position-tracking.service';
+
+type MockRepo<T extends ObjectLiteral> = jest.Mocked<Repository<T>>;
+
+const createPosition = (overrides: Partial<UserStrategyPosition> = {}): UserStrategyPosition =>
+  ({
+    id: 'pos-1',
+    userId: 'user-1',
+    strategyConfigId: 'strat-1',
+    symbol: 'BTC/USDT',
+    positionSide: 'long',
+    quantity: 0,
+    avgEntryPrice: 0,
+    unrealizedPnL: 0,
+    realizedPnL: 0,
+    ...overrides
+  }) as UserStrategyPosition;
+
+describe('PositionTrackingService', () => {
+  let service: PositionTrackingService;
+  let repo: MockRepo<UserStrategyPosition>;
+
+  beforeEach(async () => {
+    repo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn((data) => ({ ...createPosition(), ...data })),
+      save: jest.fn((entity) => Promise.resolve(entity))
+    } as unknown as MockRepo<UserStrategyPosition>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PositionTrackingService, { provide: getRepositoryToken(UserStrategyPosition), useValue: repo }]
+    }).compile();
+
+    service = module.get(PositionTrackingService);
+  });
+
+  describe('getPositions', () => {
+    it('queries all positions for a user without strategy filter', async () => {
+      repo.find.mockResolvedValue([]);
+      await service.getPositions('user-1');
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        relations: ['strategyConfig', 'user'],
+        order: { updatedAt: 'DESC' }
+      });
+    });
+
+    it('includes strategyConfigId in query when provided', async () => {
+      repo.find.mockResolvedValue([]);
+      await service.getPositions('user-1', 'strat-1');
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { userId: 'user-1', strategyConfigId: 'strat-1' },
+        relations: ['strategyConfig', 'user'],
+        order: { updatedAt: 'DESC' }
+      });
+    });
+  });
+
+  describe('getPosition', () => {
+    it('queries with positionSide=long by default', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await service.getPosition('user-1', 'strat-1', 'BTC/USDT');
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { userId: 'user-1', strategyConfigId: 'strat-1', symbol: 'BTC/USDT', positionSide: 'long' },
+        relations: ['strategyConfig', 'user']
+      });
+    });
+
+    it('queries with positionSide=short when specified', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await service.getPosition('user-1', 'strat-1', 'BTC/USDT', 'short');
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { userId: 'user-1', strategyConfigId: 'strat-1', symbol: 'BTC/USDT', positionSide: 'short' },
+        relations: ['strategyConfig', 'user']
+      });
+    });
+  });
+
+  describe('updatePosition - long', () => {
+    it('creates a new long position on buy', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, 50000, 'buy');
+
+      expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ positionSide: 'long' }));
+      expect(result.quantity).toBe(1);
+      expect(result.avgEntryPrice).toBe(50000);
+    });
+
+    it('adds to existing position with weighted average entry price', async () => {
+      const existing = createPosition({ quantity: 1, avgEntryPrice: 50000 });
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, 60000, 'buy');
+
+      // Weighted avg: (1 * 50000 + 1 * 60000) / 2 = 55000
+      expect(result.quantity).toBe(2);
+      expect(result.avgEntryPrice).toBe(55000);
+    });
+
+    it('realizes positive P&L on full sell when price rises', async () => {
+      const existing = createPosition({ quantity: 1, avgEntryPrice: 50000 });
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, 55000, 'sell');
+
+      // P&L = (55000 - 50000) * 1 = 5000
+      expect(result.realizedPnL).toBe(5000);
+      expect(result.quantity).toBe(0);
+      expect(result.avgEntryPrice).toBe(0);
+      expect(result.unrealizedPnL).toBe(0);
+    });
+
+    it('realizes negative P&L on full sell when price drops', async () => {
+      const existing = createPosition({ quantity: 1, avgEntryPrice: 50000 });
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, 45000, 'sell');
+
+      // P&L = (45000 - 50000) * 1 = -5000
+      expect(result.realizedPnL).toBe(-5000);
+      expect(result.quantity).toBe(0);
+    });
+
+    it('partially sells a position preserving remaining quantity and avg price', async () => {
+      const existing = createPosition({ quantity: 2, avgEntryPrice: 50000 });
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, 55000, 'sell');
+
+      // P&L on 1 unit: (55000 - 50000) * 1 = 5000
+      expect(result.realizedPnL).toBe(5000);
+      expect(result.quantity).toBe(1);
+      expect(result.avgEntryPrice).toBe(50000);
+    });
+  });
+
+  describe('updatePosition - short', () => {
+    it('creates a new short position on buy', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, 50000, 'buy', 'short');
+
+      expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ positionSide: 'short' }));
+      expect(result.quantity).toBe(1);
+      expect(result.avgEntryPrice).toBe(50000);
+    });
+
+    it.each([
+      { exitPrice: 45000, expectedPnL: 5000, desc: 'positive P&L when price drops' },
+      { exitPrice: 55000, expectedPnL: -5000, desc: 'negative P&L when price rises' }
+    ])('realizes $desc on short exit', async ({ exitPrice, expectedPnL }) => {
+      const existing = createPosition({ positionSide: 'short', quantity: 1, avgEntryPrice: 50000 });
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, exitPrice, 'sell', 'short');
+
+      expect(result.realizedPnL).toBe(expectedPnL);
+      expect(result.quantity).toBe(0);
+    });
+
+    it('does not collide short and long positions for the same symbol', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 1, 50000, 'buy', 'long');
+      await service.updatePosition('user-1', 'strat-1', 'BTC/USDT', 0.5, 50000, 'buy', 'short');
+
+      expect(repo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ positionSide: 'long' }) })
+      );
+      expect(repo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ positionSide: 'short' }) })
+      );
+    });
+  });
+
+  describe('calculateUnrealizedPnL', () => {
+    it('calculates positive unrealized P&L for long position', async () => {
+      const position = createPosition({ quantity: 1, avgEntryPrice: 50000, positionSide: 'long' });
+      repo.find.mockResolvedValue([position]);
+
+      const result = await service.calculateUnrealizedPnL('user-1', 'strat-1', new Map([['BTC/USDT', 55000]]));
+
+      expect(result).toBe(5000);
+      expect(position.unrealizedPnL).toBe(5000);
+    });
+
+    it.each([
+      { side: 'short' as const, price: 45000, expected: 5000, desc: 'positive for short when price drops' },
+      { side: 'short' as const, price: 55000, expected: -5000, desc: 'negative for short when price rises' },
+      { side: 'long' as const, price: 45000, expected: -5000, desc: 'negative for long when price drops' }
+    ])('calculates $desc', async ({ side, price, expected }) => {
+      const position = createPosition({ quantity: 1, avgEntryPrice: 50000, positionSide: side });
+      repo.find.mockResolvedValue([position]);
+
+      const result = await service.calculateUnrealizedPnL('user-1', 'strat-1', new Map([['BTC/USDT', price]]));
+
+      expect(result).toBe(expected);
+      expect(position.unrealizedPnL).toBe(expected);
+    });
+
+    it('skips positions with no current price or zero quantity', async () => {
+      const noPrice = createPosition({ quantity: 1, avgEntryPrice: 50000, symbol: 'ETH/USDT' });
+      const zeroQty = createPosition({ quantity: 0, avgEntryPrice: 50000, symbol: 'BTC/USDT' });
+      repo.find.mockResolvedValue([noPrice, zeroQty]);
+
+      const result = await service.calculateUnrealizedPnL(
+        'user-1',
+        'strat-1',
+        new Map([['BTC/USDT', 55000]]) // no ETH/USDT price
+      );
+
+      expect(result).toBe(0);
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closePosition', () => {
+    it('closes long position with correct P&L', async () => {
+      const position = createPosition({ quantity: 1, avgEntryPrice: 50000 });
+      repo.findOne.mockResolvedValue(position);
+
+      await service.closePosition('user-1', 'strat-1', 'BTC/USDT', 55000);
+
+      expect(position.realizedPnL).toBe(5000);
+      expect(position.quantity).toBe(0);
+      expect(position.avgEntryPrice).toBe(0);
+      expect(position.unrealizedPnL).toBe(0);
+      expect(repo.save).toHaveBeenCalledWith(position);
+    });
+
+    it.each([
+      { exitPrice: 45000, expectedPnL: 5000, desc: 'profit when price drops' },
+      { exitPrice: 55000, expectedPnL: -5000, desc: 'loss when price rises' }
+    ])('closes short position with $desc', async ({ exitPrice, expectedPnL }) => {
+      const position = createPosition({ positionSide: 'short', quantity: 1, avgEntryPrice: 50000 });
+      repo.findOne.mockResolvedValue(position);
+
+      await service.closePosition('user-1', 'strat-1', 'BTC/USDT', exitPrice, 'short');
+
+      expect(position.realizedPnL).toBe(expectedPnL);
+      expect(position.quantity).toBe(0);
+    });
+
+    it('returns early without saving when no position exists', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await service.closePosition('user-1', 'strat-1', 'BTC/USDT', 50000);
+
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('returns early without saving when position quantity is zero', async () => {
+      const position = createPosition({ quantity: 0 });
+      repo.findOne.mockResolvedValue(position);
+
+      await service.closePosition('user-1', 'strat-1', 'BTC/USDT', 50000);
+
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('passes positionSide to getPosition query', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await service.closePosition('user-1', 'strat-1', 'BTC/USDT', 50000, 'short');
+
+      expect(repo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ positionSide: 'short' }) })
+      );
+    });
+  });
+
+  describe('getUserTotalPnL', () => {
+    it('aggregates realized and unrealized P&L across all positions', async () => {
+      repo.find.mockResolvedValue([
+        createPosition({ realizedPnL: 1000, unrealizedPnL: 500 }),
+        createPosition({ id: 'pos-2', realizedPnL: -300, unrealizedPnL: 200 })
+      ]);
+
+      const result = await service.getUserTotalPnL('user-1');
+
+      expect(result).toEqual({ realizedPnL: 700, unrealizedPnL: 700, totalPnL: 1400 });
+    });
+
+    it('returns zeros when user has no positions', async () => {
+      repo.find.mockResolvedValue([]);
+
+      const result = await service.getUserTotalPnL('user-1');
+
+      expect(result).toEqual({ realizedPnL: 0, unrealizedPnL: 0, totalPnL: 0 });
+    });
+  });
+
+  describe('getStrategyPnL', () => {
+    it('aggregates P&L for a specific strategy', async () => {
+      repo.find.mockResolvedValue([
+        createPosition({ realizedPnL: 2000, unrealizedPnL: -500 }),
+        createPosition({ id: 'pos-2', realizedPnL: 800, unrealizedPnL: 300 })
+      ]);
+
+      const result = await service.getStrategyPnL('user-1', 'strat-1');
+
+      expect(result).toEqual({ realizedPnL: 2800, unrealizedPnL: -200, totalPnL: 2600 });
+    });
+  });
+
+  describe('getAllUserPositionsBySymbol', () => {
+    it('aggregates multiple positions for the same symbol', async () => {
+      repo.find.mockResolvedValue([
+        createPosition({
+          symbol: 'BTC/USDT',
+          quantity: 1,
+          avgEntryPrice: 50000,
+          realizedPnL: 1000,
+          unrealizedPnL: 500
+        }),
+        createPosition({
+          id: 'pos-2',
+          symbol: 'BTC/USDT',
+          quantity: 2,
+          avgEntryPrice: 55000,
+          realizedPnL: 200,
+          unrealizedPnL: -100
+        })
+      ]);
+
+      const result = await service.getAllUserPositionsBySymbol('user-1');
+
+      const btc = result.get('BTC/USDT');
+      expect(btc).toBeDefined();
+      // Total qty = 3, weighted avg = (1*50000 + 2*55000) / 3 ≈ 53333.33
+      expect(btc!.quantity).toBe(3);
+      expect(btc!.avgPrice).toBeCloseTo(53333.33, 1);
+      // Total PnL = (1000 + 500) + (200 + -100) = 1600
+      expect(btc!.pnl).toBe(1600);
+    });
+
+    it('separates different symbols into distinct map entries', async () => {
+      repo.find.mockResolvedValue([
+        createPosition({ symbol: 'BTC/USDT', quantity: 1, avgEntryPrice: 50000, realizedPnL: 100, unrealizedPnL: 0 }),
+        createPosition({
+          id: 'pos-2',
+          symbol: 'ETH/USDT',
+          quantity: 10,
+          avgEntryPrice: 3000,
+          realizedPnL: 50,
+          unrealizedPnL: 20
+        })
+      ]);
+
+      const result = await service.getAllUserPositionsBySymbol('user-1');
+
+      expect(result.size).toBe(2);
+      expect(result.get('BTC/USDT')).toEqual({ quantity: 1, avgPrice: 50000, pnl: 100 });
+      expect(result.get('ETH/USDT')).toEqual({ quantity: 10, avgPrice: 3000, pnl: 70 });
+    });
+  });
+});

--- a/apps/api/src/strategy/position-tracking.service.ts
+++ b/apps/api/src/strategy/position-tracking.service.ts
@@ -31,9 +31,14 @@ export class PositionTrackingService {
     });
   }
 
-  async getPosition(userId: string, strategyConfigId: string, symbol: string): Promise<UserStrategyPosition | null> {
+  async getPosition(
+    userId: string,
+    strategyConfigId: string,
+    symbol: string,
+    positionSide: 'long' | 'short' = 'long'
+  ): Promise<UserStrategyPosition | null> {
     return this.positionRepo.findOne({
-      where: { userId, strategyConfigId, symbol },
+      where: { userId, strategyConfigId, symbol, positionSide },
       relations: ['strategyConfig', 'user']
     });
   }
@@ -44,15 +49,17 @@ export class PositionTrackingService {
     symbol: string,
     quantity: number,
     price: number,
-    side: 'buy' | 'sell'
+    side: 'buy' | 'sell',
+    positionSide: 'long' | 'short' = 'long'
   ): Promise<UserStrategyPosition> {
-    let position = await this.getPosition(userId, strategyConfigId, symbol);
+    let position = await this.getPosition(userId, strategyConfigId, symbol, positionSide);
 
     if (!position) {
       position = this.positionRepo.create({
         userId,
         strategyConfigId,
         symbol,
+        positionSide,
         quantity: 0,
         avgEntryPrice: 0,
         unrealizedPnL: 0,
@@ -71,7 +78,8 @@ export class PositionTrackingService {
     } else if (side === 'sell') {
       const soldValue = quantity * price;
       const costBasis = quantity * currentAvgPrice;
-      const tradePnL = soldValue - costBasis;
+      // For shorts, P&L is inverted: profit when price drops (entry - exit)
+      const tradePnL = positionSide === 'short' ? costBasis - soldValue : soldValue - costBasis;
 
       position.quantity = currentQuantity - quantity;
       position.realizedPnL = Number(position.realizedPnL) + tradePnL;
@@ -102,7 +110,8 @@ export class PositionTrackingService {
 
       const currentValue = Number(position.quantity) * currentPrice;
       const costBasis = Number(position.quantity) * Number(position.avgEntryPrice);
-      const unrealizedPnL = currentValue - costBasis;
+      // For shorts, profit when price drops: (entry - current) * qty
+      const unrealizedPnL = position.positionSide === 'short' ? costBasis - currentValue : currentValue - costBasis;
 
       position.unrealizedPnL = unrealizedPnL;
       await this.positionRepo.save(position);
@@ -113,8 +122,14 @@ export class PositionTrackingService {
     return totalUnrealizedPnL;
   }
 
-  async closePosition(userId: string, strategyConfigId: string, symbol: string, currentPrice: number): Promise<void> {
-    const position = await this.getPosition(userId, strategyConfigId, symbol);
+  async closePosition(
+    userId: string,
+    strategyConfigId: string,
+    symbol: string,
+    currentPrice: number,
+    positionSide: 'long' | 'short' = 'long'
+  ): Promise<void> {
+    const position = await this.getPosition(userId, strategyConfigId, symbol, positionSide);
     if (!position || Number(position.quantity) === 0) {
       this.logger.warn(`No position to close for user ${userId}, strategy ${strategyConfigId}, symbol ${symbol}`);
       return;
@@ -122,7 +137,8 @@ export class PositionTrackingService {
 
     const soldValue = Number(position.quantity) * currentPrice;
     const costBasis = Number(position.quantity) * Number(position.avgEntryPrice);
-    const tradePnL = soldValue - costBasis;
+    // For shorts, P&L is inverted: profit when price drops (entry - exit)
+    const tradePnL = positionSide === 'short' ? costBasis - soldValue : soldValue - costBasis;
 
     position.realizedPnL = Number(position.realizedPnL) + tradePnL;
     position.quantity = 0;

--- a/apps/api/src/strategy/strategy-executor.service.spec.ts
+++ b/apps/api/src/strategy/strategy-executor.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { CompositeRegimeType, MarketRegimeType } from '@chansey/api-interfaces';
 
-import { MarketData, StrategyExecutorService } from './strategy-executor.service';
+import { MarketData, StrategyExecutorService, TradingSignal } from './strategy-executor.service';
 
 import {
   TradingSignal as AlgorithmTradingSignal,
@@ -12,7 +12,103 @@ import { AlgorithmRegistry } from '../algorithm/registry/algorithm-registry.serv
 import { AlgorithmContextBuilder } from '../algorithm/services/algorithm-context-builder.service';
 import { Coin } from '../coin/coin.entity';
 import { CompositeRegimeService } from '../market-regime/composite-regime.service';
+import { MetricsService } from '../metrics/metrics.service';
 import { SignalThrottleService } from '../order/backtest/shared/throttle';
+
+// ---------------------------------------------------------------------------
+// Shared mock factory – eliminates duplication across describe blocks
+// ---------------------------------------------------------------------------
+interface MockBundle {
+  service: StrategyExecutorService;
+  algorithmRegistry: jest.Mocked<AlgorithmRegistry>;
+  algorithmContextBuilder: jest.Mocked<AlgorithmContextBuilder>;
+  signalThrottle: {
+    createState: jest.Mock;
+    resolveConfig: jest.Mock;
+    filterSignals: jest.Mock;
+    toThrottleSignal: jest.Mock;
+  };
+  compositeRegimeService: {
+    getCompositeRegime: jest.Mock;
+    getVolatilityRegime: jest.Mock;
+  };
+}
+
+async function createMockModule(
+  coins: Partial<Coin>[] = [{ id: 'btc-id', symbol: 'BTC' }],
+  overrides?: {
+    signalThrottle?: Partial<MockBundle['signalThrottle']>;
+  }
+): Promise<MockBundle> {
+  const algorithmRegistry = {
+    executeAlgorithm: jest.fn()
+  } as unknown as jest.Mocked<AlgorithmRegistry>;
+
+  const algorithmContextBuilder = {
+    buildContext: jest.fn().mockResolvedValue({
+      config: {},
+      coins,
+      availableBalance: 0,
+      positions: {}
+    })
+  } as unknown as jest.Mocked<AlgorithmContextBuilder>;
+
+  const signalThrottle = {
+    createState: jest.fn().mockReturnValue({ lastSignalTime: {}, tradeTimestamps: [] }),
+    resolveConfig: jest.fn().mockReturnValue({ cooldownMs: 86_400_000, maxTradesPerDay: 6, minSellPercent: 0.5 }),
+    filterSignals: jest.fn().mockImplementation((signals) => signals),
+    toThrottleSignal: jest.fn().mockImplementation((s: any) => {
+      const map: Record<string, string> = {
+        BUY: 'BUY',
+        SELL: 'SELL',
+        HOLD: 'HOLD',
+        SHORT_ENTRY: 'OPEN_SHORT',
+        SHORT_EXIT: 'CLOSE_SHORT',
+        STOP_LOSS: 'SELL',
+        TAKE_PROFIT: 'SELL'
+      };
+      return {
+        action: map[s.type] ?? 'HOLD',
+        coinId: s.coinId,
+        quantity: s.quantity,
+        reason: s.reason,
+        confidence: s.confidence,
+        originalType: s.type
+      };
+    }),
+    ...overrides?.signalThrottle
+  };
+
+  const compositeRegimeService = {
+    getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.NEUTRAL),
+    getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      StrategyExecutorService,
+      { provide: AlgorithmRegistry, useValue: algorithmRegistry },
+      { provide: AlgorithmContextBuilder, useValue: algorithmContextBuilder },
+      { provide: SignalThrottleService, useValue: signalThrottle },
+      { provide: CompositeRegimeService, useValue: compositeRegimeService },
+      {
+        provide: MetricsService,
+        useValue: {
+          recordSignalThrottleSuppressed: jest.fn(),
+          recordSignalThrottlePassed: jest.fn()
+        }
+      }
+    ]
+  }).compile();
+
+  return {
+    service: module.get(StrategyExecutorService),
+    algorithmRegistry,
+    algorithmContextBuilder,
+    signalThrottle,
+    compositeRegimeService
+  };
+}
 
 /**
  * Helper to invoke the private mapAlgorithmSignal via executeStrategy.
@@ -22,41 +118,13 @@ import { SignalThrottleService } from '../order/backtest/shared/throttle';
 describe('StrategyExecutorService – per-trade position cap', () => {
   let service: StrategyExecutorService;
   let algorithmRegistry: jest.Mocked<AlgorithmRegistry>;
-  let algorithmContextBuilder: jest.Mocked<AlgorithmContextBuilder>;
 
   const coin: Partial<Coin> = { id: 'btc-id', symbol: 'BTC' };
 
   beforeEach(async () => {
-    algorithmRegistry = {
-      executeAlgorithm: jest.fn()
-    } as unknown as jest.Mocked<AlgorithmRegistry>;
-
-    algorithmContextBuilder = {
-      buildContext: jest.fn().mockResolvedValue({
-        config: {},
-        coins: [coin],
-        availableBalance: 0,
-        positions: {}
-      })
-    } as unknown as jest.Mocked<AlgorithmContextBuilder>;
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        StrategyExecutorService,
-        { provide: AlgorithmRegistry, useValue: algorithmRegistry },
-        { provide: AlgorithmContextBuilder, useValue: algorithmContextBuilder },
-        { provide: SignalThrottleService, useValue: { createState: jest.fn().mockReturnValue({}) } },
-        {
-          provide: CompositeRegimeService,
-          useValue: {
-            getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.NEUTRAL),
-            getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
-          }
-        }
-      ]
-    }).compile();
-
-    service = module.get(StrategyExecutorService);
+    const mocks = await createMockModule([coin]);
+    service = mocks.service;
+    algorithmRegistry = mocks.algorithmRegistry;
   });
 
   /** Helper: execute a strategy that returns a single signal with given params */
@@ -92,14 +160,45 @@ describe('StrategyExecutorService – per-trade position cap', () => {
     return result;
   }
 
-  it('caps buy quantity exceeding 20% of allocated capital', async () => {
-    // strength=1.0 → uncapped quantity would be (10000 * 1.0) / 50000 = 0.2 BTC
-    // 20% cap → max quantity = (10000 * 0.20) / 50000 = 0.04 BTC
-    const result = await executeWithSignal({ strength: 1.0 }, 10000, 50000);
+  it.each([
+    {
+      scenario: 'caps buy quantity exceeding 20% of allocated capital',
+      signalOverrides: { strength: 1.0 },
+      availableCapital: 10000,
+      price: 50000,
+      expectedAction: 'buy' as const,
+      expectedQuantity: 0.04 // 20% of 10000 / 50000
+    },
+    {
+      scenario: 'applies 5% minimum floor to small buy signals',
+      signalOverrides: { strength: 0.01 },
+      availableCapital: 10000,
+      price: 50000,
+      expectedAction: 'buy' as const,
+      expectedQuantity: 0.01 // 5% of 10000 / 50000
+    },
+    {
+      scenario: 'passes through signals within 5%-20% range',
+      signalOverrides: { strength: 0.1 },
+      availableCapital: 10000,
+      price: 50000,
+      expectedAction: 'buy' as const,
+      expectedQuantity: 0.02 // (10000 * 0.10) / 50000 = 0.02, within range
+    },
+    {
+      scenario: 'caps explicit signal.quantity when it exceeds 20%',
+      signalOverrides: { quantity: 0.1 },
+      availableCapital: 10000,
+      price: 50000,
+      expectedAction: 'buy' as const,
+      expectedQuantity: 0.04 // explicit 0.1 BTC at 50000 = $5000 = 50%, capped to 20% -> 0.04
+    }
+  ])('$scenario', async ({ signalOverrides, availableCapital, price, expectedAction, expectedQuantity }) => {
+    const result = await executeWithSignal(signalOverrides, availableCapital, price);
 
     expect(result).not.toBeNull();
-    expect(result!.action).toBe('buy');
-    expect(result!.quantity).toBeCloseTo(0.04, 8); // 20% of 10000 / 50000
+    expect(result!.action).toBe(expectedAction);
+    expect(result!.quantity).toBeCloseTo(expectedQuantity, 8);
   });
 
   it('does not cap sell signals', async () => {
@@ -110,34 +209,404 @@ describe('StrategyExecutorService – per-trade position cap', () => {
     expect(result!.action).toBe('sell');
     expect(result!.quantity).toBe(0.5); // Not capped
   });
+});
 
-  it('applies 5% minimum floor to small buy signals', async () => {
-    // strength=0.01 → quantity = (10000 * 0.01) / 50000 = 0.002
-    // 5% min → min quantity = (10000 * 0.05) / 50000 = 0.01
-    const result = await executeWithSignal({ strength: 0.01 }, 10000, 50000);
+describe('StrategyExecutorService – signal throttle integration', () => {
+  let service: StrategyExecutorService;
+  let algorithmRegistry: jest.Mocked<AlgorithmRegistry>;
+  let signalThrottle: MockBundle['signalThrottle'];
 
-    expect(result).not.toBeNull();
-    expect(result!.action).toBe('buy');
-    expect(result!.quantity).toBeCloseTo(0.01, 8); // 5% of 10000 / 50000
+  const coins: Partial<Coin>[] = [
+    { id: 'btc-id', symbol: 'BTC' },
+    { id: 'eth-id', symbol: 'ETH' }
+  ];
+
+  const strategy = {
+    id: 'strat-1',
+    algorithm: { id: 'algo-1' },
+    parameters: { cooldownMs: 3600_000 }
+  } as any;
+
+  const marketData: MarketData[] = [
+    { symbol: 'BTC/USDT', price: 50000, timestamp: new Date() },
+    { symbol: 'ETH/USDT', price: 3000, timestamp: new Date() }
+  ];
+
+  beforeEach(async () => {
+    const mocks = await createMockModule(coins);
+    service = mocks.service;
+    algorithmRegistry = mocks.algorithmRegistry;
+    signalThrottle = mocks.signalThrottle;
   });
 
-  it('passes through signals within 5%-20% range', async () => {
-    // strength=0.10 → quantity = (10000 * 0.10) / 50000 = 0.02
-    // 5% min = 0.01, 20% max = 0.04 → 0.02 is within range
-    const result = await executeWithSignal({ strength: 0.1 }, 10000, 50000);
+  it('calls filterSignals with correct args and converted signals', async () => {
+    const btcSignal: AlgorithmTradingSignal = {
+      type: SignalType.BUY,
+      coinId: 'btc-id',
+      strength: 0.5,
+      confidence: 0.9,
+      reason: 'bullish'
+    };
 
-    expect(result).not.toBeNull();
-    expect(result!.action).toBe('buy');
-    expect(result!.quantity).toBeCloseTo(0.02, 8); // Untouched
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [btcSignal],
+      timestamp: new Date()
+    });
+
+    await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(signalThrottle.resolveConfig).toHaveBeenCalledWith(strategy.parameters);
+    expect(signalThrottle.filterSignals).toHaveBeenCalledTimes(1);
+
+    const [signals] = signalThrottle.filterSignals.mock.calls[0];
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toEqual(
+      expect.objectContaining({
+        action: 'BUY',
+        coinId: 'btc-id',
+        originalType: SignalType.BUY
+      })
+    );
   });
 
-  it('caps explicit signal.quantity when it exceeds 20%', async () => {
-    // explicit quantity=0.1 BTC at 50000 = $5000, which is 50% of $10000 capital
-    // Should be capped to 20% → 0.04
-    const result = await executeWithSignal({ quantity: 0.1 }, 10000, 50000);
+  it('returns null when all signals are throttled', async () => {
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [{ type: SignalType.BUY, coinId: 'btc-id', strength: 0.5, confidence: 0.9, reason: 'buy' }],
+      timestamp: new Date()
+    });
+
+    signalThrottle.filterSignals.mockReturnValue([]);
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(result).toBeNull();
+  });
+
+  it('falls back to second-best signal when best is throttled', async () => {
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [
+        { type: SignalType.BUY, coinId: 'btc-id', strength: 0.8, confidence: 0.95, reason: 'btc buy' },
+        { type: SignalType.BUY, coinId: 'eth-id', strength: 0.6, confidence: 0.85, reason: 'eth buy' }
+      ],
+      timestamp: new Date()
+    });
+
+    // Filter out BTC, keep ETH
+    signalThrottle.filterSignals.mockImplementation((signals: any[]) =>
+      signals.filter((s: any) => s.coinId !== 'btc-id')
+    );
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
 
     expect(result).not.toBeNull();
-    expect(result!.action).toBe('buy');
-    expect(result!.quantity).toBeCloseTo(0.04, 8);
+    expect(result!.symbol).toBe('ETH/USDT');
+  });
+
+  it('preserves originalType for STOP_LOSS bypass', async () => {
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [
+        {
+          type: SignalType.STOP_LOSS,
+          coinId: 'btc-id',
+          strength: 1.0,
+          confidence: 1.0,
+          reason: 'stop loss',
+          quantity: 0.1
+        }
+      ],
+      timestamp: new Date()
+    });
+
+    await service.executeStrategy(strategy, marketData, [], 10000);
+
+    const [signals] = signalThrottle.filterSignals.mock.calls[0];
+    expect(signals[0].originalType).toBe(SignalType.STOP_LOSS);
+    expect(signals[0].action).toBe('SELL');
+  });
+});
+
+describe('StrategyExecutorService – validateSignal', () => {
+  let service: StrategyExecutorService;
+
+  beforeEach(async () => {
+    const mocks = await createMockModule();
+    service = mocks.service;
+  });
+
+  it('returns invalid when signal is null', () => {
+    const result = service.validateSignal(null as unknown as TradingSignal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('No signal provided');
+  });
+
+  it('returns invalid when signal is undefined', () => {
+    const result = service.validateSignal(undefined as unknown as TradingSignal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('No signal provided');
+  });
+
+  it('returns valid for hold action without further validation', () => {
+    const signal: TradingSignal = {
+      action: 'hold',
+      symbol: 'BTC/USDT',
+      quantity: 0,
+      price: 0
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('returns invalid when quantity is zero', () => {
+    const signal: TradingSignal = {
+      action: 'buy',
+      symbol: 'BTC/USDT',
+      quantity: 0,
+      price: 50000
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Quantity must be greater than 0');
+  });
+
+  it('returns invalid when quantity is negative', () => {
+    const signal: TradingSignal = {
+      action: 'buy',
+      symbol: 'BTC/USDT',
+      quantity: -0.1,
+      price: 50000
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Quantity must be greater than 0');
+  });
+
+  it('returns invalid when price is zero', () => {
+    const signal: TradingSignal = {
+      action: 'buy',
+      symbol: 'BTC/USDT',
+      quantity: 0.1,
+      price: 0
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Price must be greater than 0');
+  });
+
+  it('returns invalid when price is negative', () => {
+    const signal: TradingSignal = {
+      action: 'buy',
+      symbol: 'BTC/USDT',
+      quantity: 0.1,
+      price: -100
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Price must be greater than 0');
+  });
+
+  it('returns invalid when buy cost exceeds available capital', () => {
+    const signal: TradingSignal = {
+      action: 'buy',
+      symbol: 'BTC/USDT',
+      quantity: 1,
+      price: 50000
+      // cost = 50000, capital = 10000
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Insufficient capital');
+    expect(result.reason).toContain('50000.00');
+    expect(result.reason).toContain('10000.00');
+  });
+
+  it('returns valid for a buy within available capital', () => {
+    const signal: TradingSignal = {
+      action: 'buy',
+      symbol: 'BTC/USDT',
+      quantity: 0.1,
+      price: 50000
+      // cost = 5000 <= 10000
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('returns invalid for short_entry exceeding available capital', () => {
+    const signal: TradingSignal = {
+      action: 'short_entry',
+      symbol: 'BTC/USDT',
+      quantity: 1,
+      price: 50000
+      // cost = 50000, capital = 10000
+    };
+
+    const result = service.validateSignal(signal, 10000);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Insufficient capital');
+  });
+
+  it('does not check capital for sell signals', () => {
+    const signal: TradingSignal = {
+      action: 'sell',
+      symbol: 'BTC/USDT',
+      quantity: 10,
+      price: 50000
+      // cost would be 500000, but sell should not be checked
+    };
+
+    const result = service.validateSignal(signal, 100);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('does not check capital for short_exit signals', () => {
+    const signal: TradingSignal = {
+      action: 'short_exit',
+      symbol: 'BTC/USDT',
+      quantity: 10,
+      price: 50000
+    };
+
+    const result = service.validateSignal(signal, 100);
+
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('StrategyExecutorService – executeStrategy edge cases', () => {
+  let service: StrategyExecutorService;
+  let algorithmRegistry: jest.Mocked<AlgorithmRegistry>;
+
+  const strategy = {
+    id: 'strat-1',
+    algorithm: { id: 'algo-1' },
+    parameters: {}
+  } as any;
+
+  const marketData: MarketData[] = [{ symbol: 'BTC/USDT', price: 50000, timestamp: new Date() }];
+
+  beforeEach(async () => {
+    const mocks = await createMockModule([{ id: 'btc-id', symbol: 'BTC' }]);
+    service = mocks.service;
+    algorithmRegistry = mocks.algorithmRegistry;
+  });
+
+  it('returns null when algorithm returns success: false', async () => {
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: false,
+      signals: [],
+      timestamp: new Date()
+    });
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when algorithm returns empty signals array', async () => {
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [],
+      timestamp: new Date()
+    });
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when all signals are below confidence threshold', async () => {
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [
+        {
+          type: SignalType.BUY,
+          coinId: 'btc-id',
+          strength: 0.8,
+          confidence: 0.3, // Below MIN_CONFIDENCE_THRESHOLD of 0.5
+          reason: 'low confidence signal'
+        }
+      ],
+      timestamp: new Date()
+    });
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when algorithm throws an error', async () => {
+    algorithmRegistry.executeAlgorithm.mockRejectedValue(new Error('Algorithm crashed'));
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when coinId does not match any coin in context', async () => {
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [
+        {
+          type: SignalType.BUY,
+          coinId: 'unknown-coin-id', // Not in context coins
+          strength: 0.8,
+          confidence: 0.9,
+          reason: 'buy unknown'
+        }
+      ],
+      timestamp: new Date()
+    });
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(result).toBeNull();
+  });
+
+  it('applies cap to short_entry signals same as buy', async () => {
+    // strength=1.0 -> uncapped quantity would be (10000 * 1.0) / 50000 = 0.2 BTC
+    // 20% cap -> max quantity = (10000 * 0.20) / 50000 = 0.04 BTC
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [
+        {
+          type: SignalType.SHORT_ENTRY,
+          coinId: 'btc-id',
+          strength: 1.0,
+          confidence: 0.9,
+          reason: 'short entry test'
+        }
+      ],
+      timestamp: new Date()
+    });
+
+    const result = await service.executeStrategy(strategy, marketData, [], 10000);
+
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('short_entry');
+    expect(result!.quantity).toBeCloseTo(0.04, 8); // 20% of 10000 / 50000
   });
 });

--- a/apps/api/src/strategy/strategy-executor.service.ts
+++ b/apps/api/src/strategy/strategy-executor.service.ts
@@ -10,6 +10,7 @@ import {
 import { AlgorithmRegistry } from '../algorithm/registry/algorithm-registry.service';
 import { AlgorithmContextBuilder } from '../algorithm/services/algorithm-context-builder.service';
 import { CompositeRegimeService } from '../market-regime/composite-regime.service';
+import { MetricsService } from '../metrics/metrics.service';
 import { SignalThrottleService, ThrottleState } from '../order/backtest/shared/throttle';
 import { toErrorInfo } from '../shared/error.util';
 
@@ -43,24 +44,40 @@ const MIN_PER_TRADE_ALLOCATION = 0.05;
 export class StrategyExecutorService {
   private readonly logger = new Logger(StrategyExecutorService.name);
 
+  private static readonly PRUNE_THRESHOLD = 100;
+  private static readonly STALE_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
   /** Per-strategy throttle state persisted across cron cycles (keyed by strategy config ID) */
-  private readonly throttleStates = new Map<string, ThrottleState>();
+  private readonly throttleStates = new Map<string, { state: ThrottleState; lastAccessedAt: number }>();
 
   constructor(
     private readonly algorithmRegistry: AlgorithmRegistry,
     private readonly algorithmContextBuilder: AlgorithmContextBuilder,
     private readonly signalThrottle: SignalThrottleService,
-    private readonly compositeRegimeService: CompositeRegimeService
+    private readonly compositeRegimeService: CompositeRegimeService,
+    private readonly metricsService: MetricsService
   ) {}
 
-  /** Get or create throttle state for a strategy */
+  /** Get or create throttle state for a strategy, with last-access tracking */
   private getThrottleState(strategyId: string): ThrottleState {
-    let state = this.throttleStates.get(strategyId);
-    if (!state) {
-      state = this.signalThrottle.createState();
-      this.throttleStates.set(strategyId, state);
+    const now = Date.now();
+    let entry = this.throttleStates.get(strategyId);
+    if (!entry) {
+      entry = { state: this.signalThrottle.createState(), lastAccessedAt: now };
+      this.throttleStates.set(strategyId, entry);
+    } else {
+      entry.lastAccessedAt = now;
     }
-    return state;
+
+    // Opportunistic pruning when map grows too large
+    if (this.throttleStates.size > StrategyExecutorService.PRUNE_THRESHOLD) {
+      const cutoff = now - StrategyExecutorService.STALE_AGE_MS;
+      for (const [key, val] of this.throttleStates) {
+        if (val.lastAccessedAt < cutoff) this.throttleStates.delete(key);
+      }
+    }
+
+    return entry.state;
   }
 
   async executeStrategy(
@@ -106,9 +123,38 @@ export class StrategyExecutorService {
         return null;
       }
 
-      // Sort by confidence descending and take the best
-      actionableSignals.sort((a, b) => b.confidence - a.confidence);
-      const best = actionableSignals[0];
+      // Apply signal throttle: cooldowns, daily cap, min sell %
+      const throttleState = this.getThrottleState(strategy.id);
+      const throttleConfig = this.signalThrottle.resolveConfig(
+        strategy.parameters as Record<string, unknown> | undefined
+      );
+      const throttleInput = actionableSignals.map((s) => this.signalThrottle.toThrottleSignal(s));
+      const throttleOutput = this.signalThrottle.filterSignals(
+        throttleInput,
+        throttleState,
+        throttleConfig,
+        Date.now()
+      );
+
+      if (throttleInput.length > throttleOutput.length) {
+        const suppressedCount = throttleInput.length - throttleOutput.length;
+        this.metricsService.recordSignalThrottleSuppressed(strategy.id, suppressedCount);
+        this.logger.debug(`Strategy ${strategy.id}: throttled ${suppressedCount}/${throttleInput.length} signals`);
+      }
+      if (throttleOutput.length === 0) {
+        this.logger.debug(`Strategy ${strategy.id}: all signals suppressed by throttle`);
+        return null;
+      }
+
+      // Map accepted throttle signals back to original algorithm signals
+      const acceptedKeys = new Set(throttleOutput.map((s) => `${s.coinId}:${s.action}`));
+      const surviving = actionableSignals.filter((s) => {
+        const t = this.signalThrottle.toThrottleSignal(s);
+        return acceptedKeys.has(`${t.coinId}:${t.action}`);
+      });
+
+      surviving.sort((a, b) => b.confidence - a.confidence);
+      const best = surviving[0];
 
       const signal = this.mapAlgorithmSignal(best, context.coins, marketData, availableCapital);
       if (!signal) {
@@ -116,6 +162,7 @@ export class StrategyExecutorService {
         return null;
       }
 
+      this.metricsService.recordSignalThrottlePassed(strategy.id, signal.action);
       this.logger.log(
         `Strategy ${strategy.id} generated ${signal.action} signal for ${signal.symbol} at ${signal.price}`
       );


### PR DESCRIPTION
## Summary

- Add Redis-based trade cooldown service with atomic Lua check-and-set to prevent both pipelines (LiveTradingService + TradeExecutionTask) from placing the same trade within a configurable window
- Integrate signal throttle (cooldown, daily cap, min sell %) and kill switch checks into the trade execution pipeline
- Add `positionSide` (long/short) support to PositionTrackingService with inverted P&L calculations for short positions and futures signal routing

## Changes

### Trade Cooldown (`TradeCooldownService`)
- New `TradeCooldownService` using Redis atomic Lua scripts for check-and-claim semantics
- Clear-on-failure pattern so the next cycle can retry after a failed execution
- Integrated into both `LiveTradingService` and `TradeExecutionTask`

### Signal Throttle & Safety Gates
- Signal throttle with per-pair cooldown, daily trade cap, and minimum sell percentage
- Kill switch check and robo-advisor user filtering in `TradeExecutionTask` for mutual exclusion with `LiveTradingService`
- LRU-style throttle state pruning in `StrategyExecutorService` to prevent unbounded Map growth

### Futures / Short Position Support
- `positionSide` field on position tracking (long/short)
- Inverted P&L calculations for short positions
- Route futures signals (`short_entry`/`short_exit`) through `TradeExecutionService` in both pipelines

### Infrastructure
- Dedicated `lock-redis.provider.ts` to separate lock Redis from cache Redis
- Wire `AdminModule` into `OrderModule` for `TradingStateService` dependency
- Shared signal throttle interface and service in backtest module

### Tests
- Comprehensive `TradeCooldownService` test suite (atomic claim, TTL, clear-on-failure)
- Expanded `PositionTrackingService` tests (long/short P&L, unrealized P&L, close, aggregation)
- Expanded `LiveTradingService` tests (cooldown, regime gate, risk gate, futures routing)
- Expanded `StrategyExecutorService` tests (signal throttle, validateSignal edge cases, short_entry cap)
- Refactored test suites with shared mock factories and `test.each` patterns

## Test Plan

- [x] Unit tests added for `TradeCooldownService`, `PositionTrackingService`, `LiveTradingService`, and `StrategyExecutorService`
- [ ] Verify trade cooldown prevents duplicate trades across both pipelines
- [ ] Verify signal throttle respects daily cap and per-pair cooldown
- [ ] Verify short position P&L calculations are inverted correctly
- [ ] CI passes (lint + tests)