### PR TITLE
feat(api): replace static exchange key binding with dynamic exchange selection

### DIFF
--- a/apps/api/src/admin/live-trade-monitoring/live-trade-monitoring.module.ts
+++ b/apps/api/src/admin/live-trade-monitoring/live-trade-monitoring.module.ts
@@ -8,6 +8,7 @@ import { AlgorithmActivation } from '../../algorithm/algorithm-activation.entity
 import { AlgorithmPerformance } from '../../algorithm/algorithm-performance.entity';
 import { Algorithm } from '../../algorithm/algorithm.entity';
 import { AlgorithmModule } from '../../algorithm/algorithm.module';
+import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { Backtest, SimulatedOrderFill } from '../../order/backtest/backtest.entity';
 import { Order } from '../../order/order.entity';
 import { User } from '../../users/users.entity';
@@ -29,7 +30,8 @@ import { User } from '../../users/users.entity';
       Backtest,
       SimulatedOrderFill,
       Algorithm,
-      User
+      User,
+      ExchangeKey
     ]),
     forwardRef(() => AlgorithmModule)
   ],

--- a/apps/api/src/admin/live-trade-monitoring/live-trade-monitoring.service.ts
+++ b/apps/api/src/admin/live-trade-monitoring/live-trade-monitoring.service.ts
@@ -43,6 +43,7 @@ import { PaginatedUserActivityDto, UserActivityItemDto, UserAlgorithmSummaryDto 
 import { AlgorithmActivation } from '../../algorithm/algorithm-activation.entity';
 import { AlgorithmPerformance } from '../../algorithm/algorithm-performance.entity';
 import { Algorithm } from '../../algorithm/algorithm.entity';
+import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { Backtest, BacktestStatus, SimulatedOrderFill } from '../../order/backtest/backtest.entity';
 import { Order } from '../../order/order.entity';
 import { User } from '../../users/users.entity';
@@ -105,7 +106,9 @@ export class LiveTradeMonitoringService {
     @InjectRepository(Algorithm)
     private readonly algorithmRepo: Repository<Algorithm>,
     @InjectRepository(User)
-    private readonly userRepo: Repository<User>
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(ExchangeKey)
+    private readonly exchangeKeyRepo: Repository<ExchangeKey>
   ) {}
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -152,10 +155,7 @@ export class LiveTradeMonitoringService {
     const qb = this.activationRepo
       .createQueryBuilder('aa')
       .leftJoinAndSelect('aa.algorithm', 'a')
-      .leftJoinAndSelect('aa.user', 'u')
-      .leftJoinAndSelect('aa.exchangeKey', 'ek')
-      .leftJoin('ek.exchange', 'ex');
-
+      .leftJoinAndSelect('aa.user', 'u');
     // Join performance for metrics
     qb.leftJoin(
       (subQuery) =>
@@ -223,6 +223,26 @@ export class LiveTradeMonitoringService {
     const activationIds = activations.entities.map((aa) => aa.id);
     const orderStatsMap = await this.getBatchActivationOrderStats(activationIds);
 
+    // Batch-load exchange names for all unique users in one query
+    const uniqueUserIds = [...new Set(activations.entities.map((aa) => aa.userId))];
+    const exchangeNameMap = new Map<string, string>();
+    if (uniqueUserIds.length > 0) {
+      const userKeys = await this.exchangeKeyRepo.find({
+        where: uniqueUserIds.map((uid) => ({ userId: uid, isActive: true })),
+        relations: ['exchange']
+      });
+      for (const key of userKeys) {
+        const name = key.exchange?.name;
+        if (!name) continue;
+        const existing = exchangeNameMap.get(key.userId);
+        if (!existing) {
+          exchangeNameMap.set(key.userId, name);
+        } else if (!existing.includes(name)) {
+          exchangeNameMap.set(key.userId, `${existing}, ${name}`);
+        }
+      }
+    }
+
     // Map to DTOs
     const data: AlgorithmActivationListItemDto[] = activations.entities.map((aa, index) => {
       const raw = activations.raw[index];
@@ -246,7 +266,7 @@ export class LiveTradeMonitoringService {
         sharpeRatio: raw.sharpeRatio ? Number(raw.sharpeRatio) : undefined,
         maxDrawdown: raw.maxDrawdown ? Number(raw.maxDrawdown) : undefined,
         avgSlippageBps: orderStats.avgSlippageBps,
-        exchangeName: aa.exchangeKey?.exchange?.name || 'Unknown',
+        exchangeName: exchangeNameMap.get(aa.userId) || 'No exchanges',
         createdAt: aa.createdAt.toISOString()
       };
     });

--- a/apps/api/src/algorithm/algorithm-activation.entity.ts
+++ b/apps/api/src/algorithm/algorithm-activation.entity.ts
@@ -15,7 +15,6 @@ import {
 import type { Algorithm } from './algorithm.entity';
 import { AlgorithmConfig } from './algorithm.entity';
 
-import type { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
 import type { User } from '../users/users.entity';
 
 /**
@@ -27,7 +26,6 @@ import type { User } from '../users/users.entity';
 @Entity('algorithm_activations')
 @Index(['userId', 'algorithmId'], { unique: true }) // User can activate algorithm once
 @Index(['userId', 'isActive']) // Query active algorithms
-@Index(['exchangeKeyId']) // Query by exchange
 export class AlgorithmActivation {
   @PrimaryGeneratedColumn('uuid')
   @ApiProperty({
@@ -63,20 +61,6 @@ export class AlgorithmActivation {
     description: 'Algorithm that is activated'
   })
   algorithm: Relation<Algorithm>;
-
-  @Column({ type: 'uuid' })
-  @ApiProperty({
-    description: 'Exchange key ID to use for trading',
-    example: 'd6ee401g-1eh2-6111-2235-dfh7h9876335'
-  })
-  exchangeKeyId: string;
-
-  @ManyToOne('ExchangeKey', { nullable: false, onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'exchangeKeyId' })
-  @ApiProperty({
-    description: 'Exchange key to use for trading'
-  })
-  exchangeKey: Relation<ExchangeKey>;
 
   @Column({ type: 'boolean', default: false })
   @ApiProperty({

--- a/apps/api/src/algorithm/algorithm.controller.ts
+++ b/apps/api/src/algorithm/algorithm.controller.ts
@@ -8,21 +8,21 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
-  UseGuards,
   Query,
-  Req
+  Req,
+  UseGuards
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags, ApiQuery } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { Role } from '@chansey/api-interfaces';
 
 import { AlgorithmService } from './algorithm.service';
 import {
-  CreateAlgorithmDto,
-  UpdateAlgorithmDto,
+  ActivateAlgorithmDto,
   AlgorithmResponseDto,
+  CreateAlgorithmDto,
   DeleteResponseDto,
-  ActivateAlgorithmDto
+  UpdateAlgorithmDto
 } from './dto';
 import { AlgorithmRegistry } from './registry/algorithm-registry.service';
 import { AlgorithmActivationService } from './services/algorithm-activation.service';
@@ -289,7 +289,7 @@ export class AlgorithmController {
   @Post(':id/activate')
   @ApiOperation({
     summary: 'Activate an algorithm',
-    description: 'Activate an algorithm for automated trading with a specific exchange key.'
+    description: 'Activate an algorithm for automated trading. Exchange selection happens dynamically at trade time.'
   })
   @ApiParam({
     name: 'id',
@@ -302,7 +302,7 @@ export class AlgorithmController {
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
-    description: 'Algorithm is already activated or exchange key not found.'
+    description: 'Algorithm is already activated.'
   })
   @ApiResponse({
     status: HttpStatus.UNAUTHORIZED,
@@ -314,12 +314,7 @@ export class AlgorithmController {
     @Req() request: any
   ) {
     const userId = request.user.id;
-    return await this.algorithmActivationService.activate(
-      userId,
-      algorithmId,
-      activateAlgorithmDto.exchangeKeyId,
-      activateAlgorithmDto.config
-    );
+    return await this.algorithmActivationService.activate(userId, algorithmId, activateAlgorithmDto.config);
   }
 
   @Post(':id/deactivate')

--- a/apps/api/src/algorithm/algorithm.module.ts
+++ b/apps/api/src/algorithm/algorithm.module.ts
@@ -33,7 +33,6 @@ import { Coin } from '../coin/coin.entity';
 import { CoinService } from '../coin/coin.service';
 import { TickerPairs } from '../coin/ticker-pairs/ticker-pairs.entity';
 import { TickerPairService } from '../coin/ticker-pairs/ticker-pairs.service';
-import { ExchangeKeyModule } from '../exchange/exchange-key/exchange-key.module';
 import { ExchangeModule } from '../exchange/exchange.module';
 import { OHLCModule } from '../ohlc/ohlc.module';
 import { Backtest } from '../order/backtest/backtest.entity';
@@ -58,7 +57,6 @@ import { UsersModule } from '../users/users.module';
     SharedCacheModule,
     IndicatorModule,
     forwardRef(() => ExchangeModule),
-    forwardRef(() => ExchangeKeyModule),
     forwardRef(() => OrderModule),
     forwardRef(() => UsersModule),
     forwardRef(() => PortfolioModule),

--- a/apps/api/src/algorithm/dto/activate-algorithm.dto.ts
+++ b/apps/api/src/algorithm/dto/activate-algorithm.dto.ts
@@ -1,19 +1,11 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 import { Type } from 'class-transformer';
-import { IsOptional, IsUUID, ValidateNested } from 'class-validator';
+import { IsOptional, ValidateNested } from 'class-validator';
 
 import { AlgorithmConfig } from '../algorithm.entity';
 
 export class ActivateAlgorithmDto {
-  @IsUUID()
-  @ApiProperty({
-    description: 'Exchange key ID to use for trading',
-    example: 'd6ee401g-1eh2-6111-2235-dfh7h9876335',
-    required: true
-  })
-  exchangeKeyId: string;
-
   @IsOptional()
   @ValidateNested()
   @Type(() => Object)

--- a/apps/api/src/algorithm/services/algorithm-activation.service.ts
+++ b/apps/api/src/algorithm/services/algorithm-activation.service.ts
@@ -3,7 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import { ExchangeKeyService } from '../../exchange/exchange-key/exchange-key.service';
 import { AlgorithmActivation } from '../algorithm-activation.entity';
 import { AlgorithmConfig } from '../algorithm.entity';
 
@@ -11,41 +10,28 @@ import { AlgorithmConfig } from '../algorithm.entity';
  * AlgorithmActivationService
  *
  * Manages user-specific algorithm activations and deactivations.
- * Validates exchange keys and handles activation state transitions.
+ * Exchange key selection is handled dynamically at trade time by ExchangeSelectionService.
  */
 @Injectable()
 export class AlgorithmActivationService {
   constructor(
     @InjectRepository(AlgorithmActivation)
-    private readonly algorithmActivationRepository: Repository<AlgorithmActivation>,
-    private readonly exchangeKeyService: ExchangeKeyService
+    private readonly algorithmActivationRepository: Repository<AlgorithmActivation>
   ) {}
 
   /**
-   * Activate an algorithm for a user with a specific exchange key
+   * Activate an algorithm for a user
    * @param userId - User ID who is activating the algorithm
    * @param algorithmId - Algorithm ID to activate
-   * @param exchangeKeyId - Exchange key ID to use for trading
    * @param config - Optional user-specific configuration overrides
    * @returns The created or updated AlgorithmActivation
-   * @throws BadRequestException if already activated or exchange key not found
+   * @throws BadRequestException if already activated
    */
-  async activate(
-    userId: string,
-    algorithmId: string,
-    exchangeKeyId: string,
-    config?: AlgorithmConfig
-  ): Promise<AlgorithmActivation> {
-    // Validate that exchange key exists and belongs to the user
-    const exchangeKey = await this.exchangeKeyService.findOne(exchangeKeyId, userId);
-    if (!exchangeKey) {
-      throw new NotFoundException('Exchange key not found');
-    }
-
+  async activate(userId: string, algorithmId: string, config?: AlgorithmConfig): Promise<AlgorithmActivation> {
     // Check if activation already exists
     const existingActivation = await this.algorithmActivationRepository.findOne({
       where: { userId, algorithmId },
-      relations: ['algorithm', 'exchangeKey']
+      relations: ['algorithm']
     });
 
     if (existingActivation && existingActivation.isActive) {
@@ -54,7 +40,6 @@ export class AlgorithmActivationService {
 
     // If activation exists but was deactivated, reactivate it
     if (existingActivation) {
-      existingActivation.exchangeKeyId = exchangeKeyId;
       existingActivation.config = config || existingActivation.config;
       existingActivation.activate();
       return await this.algorithmActivationRepository.save(existingActivation);
@@ -64,7 +49,6 @@ export class AlgorithmActivationService {
     const activation = new AlgorithmActivation({
       userId,
       algorithmId,
-      exchangeKeyId,
       isActive: true,
       allocationPercentage: 5.0, // Default 5% allocation
       config,
@@ -86,7 +70,7 @@ export class AlgorithmActivationService {
   async deactivate(userId: string, algorithmId: string): Promise<AlgorithmActivation> {
     const activation = await this.algorithmActivationRepository.findOne({
       where: { userId, algorithmId },
-      relations: ['algorithm', 'exchangeKey']
+      relations: ['algorithm']
     });
 
     if (!activation) {
@@ -109,7 +93,7 @@ export class AlgorithmActivationService {
   async findUserActiveAlgorithms(userId: string): Promise<AlgorithmActivation[]> {
     return await this.algorithmActivationRepository.find({
       where: { userId, isActive: true },
-      relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange'],
+      relations: ['algorithm'],
       order: { activatedAt: 'DESC' }
     });
   }
@@ -122,7 +106,7 @@ export class AlgorithmActivationService {
   async findUserAlgorithms(userId: string): Promise<AlgorithmActivation[]> {
     return await this.algorithmActivationRepository.find({
       where: { userId },
-      relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange'],
+      relations: ['algorithm'],
       order: { createdAt: 'DESC' }
     });
   }
@@ -139,7 +123,7 @@ export class AlgorithmActivationService {
 
     const activation = await this.algorithmActivationRepository.findOne({
       where,
-      relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange']
+      relations: ['algorithm']
     });
 
     if (!activation) {
@@ -156,7 +140,7 @@ export class AlgorithmActivationService {
   async findAllActiveAlgorithms(): Promise<AlgorithmActivation[]> {
     return await this.algorithmActivationRepository.find({
       where: { isActive: true },
-      relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange', 'user']
+      relations: ['algorithm', 'user']
     });
   }
 

--- a/apps/api/src/exchange/exchange-selection/exchange-selection.module.ts
+++ b/apps/api/src/exchange/exchange-selection/exchange-selection.module.ts
@@ -1,0 +1,20 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { ExchangeSelectionService } from './exchange-selection.service';
+
+import { Order } from '../../order/order.entity';
+import { UserStrategyPosition } from '../../strategy/entities/user-strategy-position.entity';
+import { ExchangeKeyModule } from '../exchange-key/exchange-key.module';
+import { ExchangeModule } from '../exchange.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([UserStrategyPosition, Order]),
+    forwardRef(() => ExchangeKeyModule),
+    forwardRef(() => ExchangeModule)
+  ],
+  providers: [ExchangeSelectionService],
+  exports: [ExchangeSelectionService]
+})
+export class ExchangeSelectionModule {}

--- a/apps/api/src/exchange/exchange-selection/exchange-selection.service.spec.ts
+++ b/apps/api/src/exchange/exchange-selection/exchange-selection.service.spec.ts
@@ -1,0 +1,264 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ExchangeSelectionService } from './exchange-selection.service';
+
+import { Order } from '../../order/order.entity';
+import { UserStrategyPosition } from '../../strategy/entities/user-strategy-position.entity';
+import { ExchangeKey } from '../exchange-key/exchange-key.entity';
+import { ExchangeKeyService } from '../exchange-key/exchange-key.service';
+import { ExchangeManagerService } from '../exchange-manager.service';
+
+describe('ExchangeSelectionService', () => {
+  let service: ExchangeSelectionService;
+  let exchangeKeyService: { findAll: jest.Mock; findOne: jest.Mock };
+  let exchangeManagerService: { getPrice: jest.Mock; getQuoteAsset: jest.Mock };
+  let positionRepo: { findOne: jest.Mock };
+  let orderRepo: { createQueryBuilder: jest.Mock };
+
+  const userId = 'user-1';
+  const symbol = 'BTC/USDT';
+
+  const makeKey = (overrides: Partial<ExchangeKey> = {}): ExchangeKey =>
+    ({ id: 'key-1', isActive: true, exchange: { slug: 'binance' }, ...overrides }) as ExchangeKey;
+
+  const makeQueryBuilder = (result: unknown = null) => ({
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(result)
+  });
+
+  beforeEach(async () => {
+    exchangeKeyService = { findAll: jest.fn(), findOne: jest.fn() };
+    exchangeManagerService = { getPrice: jest.fn(), getQuoteAsset: jest.fn().mockReturnValue('USDT') };
+    positionRepo = { findOne: jest.fn() };
+    orderRepo = { createQueryBuilder: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExchangeSelectionService,
+        { provide: ExchangeKeyService, useValue: exchangeKeyService },
+        { provide: ExchangeManagerService, useValue: exchangeManagerService },
+        { provide: getRepositoryToken(UserStrategyPosition), useValue: positionRepo },
+        { provide: getRepositoryToken(Order), useValue: orderRepo }
+      ]
+    }).compile();
+
+    service = module.get(ExchangeSelectionService);
+  });
+
+  describe('selectDefault', () => {
+    it('returns the first active key without symbol checks', async () => {
+      const key = makeKey();
+      exchangeKeyService.findAll.mockResolvedValue([key]);
+
+      const result = await service.selectDefault(userId);
+
+      expect(result).toBe(key);
+      expect(exchangeManagerService.getPrice).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when no active keys exist', async () => {
+      exchangeKeyService.findAll.mockResolvedValue([makeKey({ isActive: false })]);
+
+      await expect(service.selectDefault(userId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns the first active key when multiple exist', async () => {
+      const key1 = makeKey({ id: 'key-1' });
+      const key2 = makeKey({ id: 'key-2' });
+      exchangeKeyService.findAll.mockResolvedValue([key1, key2]);
+
+      const result = await service.selectDefault(userId);
+
+      expect(result).toBe(key1);
+    });
+  });
+
+  describe('selectForBuy', () => {
+    it('throws NotFoundException when no active keys exist', async () => {
+      exchangeKeyService.findAll.mockResolvedValue([makeKey({ isActive: false })]);
+
+      await expect(service.selectForBuy(userId, symbol)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when user has no keys at all', async () => {
+      exchangeKeyService.findAll.mockResolvedValue([]);
+
+      await expect(service.selectForBuy(userId, symbol)).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns the single active key without checking symbol support', async () => {
+      const key = makeKey();
+      exchangeKeyService.findAll.mockResolvedValue([key]);
+
+      const result = await service.selectForBuy(userId, symbol);
+
+      expect(result).toBe(key);
+      expect(exchangeManagerService.getPrice).not.toHaveBeenCalled();
+    });
+
+    it('returns the first key that supports the symbol when multiple keys exist', async () => {
+      const key1 = makeKey({ id: 'key-1', exchange: { slug: 'coinbase' } } as Partial<ExchangeKey>);
+      const key2 = makeKey({ id: 'key-2', exchange: { slug: 'binance' } } as Partial<ExchangeKey>);
+      exchangeKeyService.findAll.mockResolvedValue([key1, key2]);
+      exchangeManagerService.getQuoteAsset.mockImplementation((slug: string) => (slug === 'coinbase' ? 'USD' : 'USDT'));
+      exchangeManagerService.getPrice.mockRejectedValueOnce(new Error('unsupported')).mockResolvedValueOnce(50000);
+
+      const result = await service.selectForBuy(userId, symbol);
+
+      expect(result).toBe(key2);
+      expect(exchangeManagerService.getPrice).toHaveBeenCalledWith('coinbase', 'BTC/USD');
+      expect(exchangeManagerService.getPrice).toHaveBeenCalledWith('binance', 'BTC/USDT');
+    });
+
+    it('skips keys with no exchange slug', async () => {
+      const keyNoSlug = makeKey({ id: 'key-1', exchange: undefined } as Partial<ExchangeKey>);
+      const keyWithSlug = makeKey({ id: 'key-2' });
+      exchangeKeyService.findAll.mockResolvedValue([keyNoSlug, keyWithSlug]);
+      exchangeManagerService.getPrice.mockResolvedValue(50000);
+
+      const result = await service.selectForBuy(userId, symbol);
+
+      expect(result).toBe(keyWithSlug);
+      expect(exchangeManagerService.getPrice).toHaveBeenCalledTimes(1);
+      expect(exchangeManagerService.getPrice).toHaveBeenCalledWith('binance', 'BTC/USDT');
+    });
+
+    it('falls back to first active key when no exchange supports the symbol', async () => {
+      const key1 = makeKey({ id: 'key-1' });
+      const key2 = makeKey({ id: 'key-2' });
+      exchangeKeyService.findAll.mockResolvedValue([key1, key2]);
+      exchangeManagerService.getPrice.mockRejectedValue(new Error('unsupported'));
+
+      const result = await service.selectForBuy(userId, symbol);
+
+      expect(result).toBe(key1);
+    });
+  });
+
+  describe('selectForSell', () => {
+    const strategyConfigId = 'strategy-1';
+
+    it('returns position exchange key when position has active key', async () => {
+      const key = makeKey({ id: 'pos-key' });
+      positionRepo.findOne.mockResolvedValue({ exchangeKeyId: 'pos-key', exchangeKey: key });
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(result).toBe(key);
+      expect(positionRepo.findOne).toHaveBeenCalledWith({
+        where: { userId, strategyConfigId, symbol },
+        relations: ['exchangeKey', 'exchangeKey.exchange']
+      });
+    });
+
+    it('falls through when position exists but key is inactive', async () => {
+      const inactiveKey = makeKey({ id: 'pos-key', isActive: false });
+      positionRepo.findOne.mockResolvedValue({ exchangeKeyId: 'pos-key', exchangeKey: inactiveKey });
+      const qb = makeQueryBuilder(null);
+      orderRepo.createQueryBuilder.mockReturnValue(qb);
+      // Falls all the way to selectForBuy
+      const fallbackKey = makeKey({ id: 'fallback' });
+      exchangeKeyService.findAll.mockResolvedValue([fallbackKey]);
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(result).toBe(fallbackKey);
+    });
+
+    it('falls through when position has no exchangeKeyId', async () => {
+      positionRepo.findOne.mockResolvedValue({ exchangeKeyId: null, exchangeKey: null });
+      const qb = makeQueryBuilder(null);
+      orderRepo.createQueryBuilder.mockReturnValue(qb);
+      const fallbackKey = makeKey({ id: 'fallback' });
+      exchangeKeyService.findAll.mockResolvedValue([fallbackKey]);
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(result).toBe(fallbackKey);
+    });
+
+    it('falls through gracefully when position lookup throws', async () => {
+      positionRepo.findOne.mockRejectedValue(new Error('db error'));
+      const qb = makeQueryBuilder(null);
+      orderRepo.createQueryBuilder.mockReturnValue(qb);
+      const fallbackKey = makeKey({ id: 'fallback' });
+      exchangeKeyService.findAll.mockResolvedValue([fallbackKey]);
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(result).toBe(fallbackKey);
+    });
+
+    it('skips position lookup when no strategyConfigId provided', async () => {
+      const qb = makeQueryBuilder(null);
+      orderRepo.createQueryBuilder.mockReturnValue(qb);
+      const fallbackKey = makeKey({ id: 'fallback' });
+      exchangeKeyService.findAll.mockResolvedValue([fallbackKey]);
+
+      const result = await service.selectForSell(userId, symbol);
+
+      expect(positionRepo.findOne).not.toHaveBeenCalled();
+      expect(result).toBe(fallbackKey);
+    });
+
+    it('returns key from most recent filled BUY order', async () => {
+      positionRepo.findOne.mockResolvedValue(null);
+      const orderKey = makeKey({ id: 'order-key' });
+      const qb = makeQueryBuilder({ exchangeKeyId: 'order-key' });
+      orderRepo.createQueryBuilder.mockReturnValue(qb);
+      exchangeKeyService.findOne.mockResolvedValue(orderKey);
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(exchangeKeyService.findOne).toHaveBeenCalledWith('order-key', userId);
+      expect(result).toBe(orderKey);
+    });
+
+    it('falls through when BUY order key is inactive', async () => {
+      positionRepo.findOne.mockResolvedValue(null);
+      const inactiveKey = makeKey({ id: 'order-key', isActive: false });
+      const qb = makeQueryBuilder({ exchangeKeyId: 'order-key' });
+      orderRepo.createQueryBuilder.mockReturnValue(qb);
+      exchangeKeyService.findOne.mockResolvedValue(inactiveKey);
+      const fallbackKey = makeKey({ id: 'fallback' });
+      exchangeKeyService.findAll.mockResolvedValue([fallbackKey]);
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(result).toBe(fallbackKey);
+    });
+
+    it('falls through gracefully when order lookup throws', async () => {
+      positionRepo.findOne.mockResolvedValue(null);
+      orderRepo.createQueryBuilder.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockRejectedValue(new Error('db error'))
+      });
+      const fallbackKey = makeKey({ id: 'fallback' });
+      exchangeKeyService.findAll.mockResolvedValue([fallbackKey]);
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(result).toBe(fallbackKey);
+    });
+
+    it('falls back to selectForBuy when no position or order history exists', async () => {
+      positionRepo.findOne.mockResolvedValue(null);
+      const qb = makeQueryBuilder(null);
+      orderRepo.createQueryBuilder.mockReturnValue(qb);
+      const buyKey = makeKey({ id: 'buy-key' });
+      exchangeKeyService.findAll.mockResolvedValue([buyKey]);
+
+      const result = await service.selectForSell(userId, symbol, strategyConfigId);
+
+      expect(exchangeKeyService.findAll).toHaveBeenCalledWith(userId);
+      expect(result).toBe(buyKey);
+    });
+  });
+});

--- a/apps/api/src/exchange/exchange-selection/exchange-selection.service.ts
+++ b/apps/api/src/exchange/exchange-selection/exchange-selection.service.ts
@@ -1,0 +1,141 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { Order } from '../../order/order.entity';
+import { toErrorInfo } from '../../shared/error.util';
+import { UserStrategyPosition } from '../../strategy/entities/user-strategy-position.entity';
+import { ExchangeKey } from '../exchange-key/exchange-key.entity';
+import { ExchangeKeyService } from '../exchange-key/exchange-key.service';
+import { ExchangeManagerService } from '../exchange-manager.service';
+
+/**
+ * ExchangeSelectionService
+ *
+ * Smart exchange routing for automated trading.
+ * BUY orders auto-select the best exchange based on symbol support and balance.
+ * SELL orders route to the exchange where the position was opened.
+ */
+@Injectable()
+export class ExchangeSelectionService {
+  private readonly logger = new Logger(ExchangeSelectionService.name);
+
+  constructor(
+    private readonly exchangeKeyService: ExchangeKeyService,
+    private readonly exchangeManagerService: ExchangeManagerService,
+    @InjectRepository(UserStrategyPosition)
+    private readonly positionRepo: Repository<UserStrategyPosition>,
+    @InjectRepository(Order)
+    private readonly orderRepo: Repository<Order>
+  ) {}
+
+  /**
+   * Select any active exchange key for a user without symbol-specific filtering.
+   * Use when the trading symbol is not known yet (e.g., paper trading session creation
+   * where symbols are determined by algorithm signals at runtime).
+   */
+  async selectDefault(userId: string): Promise<ExchangeKey> {
+    const allKeys = await this.exchangeKeyService.findAll(userId);
+    const activeKeys = allKeys.filter((k) => k.isActive);
+
+    if (activeKeys.length === 0) {
+      throw new NotFoundException(`No active exchange keys found for user ${userId}`);
+    }
+
+    return activeKeys[0];
+  }
+
+  /**
+   * Select the best exchange key for a BUY order.
+   * 1. Single active key → return immediately
+   * 2. Filter by symbol support (price lookup, checked in parallel)
+   * 3. Return first supported key
+   */
+  async selectForBuy(userId: string, symbol: string): Promise<ExchangeKey> {
+    const allKeys = await this.exchangeKeyService.findAll(userId);
+    const activeKeys = allKeys.filter((k) => k.isActive);
+
+    if (activeKeys.length === 0) {
+      throw new NotFoundException(`No active exchange keys found for user ${userId}`);
+    }
+
+    // Single active key — no selection needed
+    if (activeKeys.length === 1) {
+      return activeKeys[0];
+    }
+
+    // Check all exchanges for symbol support in parallel
+    const results = await Promise.allSettled(
+      activeKeys.map(async (key) => {
+        const exchangeSlug = key.exchange?.slug;
+        if (!exchangeSlug) throw new Error('no slug');
+        // Resolve exchange-specific quote currency (e.g., USD for Coinbase, USDT for Binance)
+        const quoteAsset = this.exchangeManagerService.getQuoteAsset(exchangeSlug);
+        const [base] = symbol.split('/');
+        const exchangeSymbol = `${base}/${quoteAsset}`;
+        await this.exchangeManagerService.getPrice(exchangeSlug, exchangeSymbol);
+        return key;
+      })
+    );
+
+    const firstSupported = results.find((r): r is PromiseFulfilledResult<ExchangeKey> => r.status === 'fulfilled');
+    if (firstSupported) return firstSupported.value;
+
+    // Fallback: return first active key (let the trade fail at execution if unsupported)
+    this.logger.warn(`No exchange supports symbol ${symbol} for user ${userId}, falling back to first active key`);
+    return activeKeys[0];
+  }
+
+  /**
+   * Select the exchange key for a SELL order.
+   * 1. Check UserStrategyPosition.exchangeKeyId for the position
+   * 2. Fallback to most recent FILLED BUY order for user+symbol
+   * 3. Final fallback to selectForBuy()
+   */
+  async selectForSell(userId: string, symbol: string, strategyConfigId?: string): Promise<ExchangeKey> {
+    // 1. Check position record for exchange key
+    if (strategyConfigId) {
+      try {
+        const position = await this.positionRepo.findOne({
+          where: { userId, strategyConfigId, symbol },
+          relations: ['exchangeKey', 'exchangeKey.exchange']
+        });
+
+        if (position?.exchangeKeyId && position.exchangeKey?.isActive) {
+          return position.exchangeKey;
+        }
+      } catch (error) {
+        const err = toErrorInfo(error);
+        this.logger.debug(`Position lookup failed for sell routing: ${err.message}`);
+      }
+    }
+
+    // 2. Fallback: find most recent filled BUY order for user+symbol
+    try {
+      const recentBuyOrder = await this.orderRepo
+        .createQueryBuilder('order')
+        .where('order.userId = :userId', { userId })
+        .andWhere('order.symbol = :symbol', { symbol })
+        .andWhere('order.side = :side', { side: 'BUY' })
+        .andWhere('order.status = :status', { status: 'FILLED' })
+        .andWhere('order.exchange_key_id IS NOT NULL')
+        .orderBy('order.createdAt', 'DESC')
+        .getOne();
+
+      if (recentBuyOrder?.exchangeKeyId) {
+        const key = await this.exchangeKeyService.findOne(recentBuyOrder.exchangeKeyId, userId);
+        if (key?.isActive) {
+          return key;
+        }
+      }
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.debug(`Order history lookup failed for sell routing: ${err.message}`);
+    }
+
+    // 3. Final fallback: use buy selection logic
+    this.logger.debug(`No position/order history for sell routing, falling back to selectForBuy for ${symbol}`);
+    return this.selectForBuy(userId, symbol);
+  }
+}

--- a/apps/api/src/migrations/1741200000000-RemoveExchangeKeyFromActivationsAndPipelines.ts
+++ b/apps/api/src/migrations/1741200000000-RemoveExchangeKeyFromActivationsAndPipelines.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveExchangeKeyFromActivationsAndPipelines1741200000000 implements MigrationInterface {
+  name = 'RemoveExchangeKeyFromActivationsAndPipelines1741200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Drop FK and index on algorithm_activations.exchangeKeyId
+    await queryRunner.query(
+      `ALTER TABLE "algorithm_activations" DROP CONSTRAINT IF EXISTS "FK_algorithm_activations_exchangeKeyId"`
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_algorithm_activations_exchangeKeyId"`);
+    // Also drop the generic index name that TypeORM may have generated
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_exchangeKeyId"`);
+    await queryRunner.query(`ALTER TABLE "algorithm_activations" DROP COLUMN IF EXISTS "exchangeKeyId"`);
+
+    // 2. Drop FK and column on pipelines.exchangeKeyId
+    await queryRunner.query(`ALTER TABLE "pipelines" DROP CONSTRAINT IF EXISTS "fk_pipelines_exchange_key"`);
+    await queryRunner.query(`ALTER TABLE "pipelines" DROP CONSTRAINT IF EXISTS "FK_pipelines_exchangeKeyId"`);
+    await queryRunner.query(`ALTER TABLE "pipelines" DROP COLUMN IF EXISTS "exchangeKeyId"`);
+
+    // 3. Add exchangeKeyId column to user_strategy_positions
+    await queryRunner.query(`ALTER TABLE "user_strategy_positions" ADD "exchangeKeyId" uuid`);
+
+    // 4. Add FK constraint on user_strategy_positions.exchangeKeyId → exchange_key.id
+    await queryRunner.query(
+      `ALTER TABLE "user_strategy_positions" ADD CONSTRAINT "FK_user_strategy_positions_exchangeKeyId" FOREIGN KEY ("exchangeKeyId") REFERENCES "exchange_key"("id") ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 1. Drop FK and column from user_strategy_positions
+    await queryRunner.query(
+      `ALTER TABLE "user_strategy_positions" DROP CONSTRAINT IF EXISTS "FK_user_strategy_positions_exchangeKeyId"`
+    );
+    await queryRunner.query(`ALTER TABLE "user_strategy_positions" DROP COLUMN IF EXISTS "exchangeKeyId"`);
+
+    // 2. Re-add exchangeKeyId to pipelines
+    await queryRunner.query(`ALTER TABLE "pipelines" ADD "exchangeKeyId" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "pipelines" ADD CONSTRAINT "fk_pipelines_exchange_key" FOREIGN KEY ("exchangeKeyId") REFERENCES "exchange_key"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+
+    // 3. Re-add exchangeKeyId to algorithm_activations
+    await queryRunner.query(`ALTER TABLE "algorithm_activations" ADD "exchangeKeyId" uuid`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_algorithm_activations_exchangeKeyId" ON "algorithm_activations" ("exchangeKeyId")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "algorithm_activations" ADD CONSTRAINT "FK_algorithm_activations_exchangeKeyId" FOREIGN KEY ("exchangeKeyId") REFERENCES "exchange_key"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+}

--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -66,6 +66,7 @@ import { CoinService } from '../coin/coin.service';
 import { TickerPairs } from '../coin/ticker-pairs/ticker-pairs.entity';
 import { TickerPairService } from '../coin/ticker-pairs/ticker-pairs.service';
 import { ExchangeKeyModule } from '../exchange/exchange-key/exchange-key.module';
+import { ExchangeSelectionModule } from '../exchange/exchange-selection/exchange-selection.module';
 import { ExchangeModule } from '../exchange/exchange.module';
 import { MarketRegimeModule } from '../market-regime/market-regime.module';
 import { MetricsModule } from '../metrics/metrics.module';
@@ -135,6 +136,7 @@ const BACKTEST_DEFAULTS = backtestConfig();
     forwardRef(() => BalanceModule),
     forwardRef(() => ExchangeModule),
     forwardRef(() => ExchangeKeyModule),
+    ExchangeSelectionModule,
     forwardRef(() => OHLCModule),
     forwardRef(() => UsersModule),
     forwardRef(() => MarketRegimeModule),

--- a/apps/api/src/order/tasks/trade-execution.task.spec.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.spec.ts
@@ -14,6 +14,7 @@ import { AlgorithmActivationService } from '../../algorithm/services/algorithm-a
 import { AlgorithmContextBuilder } from '../../algorithm/services/algorithm-context-builder.service';
 import { BalanceService } from '../../balance/balance.service';
 import { CoinService } from '../../coin/coin.service';
+import { ExchangeSelectionService } from '../../exchange/exchange-selection/exchange-selection.service';
 import { MetricsService } from '../../metrics/metrics.service';
 import { TradeCooldownService } from '../../shared/trade-cooldown.service';
 import { DailyLossLimitGateService } from '../../strategy/daily-loss-limit-gate.service';
@@ -40,6 +41,7 @@ describe('TradeExecutionTask', () => {
   let mockSignalThrottle: any;
   let mockDailyLossLimitGate: any;
   let mockMetricsService: any;
+  let mockExchangeSelectionService: any;
 
   const mockJob = {
     id: 'job-1',
@@ -52,7 +54,6 @@ describe('TradeExecutionTask', () => {
       id: 'activation-1',
       userId: 'user-1',
       algorithmId: 'algo-1',
-      exchangeKeyId: 'key-1',
       allocationPercentage: 5,
       isActive: true,
       createdAt: new Date(),
@@ -62,9 +63,6 @@ describe('TradeExecutionTask', () => {
         name: 'Test Algorithm',
         strategyId: 'strategy-1',
         service: null
-      },
-      exchangeKey: {
-        exchange: { slug: 'binance_us' }
       },
       user: { id: 'user-1' },
       activate: jest.fn(),
@@ -177,6 +175,11 @@ describe('TradeExecutionTask', () => {
       recordDailyLossGateBlock: jest.fn()
     };
 
+    mockExchangeSelectionService = {
+      selectForBuy: jest.fn().mockResolvedValue({ id: 'key-1', exchange: { slug: 'binance_us' } }),
+      selectForSell: jest.fn().mockResolvedValue({ id: 'key-1', exchange: { slug: 'binance_us' } })
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TradeExecutionTask,
@@ -194,7 +197,8 @@ describe('TradeExecutionTask', () => {
         { provide: TradeCooldownService, useValue: mockTradeCooldownService },
         { provide: SignalThrottleService, useValue: mockSignalThrottle },
         { provide: DailyLossLimitGateService, useValue: mockDailyLossLimitGate },
-        { provide: MetricsService, useValue: mockMetricsService }
+        { provide: MetricsService, useValue: mockMetricsService },
+        { provide: ExchangeSelectionService, useValue: mockExchangeSelectionService }
       ]
     }).compile();
 
@@ -391,8 +395,9 @@ describe('TradeExecutionTask', () => {
       ['kraken', 'BTC/USD'],
       ['unknown_exchange', 'BTC/USDT']
     ])('should resolve quote currency for %s → %s', async (slug, expectedSymbol) => {
-      const activation = buildActivation({ exchangeKey: { exchange: { slug } } });
+      const activation = buildActivation();
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockExchangeSelectionService.selectForBuy.mockResolvedValue({ id: 'key-1', exchange: { slug } });
       configureActionableSignal();
 
       await task.process(mockJob);
@@ -400,9 +405,10 @@ describe('TradeExecutionTask', () => {
       expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe(expectedSymbol);
     });
 
-    it('should skip when exchange relation is missing (null-safety)', async () => {
-      const activation = buildActivation({ exchangeKey: null });
+    it('should skip when exchange selection fails', async () => {
+      const activation = buildActivation();
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockExchangeSelectionService.selectForBuy.mockRejectedValue(new Error('No active exchange keys'));
       configureActionableSignal();
 
       const result: any = await task.process(mockJob);

--- a/apps/api/src/order/tasks/trade-execution.task.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.ts
@@ -17,6 +17,7 @@ import { AlgorithmContextBuilder } from '../../algorithm/services/algorithm-cont
 import { BalanceService } from '../../balance/balance.service';
 import { CoinService } from '../../coin/coin.service';
 import { DEFAULT_QUOTE_CURRENCY, EXCHANGE_QUOTE_CURRENCY } from '../../exchange/constants';
+import { ExchangeSelectionService } from '../../exchange/exchange-selection/exchange-selection.service';
 import { MetricsService } from '../../metrics/metrics.service';
 import { toErrorInfo } from '../../shared/error.util';
 import { TradeCooldownService } from '../../shared/trade-cooldown.service';
@@ -67,7 +68,8 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     private readonly tradeCooldownService: TradeCooldownService,
     private readonly signalThrottle: SignalThrottleService,
     private readonly dailyLossLimitGate: DailyLossLimitGateService,
-    private readonly metricsService: MetricsService
+    private readonly metricsService: MetricsService,
+    private readonly exchangeSelectionService: ExchangeSelectionService
   ) {
     super();
   }
@@ -212,7 +214,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
         }
       }
 
-      // Phase 2: Group by exchangeKeyId to avoid CCXT client concurrency issues,
+      // Phase 2: Group by userId to serialize each user's trades,
       // then process groups in parallel (up to CONCURRENCY_LIMIT) with sequential
       // processing within each group.
       let successCount = 0;
@@ -221,7 +223,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       let blockedCount = 0;
       let processedActivations = 0;
 
-      const groups = this.groupByExchangeKey(activeActivations);
+      const groups = this.groupByUser(activeActivations);
       const chunks = this.chunkArray(groups, TradeExecutionTask.CONCURRENCY_LIMIT);
 
       for (const chunk of chunks) {
@@ -419,8 +421,8 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       current.strength * current.confidence > best.strength * best.confidence ? current : best
     );
 
-    // Resolve trading symbol (e.g. "BTC/USDT")
-    const symbol = await this.resolveTradingSymbol(bestSignal.coinId, activation);
+    // Resolve trading symbol (e.g. "BTC/USDT") — use default quote currency first
+    const symbol = await this.resolveTradingSymbol(bestSignal.coinId);
     if (!symbol) {
       this.logger.warn(`Could not resolve trading symbol for coin ${bestSignal.coinId}, skipping`);
       return null;
@@ -434,12 +436,31 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     }
     const { action, positionSide } = mapped;
 
+    // Dynamically select exchange key based on signal action
+    let exchangeKey;
+    try {
+      exchangeKey =
+        action === 'BUY'
+          ? await this.exchangeSelectionService.selectForBuy(activation.userId, symbol)
+          : await this.exchangeSelectionService.selectForSell(activation.userId, symbol);
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Exchange selection failed for activation ${activation.id}: ${err.message}`);
+      return null;
+    }
+
+    // Re-resolve symbol with correct exchange-specific quote currency if needed
+    const exchangeSlug = exchangeKey.exchange?.slug;
+    const finalSymbol = exchangeSlug
+      ? ((await this.resolveTradingSymbol(bestSignal.coinId, exchangeSlug)) ?? symbol)
+      : symbol;
+
     return {
       algorithmActivationId: activation.id,
       userId: activation.userId,
-      exchangeKeyId: activation.exchangeKeyId,
+      exchangeKeyId: exchangeKey.id,
       action,
-      symbol,
+      symbol: finalSymbol,
       quantity: 0,
       autoSize: true,
       portfolioValue,
@@ -502,18 +523,15 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
   }
 
   /**
-   * Resolve a coin ID + exchange into a trading symbol (e.g. "BTC/USDT")
+   * Resolve a coin ID into a trading symbol (e.g. "BTC/USDT")
+   * @param exchangeSlug - Exchange slug for quote currency lookup (optional)
    */
-  private async resolveTradingSymbol(coinId: string, activation: AlgorithmActivation): Promise<string | null> {
+  private async resolveTradingSymbol(coinId: string, exchangeSlug?: string): Promise<string | null> {
     try {
-      const exchangeSlug = activation.exchangeKey?.exchange?.slug;
-      if (!exchangeSlug) {
-        this.logger.warn(`Activation ${activation.id} missing exchange relation, cannot resolve symbol`);
-        return null;
-      }
-
       const coin = await this.coinService.getCoinById(coinId);
-      const quoteCurrency = EXCHANGE_QUOTE_CURRENCY[exchangeSlug] || DEFAULT_QUOTE_CURRENCY;
+      const quoteCurrency = exchangeSlug
+        ? EXCHANGE_QUOTE_CURRENCY[exchangeSlug] || DEFAULT_QUOTE_CURRENCY
+        : DEFAULT_QUOTE_CURRENCY;
       return `${coin.symbol.toUpperCase()}/${quoteCurrency}`;
     } catch (error) {
       const err = toErrorInfo(error);
@@ -570,10 +588,16 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     return chunks;
   }
 
-  private groupByExchangeKey(activations: AlgorithmActivation[]): AlgorithmActivation[][] {
+  /**
+   * Groups activations by userId (not exchangeKeyId) because exchange keys are
+   * selected dynamically per-activation at trade time. Per-user serialization
+   * prevents concurrent portfolio/balance reads for the same user, while different
+   * users' trades are parallelized via CONCURRENCY_LIMIT chunking.
+   */
+  private groupByUser(activations: AlgorithmActivation[]): AlgorithmActivation[][] {
     const groups = new Map<string, AlgorithmActivation[]>();
     for (const activation of activations) {
-      const key = activation.exchangeKeyId;
+      const key = activation.userId;
       const group = groups.get(key) ?? [];
       group.push(activation);
       groups.set(key, group);

--- a/apps/api/src/pipeline/dto/index.ts
+++ b/apps/api/src/pipeline/dto/index.ts
@@ -9,7 +9,6 @@ export interface CreatePipelineInput {
   name: string;
   description?: string;
   strategyConfigId: string;
-  exchangeKeyId: string;
   stageConfig: PipelineStageConfig;
   progressionRules?: PipelineProgressionRules;
   /** Optional initial stage to start at (defaults to OPTIMIZE) */

--- a/apps/api/src/pipeline/entities/pipeline.entity.ts
+++ b/apps/api/src/pipeline/entities/pipeline.entity.ts
@@ -13,7 +13,6 @@ import {
   UpdateDateColumn
 } from 'typeorm';
 
-import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { OptimizationRun } from '../../optimization/entities/optimization-run.entity';
 import { Backtest } from '../../order/backtest/backtest.entity';
 import { PaperTradingSession } from '../../order/paper-trading/entities/paper-trading-session.entity';
@@ -72,16 +71,6 @@ export class Pipeline {
   @JoinColumn({ name: 'strategyConfigId' })
   @ApiProperty({ description: 'Strategy configuration entity' })
   strategyConfig: StrategyConfig;
-
-  @IsUUID()
-  @Column({ type: 'uuid' })
-  @ApiProperty({ description: 'Exchange key for live replay and paper trading' })
-  exchangeKeyId: string;
-
-  @ManyToOne(() => ExchangeKey, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'exchangeKeyId' })
-  @ApiProperty({ description: 'Exchange key entity' })
-  exchangeKey: Relation<ExchangeKey>;
 
   @IsUUID()
   @IsOptional()

--- a/apps/api/src/pipeline/pipeline.module.ts
+++ b/apps/api/src/pipeline/pipeline.module.ts
@@ -14,7 +14,7 @@ import { PipelineReportService } from './services/pipeline-report.service';
 
 import { AlgorithmModule } from '../algorithm/algorithm.module';
 import { AuthenticationModule } from '../authentication/authentication.module';
-import { ExchangeKey } from '../exchange/exchange-key/exchange-key.entity';
+import { ExchangeSelectionModule } from '../exchange/exchange-selection/exchange-selection.module';
 import { MarketRegimeModule } from '../market-regime/market-regime.module';
 import { OptimizationModule } from '../optimization/optimization.module';
 import { OrderModule } from '../order/order.module';
@@ -27,7 +27,7 @@ const PIPELINE_CONFIG = pipelineConfig();
 @Module({
   imports: [
     ConfigModule.forFeature(pipelineConfig),
-    TypeOrmModule.forFeature([Pipeline, StrategyConfig, ExchangeKey]),
+    TypeOrmModule.forFeature([Pipeline, StrategyConfig]),
     BullModule.registerQueue({ name: PIPELINE_CONFIG.queue }),
     EventEmitterModule.forRoot(),
     forwardRef(() => AlgorithmModule),
@@ -36,7 +36,8 @@ const PIPELINE_CONFIG = pipelineConfig();
     forwardRef(() => OrderModule),
     forwardRef(() => PaperTradingModule),
     forwardRef(() => ScoringModule),
-    forwardRef(() => MarketRegimeModule)
+    forwardRef(() => MarketRegimeModule),
+    ExchangeSelectionModule
   ],
   controllers: [PipelineController],
   providers: [PipelineOrchestratorService, PipelineProcessor, PipelineEventListener, PipelineReportService],

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
@@ -1,5 +1,5 @@
 import { getQueueToken } from '@nestjs/bullmq';
-import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -13,7 +13,7 @@ import { StrategyGrade } from '@chansey/api-interfaces';
 import { PipelineOrchestratorService } from './pipeline-orchestrator.service';
 
 import { AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
-import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
+import { ExchangeSelectionService } from '../../exchange/exchange-selection/exchange-selection.service';
 import { MarketRegimeService } from '../../market-regime/market-regime.service';
 import { OptimizationOrchestratorService } from '../../optimization/services/optimization-orchestrator.service';
 import { BacktestService } from '../../order/backtest/backtest.service';
@@ -30,7 +30,6 @@ describe('PipelineOrchestratorService', () => {
   let service: PipelineOrchestratorService;
   let pipelineRepository: jest.Mocked<Repository<Pipeline>>;
   let strategyConfigRepository: jest.Mocked<Repository<StrategyConfig>>;
-  let exchangeKeyRepository: jest.Mocked<Repository<ExchangeKey>>;
   let pipelineQueue: jest.Mocked<Queue>;
   let eventEmitter: jest.Mocked<EventEmitter2>;
   let scoringService: jest.Mocked<ScoringService>;
@@ -49,19 +48,12 @@ describe('PipelineOrchestratorService', () => {
     parameters: { param1: 10 }
   } as unknown as StrategyConfig;
 
-  const mockExchangeKey: ExchangeKey = {
-    id: 'exchange-key-123',
-    user: mockUser,
-    exchange: { name: 'Binance' }
-  } as unknown as ExchangeKey;
-
   const mockPipeline: Pipeline = {
     id: 'pipeline-123',
     name: 'Test Pipeline',
     status: PipelineStatus.PENDING,
     currentStage: PipelineStage.OPTIMIZE,
     strategyConfigId: 'strategy-123',
-    exchangeKeyId: 'exchange-key-123',
     stageConfig: {
       optimization: {
         trainDays: 90,
@@ -87,7 +79,6 @@ describe('PipelineOrchestratorService', () => {
     progressionRules: DEFAULT_PROGRESSION_RULES,
     user: mockUser,
     strategyConfig: mockStrategyConfig,
-    exchangeKey: mockExchangeKey,
     createdAt: new Date(),
     updatedAt: new Date()
   } as Pipeline;
@@ -95,7 +86,6 @@ describe('PipelineOrchestratorService', () => {
   const mockCreateDto: CreatePipelineInput = {
     name: 'Test Pipeline',
     strategyConfigId: 'strategy-123',
-    exchangeKeyId: 'exchange-key-123',
     stageConfig: mockPipeline.stageConfig
   };
 
@@ -133,12 +123,6 @@ describe('PipelineOrchestratorService', () => {
         },
         {
           provide: getRepositoryToken(StrategyConfig),
-          useValue: {
-            findOne: jest.fn()
-          }
-        },
-        {
-          provide: getRepositoryToken(ExchangeKey),
           useValue: {
             findOne: jest.fn()
           }
@@ -215,6 +199,13 @@ describe('PipelineOrchestratorService', () => {
           useValue: {
             transaction: jest.fn((cb) => cb({ save: jest.fn() }))
           }
+        },
+        {
+          provide: ExchangeSelectionService,
+          useValue: {
+            selectForBuy: jest.fn().mockResolvedValue({ id: 'exchange-key-123', exchange: { slug: 'binance_us' } }),
+            selectForSell: jest.fn().mockResolvedValue({ id: 'exchange-key-123', exchange: { slug: 'binance_us' } })
+          }
         }
       ]
     }).compile();
@@ -222,7 +213,6 @@ describe('PipelineOrchestratorService', () => {
     service = module.get<PipelineOrchestratorService>(PipelineOrchestratorService);
     pipelineRepository = module.get(getRepositoryToken(Pipeline));
     strategyConfigRepository = module.get(getRepositoryToken(StrategyConfig));
-    exchangeKeyRepository = module.get(getRepositoryToken(ExchangeKey));
     pipelineQueue = module.get(getQueueToken('pipeline'));
     eventEmitter = module.get(EventEmitter2);
     scoringService = module.get(ScoringService);
@@ -233,7 +223,6 @@ describe('PipelineOrchestratorService', () => {
   describe('createPipeline', () => {
     it('should create a pipeline successfully', async () => {
       strategyConfigRepository.findOne.mockResolvedValue(mockStrategyConfig);
-      exchangeKeyRepository.findOne.mockResolvedValue(mockExchangeKey);
       pipelineRepository.create.mockReturnValue(mockPipeline);
       pipelineRepository.save.mockResolvedValue(mockPipeline);
       pipelineRepository.findOne.mockResolvedValue(mockPipeline);
@@ -243,10 +232,6 @@ describe('PipelineOrchestratorService', () => {
       expect(result).toEqual(mockPipeline);
       expect(strategyConfigRepository.findOne).toHaveBeenCalledWith({
         where: { id: mockCreateDto.strategyConfigId }
-      });
-      expect(exchangeKeyRepository.findOne).toHaveBeenCalledWith({
-        where: { id: mockCreateDto.exchangeKeyId },
-        relations: ['user', 'exchange']
       });
       expect(pipelineRepository.create).toHaveBeenCalled();
       expect(pipelineRepository.save).toHaveBeenCalled();
@@ -258,26 +243,8 @@ describe('PipelineOrchestratorService', () => {
       await expect(service.createPipeline(mockCreateDto, mockUser)).rejects.toThrow(NotFoundException);
     });
 
-    it('should throw NotFoundException if exchange key not found', async () => {
-      strategyConfigRepository.findOne.mockResolvedValue(mockStrategyConfig);
-      exchangeKeyRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.createPipeline(mockCreateDto, mockUser)).rejects.toThrow(NotFoundException);
-    });
-
-    it('should throw ForbiddenException if exchange key belongs to another user', async () => {
-      strategyConfigRepository.findOne.mockResolvedValue(mockStrategyConfig);
-      exchangeKeyRepository.findOne.mockResolvedValue({
-        ...mockExchangeKey,
-        user: { id: 'other-user' }
-      } as unknown as ExchangeKey);
-
-      await expect(service.createPipeline(mockCreateDto, mockUser)).rejects.toThrow(ForbiddenException);
-    });
-
     it('should use initialStage when provided', async () => {
       strategyConfigRepository.findOne.mockResolvedValue(mockStrategyConfig);
-      exchangeKeyRepository.findOne.mockResolvedValue(mockExchangeKey);
       pipelineRepository.create.mockReturnValue(mockPipeline);
       pipelineRepository.save.mockResolvedValue(mockPipeline);
       pipelineRepository.findOne.mockResolvedValue(mockPipeline);
@@ -291,7 +258,6 @@ describe('PipelineOrchestratorService', () => {
 
     it('should default to OPTIMIZE when initialStage not provided', async () => {
       strategyConfigRepository.findOne.mockResolvedValue(mockStrategyConfig);
-      exchangeKeyRepository.findOne.mockResolvedValue(mockExchangeKey);
       pipelineRepository.create.mockReturnValue(mockPipeline);
       pipelineRepository.save.mockResolvedValue(mockPipeline);
       pipelineRepository.findOne.mockResolvedValue(mockPipeline);

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -1,13 +1,5 @@
 import { InjectQueue } from '@nestjs/bullmq';
-import {
-  BadRequestException,
-  ForbiddenException,
-  Inject,
-  Injectable,
-  Logger,
-  NotFoundException,
-  forwardRef
-} from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException, forwardRef } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -18,7 +10,7 @@ import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { MarketRegimeType } from '@chansey/api-interfaces';
 
 import { AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
-import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
+import { ExchangeSelectionService } from '../../exchange/exchange-selection/exchange-selection.service';
 import { MarketRegimeService } from '../../market-regime/market-regime.service';
 import { OptimizationOrchestratorService } from '../../optimization/services/optimization-orchestrator.service';
 import { buildParameterSpace } from '../../optimization/utils/parameter-space-builder';
@@ -62,8 +54,6 @@ export class PipelineOrchestratorService {
     private readonly pipelineRepository: Repository<Pipeline>,
     @InjectRepository(StrategyConfig)
     private readonly strategyConfigRepository: Repository<StrategyConfig>,
-    @InjectRepository(ExchangeKey)
-    private readonly exchangeKeyRepository: Repository<ExchangeKey>,
     @InjectQueue('pipeline')
     private readonly pipelineQueue: Queue,
     @Inject(pipelineConfig.KEY)
@@ -81,7 +71,8 @@ export class PipelineOrchestratorService {
     @Inject(forwardRef(() => AlgorithmRegistry))
     private readonly algorithmRegistry: AlgorithmRegistry,
     private readonly eventEmitter: EventEmitter2,
-    private readonly dataSource: DataSource
+    private readonly dataSource: DataSource,
+    private readonly exchangeSelectionService: ExchangeSelectionService
   ) {}
 
   /**
@@ -96,18 +87,6 @@ export class PipelineOrchestratorService {
       throw new NotFoundException(`Strategy config ${dto.strategyConfigId} not found`);
     }
 
-    // Validate exchange key exists and belongs to user
-    const exchangeKey = await this.exchangeKeyRepository.findOne({
-      where: { id: dto.exchangeKeyId },
-      relations: ['user', 'exchange']
-    });
-    if (!exchangeKey) {
-      throw new NotFoundException(`Exchange key ${dto.exchangeKeyId} not found`);
-    }
-    if (exchangeKey.user.id !== user.id) {
-      throw new ForbiddenException('Exchange key does not belong to user');
-    }
-
     // Use provided progression rules or defaults
     const progressionRules: PipelineProgressionRules = dto.progressionRules ?? {
       ...DEFAULT_PROGRESSION_RULES
@@ -119,7 +98,6 @@ export class PipelineOrchestratorService {
       status: PipelineStatus.PENDING,
       currentStage: dto.initialStage ?? PipelineStage.OPTIMIZE,
       strategyConfigId: dto.strategyConfigId,
-      exchangeKeyId: dto.exchangeKeyId,
       stageConfig: dto.stageConfig,
       progressionRules,
       user
@@ -138,7 +116,7 @@ export class PipelineOrchestratorService {
   async findOne(id: string, user: User): Promise<Pipeline> {
     const pipeline = await this.pipelineRepository.findOne({
       where: { id, user: { id: user.id } },
-      relations: ['strategyConfig', 'exchangeKey', 'exchangeKey.exchange', 'user']
+      relations: ['strategyConfig', 'user']
     });
 
     if (!pipeline) {
@@ -208,7 +186,7 @@ export class PipelineOrchestratorService {
   async findOneAdmin(id: string): Promise<Pipeline> {
     const pipeline = await this.pipelineRepository.findOne({
       where: { id },
-      relations: ['strategyConfig', 'exchangeKey', 'exchangeKey.exchange', 'user']
+      relations: ['strategyConfig', 'user']
     });
 
     if (!pipeline) {
@@ -401,7 +379,7 @@ export class PipelineOrchestratorService {
   async executeStage(pipelineId: string, stage: PipelineStage): Promise<void> {
     const pipeline = await this.pipelineRepository.findOne({
       where: { id: pipelineId },
-      relations: ['strategyConfig', 'strategyConfig.algorithm', 'exchangeKey', 'user', 'user.risk']
+      relations: ['strategyConfig', 'strategyConfig.algorithm', 'user', 'user.risk']
     });
 
     if (!pipeline) {
@@ -1187,11 +1165,14 @@ export class PipelineOrchestratorService {
       throw new Error(`Pipeline ${pipeline.id} missing user relation for paper trading stage`);
     }
 
+    // Dynamically select exchange key for paper trading (symbol not known yet — determined at runtime by algorithm signals)
+    const exchangeKey = await this.exchangeSelectionService.selectDefault(pipeline.user.id);
+
     // Start paper trading session through the pipeline integration method
     const session = await this.paperTradingService.startFromPipeline({
       pipelineId: pipeline.id,
       algorithmId: pipeline.strategyConfig.algorithmId,
-      exchangeKeyId: pipeline.exchangeKeyId,
+      exchangeKeyId: exchangeKey.id,
       initialCapital: config.initialCapital,
       optimizedParameters: pipeline.optimizedParameters as Record<string, number>,
       duration: config.duration,

--- a/apps/api/src/strategy/entities/user-strategy-position.entity.ts
+++ b/apps/api/src/strategy/entities/user-strategy-position.entity.ts
@@ -12,6 +12,7 @@ import {
 
 import { StrategyConfig } from './strategy-config.entity';
 
+import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { User } from '../../users/users.entity';
 
 /**
@@ -134,6 +135,17 @@ export class UserStrategyPosition {
     comment: 'Maintenance margin required to keep position open'
   })
   maintenanceMargin?: number | null;
+
+  @Column({
+    type: 'uuid',
+    nullable: true,
+    comment: 'Exchange key used to open this position (for SELL routing)'
+  })
+  exchangeKeyId?: string;
+
+  @ManyToOne(() => ExchangeKey, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'exchangeKeyId' })
+  exchangeKey?: ExchangeKey;
 
   @CreateDateColumn({
     type: 'timestamptz',

--- a/apps/api/src/strategy/live-trading.service.spec.ts
+++ b/apps/api/src/strategy/live-trading.service.spec.ts
@@ -14,6 +14,7 @@ import { StrategyExecutorService, TradingSignal } from './strategy-executor.serv
 import { TradingStateService } from '../admin/trading-state/trading-state.service';
 import { BalanceService } from '../balance/balance.service';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
+import { ExchangeSelectionService } from '../exchange/exchange-selection/exchange-selection.service';
 import { CompositeRegimeService } from '../market-regime/composite-regime.service';
 import { RegimeGateService } from '../market-regime/regime-gate.service';
 import { MetricsService } from '../metrics/metrics.service';
@@ -146,6 +147,13 @@ describe('LiveTradingService', () => {
         { provide: TradeExecutionService, useValue: tradeExecutionService },
         { provide: TradeCooldownService, useValue: tradeCooldownService },
         {
+          provide: ExchangeSelectionService,
+          useValue: {
+            selectForBuy: jest.fn().mockResolvedValue({ id: 'ek-1', exchange: { slug: 'binance_us' } }),
+            selectForSell: jest.fn().mockResolvedValue({ id: 'ek-1', exchange: { slug: 'binance_us' } })
+          }
+        },
+        {
           provide: MetricsService,
           useValue: {
             recordTradeCooldownBlock: jest.fn(),
@@ -212,7 +220,7 @@ describe('LiveTradingService', () => {
 
     await service.executeLiveTrading();
 
-    expect(orderService.placeAlgorithmicOrder).toHaveBeenCalledWith(user.id, 'strategy-1', signal, 'ex-2');
+    expect(orderService.placeAlgorithmicOrder).toHaveBeenCalledWith(user.id, 'strategy-1', signal, 'ek-1');
     expect(positionTracking.updatePosition).toHaveBeenCalledWith(
       user.id,
       'strategy-1',
@@ -220,7 +228,8 @@ describe('LiveTradingService', () => {
       0.01,
       30000,
       'buy',
-      'long'
+      'long',
+      'ek-1'
     );
     expect(lockService.release).toHaveBeenCalledWith(LOCK_KEYS.LIVE_TRADING, 'lock-1');
   });
@@ -278,7 +287,8 @@ describe('LiveTradingService', () => {
       0.01,
       30000,
       'sell',
-      'long'
+      'long',
+      undefined
     );
   });
 
@@ -311,7 +321,8 @@ describe('LiveTradingService', () => {
       0.01,
       30000,
       'buy',
-      'short'
+      'short',
+      undefined
     );
   });
 
@@ -344,7 +355,8 @@ describe('LiveTradingService', () => {
       0.01,
       30000,
       'sell',
-      'short'
+      'short',
+      'ek-1'
     );
   });
 

--- a/apps/api/src/strategy/live-trading.service.ts
+++ b/apps/api/src/strategy/live-trading.service.ts
@@ -18,8 +18,8 @@ import { TradingStateService } from '../admin/trading-state/trading-state.servic
 import { BalanceService } from '../balance/balance.service';
 import { ExchangeBalanceDto } from '../balance/dto';
 import { DEFAULT_QUOTE_CURRENCY, EXCHANGE_QUOTE_CURRENCY } from '../exchange/constants';
-import { SupportedExchangeKeyDto } from '../exchange/exchange-key/dto';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
+import { ExchangeSelectionService } from '../exchange/exchange-selection/exchange-selection.service';
 import { CompositeRegimeService } from '../market-regime/composite-regime.service';
 import { RegimeGateService } from '../market-regime/regime-gate.service';
 import { MetricsService } from '../metrics/metrics.service';
@@ -63,7 +63,8 @@ export class LiveTradingService implements OnApplicationShutdown {
     private readonly dailyLossLimitGate: DailyLossLimitGateService,
     private readonly tradeExecutionService: TradeExecutionService,
     private readonly tradeCooldownService: TradeCooldownService,
-    private readonly metricsService: MetricsService
+    private readonly metricsService: MetricsService,
+    private readonly exchangeSelectionService: ExchangeSelectionService
   ) {}
 
   @Cron('*/2 * * * *')
@@ -259,8 +260,14 @@ export class LiveTradingService implements OnApplicationShutdown {
     strategy: StrategyConfig
   ): Promise<void> {
     try {
-      const exchangeKey = this.selectBestExchange(user.exchanges, signal.symbol);
-      if (!exchangeKey) {
+      // Dynamically select exchange key based on signal action
+      const isBuyAction = signal.action === 'buy' || signal.action === 'short_exit';
+      let exchangeKey;
+      try {
+        exchangeKey = isBuyAction
+          ? await this.exchangeSelectionService.selectForBuy(user.id, signal.symbol)
+          : await this.exchangeSelectionService.selectForSell(user.id, signal.symbol, strategyConfigId);
+      } catch {
         this.logger.error(`No suitable exchange key found for user ${user.id} and symbol ${signal.symbol}`);
         return;
       }
@@ -346,7 +353,8 @@ export class LiveTradingService implements OnApplicationShutdown {
           signal.quantity,
           signal.price,
           trackingSide,
-          trackingPositionSide
+          trackingPositionSide,
+          isBuyAction ? exchangeKey.id : undefined
         );
       } catch (error: unknown) {
         // Clear cooldown on failure so next cycle can retry
@@ -425,37 +433,6 @@ export class LiveTradingService implements OnApplicationShutdown {
         this.logger.error(`Unknown signal action "${action}" for position tracking`);
         throw new Error(`Unknown signal action for position tracking: ${action}`);
     }
-  }
-
-  /**
-   * Select the best exchange for a given trading symbol.
-   * Prioritizes active exchanges that support the symbol.
-   */
-  private selectBestExchange(exchanges: SupportedExchangeKeyDto[], symbol: string): SupportedExchangeKeyDto | null {
-    if (!exchanges || exchanges.length === 0) {
-      return null;
-    }
-
-    // Filter to only active exchanges
-    const activeExchanges = exchanges.filter((ex) => ex.isActive);
-
-    if (activeExchanges.length === 0) {
-      this.logger.warn('No active exchanges found');
-      return null;
-    }
-
-    // For BTC pairs, prefer Binance US for better liquidity
-    // For other pairs, use the first active exchange
-    const baseCurrency = symbol.split('/')[0];
-    if (baseCurrency === 'BTC' || baseCurrency === 'ETH') {
-      const binance = activeExchanges.find((ex) => ex.slug === 'binance_us');
-      if (binance) {
-        return binance;
-      }
-    }
-
-    // Default to first active exchange
-    return activeExchanges[0];
   }
 
   /**

--- a/apps/api/src/strategy/position-tracking.service.ts
+++ b/apps/api/src/strategy/position-tracking.service.ts
@@ -50,7 +50,8 @@ export class PositionTrackingService {
     quantity: number,
     price: number,
     side: 'buy' | 'sell',
-    positionSide: 'long' | 'short' = 'long'
+    positionSide: 'long' | 'short' = 'long',
+    exchangeKeyId?: string
   ): Promise<UserStrategyPosition> {
     let position = await this.getPosition(userId, strategyConfigId, symbol, positionSide);
 
@@ -75,6 +76,10 @@ export class PositionTrackingService {
       const newQuantity = currentQuantity + quantity;
       position.quantity = newQuantity;
       position.avgEntryPrice = newQuantity > 0 ? totalCost / newQuantity : 0;
+      // Track which exchange was used to open the position (for SELL routing)
+      if (exchangeKeyId) {
+        position.exchangeKeyId = exchangeKeyId;
+      }
     } else if (side === 'sell') {
       const soldValue = quantity * price;
       const costBasis = quantity * currentAvgPrice;

--- a/apps/api/src/strategy/strategy.module.ts
+++ b/apps/api/src/strategy/strategy.module.ts
@@ -43,6 +43,7 @@ import { AdminModule } from '../admin/admin.module';
 import { AlgorithmModule } from '../algorithm/algorithm.module';
 import { AuditModule } from '../audit/audit.module';
 import { BalanceModule } from '../balance/balance.module';
+import { ExchangeSelectionModule } from '../exchange/exchange-selection/exchange-selection.module';
 import { ExchangeModule } from '../exchange/exchange.module';
 import { MarketRegimeModule } from '../market-regime/market-regime.module';
 import { MetricsModule } from '../metrics/metrics.module';
@@ -72,6 +73,7 @@ import { User } from '../users/users.entity';
     AuditModule,
     forwardRef(() => BalanceModule),
     forwardRef(() => ExchangeModule),
+    ExchangeSelectionModule,
     forwardRef(() => MarketRegimeModule),
     MetricsModule,
     forwardRef(() => OrderModule),

--- a/apps/api/src/tasks/pipeline-orchestration.service.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.ts
@@ -196,7 +196,7 @@ export class PipelineOrchestrationService {
       // Process each strategy config
       for (const strategyConfig of strategyConfigs) {
         try {
-          await this.processStrategyConfig(user, strategyConfig, exchangeKey, riskLevel, result);
+          await this.processStrategyConfig(user, strategyConfig, riskLevel, result);
         } catch (error: unknown) {
           const err = toErrorInfo(error);
           const errorMsg = `Failed to process strategy config ${strategyConfig.id}: ${err.message}`;
@@ -309,7 +309,6 @@ export class PipelineOrchestrationService {
   private async processStrategyConfig(
     user: User,
     strategyConfig: StrategyConfig,
-    exchangeKey: ExchangeKey,
     riskLevel: number,
     result: PipelineOrchestrationResult
   ): Promise<void> {
@@ -341,7 +340,6 @@ export class PipelineOrchestrationService {
         name: `Auto: ${strategyName} - ${dateStr}`,
         description: `Orchestrated pipeline for ${strategyName}`,
         strategyConfigId,
-        exchangeKeyId: exchangeKey.id,
         stageConfig,
         initialStage
       },

--- a/apps/api/src/users/dto/enroll-algo-trading.dto.ts
+++ b/apps/api/src/users/dto/enroll-algo-trading.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { IsNumber, IsPositive, IsUUID, Max, Min } from 'class-validator';
+import { IsNumber, IsPositive, Max, Min } from 'class-validator';
 
 /**
  * DTO for enabling algo trading (robo-advisor).
@@ -18,13 +18,6 @@ export class EnrollInAlgoTradingDto {
   @Min(5, { message: 'Minimum capital allocation is 5% of your free balance' })
   @Max(100, { message: 'Maximum capital allocation is 100% of your free balance' })
   capitalAllocationPercentage: number;
-
-  @ApiProperty({
-    description: 'Exchange key ID to use for algo trading',
-    example: 'e5f6g7h8-i9j0-k1l2-m3n4-o5p6q7r8s9t0'
-  })
-  @IsUUID()
-  exchangeKeyId: string;
 }
 
 /**
@@ -81,11 +74,4 @@ export class AlgoTradingStatusDto {
     example: 25
   })
   activeStrategies: number;
-
-  @ApiProperty({
-    description: 'Exchange key ID being used',
-    example: 'e5f6g7h8-i9j0-k1l2-m3n4-o5p6q7r8s9t0',
-    nullable: true
-  })
-  exchangeKeyId: string | null;
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -143,7 +143,7 @@ export class UserController {
     type: UserResponseDto
   })
   async enrollInAlgoTrading(@Body() dto: EnrollInAlgoTradingDto, @GetUser() user: User) {
-    return this.user.enrollInAlgoTrading(user.id, dto.capitalAllocationPercentage, dto.exchangeKeyId);
+    return this.user.enrollInAlgoTrading(user.id, dto.capitalAllocationPercentage);
   }
 
   @Patch('algo-trading/pause')

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -210,14 +210,9 @@ export class UsersService {
     }
   }
 
-  async enrollInAlgoTrading(userId: string, capitalAllocationPercentage: number, exchangeKeyId: string): Promise<User> {
+  async enrollInAlgoTrading(userId: string, capitalAllocationPercentage: number): Promise<User> {
     try {
       const user = await this.user.findOneOrFail({ where: { id: userId }, relations: ['risk'] });
-
-      const exchangeKey = await this.exchangeKeyService.findOne(exchangeKeyId, userId);
-      if (!exchangeKey) {
-        throw new NotFoundException('Exchange key not found');
-      }
 
       user.algoTradingEnabled = true;
       user.algoCapitalAllocationPercentage = capitalAllocationPercentage;
@@ -302,15 +297,12 @@ export class UsersService {
         activeStrategies = strategies.length;
       }
 
-      const exchanges = await this.exchangeKeyService.getSupportedExchangeKeys(user.id);
-
       return {
         enabled: user.algoTradingEnabled,
         capitalAllocationPercentage: user.algoCapitalAllocationPercentage,
         enrolledAt: user.algoEnrolledAt,
         riskLevel: user.risk?.name || 'Not set',
-        activeStrategies,
-        exchangeKeyId: exchanges?.[0]?.id || null
+        activeStrategies
       };
     } catch (error: unknown) {
       const err = toErrorInfo(error);

--- a/libs/api-interfaces/src/lib/algorithm/algorithm.interface.ts
+++ b/libs/api-interfaces/src/lib/algorithm/algorithm.interface.ts
@@ -105,7 +105,6 @@ export interface AlgorithmActivation {
   id: string;
   userId: string;
   algorithmId: string;
-  exchangeKeyId: string;
   isActive: boolean;
   allocationPercentage: number;
   config?: Record<string, unknown>;

--- a/libs/api-interfaces/src/lib/pipeline/pipeline.interface.ts
+++ b/libs/api-interfaces/src/lib/pipeline/pipeline.interface.ts
@@ -237,8 +237,6 @@ export interface PipelineSummary {
 }
 
 export interface PipelineDetail extends PipelineSummary {
-  exchangeKeyId: string;
-  exchangeName: string;
   optimizationRunId?: string;
   historicalBacktestId?: string;
   liveReplayBacktestId?: string;


### PR DESCRIPTION
## Summary

- Replace static `exchangeKeyId` binding on `AlgorithmActivation` and `Pipeline` entities with runtime exchange selection via `ExchangeSelectionService`
- BUY orders auto-select the best exchange based on symbol support and balance; SELL orders route to the exchange where the position was opened
- Fix quote currency mismatch so exchanges with different quote assets (USD vs USDT) are correctly evaluated during selection
- Fix migration rollback crash by making re-added columns nullable in `down()`

## Changes

### New: Exchange Selection Service
- `ExchangeSelectionService` with `selectForBuy()`, `selectForSell()`, and `selectDefault()` methods
- `selectForBuy()` resolves exchange-specific quote currency before price check (e.g., BTC/USD for Coinbase, BTC/USDT for Binance)
- `selectForSell()` checks position record → recent BUY order → fallback to buy selection
- `selectDefault()` for contexts where symbol is not yet known (paper trading)
- Comprehensive unit tests (264 lines)

### Entity & Schema Changes
- Remove `exchangeKeyId` from `AlgorithmActivation` and `Pipeline` entities
- Add `exchangeKeyId` to `UserStrategyPosition` for sell-side routing
- Migration with safe nullable rollback

### Updated Consumers
- `TradeExecutionTask` — uses `ExchangeSelectionService` for dynamic routing
- `LiveTradingService` — simplified, no longer needs exchange key param
- `PipelineOrchestratorService` — removed exchange key from pipeline creation
- `AlgorithmActivationService` — removed exchange key requirement
- `LiveTradeMonitoringService` — shows actual user exchange names
- Shared interfaces updated (removed `exchangeKeyId` from DTOs)

## Test Plan

- [x] `ExchangeSelectionService` unit tests pass (all scenarios)
- [x] `TradeExecutionTask` tests updated and passing
- [x] `PipelineOrchestratorService` tests updated and passing
- [x] `LiveTradingService` tests updated and passing
- [x] Full API test suite passes (2173 tests)
- [x] Lint passes on affected projects

Closes #255