### PR TITLE
fix(api): use upsertJobScheduler for paper trading tick jobs

### DIFF
--- a/apps/api/src/order/paper-trading/paper-trading-recovery.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-recovery.service.spec.ts
@@ -1,8 +1,14 @@
-import { Logger } from '@nestjs/common';
+import { Logger, NotFoundException } from '@nestjs/common';
 
 import { PaperTradingRecoveryService } from './paper-trading-recovery.service';
 
 describe('PaperTradingRecoveryService', () => {
+  const createMockQueue = (overrides: Record<string, jest.Mock> = {}) => ({
+    getRepeatableJobs: jest.fn().mockResolvedValue([]),
+    removeRepeatableByKey: jest.fn(),
+    ...overrides
+  });
+
   beforeEach(() => {
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'error').mockImplementation();
@@ -22,10 +28,12 @@ describe('PaperTradingRecoveryService', () => {
       ]),
       removeTickJobs: jest.fn(),
       scheduleTickJob: jest.fn(),
-      markFailed: jest.fn()
+      markFailed: jest.fn(),
+      getSessionStatus: jest.fn()
     };
 
-    const service = new PaperTradingRecoveryService(paperTradingService as any);
+    const queue = createMockQueue();
+    const service = new PaperTradingRecoveryService(paperTradingService as any, queue as any);
 
     await service.onApplicationBootstrap();
 
@@ -43,22 +51,121 @@ describe('PaperTradingRecoveryService', () => {
         .mockResolvedValue([{ id: 'session-3', user: { id: 'user-3' }, tickIntervalMs: 5000 }]),
       removeTickJobs: jest.fn(),
       scheduleTickJob: jest.fn().mockRejectedValue(new Error('queue down')),
-      markFailed: jest.fn()
+      markFailed: jest.fn(),
+      getSessionStatus: jest.fn()
     };
 
-    const service = new PaperTradingRecoveryService(paperTradingService as any);
+    const queue = createMockQueue();
+    const service = new PaperTradingRecoveryService(paperTradingService as any, queue as any);
 
     await service.onApplicationBootstrap();
 
     expect(paperTradingService.markFailed).toHaveBeenCalledWith('session-3', expect.stringContaining('queue down'));
   });
 
+  describe('cleanupOrphanedSchedulers', () => {
+    it('removes legacy repeatable jobs for terminal sessions', async () => {
+      const paperTradingService = {
+        findActiveSessions: jest.fn().mockResolvedValue([]),
+        removeTickJobs: jest.fn(),
+        scheduleTickJob: jest.fn(),
+        markFailed: jest.fn(),
+        getSessionStatus: jest
+          .fn()
+          .mockResolvedValueOnce({ status: 'FAILED' })
+          .mockResolvedValueOnce({ status: 'ACTIVE' })
+          .mockResolvedValueOnce({ status: 'COMPLETED' })
+      };
+
+      const queue = createMockQueue({
+        getRepeatableJobs: jest.fn().mockResolvedValue([
+          { id: 'paper-trading-tick-session-failed', key: 'tick:abc123:session-failed' },
+          { id: 'paper-trading-tick-session-active', key: 'tick:abc456:session-active' },
+          { id: 'paper-trading-tick-session-done', key: 'tick:abc789:session-done' }
+        ]),
+        removeRepeatableByKey: jest.fn()
+      });
+
+      const service = new PaperTradingRecoveryService(paperTradingService as any, queue as any);
+
+      await service.onApplicationBootstrap();
+
+      // Should remove FAILED and COMPLETED, but not ACTIVE
+      expect(queue.removeRepeatableByKey).toHaveBeenCalledWith('tick:abc123:session-failed');
+      expect(queue.removeRepeatableByKey).not.toHaveBeenCalledWith('tick:abc456:session-active');
+      expect(queue.removeRepeatableByKey).toHaveBeenCalledWith('tick:abc789:session-done');
+      expect(queue.removeRepeatableByKey).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes legacy repeatable jobs for missing sessions', async () => {
+      const paperTradingService = {
+        findActiveSessions: jest.fn().mockResolvedValue([]),
+        removeTickJobs: jest.fn(),
+        scheduleTickJob: jest.fn(),
+        markFailed: jest.fn(),
+        getSessionStatus: jest.fn().mockRejectedValue(new NotFoundException('not found'))
+      };
+
+      const queue = createMockQueue({
+        getRepeatableJobs: jest
+          .fn()
+          .mockResolvedValue([{ id: 'paper-trading-tick-session-gone', key: 'tick:abc123:session-gone' }]),
+        removeRepeatableByKey: jest.fn()
+      });
+
+      const service = new PaperTradingRecoveryService(paperTradingService as any, queue as any);
+
+      await service.onApplicationBootstrap();
+
+      expect(queue.removeRepeatableByKey).toHaveBeenCalledWith('tick:abc123:session-gone');
+    });
+
+    it('skips non-tick repeatable jobs', async () => {
+      const paperTradingService = {
+        findActiveSessions: jest.fn().mockResolvedValue([]),
+        removeTickJobs: jest.fn(),
+        scheduleTickJob: jest.fn(),
+        markFailed: jest.fn(),
+        getSessionStatus: jest.fn()
+      };
+
+      const queue = createMockQueue({
+        getRepeatableJobs: jest.fn().mockResolvedValue([{ id: 'some-other-job', key: 'other:abc123' }]),
+        removeRepeatableByKey: jest.fn()
+      });
+
+      const service = new PaperTradingRecoveryService(paperTradingService as any, queue as any);
+
+      await service.onApplicationBootstrap();
+
+      expect(paperTradingService.getSessionStatus).not.toHaveBeenCalled();
+      expect(queue.removeRepeatableByKey).not.toHaveBeenCalled();
+    });
+
+    it('no-op when no repeatable jobs exist', async () => {
+      const paperTradingService = {
+        findActiveSessions: jest.fn().mockResolvedValue([]),
+        removeTickJobs: jest.fn(),
+        scheduleTickJob: jest.fn(),
+        markFailed: jest.fn(),
+        getSessionStatus: jest.fn()
+      };
+
+      const queue = createMockQueue();
+      const service = new PaperTradingRecoveryService(paperTradingService as any, queue as any);
+
+      await service.onApplicationBootstrap();
+
+      expect(queue.removeRepeatableByKey).not.toHaveBeenCalled();
+    });
+  });
+
   describe('detectStaleSessions', () => {
-    const TEN_MINUTES = 10 * 60 * 1000;
     const TWENTY_MINUTES = 20 * 60 * 1000;
 
     function createService(paperTradingService: any, bootedAgo = TWENTY_MINUTES): PaperTradingRecoveryService {
-      const service = new PaperTradingRecoveryService(paperTradingService as any);
+      const queue = createMockQueue();
+      const service = new PaperTradingRecoveryService(paperTradingService as any, queue as any);
       // Override bootedAt to simulate time since boot
       (service as any).bootedAt = Date.now() - bootedAgo;
       return service;

--- a/apps/api/src/order/paper-trading/paper-trading-recovery.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-recovery.service.ts
@@ -1,6 +1,10 @@
-import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger, NotFoundException, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 
+import { Queue } from 'bullmq';
+
+import { PaperTradingStatus } from './entities';
 import { PaperTradingService } from './paper-trading.service';
 
 import { toErrorInfo } from '../../shared/error.util';
@@ -11,14 +15,24 @@ export class PaperTradingRecoveryService implements OnApplicationBootstrap {
   private static readonly STALE_RECOVERY_THRESHOLD_MS = 10 * 60 * 1000; // 10 min — attempt recovery
   private static readonly STALE_FAIL_THRESHOLD_MS = 20 * 60 * 1000; // 20 min — mark FAILED
 
+  private static readonly TERMINAL_STATUSES: ReadonlySet<PaperTradingStatus> = new Set([
+    PaperTradingStatus.FAILED,
+    PaperTradingStatus.STOPPED,
+    PaperTradingStatus.COMPLETED
+  ]);
+
   private readonly logger = new Logger(PaperTradingRecoveryService.name);
   private readonly bootedAt = Date.now();
 
-  constructor(private readonly paperTradingService: PaperTradingService) {}
+  constructor(
+    private readonly paperTradingService: PaperTradingService,
+    @InjectQueue('paper-trading') private readonly paperTradingQueue: Queue
+  ) {}
 
   async onApplicationBootstrap(): Promise<void> {
     // OnApplicationBootstrap is called after all modules are initialized
     // This is the proper lifecycle hook for recovery operations
+    await this.cleanupOrphanedSchedulers();
     await this.recoverActiveSessions();
   }
 
@@ -88,6 +102,57 @@ export class PaperTradingRecoveryService implements OnApplicationBootstrap {
 
     if (recovered > 0 || failed > 0) {
       this.logger.log(`Stale session watchdog: recovered=${recovered}, failed=${failed}`);
+    }
+  }
+
+  /**
+   * One-time cleanup of legacy repeatable jobs created by the old queue.add({ repeat }) API.
+   * Those schedulers are stored under an MD5 hash key, so removeJobScheduler(jobId) never matches them.
+   * This method uses the legacy getRepeatableJobs() / removeRepeatableByKey() APIs to remove them
+   * for sessions that are already in a terminal state (FAILED / STOPPED / COMPLETED).
+   */
+  private async cleanupOrphanedSchedulers(): Promise<void> {
+    try {
+      const repeatableJobs = await this.paperTradingQueue.getRepeatableJobs();
+
+      if (repeatableJobs.length === 0) return;
+
+      let cleaned = 0;
+
+      for (const job of repeatableJobs) {
+        // Extract sessionId from the legacy jobId (format: "paper-trading-tick-{sessionId}")
+        const match = (job.id ?? '').match(/^paper-trading-tick-(.+)$/);
+        if (!match) continue;
+
+        const sessionId = match[1];
+
+        try {
+          const { status } = await this.paperTradingService.getSessionStatus(sessionId);
+
+          if (PaperTradingRecoveryService.TERMINAL_STATUSES.has(status as PaperTradingStatus)) {
+            await this.paperTradingQueue.removeRepeatableByKey(job.key);
+            cleaned++;
+            this.logger.log(`Removed orphaned legacy scheduler for terminal session ${sessionId} (status: ${status})`);
+          }
+        } catch (error: unknown) {
+          if (error instanceof NotFoundException) {
+            // Session not found in DB — safe to remove the orphaned scheduler
+            await this.paperTradingQueue.removeRepeatableByKey(job.key);
+            cleaned++;
+            this.logger.log(`Removed orphaned legacy scheduler for missing session ${sessionId}`);
+          } else {
+            const err = toErrorInfo(error);
+            this.logger.warn(`Failed to check session ${sessionId} for orphan cleanup: ${err.message}`);
+          }
+        }
+      }
+
+      if (cleaned > 0) {
+        this.logger.log(`Orphaned scheduler cleanup complete: removed ${cleaned} legacy repeatable job(s)`);
+      }
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Orphaned scheduler cleanup failed: ${err.message}`, err.stack);
     }
   }
 

--- a/apps/api/src/order/paper-trading/paper-trading.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.service.spec.ts
@@ -47,7 +47,8 @@ describe('PaperTradingService', () => {
     const paperTradingQueue = {
       add: jest.fn(),
       getJob: jest.fn().mockResolvedValue(null),
-      removeJobScheduler: jest.fn()
+      removeJobScheduler: jest.fn(),
+      upsertJobScheduler: jest.fn()
     };
 
     const eventEmitter = {
@@ -205,6 +206,20 @@ describe('PaperTradingService', () => {
     expect(paperTradingQueue.removeJobScheduler).toHaveBeenCalledWith('paper-trading-tick-session-4');
     // Verify forceRemoveJob was called for the retry job
     expect(paperTradingQueue.getJob).toHaveBeenCalledWith('paper-trading-retry-session-4');
+  });
+
+  it('scheduleTickJob uses upsertJobScheduler with matching jobId', async () => {
+    const { service, paperTradingQueue } = createService();
+
+    paperTradingQueue.upsertJobScheduler.mockResolvedValue(undefined);
+
+    await service.scheduleTickJob('session-tick-1', 'user-1', 30000);
+
+    expect(paperTradingQueue.upsertJobScheduler).toHaveBeenCalledWith(
+      'paper-trading-tick-session-tick-1',
+      { every: 30000 },
+      { name: 'tick', data: { type: PaperTradingJobType.TICK, sessionId: 'session-tick-1', userId: 'user-1' } }
+    );
   });
 
   it('stops a session and enqueues pipeline notification', async () => {

--- a/apps/api/src/order/paper-trading/paper-trading.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.service.ts
@@ -605,18 +605,13 @@ export class PaperTradingService {
   async scheduleTickJob(sessionId: string, userId: string, intervalMs: number): Promise<void> {
     const jobId = `paper-trading-tick-${sessionId}`;
 
-    // Add repeatable tick job
-    await this.paperTradingQueue.add(
-      'tick',
-      {
-        type: PaperTradingJobType.TICK,
-        sessionId,
-        userId
-      },
-      {
-        repeat: { every: intervalMs },
-        jobId
-      }
+    // Use upsertJobScheduler so the scheduler key matches the jobId used by removeJobScheduler().
+    // The legacy queue.add(name, data, { repeat, jobId }) stores schedulers under an MD5 hash key,
+    // causing removeJobScheduler(jobId) to silently no-op.
+    await this.paperTradingQueue.upsertJobScheduler(
+      jobId,
+      { every: intervalMs },
+      { name: 'tick', data: { type: PaperTradingJobType.TICK, sessionId, userId } }
     );
 
     this.logger.debug(`Scheduled tick job ${jobId} with interval ${intervalMs}ms`);


### PR DESCRIPTION
## Summary
- Replace `queue.add` with `repeat` option with `upsertJobScheduler` so the scheduler key matches what `removeJobScheduler` looks up — fixes silent no-op when stopping tick jobs
- Add one-time orphaned scheduler cleanup on bootstrap to remove legacy repeatable jobs for terminal or missing sessions
- Remove unused `TEN_MINUTES` constant from recovery service tests

## Test plan
- [x] Unit test verifies `upsertJobScheduler` is called with correct jobId and interval
- [x] Unit tests cover orphan cleanup for terminal, missing, active, and non-tick jobs
- [x] All existing paper trading tests pass