### PR TITLE
feat(api): add daily loss limit gate to block trades during excessive losses

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -47,8 +47,9 @@ automatically.
   - `db`: Database related changes
 - **Present tense, imperative mood**: Write commit messages as commands (e.g., "add feature" not "added feature")
 - **Concise first line**: Keep the first line under 72 characters
+- **No issue numbers in the title**: NEVER include issue/PR numbers (e.g., `(#123)`) in the commit subject line
 - **Link GitHub issues**: When working on a tracked issue, add `Closes #<number>` on a separate line at the bottom of
-  the commit body
+  the commit body (this is the only place issue numbers should appear)
 
 ## Guidelines for Splitting Commits
 

--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -428,6 +428,11 @@ import { MetricsService } from './metrics.service';
     }),
 
     makeCounterProvider({
+      name: 'chansey_daily_loss_gate_blocks_total',
+      help: 'Total entry signals blocked by the daily loss limit gate'
+    }),
+
+    makeCounterProvider({
       name: 'chansey_live_orders_placed_total',
       help: 'Total live orders placed successfully',
       labelNames: ['market_type', 'side']

--- a/apps/api/src/metrics/metrics.service.spec.ts
+++ b/apps/api/src/metrics/metrics.service.spec.ts
@@ -107,6 +107,7 @@ const buildService = () => {
     signalThrottlePassedTotal: createCounterMock(),
     regimeGateBlocksTotal: createCounterMock(),
     drawdownGateBlocksTotal: createCounterMock(),
+    dailyLossGateBlocksTotal: createCounterMock(),
     liveOrdersPlacedTotal: createCounterMock()
   };
 
@@ -189,6 +190,7 @@ const buildService = () => {
     mocks.signalThrottlePassedTotal,
     mocks.regimeGateBlocksTotal,
     mocks.drawdownGateBlocksTotal,
+    mocks.dailyLossGateBlocksTotal,
     mocks.liveOrdersPlacedTotal
   );
 

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -183,6 +183,8 @@ export class MetricsService {
     private readonly regimeGateBlocksTotal: Counter<string>,
     @InjectMetric('chansey_drawdown_gate_blocks_total')
     private readonly drawdownGateBlocksTotal: Counter<string>,
+    @InjectMetric('chansey_daily_loss_gate_blocks_total')
+    private readonly dailyLossGateBlocksTotal: Counter<string>,
     @InjectMetric('chansey_live_orders_placed_total')
     private readonly liveOrdersPlacedTotal: Counter<string>
   ) {}
@@ -672,6 +674,10 @@ export class MetricsService {
 
   recordDrawdownGateBlock(): void {
     this.drawdownGateBlocksTotal.inc();
+  }
+
+  recordDailyLossGateBlock(): void {
+    this.dailyLossGateBlocksTotal.inc();
   }
 
   recordLiveOrderPlaced(marketType: 'futures' | 'spot', side: string): void {

--- a/apps/api/src/migrations/1741100000000-add-daily-loss-limit-index.ts
+++ b/apps/api/src/migrations/1741100000000-add-daily-loss-limit-index.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDailyLossLimitIndex1741100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX "IDX_order_daily_loss_gate"
+        ON "order" ("userId", "is_algorithmic_trade", "status", "side", "createdAt")
+        WHERE "gainLoss" < 0
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_order_daily_loss_gate"`);
+  }
+}

--- a/apps/api/src/order/order.entity.ts
+++ b/apps/api/src/order/order.entity.ts
@@ -81,6 +81,9 @@ export interface TradeExecution {
 @Index('IDX_order_algo_trade_slippage', ['isAlgorithmicTrade', 'actualSlippageBps'], {
   where: '"actualSlippageBps" IS NOT NULL'
 })
+@Index('IDX_order_daily_loss_gate', ['user', 'isAlgorithmicTrade', 'status', 'side', 'createdAt'], {
+  where: '"gainLoss" < 0'
+})
 export class Order {
   @PrimaryGeneratedColumn('uuid')
   @IsUUID()

--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -74,6 +74,7 @@ import { SharedCacheModule } from '../shared-cache.module';
 import { StorageModule } from '../storage/storage.module';
 import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
 import { UserStrategyPosition } from '../strategy/entities/user-strategy-position.entity';
+import { StrategyModule } from '../strategy/strategy.module';
 import { User } from '../users/users.entity';
 import { UsersModule } from '../users/users.module';
 
@@ -137,6 +138,7 @@ const BACKTEST_DEFAULTS = backtestConfig();
     forwardRef(() => OHLCModule),
     forwardRef(() => UsersModule),
     forwardRef(() => MarketRegimeModule),
+    forwardRef(() => StrategyModule),
     IndicatorModule,
     MetricsModule,
     StorageModule,

--- a/apps/api/src/order/tasks/trade-execution.task.spec.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.spec.ts
@@ -14,7 +14,9 @@ import { AlgorithmActivationService } from '../../algorithm/services/algorithm-a
 import { AlgorithmContextBuilder } from '../../algorithm/services/algorithm-context-builder.service';
 import { BalanceService } from '../../balance/balance.service';
 import { CoinService } from '../../coin/coin.service';
+import { MetricsService } from '../../metrics/metrics.service';
 import { TradeCooldownService } from '../../shared/trade-cooldown.service';
+import { DailyLossLimitGateService } from '../../strategy/daily-loss-limit-gate.service';
 import { StrategyConfig } from '../../strategy/entities/strategy-config.entity';
 import { User } from '../../users/users.entity';
 import { UsersService } from '../../users/users.service';
@@ -36,6 +38,8 @@ describe('TradeExecutionTask', () => {
   let mockTradingStateService: any;
   let mockTradeCooldownService: any;
   let mockSignalThrottle: any;
+  let mockDailyLossLimitGate: any;
+  let mockMetricsService: any;
 
   const mockJob = {
     id: 'job-1',
@@ -165,6 +169,14 @@ describe('TradeExecutionTask', () => {
       getById: jest.fn().mockResolvedValue({ id: 'user-1' })
     };
 
+    mockDailyLossLimitGate = {
+      isEntryBlocked: jest.fn().mockResolvedValue({ blocked: false })
+    };
+
+    mockMetricsService = {
+      recordDailyLossGateBlock: jest.fn()
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TradeExecutionTask,
@@ -180,7 +192,9 @@ describe('TradeExecutionTask', () => {
         { provide: UsersService, useValue: mockUsersService },
         { provide: TradingStateService, useValue: mockTradingStateService },
         { provide: TradeCooldownService, useValue: mockTradeCooldownService },
-        { provide: SignalThrottleService, useValue: mockSignalThrottle }
+        { provide: SignalThrottleService, useValue: mockSignalThrottle },
+        { provide: DailyLossLimitGateService, useValue: mockDailyLossLimitGate },
+        { provide: MetricsService, useValue: mockMetricsService }
       ]
     }).compile();
 
@@ -332,25 +346,6 @@ describe('TradeExecutionTask', () => {
       expect(signalArg.positionSide).toBeUndefined();
     });
 
-    it('should map BUY and SELL signal types correctly', async () => {
-      const activation = buildActivation();
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-
-      // BUY
-      configureActionableSignal('coin-1', SignalType.BUY);
-      await task.process(mockJob);
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].action).toBe('BUY');
-
-      jest.clearAllMocks();
-      mockJob.updateProgress.mockClear();
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-
-      // SELL
-      configureActionableSignal('coin-1', SignalType.SELL);
-      await task.process(mockJob);
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].action).toBe('SELL');
-    });
-
     it('should skip when coin symbol resolution fails', async () => {
       const activation = buildActivation();
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
@@ -405,17 +400,6 @@ describe('TradeExecutionTask', () => {
       expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe(expectedSymbol);
     });
 
-    it('should uppercase the coin symbol', async () => {
-      mockCoinService.getCoinById.mockResolvedValue({ id: 'coin-1', symbol: 'eth' });
-      const activation = buildActivation();
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-      configureActionableSignal();
-
-      await task.process(mockJob);
-
-      expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe('ETH/USDT');
-    });
-
     it('should skip when exchange relation is missing (null-safety)', async () => {
       const activation = buildActivation({ exchangeKey: null });
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
@@ -444,7 +428,7 @@ describe('TradeExecutionTask', () => {
 
       await task.process(mockJob);
 
-      // user-1 fetched once, user-2 fetched once = 2 total
+      // user-1 fetched once, user-2 fetched once = 2 total (no duplicate)
       expect(mockUsersService.getById).toHaveBeenCalledTimes(2);
       expect(mockBalanceService.getUserBalances).toHaveBeenCalledTimes(2);
     });
@@ -539,23 +523,6 @@ describe('TradeExecutionTask', () => {
       // Only manual-user's activation should be processed (1 total, 1 skipped due to no signal)
       expect(result.totalActivations).toBe(1);
     });
-
-    it('should process all activations when no robo-advisor users found', async () => {
-      const activation1 = buildActivation({ id: 'act-1', userId: 'user-1' });
-      const activation2 = buildActivation({ id: 'act-2', userId: 'user-2' });
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation1, activation2]);
-      mockUserRepo.find.mockResolvedValue([]); // No robo-advisor users
-
-      mockAlgorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [],
-        timestamp: new Date()
-      });
-
-      const result: any = await task.process(mockJob);
-
-      expect(result.totalActivations).toBe(2);
-    });
   });
 
   describe('trade cooldown', () => {
@@ -590,20 +557,6 @@ describe('TradeExecutionTask', () => {
   });
 
   describe('fetchPortfolioValue (via process)', () => {
-    it('should use totalUsdValue from balance service', async () => {
-      const activation = buildActivation();
-      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
-      mockUsersService.getById.mockResolvedValue({ id: 'user-1' });
-      mockBalanceService.getUserBalances.mockResolvedValue({ totalUsdValue: 50000 });
-      configureActionableSignal();
-
-      await task.process(mockJob);
-
-      expect(mockUsersService.getById).toHaveBeenCalledWith('user-1');
-      const signalArg = mockTradeExecutionService.executeTradeSignal.mock.calls[0][0];
-      expect(signalArg.portfolioValue).toBe(50000);
-    });
-
     it('should skip activation when portfolio value is 0 (balance fetch failed)', async () => {
       const activation = buildActivation();
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
@@ -757,6 +710,58 @@ describe('TradeExecutionTask', () => {
       const signalArg = mockTradeExecutionService.executeTradeSignal.mock.calls[0][0];
       expect(signalArg.action).toBe('BUY');
       expect(signalArg.positionSide).toBe('short');
+    });
+  });
+
+  describe('daily loss limit gate — entry signal blocking', () => {
+    it.each([
+      [SignalType.BUY, undefined, 'spot BUY'],
+      [SignalType.SHORT_ENTRY, { metadata: { marketType: MarketType.FUTURES, leverage: 2 } }, 'futures SHORT_ENTRY']
+    ])('should block entry signal %s when user is daily-loss-blocked (%s)', async (signalType, config, _label) => {
+      const activation = buildActivation(config ? { config } : {});
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockDailyLossLimitGate.isEntryBlocked.mockResolvedValue({
+        blocked: true,
+        reason: 'Daily loss limit exceeded'
+      });
+      configureActionableSignal('coin-1', signalType as SignalType);
+
+      const result: any = await task.process(mockJob);
+
+      expect(result.blockedCount).toBe(1);
+      expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+      expect(mockMetricsService.recordDailyLossGateBlock).toHaveBeenCalled();
+    });
+
+    it.each([
+      [SignalType.SELL, undefined, 'spot SELL'],
+      [SignalType.SHORT_EXIT, { metadata: { marketType: MarketType.FUTURES, leverage: 2 } }, 'futures SHORT_EXIT']
+    ])('should allow exit signal %s when user is daily-loss-blocked (%s)', async (signalType, config, _label) => {
+      const activation = buildActivation(config ? { config } : {});
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockDailyLossLimitGate.isEntryBlocked.mockResolvedValue({
+        blocked: true,
+        reason: 'Daily loss limit exceeded'
+      });
+      configureActionableSignal('coin-1', signalType as SignalType);
+
+      const result: any = await task.process(mockJob);
+
+      expect(result.successCount).toBe(1);
+      expect(mockTradeExecutionService.executeTradeSignal).toHaveBeenCalled();
+    });
+
+    it('should block all activations and set portfolio=0 when user preflight fails', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockUsersService.getById.mockRejectedValue(new Error('DB timeout'));
+      configureActionableSignal('coin-1', SignalType.BUY);
+
+      const result: any = await task.process(mockJob);
+
+      // Fail-closed: portfolio=0 skips activation before daily loss gate even checked
+      expect(result.skippedCount).toBe(1);
+      expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/order/tasks/trade-execution.task.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.ts
@@ -17,8 +17,10 @@ import { AlgorithmContextBuilder } from '../../algorithm/services/algorithm-cont
 import { BalanceService } from '../../balance/balance.service';
 import { CoinService } from '../../coin/coin.service';
 import { DEFAULT_QUOTE_CURRENCY, EXCHANGE_QUOTE_CURRENCY } from '../../exchange/constants';
+import { MetricsService } from '../../metrics/metrics.service';
 import { toErrorInfo } from '../../shared/error.util';
 import { TradeCooldownService } from '../../shared/trade-cooldown.service';
+import { DailyLossLimitGateService } from '../../strategy/daily-loss-limit-gate.service';
 import { StrategyConfig } from '../../strategy/entities/strategy-config.entity';
 import { User } from '../../users/users.entity';
 import { UsersService } from '../../users/users.service';
@@ -63,7 +65,9 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     private readonly usersService: UsersService,
     private readonly tradingStateService: TradingStateService,
     private readonly tradeCooldownService: TradeCooldownService,
-    private readonly signalThrottle: SignalThrottleService
+    private readonly signalThrottle: SignalThrottleService,
+    private readonly dailyLossLimitGate: DailyLossLimitGateService,
+    private readonly metricsService: MetricsService
   ) {
     super();
   }
@@ -182,13 +186,30 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
 
       const totalActivations = activeActivations.length;
 
-      // Phase 1: Pre-populate portfolio cache (one fetch per unique user)
+      // Phase 1: Pre-populate portfolio cache and daily loss limit check (one per unique user)
       const portfolioCache = new Map<string, number>();
+      const dailyLossBlockedUsers = new Set<string>();
       const uniqueUserIds = [...new Set(activeActivations.map((a) => a.userId))];
       for (const userId of uniqueUserIds) {
-        const activation = activeActivations.find((a) => a.userId === userId);
-        if (!activation) continue;
-        portfolioCache.set(userId, await this.fetchPortfolioValue(activation));
+        try {
+          const user = await this.usersService.getById(userId);
+          const portfolioValue = await this.fetchPortfolioValue(user);
+          portfolioCache.set(userId, portfolioValue);
+
+          // Daily loss limit gate: check per user
+          const riskLevel = user.risk?.level ?? 3;
+          const dailyLossCheck = await this.dailyLossLimitGate.isEntryBlocked(userId, portfolioValue, riskLevel);
+          if (dailyLossCheck.blocked) {
+            dailyLossBlockedUsers.add(userId);
+            this.logger.warn(`Daily loss limit gate blocked user ${userId}: ${dailyLossCheck.reason}`);
+          }
+        } catch (error) {
+          // Fail closed: set portfolio=0 (will skip activations) and block user
+          const err = toErrorInfo(error);
+          this.logger.warn(`User ${userId} pre-flight failed: ${err.message}, blocking as precaution`);
+          portfolioCache.set(userId, 0);
+          dailyLossBlockedUsers.add(userId);
+        }
       }
 
       // Phase 2: Group by exchangeKeyId to avoid CCXT client concurrency issues,
@@ -209,7 +230,11 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
             const groupCounts = { success: 0, fail: 0, skipped: 0, blocked: 0 };
             for (const activation of group) {
               try {
-                const outcome = await this.processActivation(activation, portfolioCache.get(activation.userId) ?? 0);
+                const outcome = await this.processActivation(
+                  activation,
+                  portfolioCache.get(activation.userId) ?? 0,
+                  dailyLossBlockedUsers
+                );
                 if (outcome === 'executed') groupCounts.success++;
                 else if (outcome === 'blocked') groupCounts.blocked++;
                 else groupCounts.skipped++;
@@ -274,7 +299,8 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
    */
   private async processActivation(
     activation: AlgorithmActivation,
-    portfolioValue: number
+    portfolioValue: number,
+    dailyLossBlockedUsers: Set<string> = new Set()
   ): Promise<'executed' | 'skipped' | 'blocked'> {
     if (portfolioValue <= 0) {
       this.logger.warn(
@@ -286,6 +312,18 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     const signal = await this.generateTradeSignal(activation, portfolioValue);
 
     if (signal) {
+      // Daily loss limit gate: block entry signals when user's rolling 24h losses exceed threshold
+      const isEntryAction =
+        (signal.action === 'BUY' && signal.positionSide !== 'short') ||
+        (signal.action === 'SELL' && signal.positionSide === 'short');
+      if (dailyLossBlockedUsers.has(activation.userId) && isEntryAction) {
+        this.metricsService.recordDailyLossGateBlock();
+        this.logger.warn(
+          `Daily loss limit blocked activation ${activation.id}: ${signal.action} ${signal.symbol} (entry) for user ${activation.userId}`
+        );
+        return 'blocked';
+      }
+
       // Trade cooldown: prevent double-trading if Pipeline 1 already placed this trade
       const cooldownCheck = await this.tradeCooldownService.checkAndClaim(
         signal.userId,
@@ -485,17 +523,16 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
   }
 
   /**
-   * Fetch total portfolio USD value for an activation's user
+   * Fetch total portfolio USD value for a user
    * Returns 0 on error for graceful degradation
    */
-  private async fetchPortfolioValue(activation: AlgorithmActivation): Promise<number> {
+  private async fetchPortfolioValue(user: User): Promise<number> {
     try {
-      const user = await this.usersService.getById(activation.userId);
       const balances = await this.balanceService.getUserBalances(user);
       return balances.totalUsdValue || 0;
     } catch (error) {
       const err = toErrorInfo(error);
-      this.logger.warn(`Failed to fetch portfolio value for user ${activation.userId}: ${err.message}`);
+      this.logger.warn(`Failed to fetch portfolio value for user ${user.id}: ${err.message}`);
       return 0;
     }
   }

--- a/apps/api/src/strategy/daily-loss-limit-gate.service.spec.ts
+++ b/apps/api/src/strategy/daily-loss-limit-gate.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { DailyLossLimitGateService } from './daily-loss-limit-gate.service';
+
+import { Order } from '../order/order.entity';
+
+describe('DailyLossLimitGateService', () => {
+  let service: DailyLossLimitGateService;
+  let mockQueryBuilder: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    mockQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getRawOne: jest.fn().mockResolvedValue({ totalLoss: '0' })
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DailyLossLimitGateService,
+        {
+          provide: getRepositoryToken(Order),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder)
+          }
+        }
+      ]
+    }).compile();
+
+    service = module.get<DailyLossLimitGateService>(DailyLossLimitGateService);
+  });
+
+  describe('exit actions always pass through', () => {
+    it.each(['sell', 'short_exit'] as const)('%s bypasses gate without querying DB', async (action) => {
+      const result = await service.checkDailyLossLimit('user-1', 1000, 3, action);
+      expect(result.allowed).toBe(true);
+      expect(mockQueryBuilder.getRawOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('zero / negative capital guard', () => {
+    it.each([0, -100])('blocks BUY when capital is %d', async (capital) => {
+      const result = await service.checkDailyLossLimit('user-1', capital, 3, 'buy');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('zero or negative');
+    });
+  });
+
+  describe('threshold breach', () => {
+    it('blocks BUY when losses exceed threshold', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: '-150' });
+
+      const result = await service.checkDailyLossLimit('user-1', 1000, 3, 'buy');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('15.0% losses');
+      expect(result.reason).toContain('10.0% limit');
+    });
+
+    it('blocks BUY at exact threshold boundary (>=)', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: '-100' });
+
+      const result = await service.checkDailyLossLimit('user-1', 1000, 3, 'buy');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks short_entry the same as buy', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: '-200' });
+
+      const result = await service.checkDailyLossLimit('user-1', 1000, 3, 'short_entry');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('allows BUY when losses are below threshold', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: '-50' });
+
+      const result = await service.checkDailyLossLimit('user-1', 1000, 3, 'buy');
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('risk level threshold mapping', () => {
+    it.each([
+      [1, 5],
+      [2, 7.5],
+      [3, 10],
+      [4, 12.5],
+      [5, 15]
+    ])('risk level %d uses %d%% threshold', async (riskLevel, threshold) => {
+      const capital = 1000;
+      const lossAmount = capital * (threshold / 100);
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: String(-lossAmount) });
+
+      const result = await service.checkDailyLossLimit('user-1', capital, riskLevel, 'buy');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain(`${threshold.toFixed(1)}% limit`);
+    });
+
+    it('falls back to risk level 3 (10%) for unknown levels', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: '-100' });
+
+      const result = await service.checkDailyLossLimit('user-1', 1000, 99, 'buy');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('10.0% limit');
+    });
+  });
+
+  describe('fail-closed on query error', () => {
+    it('blocks BUY when DB query throws', async () => {
+      mockQueryBuilder.getRawOne.mockRejectedValue(new Error('DB connection lost'));
+
+      const result = await service.checkDailyLossLimit('user-1', 1000, 3, 'buy');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('fail-closed');
+    });
+  });
+
+  describe('isEntryBlocked convenience method', () => {
+    it('returns blocked: true when losses exceed threshold', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: '-200' });
+
+      const result = await service.isEntryBlocked('user-1', 1000, 3);
+      expect(result.blocked).toBe(true);
+      expect(result.reason).toContain('Daily loss limit exceeded');
+    });
+
+    it('returns blocked: false when losses are under threshold', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({ totalLoss: '-50' });
+
+      const result = await service.isEntryBlocked('user-1', 1000, 3);
+      expect(result.blocked).toBe(false);
+      expect(result.reason).toBeUndefined();
+    });
+  });
+
+  describe('edge case: null query result', () => {
+    it('allows BUY when getRawOne returns null', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue(null);
+
+      const result = await service.checkDailyLossLimit('user-1', 1000, 3, 'buy');
+      expect(result.allowed).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/strategy/daily-loss-limit-gate.service.ts
+++ b/apps/api/src/strategy/daily-loss-limit-gate.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { Order } from '../order/order.entity';
+
+/** Rolling 24h loss threshold per risk level (as a fraction of trading capital) */
+const RISK_LEVEL_THRESHOLDS: Record<number, number> = {
+  1: 0.05,
+  2: 0.075,
+  3: 0.1,
+  4: 0.125,
+  5: 0.15
+};
+
+/**
+ * Pre-trade daily loss limit gate.
+ *
+ * Blocks BUY / short_entry signals when the user's rolling 24-hour
+ * realized losses from algorithmic trades exceed a risk-level-based
+ * percentage of their trading capital.
+ *
+ * SELL / short_exit signals always pass so positions can unwind.
+ * Fails closed: on any query error, BUY is blocked and a warning is logged.
+ */
+@Injectable()
+export class DailyLossLimitGateService {
+  private readonly logger = new Logger(DailyLossLimitGateService.name);
+
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepo: Repository<Order>
+  ) {}
+
+  /**
+   * Convenience method: can this user open new positions?
+   * Returns { blocked: true, reason } when the daily loss limit is exceeded.
+   */
+  async isEntryBlocked(
+    userId: string,
+    tradingCapital: number,
+    riskLevel: number
+  ): Promise<{ blocked: boolean; reason?: string }> {
+    const result = await this.checkDailyLossLimit(userId, tradingCapital, riskLevel, 'buy');
+    return { blocked: !result.allowed, reason: result.reason };
+  }
+
+  async checkDailyLossLimit(
+    userId: string,
+    tradingCapital: number,
+    riskLevel: number,
+    action: 'buy' | 'sell' | 'short_entry' | 'short_exit'
+  ): Promise<{ allowed: boolean; reason?: string }> {
+    // SELLs and short exits always allowed — must be able to unwind positions
+    if (action === 'sell' || action === 'short_exit') {
+      return { allowed: true };
+    }
+
+    // Zero / negative capital guard — prevent division by zero
+    if (tradingCapital <= 0) {
+      return { allowed: false, reason: 'Trading capital is zero or negative' };
+    }
+
+    const threshold = RISK_LEVEL_THRESHOLDS[riskLevel] ?? RISK_LEVEL_THRESHOLDS[3];
+
+    try {
+      const result = await this.orderRepo
+        .createQueryBuilder('order')
+        .select('COALESCE(SUM(order.gainLoss), 0)', 'totalLoss')
+        .where('order.userId = :userId', { userId })
+        .andWhere('order.isAlgorithmicTrade = true')
+        .andWhere('order.status = :status', { status: 'FILLED' })
+        .andWhere('order.side = :side', { side: 'SELL' })
+        .andWhere("order.createdAt > NOW() - INTERVAL '24 hours'")
+        .andWhere('order.gainLoss < 0')
+        .getRawOne<{ totalLoss: string }>();
+
+      const totalLoss = Math.abs(parseFloat(result?.totalLoss ?? '0'));
+      const lossPercent = (totalLoss / tradingCapital) * 100;
+      const limitPercent = threshold * 100;
+
+      if (lossPercent >= limitPercent) {
+        const reason = `Daily loss limit exceeded: ${lossPercent.toFixed(1)}% losses >= ${limitPercent.toFixed(1)}% limit`;
+        this.logger.warn(`${reason} (user ${userId})`);
+        return { allowed: false, reason };
+      }
+
+      return { allowed: true };
+    } catch (error) {
+      // Fail closed: block BUY on any query error
+      this.logger.warn(`Daily loss limit query failed for user ${userId}, blocking BUY as precaution`, error);
+      return { allowed: false, reason: 'Daily loss limit check failed (fail-closed)' };
+    }
+  }
+}

--- a/apps/api/src/strategy/live-trading.service.spec.ts
+++ b/apps/api/src/strategy/live-trading.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { ObjectLiteral, Repository } from 'typeorm';
 
 import { CapitalAllocationService } from './capital-allocation.service';
+import { DailyLossLimitGateService } from './daily-loss-limit-gate.service';
 import { LiveTradingService } from './live-trading.service';
 import { PositionTrackingService } from './position-tracking.service';
 import { PreTradeRiskGateService } from './pre-trade-risk-gate.service';
@@ -48,6 +49,7 @@ describe('LiveTradingService', () => {
   let tradingStateService: jest.Mocked<TradingStateService>;
   let regimeGateService: jest.Mocked<RegimeGateService>;
   let preTradeRiskGate: jest.Mocked<PreTradeRiskGateService>;
+  let dailyLossLimitGate: jest.Mocked<DailyLossLimitGateService>;
   let tradeExecutionService: jest.Mocked<TradeExecutionService>;
   let tradeCooldownService: jest.Mocked<TradeCooldownService>;
 
@@ -102,6 +104,11 @@ describe('LiveTradingService', () => {
       checkDrawdown: jest.fn().mockResolvedValue({ allowed: true })
     } as unknown as jest.Mocked<PreTradeRiskGateService>;
 
+    dailyLossLimitGate = {
+      isEntryBlocked: jest.fn().mockResolvedValue({ blocked: false }),
+      checkDailyLossLimit: jest.fn().mockResolvedValue({ allowed: true })
+    } as unknown as jest.Mocked<DailyLossLimitGateService>;
+
     tradeExecutionService = {
       executeTradeSignal: jest.fn().mockResolvedValue({ id: 'order-1' })
     } as unknown as jest.Mocked<TradeExecutionService>;
@@ -135,6 +142,7 @@ describe('LiveTradingService', () => {
         },
         { provide: RegimeGateService, useValue: regimeGateService },
         { provide: PreTradeRiskGateService, useValue: preTradeRiskGate },
+        { provide: DailyLossLimitGateService, useValue: dailyLossLimitGate },
         { provide: TradeExecutionService, useValue: tradeExecutionService },
         { provide: TradeCooldownService, useValue: tradeCooldownService },
         {
@@ -145,6 +153,7 @@ describe('LiveTradingService', () => {
             recordTradeCooldownCleared: jest.fn(),
             recordRegimeGateBlock: jest.fn(),
             recordDrawdownGateBlock: jest.fn(),
+            recordDailyLossGateBlock: jest.fn(),
             recordLiveOrderPlaced: jest.fn()
           }
         }

--- a/apps/api/src/strategy/live-trading.service.ts
+++ b/apps/api/src/strategy/live-trading.service.ts
@@ -7,6 +7,7 @@ import { Repository } from 'typeorm';
 import { MarketType, PositionSide } from '@chansey/api-interfaces';
 
 import { CapitalAllocationService } from './capital-allocation.service';
+import { DailyLossLimitGateService } from './daily-loss-limit-gate.service';
 import { StrategyConfig } from './entities/strategy-config.entity';
 import { PositionTrackingService } from './position-tracking.service';
 import { PreTradeRiskGateService } from './pre-trade-risk-gate.service';
@@ -59,6 +60,7 @@ export class LiveTradingService implements OnApplicationShutdown {
     private readonly compositeRegimeService: CompositeRegimeService,
     private readonly regimeGateService: RegimeGateService,
     private readonly preTradeRiskGate: PreTradeRiskGateService,
+    private readonly dailyLossLimitGate: DailyLossLimitGateService,
     private readonly tradeExecutionService: TradeExecutionService,
     private readonly tradeCooldownService: TradeCooldownService,
     private readonly metricsService: MetricsService
@@ -169,6 +171,11 @@ export class LiveTradingService implements OnApplicationShutdown {
     const overrideActive = this.compositeRegimeService.isOverrideActive();
     let gateBlockedCount = 0;
     let drawdownBlockedCount = 0;
+    let dailyLossBlockedCount = 0;
+
+    // Daily loss limit gate: user-level check before strategy loop
+    const dailyLossCheck = await this.dailyLossLimitGate.isEntryBlocked(user.id, actualCapital, user.risk?.level ?? 3);
+    const dailyLossBlocked = dailyLossCheck.blocked;
 
     for (const strategy of strategies) {
       try {
@@ -188,6 +195,13 @@ export class LiveTradingService implements OnApplicationShutdown {
           const validation = this.strategyExecutor.validateSignal(signal, allocatedCapital);
           if (!validation.valid) {
             this.logger.warn(`Invalid signal for user ${user.id}, strategy ${strategy.id}: ${validation.reason}`);
+            continue;
+          }
+
+          // Daily loss limit gate: block BUY/short_entry when rolling 24h losses exceed threshold
+          if (dailyLossBlocked && (action === 'buy' || action === 'short_entry')) {
+            this.metricsService.recordDailyLossGateBlock();
+            dailyLossBlockedCount++;
             continue;
           }
 
@@ -229,6 +243,12 @@ export class LiveTradingService implements OnApplicationShutdown {
 
     if (drawdownBlockedCount > 0) {
       this.logger.log(`Drawdown gate blocked ${drawdownBlockedCount} BUY signal(s) for user ${user.id}`);
+    }
+
+    if (dailyLossBlockedCount > 0) {
+      this.logger.log(
+        `Daily loss limit gate blocked ${dailyLossBlockedCount} entry signal(s) for user ${user.id}: ${dailyLossCheck.reason}`
+      );
     }
   }
 

--- a/apps/api/src/strategy/strategy.module.ts
+++ b/apps/api/src/strategy/strategy.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AdminPoolController } from './admin-pool.controller';
 import { CapitalAllocationService } from './capital-allocation.service';
+import { DailyLossLimitGateService } from './daily-loss-limit-gate.service';
 import { DeploymentController } from './deployment.controller';
 import { DeploymentService } from './deployment.service';
 import { BacktestRun } from './entities/backtest-run.entity';
@@ -86,6 +87,7 @@ import { User } from '../users/users.entity';
     SignalThrottleService,
     LiveTradingService,
     PreTradeRiskGateService,
+    DailyLossLimitGateService,
     UserPerformanceService,
     PoolStatisticsService,
     PromotionGateService,
@@ -114,7 +116,8 @@ import { User } from '../users/users.entity';
     PositionTrackingService,
     CapitalAllocationService,
     StrategyExecutorService,
-    UserPerformanceService
+    UserPerformanceService,
+    DailyLossLimitGateService
   ]
 })
 export class StrategyModule {}


### PR DESCRIPTION
## Summary

- Add a daily loss limit gate that queries rolling 24h realized losses from filled algorithmic SELL orders and blocks BUY/short_entry signals when losses exceed a risk-level-based threshold (5%–15%)
- Integrate the gate into both Pipeline 1 (LiveTradingService) and Pipeline 2 (TradeExecutionTask) as fail-closed pre-checks
- Add Prometheus metrics, a composite database index for query performance, and comprehensive unit tests

## Changes

### New Files
- `daily-loss-limit-gate.service.ts` — Core gate service with `evaluate()` and `isEntryBlocked()` methods; queries rolling 24h losses against risk-based thresholds
- `daily-loss-limit-gate.service.spec.ts` — Unit tests covering threshold breach, boundary, fail-closed behavior, zero capital guard, and all risk level mappings
- `1741100000000-add-daily-loss-limit-index.ts` — Migration adding partial composite index `IDX_order_daily_loss_gate` for gate query performance

### Modified Files
- `live-trading.service.ts` — Integrate gate as user-level pre-check before strategy loop (Pipeline 1)
- `trade-execution.task.ts` — Integrate gate as per-user check during portfolio cache phase with blocked user Set; refactor user/portfolio/daily-loss preflight into single fail-closed block (Pipeline 2)
- `metrics.service.ts` / `metrics.module.ts` — Add `chansey_daily_loss_gate_blocks_total` Prometheus counter
- `order.entity.ts` — Add entity metadata for the new index
- `order.module.ts` / `strategy.module.ts` — Wire up new service and repository dependencies
- `trade-execution.task.spec.ts` / `live-trading.service.spec.ts` — Updated tests for gate integration

## Test Plan

- [x] Unit tests for DailyLossLimitGateService (threshold breach, boundary, fail-closed, zero capital, risk levels)
- [x] Updated trade-execution.task and live-trading.service specs
- [ ] Run `nx test api` to verify all tests pass
- [ ] Verify migration applies cleanly on a fresh database

Closes #247