### PR TITLE
feat(api): add strategy-provided exit configurations to trading signals

### DIFF
--- a/apps/api/src/algorithm/base/base-algorithm-strategy.ts
+++ b/apps/api/src/algorithm/base/base-algorithm-strategy.ts
@@ -4,6 +4,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
 
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { Algorithm, AlgorithmStatus } from '../algorithm.entity';
 import { IndicatorRequirement } from '../indicators/indicator-requirements.interface';
@@ -284,13 +285,15 @@ export abstract class BaseAlgorithmStrategy implements AlgorithmStrategy {
   protected createSuccessResult(
     signals: AlgorithmResult['signals'],
     chartData?: AlgorithmResult['chartData'],
-    metadata?: AlgorithmResult['metadata']
+    metadata?: AlgorithmResult['metadata'],
+    exitConfig?: Partial<ExitConfig>
   ): AlgorithmResult {
     return {
       success: true,
       signals,
       chartData,
       metadata,
+      exitConfig,
       metrics: {
         executionTime: 0, // Will be set by safeExecute
         signalsGenerated: signals.length,

--- a/apps/api/src/algorithm/interfaces/algorithm-result.interface.ts
+++ b/apps/api/src/algorithm/interfaces/algorithm-result.interface.ts
@@ -1,3 +1,5 @@
+import { ExitConfig } from '../../order/interfaces/exit-config.interface';
+
 /**
  * Types of signals an algorithm can generate
  */
@@ -54,6 +56,12 @@ export interface TradingSignal {
    * Additional metadata
    */
   metadata?: Record<string, unknown>;
+
+  /**
+   * Strategy-provided exit configuration for this signal.
+   * When present, overrides result-level and default exit configs.
+   */
+  exitConfig?: Partial<ExitConfig>;
 }
 
 /**
@@ -106,6 +114,12 @@ export interface AlgorithmResult {
    * Additional metadata
    */
   metadata?: Record<string, unknown>;
+
+  /**
+   * Strategy-provided exit configuration applied to all signals in this result.
+   * Per-signal exitConfig takes priority over this.
+   */
+  exitConfig?: Partial<ExitConfig>;
 
   /**
    * Timestamp of the execution

--- a/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
+++ b/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
@@ -2,6 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import {
+  ExitConfig,
+  StopLossType,
+  TakeProfitType,
+  TrailingActivationType,
+  TrailingType
+} from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -88,10 +95,14 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
             )
           ).values;
 
+        // Build strategy-provided exit config from ATR parameters
+        const exitConfig = this.buildExitConfig(config, atr[priceHistory.length - 1]);
+
         // Generate entry signals based on trend-flip detection, then stop signals
         if (config.tradeDirection === 'long' || config.tradeDirection === 'both') {
           const longEntry = this.generateLongEntrySignal(coin.id, coin.symbol, priceHistory, atr, config);
           if (longEntry && longEntry.confidence >= config.minConfidence) {
+            longEntry.exitConfig = exitConfig;
             signals.push(longEntry);
           }
 
@@ -104,6 +115,7 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
         if (config.tradeDirection === 'short' || config.tradeDirection === 'both') {
           const shortEntry = this.generateShortEntrySignal(coin.id, coin.symbol, priceHistory, atr, config);
           if (shortEntry && shortEntry.confidence >= config.minConfidence) {
+            shortEntry.exitConfig = exitConfig;
             signals.push(shortEntry);
           }
 
@@ -118,11 +130,14 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      // Result-level exitConfig from the last config computed (covers all coins uniformly)
+      const resultExitConfig = this.buildExitConfig(this.getConfigWithDefaults(context.config));
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        { algorithm: this.name, version: this.version, signalsGenerated: signals.length },
+        resultExitConfig
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`ATR Trailing Stop strategy execution failed: ${err.message}`, err.stack);
@@ -131,12 +146,35 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
   }
 
   /**
+   * Build strategy-specific exit configuration from ATR parameters.
+   * Uses ATR-based stop loss + trailing stop, and risk-reward take profit.
+   */
+  private buildExitConfig(config: ATRTrailingStopConfig, _currentAtr?: number): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.ATR,
+      stopLossValue: config.atrMultiplier,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.RISK_REWARD,
+      takeProfitValue: 2, // 2:1 risk-reward
+      atrPeriod: config.atrPeriod,
+      atrMultiplier: config.atrMultiplier,
+      enableTrailingStop: true,
+      trailingType: TrailingType.ATR,
+      trailingValue: config.atrMultiplier,
+      trailingActivation: TrailingActivationType.PERCENTAGE,
+      trailingActivationValue: 1, // Activate at 1% profit
+      useOco: true
+    };
+  }
+
+  /**
    * Get configuration with defaults
    */
   private getConfigWithDefaults(config: Record<string, unknown>): ATRTrailingStopConfig {
     return {
-      atrPeriod: (config.atrPeriod as number) ?? 14,
-      atrMultiplier: (config.atrMultiplier as number) ?? 2.5,
+      atrPeriod: Math.max(2, Math.min(50, (config.atrPeriod as number) ?? 14)),
+      atrMultiplier: Math.max(0.5, Math.min(10, (config.atrMultiplier as number) ?? 2.5)),
       tradeDirection: (config.tradeDirection as 'long' | 'short' | 'both') ?? 'long',
       useHighLow: (config.useHighLow as boolean) ?? true,
       minConfidence: (config.minConfidence as number) ?? 0.6

--- a/apps/api/src/algorithm/strategies/confluence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/confluence.strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -831,7 +832,34 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
       price,
       confidence,
       reason,
-      metadata
+      metadata,
+      exitConfig: this.buildExitConfig(confluenceScore)
+    };
+  }
+
+  /**
+   * Build strategy-specific exit configuration scaled by confluence score.
+   * Higher confluence → tighter stops and wider take-profit (more confident trade).
+   */
+  private buildExitConfig(confluenceScore: ConfluenceScore): Partial<ExitConfig> {
+    const ratio =
+      confluenceScore.totalEnabled > 0 ? confluenceScore.confluenceCount / confluenceScore.totalEnabled : 0.5;
+
+    // Stop loss: 2-4% — tighter for higher confluence (more confident)
+    const stopLossValue = Math.max(1, 4 - ratio * 2); // ratio=1 → 2%, ratio=0.4 → 3.2%
+
+    // Take profit: 1.5:1 to 3:1 risk-reward scaled by confluence
+    const takeProfitRR = Math.max(1, 1.5 + ratio * 1.5); // ratio=1 → 3:1, ratio=0.4 → 2.1:1
+
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.RISK_REWARD,
+      takeProfitValue: takeProfitRR,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import {
@@ -182,7 +183,8 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
           movingAverage: currentMA,
           standardDeviation: currentStdDev,
           signalType: 'oversold'
-        }
+        },
+        exitConfig: this.buildExitConfig(absZScore, threshold)
       };
     }
 
@@ -201,12 +203,35 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
           movingAverage: currentMA,
           standardDeviation: currentStdDev,
           signalType: 'overbought'
-        }
+        },
+        exitConfig: this.buildExitConfig(absZScore, threshold)
       };
     }
 
     // No signal if within normal range
     return null;
+  }
+
+  /**
+   * Build strategy-specific exit configuration for mean reversion.
+   * Tight stop loss (mean reversion expects bounded moves) and
+   * take profit scaled by z-score distance from the mean.
+   */
+  private buildExitConfig(absZScore: number, threshold: number): Partial<ExitConfig> {
+    // Take profit: scaled by z-score distance, capped at 8%
+    // At threshold (e.g., 2σ) → ~3%, at 3σ → ~5%, at 4σ → 8%
+    const takeProfitPct = Math.max(1, Math.min(8, 1.5 + ((absZScore - threshold) / threshold) * 3.5));
+
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: 1.5, // Tight 1.5% stop — mean reversion expects bounded moves
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: takeProfitPct,
+      enableTrailingStop: false,
+      useOco: true
+    };
   }
 
   /**

--- a/apps/api/src/coin/tasks/coin-sync.task.ts
+++ b/apps/api/src/coin/tasks/coin-sync.task.ts
@@ -7,6 +7,7 @@ import { CoinGeckoClient } from 'coingecko-api-v3';
 
 import { ExchangeService } from '../../exchange/exchange.service';
 import { toErrorInfo } from '../../shared/error.util';
+import { withRetry } from '../../shared/retry.util';
 import { sanitizeNumericValue } from '../../utils/validators/numeric-sanitizer';
 import { CoinService } from '../coin.service';
 
@@ -16,7 +17,7 @@ export class CoinSyncTask extends WorkerHost implements OnModuleInit {
   private readonly gecko = new CoinGeckoClient({ timeout: 10000, autoRetry: true });
   private readonly logger = new Logger(CoinSyncTask.name);
   private jobScheduled = false;
-  private readonly API_RATE_LIMIT_DELAY = 1000; // 1 second delay between API calls
+  private readonly API_RATE_LIMIT_DELAY = 2500; // 2.5 second delay between API batches
 
   constructor(
     @InjectQueue('coin-queue') private readonly coinQueue: Queue,
@@ -388,7 +389,7 @@ export class CoinSyncTask extends WorkerHost implements OnModuleInit {
 
       let updatedCount = 0;
       let errorCount = 0;
-      const batchSize = 10;
+      const batchSize = 3;
 
       for (let i = 0; i < allCoins.length; i += batchSize) {
         const batch = allCoins.slice(i, i + batchSize);
@@ -396,12 +397,31 @@ export class CoinSyncTask extends WorkerHost implements OnModuleInit {
           batch.map(async ({ id, slug, symbol, geckoRank }) => {
             try {
               this.logger.debug(`Updating details for ${symbol} (${slug})`);
-              const coin = await this.gecko.coinId({
-                id: slug,
-                localization: false,
-                tickers: false
-              });
 
+              const retryResult = await withRetry(
+                () =>
+                  this.gecko.coinId({
+                    id: slug,
+                    localization: false,
+                    tickers: false
+                  }),
+                {
+                  maxRetries: 2,
+                  initialDelayMs: 3000,
+                  maxDelayMs: 10000,
+                  logger: this.logger,
+                  operationName: `coinId(${symbol})`
+                }
+              );
+
+              if (!retryResult.success) {
+                const { message } = toErrorInfo(retryResult.error);
+                this.logger.error(`Failed to update ${symbol}: ${message}`);
+                return { success: false, error: message };
+              }
+
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by retryResult.success check
+              const coin = retryResult.result!;
               const md = coin.market_data;
 
               await this.coin.update(id, {
@@ -524,9 +544,9 @@ export class CoinSyncTask extends WorkerHost implements OnModuleInit {
               this.logger.debug(`Successfully updated ${symbol}`);
               return { success: true };
             } catch (error: unknown) {
-              const err = toErrorInfo(error);
-              this.logger.error(`Failed to update ${symbol}: ${err.message}`);
-              return { success: false, error: err.message };
+              const { message } = toErrorInfo(error);
+              this.logger.error(`Failed to update ${symbol}: ${message}`);
+              return { success: false, error: message };
             }
           })
         );

--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -94,6 +94,7 @@ import {
   OpportunitySellingUserConfig
 } from '../interfaces/opportunity-selling.interface';
 import { PositionAnalysisService } from '../services/position-analysis.service';
+import { resolveExitConfig } from '../utils/exit-config-merge.util';
 
 export interface MarketData {
   timestamp: Date;
@@ -113,6 +114,8 @@ export interface TradingSignal {
   metadata?: Record<string, any>;
   /** Preserves the original algorithm signal type (e.g. STOP_LOSS, TAKE_PROFIT) */
   originalType?: AlgoSignalType;
+  /** Strategy-provided exit configuration (per-signal > result-level) */
+  exitConfig?: Partial<ExitConfig>;
 }
 
 interface ExecuteOptions {
@@ -221,7 +224,7 @@ interface ProcessExitSignalsOptions {
 // Note: Seeded random generation now uses SeededRandom class for checkpoint support
 // CheckpointResults is imported from backtest-pacing.interface.ts
 
-const mapStrategySignal = (signal: StrategySignal): TradingSignal => {
+const mapStrategySignal = (signal: StrategySignal, resultExitConfig?: Partial<ExitConfig>): TradingSignal => {
   let action: TradingSignal['action'];
   switch (signal.type) {
     case AlgoSignalType.BUY:
@@ -242,6 +245,9 @@ const mapStrategySignal = (signal: StrategySignal): TradingSignal => {
       action = 'HOLD';
   }
 
+  // Per-signal exitConfig takes priority over result-level exitConfig
+  const exitConfig = signal.exitConfig ?? resultExitConfig;
+
   return {
     action,
     coinId: signal.coinId,
@@ -250,7 +256,8 @@ const mapStrategySignal = (signal: StrategySignal): TradingSignal => {
     reason: signal.reason,
     confidence: signal.confidence,
     metadata: signal.metadata,
-    originalType: signal.type
+    originalType: signal.type,
+    exitConfig
   };
 };
 
@@ -920,7 +927,9 @@ export class BacktestEngine {
         }
 
         if (result.success && result.signals?.length) {
-          strategySignals = result.signals.map(mapStrategySignal).filter((signal) => signal.action !== 'HOLD');
+          strategySignals = result.signals
+            .map((s) => mapStrategySignal(s, result.exitConfig))
+            .filter((signal) => signal.action !== 'HOLD');
         }
         watchdog.recordSuccess();
         consecutiveErrors = 0;
@@ -979,7 +988,10 @@ export class BacktestEngine {
           price: marketData.prices.get(strategySignal.coinId),
           reason: strategySignal.reason,
           confidence: strategySignal.confidence,
-          payload: strategySignal.metadata,
+          payload: {
+            ...strategySignal.metadata,
+            ...(strategySignal.exitConfig ? { strategyExitConfig: strategySignal.exitConfig } : {})
+          },
           backtest
         };
         signals.push(signalRecord);
@@ -1065,7 +1077,13 @@ export class BacktestEngine {
           // Update exit tracker: register new BUY positions, reduce on SELL
           if (exitTracker && trade.price != null && trade.quantity != null) {
             if (strategySignal.action === 'BUY') {
-              exitTracker.onBuy(strategySignal.coinId, trade.price, trade.quantity);
+              exitTracker.onBuy(
+                strategySignal.coinId,
+                trade.price,
+                trade.quantity,
+                undefined,
+                strategySignal.exitConfig
+              );
             } else if (strategySignal.action === 'SELL') {
               exitTracker.onSell(strategySignal.coinId, trade.quantity);
             }
@@ -1726,7 +1744,9 @@ export class BacktestEngine {
         );
 
         if (result.success && result.signals?.length) {
-          strategySignals = result.signals.map(mapStrategySignal).filter((signal) => signal.action !== 'HOLD');
+          strategySignals = result.signals
+            .map((s) => mapStrategySignal(s, result.exitConfig))
+            .filter((signal) => signal.action !== 'HOLD');
         }
         watchdog.recordSuccess();
         consecutiveErrors = 0;
@@ -1785,7 +1805,10 @@ export class BacktestEngine {
           price: marketData.prices.get(strategySignal.coinId),
           reason: strategySignal.reason,
           confidence: strategySignal.confidence,
-          payload: strategySignal.metadata,
+          payload: {
+            ...strategySignal.metadata,
+            ...(strategySignal.exitConfig ? { strategyExitConfig: strategySignal.exitConfig } : {})
+          },
           backtest
         };
         signals.push(signalRecord);
@@ -1832,7 +1855,13 @@ export class BacktestEngine {
           // Update exit tracker: register new BUY positions, reduce on SELL
           if (exitTracker && trade.price != null && trade.quantity != null) {
             if (strategySignal.action === 'BUY') {
-              exitTracker.onBuy(strategySignal.coinId, trade.price, trade.quantity);
+              exitTracker.onBuy(
+                strategySignal.coinId,
+                trade.price,
+                trade.quantity,
+                undefined,
+                strategySignal.exitConfig
+              );
             } else if (strategySignal.action === 'SELL') {
               exitTracker.onSell(strategySignal.coinId, trade.quantity);
             }
@@ -2679,7 +2708,7 @@ export class BacktestEngine {
    */
   private resolveExitTracker(opts: ResolveExitTrackerOptions): BacktestExitTracker | null {
     const effectiveExitConfig = opts.exitConfig
-      ? { ...DEFAULT_BACKTEST_EXIT_CONFIG, ...opts.exitConfig }
+      ? resolveExitConfig(DEFAULT_BACKTEST_EXIT_CONFIG, opts.exitConfig)
       : opts.enableHardStopLoss !== false
         ? { ...DEFAULT_BACKTEST_EXIT_CONFIG, stopLossValue: (opts.hardStopLossPercent ?? 0.05) * 100 }
         : null;
@@ -3601,7 +3630,9 @@ export class BacktestEngine {
       try {
         const result = await this.algorithmRegistry.executeAlgorithm(config.algorithmId, context);
         if (result.success && result.signals?.length) {
-          strategySignals = result.signals.map(mapStrategySignal).filter((signal) => signal.action !== 'HOLD');
+          strategySignals = result.signals
+            .map((s) => mapStrategySignal(s, result.exitConfig))
+            .filter((signal) => signal.action !== 'HOLD');
         }
       } catch (error: unknown) {
         if (error instanceof AlgorithmNotRegisteredException) {
@@ -4062,7 +4093,9 @@ export class BacktestEngine {
       try {
         const result = await this.algorithmRegistry.executeAlgorithm(config.algorithmId, context);
         if (result.success && result.signals?.length) {
-          strategySignals = result.signals.map(mapStrategySignal).filter((signal) => signal.action !== 'HOLD');
+          strategySignals = result.signals
+            .map((s) => mapStrategySignal(s, result.exitConfig))
+            .filter((signal) => signal.action !== 'HOLD');
         }
       } catch (error: unknown) {
         if (error instanceof AlgorithmNotRegisteredException) {

--- a/apps/api/src/order/backtest/shared/exits/backtest-exit-tracker.ts
+++ b/apps/api/src/order/backtest/shared/exits/backtest-exit-tracker.ts
@@ -6,6 +6,7 @@ import {
 } from './exit-price.utils';
 
 import { ExitConfig, TrailingActivationType, TrailingType } from '../../../interfaces/exit-config.interface';
+import { resolveExitConfig } from '../../../utils/exit-config-merge.util';
 
 /**
  * Type of exit that triggered position closure.
@@ -41,6 +42,8 @@ export interface TrackedExit {
   highWaterMark: number;
   entryAtr?: number;
   ocoLinked: boolean;
+  /** Per-position exit config override (merged from strategy-provided exitConfig) */
+  positionConfig?: ExitConfig;
 }
 
 /**
@@ -85,9 +88,24 @@ export class BacktestExitTracker {
    * exit levels from the new averaged entry. Trailing activation state is
    * preserved so an already-activated trailing stop keeps ratcheting.
    */
-  onBuy(coinId: string, entryPrice: number, quantity: number, currentAtr?: number): void {
+  onBuy(
+    coinId: string,
+    entryPrice: number,
+    quantity: number,
+    currentAtr?: number,
+    overrideExitConfig?: Partial<ExitConfig>
+  ): void {
+    // Resolve effective config: strategy override merged on top of tracker-level config
+    const effectiveConfig = overrideExitConfig ? resolveExitConfig(this.config, overrideExitConfig) : this.config;
+
     const existing = this.positions.get(coinId);
     if (existing) {
+      // Update positionConfig if a new override is provided
+      if (overrideExitConfig) {
+        existing.positionConfig = effectiveConfig;
+      }
+      const cfg = existing.positionConfig ?? this.config;
+
       // Cost-average: weighted-average entry, sum quantities, recalculate exit levels
       const totalQty = existing.quantity + quantity;
       const avgEntry = (existing.entryPrice * existing.quantity + entryPrice * quantity) / totalQty;
@@ -96,22 +114,17 @@ export class BacktestExitTracker {
       existing.highWaterMark = Math.max(existing.highWaterMark, entryPrice);
       existing.entryAtr = currentAtr ?? existing.entryAtr;
 
-      if (this.config.enableStopLoss) {
-        existing.stopLossPrice = calculateStopLossPrice(avgEntry, existing.side, this.config, existing.entryAtr);
+      if (cfg.enableStopLoss) {
+        existing.stopLossPrice = calculateStopLossPrice(avgEntry, existing.side, cfg, existing.entryAtr);
       }
-      if (this.config.enableTakeProfit) {
-        existing.takeProfitPrice = calculateTakeProfitPrice(
-          avgEntry,
-          existing.side,
-          this.config,
-          existing.stopLossPrice
-        );
+      if (cfg.enableTakeProfit) {
+        existing.takeProfitPrice = calculateTakeProfitPrice(avgEntry, existing.side, cfg, existing.stopLossPrice);
       }
-      if (this.config.enableTrailingStop) {
+      if (cfg.enableTrailingStop) {
         existing.trailingStopPrice = existing.trailingActivated
           ? this.recalcTrailingStop(existing)
-          : calculateTrailingStopPrice(avgEntry, existing.side, this.config, existing.entryAtr);
-        existing.trailingActivationPrice = calculateTrailingActivationPrice(avgEntry, existing.side, this.config);
+          : calculateTrailingStopPrice(avgEntry, existing.side, cfg, existing.entryAtr);
+        existing.trailingActivationPrice = calculateTrailingActivationPrice(avgEntry, existing.side, cfg);
       }
       return;
     }
@@ -126,23 +139,24 @@ export class BacktestExitTracker {
       trailingActivated: false,
       highWaterMark: entryPrice,
       entryAtr: currentAtr,
-      ocoLinked: this.config.useOco
+      ocoLinked: effectiveConfig.useOco,
+      ...(overrideExitConfig ? { positionConfig: effectiveConfig } : {})
     };
 
-    if (this.config.enableStopLoss) {
-      tracked.stopLossPrice = calculateStopLossPrice(entryPrice, side, this.config, currentAtr);
+    if (effectiveConfig.enableStopLoss) {
+      tracked.stopLossPrice = calculateStopLossPrice(entryPrice, side, effectiveConfig, currentAtr);
     }
 
-    if (this.config.enableTakeProfit) {
-      tracked.takeProfitPrice = calculateTakeProfitPrice(entryPrice, side, this.config, tracked.stopLossPrice);
+    if (effectiveConfig.enableTakeProfit) {
+      tracked.takeProfitPrice = calculateTakeProfitPrice(entryPrice, side, effectiveConfig, tracked.stopLossPrice);
     }
 
-    if (this.config.enableTrailingStop) {
-      tracked.trailingStopPrice = calculateTrailingStopPrice(entryPrice, side, this.config, currentAtr);
-      tracked.trailingActivationPrice = calculateTrailingActivationPrice(entryPrice, side, this.config);
+    if (effectiveConfig.enableTrailingStop) {
+      tracked.trailingStopPrice = calculateTrailingStopPrice(entryPrice, side, effectiveConfig, currentAtr);
+      tracked.trailingActivationPrice = calculateTrailingActivationPrice(entryPrice, side, effectiveConfig);
 
       // Immediate activation means trailing is active from the start
-      if (this.config.trailingActivation === TrailingActivationType.IMMEDIATE) {
+      if (effectiveConfig.trailingActivation === TrailingActivationType.IMMEDIATE) {
         tracked.trailingActivated = true;
       }
     }
@@ -238,7 +252,8 @@ export class BacktestExitTracker {
       }
 
       // 3. Trailing Stop: update activation → high water mark → recalc → check breach
-      if (!exited && this.config.enableTrailingStop && tracked.trailingStopPrice != null) {
+      const posConfig = tracked.positionConfig ?? this.config;
+      if (!exited && posConfig.enableTrailingStop && tracked.trailingStopPrice != null) {
         // Check activation if not yet activated
         if (!tracked.trailingActivated && tracked.trailingActivationPrice != null) {
           if (tracked.side === 'BUY' && highPrice >= tracked.trailingActivationPrice) {
@@ -290,22 +305,23 @@ export class BacktestExitTracker {
    * known simplification; live trading would use a rolling ATR instead.
    */
   private recalcTrailingStop(tracked: TrackedExit): number {
+    const cfg = tracked.positionConfig ?? this.config;
     let distance: number;
 
-    switch (this.config.trailingType) {
+    switch (cfg.trailingType) {
       case TrailingType.AMOUNT:
-        distance = this.config.trailingValue;
+        distance = cfg.trailingValue;
         break;
 
       case TrailingType.PERCENTAGE:
-        distance = tracked.highWaterMark * (this.config.trailingValue / 100);
+        distance = tracked.highWaterMark * (cfg.trailingValue / 100);
         break;
 
       case TrailingType.ATR:
         if (!tracked.entryAtr || isNaN(tracked.entryAtr)) {
           distance = tracked.highWaterMark * 0.01; // 1% fallback
         } else {
-          distance = tracked.entryAtr * this.config.trailingValue;
+          distance = tracked.entryAtr * cfg.trailingValue;
         }
         break;
 

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.spec.ts
@@ -162,13 +162,30 @@ describe('SignalThrottleService', () => {
       it.each([
         ['STOP_LOSS', AlgoSignalType.STOP_LOSS, () => makeStopLoss('btc')],
         ['TAKE_PROFIT', AlgoSignalType.TAKE_PROFIT, () => makeTakeProfit('btc')]
-      ] as const)('%s bypasses cooldown and daily limit', (_label, expectedType, makeSignal) => {
+      ] as const)('%s bypasses daily limit', (_label, expectedType, makeSignal) => {
         const state = service.createState();
-        service.filterSignals([makeBuy('btc')], state, strictConfig, BASE_TIME);
+        // Fill daily cap with a normal trade
+        const noCooldownStrict: SignalThrottleConfig = { ...strictConfig, cooldownMs: 0 };
+        service.filterSignals([makeBuy('btc')], state, noCooldownStrict, BASE_TIME);
 
-        const result = service.filterSignals([makeSignal()], state, strictConfig, BASE_TIME + ONE_HOUR);
+        // Risk-control signal still passes despite daily cap reached
+        const result = service.filterSignals([makeSignal()], state, noCooldownStrict, BASE_TIME + ONE_HOUR);
         expect(result).toHaveLength(1);
         expect(result[0].originalType).toBe(expectedType);
+      });
+
+      it.each([
+        ['STOP_LOSS', () => makeStopLoss('btc')],
+        ['TAKE_PROFIT', () => makeTakeProfit('btc')]
+      ] as const)('%s respects cooldown', (_label, makeSignal) => {
+        const state = service.createState();
+        // First risk-control signal passes
+        const result1 = service.filterSignals([makeSignal()], state, strictConfig, BASE_TIME);
+        expect(result1).toHaveLength(1);
+
+        // Second within cooldown is suppressed
+        const result2 = service.filterSignals([makeSignal()], state, strictConfig, BASE_TIME + ONE_HOUR);
+        expect(result2).toHaveLength(0);
       });
 
       it('bypass signals do not count against daily limit', () => {
@@ -182,12 +199,23 @@ describe('SignalThrottleService', () => {
         expect(result).toHaveLength(1);
       });
 
-      it('bypass signals do not set cooldown', () => {
+      it('bypass signals set cooldown — blocks subsequent normal SELL for same coin', () => {
         const state = service.createState();
         service.filterSignals([makeStopLoss('btc')], state, config, BASE_TIME);
 
+        // Normal SELL for same coin+direction within cooldown is suppressed
         const result = service.filterSignals([makeSell('btc', 0.8, 0.6)], state, config, BASE_TIME + ONE_HOUR);
-        expect(result).toHaveLength(1);
+        expect(result).toHaveLength(0);
+      });
+
+      it('bypass signals pass freely when cooldownMs is 0', () => {
+        const state = service.createState();
+        const noCooldown: SignalThrottleConfig = { cooldownMs: 0, maxTradesPerDay: 10, minSellPercent: 0 };
+
+        const r1 = service.filterSignals([makeStopLoss('btc')], state, noCooldown, BASE_TIME);
+        const r2 = service.filterSignals([makeStopLoss('btc')], state, noCooldown, BASE_TIME + 1);
+        expect(r1).toHaveLength(1);
+        expect(r2).toHaveLength(1);
       });
     });
 
@@ -293,6 +321,54 @@ describe('SignalThrottleService', () => {
         minSellPercent: -Infinity
       });
       expect(config).toEqual({ cooldownMs: 86_400_000, maxTradesPerDay: 6, minSellPercent: 0.5 });
+    });
+  });
+
+  describe('toThrottleSignal', () => {
+    it.each([
+      [AlgoSignalType.BUY, 'BUY'],
+      [AlgoSignalType.SELL, 'SELL'],
+      [AlgoSignalType.STOP_LOSS, 'SELL'],
+      [AlgoSignalType.TAKE_PROFIT, 'SELL'],
+      [AlgoSignalType.SHORT_ENTRY, 'OPEN_SHORT'],
+      [AlgoSignalType.SHORT_EXIT, 'CLOSE_SHORT'],
+      [AlgoSignalType.HOLD, 'HOLD']
+    ] as const)('maps %s → %s', (type, expectedAction) => {
+      const result = service.toThrottleSignal({
+        type,
+        coinId: 'btc',
+        reason: 'test',
+        confidence: 0.5,
+        strength: 0.5
+      });
+      expect(result.action).toBe(expectedAction);
+      expect(result.coinId).toBe('btc');
+      expect(result.originalType).toBe(type);
+    });
+
+    it('preserves optional quantity field', () => {
+      const result = service.toThrottleSignal({
+        type: AlgoSignalType.SELL,
+        coinId: 'eth',
+        reason: 'sell all',
+        confidence: 1.0,
+        strength: 1.0,
+        quantity: 2.5
+      });
+      expect(result.quantity).toBe(2.5);
+    });
+
+    it('preserves exitConfig when present', () => {
+      const exitConfig = { enableStopLoss: true, stopLossValue: 5 };
+      const result = service.toThrottleSignal({
+        type: AlgoSignalType.BUY,
+        coinId: 'btc',
+        reason: 'test',
+        confidence: 0.8,
+        strength: 0.8,
+        exitConfig
+      });
+      expect(result.exitConfig).toEqual(exitConfig);
     });
   });
 

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.ts
@@ -23,7 +23,8 @@ const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
  * 2. Cap daily trade frequency (rolling 24h window)
  * 3. Floor sell percentages (prevent micro-sell fragmentation)
  *
- * Risk-control signals (STOP_LOSS, TAKE_PROFIT) always bypass throttling.
+ * Risk-control signals (STOP_LOSS, TAKE_PROFIT) bypass daily cap and min sell %,
+ * but respect per-coin+direction cooldowns to prevent duplicate signal spam.
  *
  * State is passed explicitly to support checkpoint/resume without service-level mutability.
  */
@@ -86,8 +87,17 @@ export class SignalThrottleService {
         continue;
       }
 
-      // Risk-control signals always pass — don't set cooldown or count against daily limit
+      // Risk-control signals bypass daily cap & min sell %, but respect cooldown
       if (signal.originalType && THROTTLE_BYPASS_TYPES.has(signal.originalType)) {
+        if (config.cooldownMs > 0) {
+          const direction = signal.action as 'BUY' | 'SELL';
+          const key: CooldownKey = `${signal.coinId}:${direction}`;
+          const lastTime = state.lastSignalTime[key];
+          if (lastTime !== undefined && currentTimestampMs - lastTime < config.cooldownMs) {
+            continue; // Duplicate risk-control signal — suppress
+          }
+          state.lastSignalTime[key] = currentTimestampMs;
+        }
         accepted.push(signal);
         continue;
       }
@@ -154,7 +164,8 @@ export class SignalThrottleService {
       quantity: signal.quantity,
       reason: signal.reason,
       confidence: signal.confidence,
-      originalType: signal.type
+      originalType: signal.type,
+      exitConfig: signal.exitConfig
     };
   }
 }

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -1,12 +1,11 @@
 import { Logger } from '@nestjs/common';
 
-import { PaperTradingMarketDataService } from './paper-trading-market-data.service';
+import { PaperTradingMarketDataService, PriceData } from './paper-trading-market-data.service';
 
 import type { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import * as retryUtil from '../../shared/retry.util';
 
-const createService = (
-  overrides: Partial<{ cacheManager: any; exchangeManager: any; config: any }> = {}
-) => {
+const createService = (overrides: Partial<{ cacheManager: any; exchangeManager: any; config: any }> = {}) => {
   const cacheManager = overrides.cacheManager ?? {
     get: jest.fn(),
     set: jest.fn(),
@@ -14,7 +13,7 @@ const createService = (
   };
 
   const exchangeManager = overrides.exchangeManager ?? {
-    formatSymbol: jest.fn(),
+    formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
     getExchangeClient: jest.fn(),
     getPublicClient: jest.fn()
   };
@@ -22,19 +21,23 @@ const createService = (
   const config = overrides.config ?? { priceCacheTtlMs: 1000 };
 
   return {
-    service: new PaperTradingMarketDataService(
-      config as any,
-      cacheManager,
-      exchangeManager as ExchangeManagerService
-    ),
+    service: new PaperTradingMarketDataService(config as any, cacheManager, exchangeManager as ExchangeManagerService),
     cacheManager,
     exchangeManager
   };
 };
 
 describe('PaperTradingMarketDataService', () => {
+  let withRetrySpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Spy on withRetry to avoid real delays in tests
+    withRetrySpy = jest.spyOn(retryUtil, 'withRetry');
+  });
+
+  afterEach(() => {
+    withRetrySpy.mockRestore();
   });
 
   it('returns cached price data when available', async () => {
@@ -60,14 +63,14 @@ describe('PaperTradingMarketDataService', () => {
   });
 
   it('fetches and caches price data when not cached', async () => {
-    const client = {
-      fetchTicker: jest.fn().mockResolvedValue({
-        last: 45000,
-        bid: 44950,
-        ask: 45050,
-        timestamp: 1700000000000
-      })
+    const ticker = {
+      last: 45000,
+      bid: 44950,
+      ask: 45050,
+      timestamp: 1700000000000
     };
+
+    const client = { fetchTicker: jest.fn().mockResolvedValue(ticker) };
 
     const cacheManager = {
       get: jest.fn().mockResolvedValue(null),
@@ -79,12 +82,19 @@ describe('PaperTradingMarketDataService', () => {
       getPublicClient: jest.fn().mockResolvedValue(client)
     };
 
+    withRetrySpy.mockResolvedValue({
+      success: true,
+      result: ticker,
+      attempts: 1,
+      totalDelayMs: 0
+    });
+
     const { service } = createService({ cacheManager, exchangeManager });
 
     const result = await service.getCurrentPrice('binance', 'BTC/USDT');
 
     expect(exchangeManager.formatSymbol).toHaveBeenCalledWith('binance', 'BTC/USDT');
-    expect(client.fetchTicker).toHaveBeenCalledWith('BTC/USDT');
+    // Normal cache write
     expect(cacheManager.set).toHaveBeenCalledWith(
       'paper-trading:price:binance:BTC/USDT',
       expect.objectContaining({
@@ -95,6 +105,12 @@ describe('PaperTradingMarketDataService', () => {
         source: 'binance'
       }),
       1000
+    );
+    // Stale cache write
+    expect(cacheManager.set).toHaveBeenCalledWith(
+      'paper-trading:price:binance:BTC/USDT:stale',
+      expect.objectContaining({ symbol: 'BTC/USDT', price: 45000 }),
+      300000
     );
     expect(result.price).toBe(45000);
   });
@@ -182,11 +198,7 @@ describe('PaperTradingMarketDataService', () => {
       );
 
       // Verify cached with 5-minute TTL
-      expect(cacheManager.set).toHaveBeenCalledWith(
-        'paper-trading:ohlcv:binance:BTC/USD:1h:public',
-        result,
-        300000
-      );
+      expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:ohlcv:binance:BTC/USD:1h:public', result, 300000);
     });
 
     it('returns empty array when fetch throws', async () => {
@@ -213,6 +225,514 @@ describe('PaperTradingMarketDataService', () => {
       expect(result).toEqual([]);
       expect(cacheManager.set).not.toHaveBeenCalled();
       loggerSpy.mockRestore();
+    });
+  });
+
+  describe('getCurrentPrice retry + stale-cache fallback', () => {
+    it('retries on transient error and succeeds on 2nd attempt', async () => {
+      const ticker = { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 };
+
+      const client = { fetchTicker: jest.fn() };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      withRetrySpy.mockResolvedValue({
+        success: true,
+        result: ticker,
+        attempts: 2,
+        totalDelayMs: 2000
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getCurrentPrice('binance', 'BTC/USDT');
+
+      expect(result.price).toBe(45000);
+      expect(withRetrySpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          maxRetries: 3,
+          initialDelayMs: 2000,
+          isRetryable: retryUtil.isTransientError
+        })
+      );
+    });
+
+    it('falls back to stale cache when all retries exhausted', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      const staleData = {
+        symbol: 'BTC/USDT',
+        price: 44000,
+        bid: 43950,
+        ask: 44050,
+        timestamp: new Date(),
+        source: 'binance'
+      };
+
+      const cacheManager = {
+        get: jest.fn().mockImplementation((key: string) => {
+          if (key === 'paper-trading:price:binance:BTC/USDT') return Promise.resolve(null);
+          if (key === 'paper-trading:price:binance:BTC/USDT:stale') return Promise.resolve(staleData);
+          return Promise.resolve(null);
+        }),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTicker: jest.fn() })
+      };
+
+      withRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('ETIMEDOUT'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getCurrentPrice('binance', 'BTC/USDT');
+
+      expect(result.price).toBe(44000);
+      expect(result.source).toBe('binance:stale');
+      loggerSpy.mockRestore();
+    });
+
+    it('throws when retries exhausted AND no stale cache exists', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTicker: jest.fn() })
+      };
+
+      const timeoutError = new Error('ETIMEDOUT');
+      withRetrySpy.mockResolvedValue({
+        success: false,
+        error: timeoutError,
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+
+      await expect(service.getCurrentPrice('binance', 'BTC/USDT')).rejects.toThrow('ETIMEDOUT');
+      loggerSpy.mockRestore();
+    });
+  });
+
+  describe('getPrices retry + stale-cache fallback', () => {
+    it('retries on transient error and succeeds on 2nd attempt', async () => {
+      const tickers = {
+        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 },
+        'ETH/USDT': { last: 2500, bid: 2490, ask: 2510, timestamp: 1700000000000 }
+      };
+
+      const client = { fetchTickers: jest.fn() };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      withRetrySpy.mockResolvedValue({
+        success: true,
+        result: tickers,
+        attempts: 2,
+        totalDelayMs: 2000
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(result.get('BTC/USDT')?.price).toBe(45000);
+      expect(result.get('ETH/USDT')?.price).toBe(2500);
+      // Each symbol should have both normal + stale cache writes
+      expect(cacheManager.set).toHaveBeenCalledTimes(4);
+    });
+
+    it('falls back to stale cache when all retries exhausted', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      const stalebtc = {
+        symbol: 'BTC/USDT',
+        price: 44000,
+        timestamp: new Date(),
+        source: 'binance'
+      };
+      const staleeth = {
+        symbol: 'ETH/USDT',
+        price: 2400,
+        timestamp: new Date(),
+        source: 'binance'
+      };
+
+      const cacheManager = {
+        get: jest.fn().mockImplementation((key: string) => {
+          // No normal cache
+          if (!key.endsWith(':stale')) return Promise.resolve(null);
+          if (key.includes('BTC/USDT')) return Promise.resolve(stalebtc);
+          if (key.includes('ETH/USDT')) return Promise.resolve(staleeth);
+          return Promise.resolve(null);
+        }),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+      };
+
+      withRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('ETIMEDOUT'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(result.get('BTC/USDT')?.price).toBe(44000);
+      expect(result.get('BTC/USDT')?.source).toBe('binance:stale');
+      expect(result.get('ETH/USDT')?.price).toBe(2400);
+      expect(result.get('ETH/USDT')?.source).toBe('binance:stale');
+      loggerSpy.mockRestore();
+    });
+
+    it('throws when retries exhausted AND some symbols have no stale cache', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      const stalebtc = {
+        symbol: 'BTC/USDT',
+        price: 44000,
+        timestamp: new Date(),
+        source: 'binance'
+      };
+
+      const cacheManager = {
+        get: jest.fn().mockImplementation((key: string) => {
+          if (!key.endsWith(':stale')) return Promise.resolve(null);
+          if (key.includes('BTC/USDT')) return Promise.resolve(stalebtc);
+          // ETH has no stale cache
+          return Promise.resolve(null);
+        }),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+      };
+
+      withRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('ETIMEDOUT'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+
+      await expect(service.getPrices('binance', ['BTC/USDT', 'ETH/USDT'])).rejects.toThrow(
+        /1 symbol\(s\) have no stale cache fallback/
+      );
+      loggerSpy.mockRestore();
+    });
+
+    it('returns cached symbols without fetching and only fetches uncached', async () => {
+      const cachedPrice: PriceData = {
+        symbol: 'BTC/USDT',
+        price: 44000,
+        bid: 43950,
+        ask: 44050,
+        timestamp: new Date(),
+        source: 'binance'
+      };
+
+      const tickers = {
+        'ETH/USDT': { last: 2500, bid: 2490, ask: 2510, timestamp: 1700000000000 }
+      };
+
+      const cacheManager = {
+        get: jest.fn().mockImplementation((key: string) => {
+          if (key === 'paper-trading:price:binance:BTC/USDT') return Promise.resolve(cachedPrice);
+          return Promise.resolve(null);
+        }),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+      };
+
+      withRetrySpy.mockResolvedValue({
+        success: true,
+        result: tickers,
+        attempts: 1,
+        totalDelayMs: 0
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(result.get('BTC/USDT')).toBe(cachedPrice);
+      expect(result.get('ETH/USDT')?.price).toBe(2500);
+      // Only ETH should have cache writes (BTC was cached)
+      expect(cacheManager.set).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips symbols missing from ticker response', async () => {
+      const tickers = {
+        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
+        // ETH/USDT intentionally missing from response
+      };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+      };
+
+      withRetrySpy.mockResolvedValue({
+        success: true,
+        result: tickers,
+        attempts: 1,
+        totalDelayMs: 0
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(result.get('BTC/USDT')?.price).toBe(45000);
+      expect(result.has('ETH/USDT')).toBe(false);
+    });
+  });
+
+  describe('getOrderBook', () => {
+    it('returns cached order book when available', async () => {
+      const cached = {
+        symbol: 'BTC/USD',
+        bids: [{ price: 100, quantity: 1 }],
+        asks: [{ price: 101, quantity: 1 }],
+        timestamp: new Date()
+      };
+
+      const { service, exchangeManager } = createService({
+        cacheManager: {
+          get: jest.fn().mockResolvedValue(cached),
+          set: jest.fn()
+        }
+      });
+
+      const result = await service.getOrderBook('binance', 'BTC/USD');
+
+      expect(result).toBe(cached);
+      expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+    });
+
+    it('fetches, maps, and caches order book on cache miss', async () => {
+      const rawOrderBook = {
+        bids: [
+          [100, 5],
+          [99, 10]
+        ],
+        asks: [
+          [101, 3],
+          [102, 7]
+        ],
+        timestamp: 1700000000000
+      };
+
+      const client = { fetchOrderBook: jest.fn().mockResolvedValue(rawOrderBook) };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getOrderBook('binance', 'BTC/USD', 10);
+
+      expect(client.fetchOrderBook).toHaveBeenCalledWith('BTC/USD', 10);
+      expect(result.bids).toEqual([
+        { price: 100, quantity: 5 },
+        { price: 99, quantity: 10 }
+      ]);
+      expect(result.asks).toEqual([
+        { price: 101, quantity: 3 },
+        { price: 102, quantity: 7 }
+      ]);
+      // Cache TTL capped at min(cacheTtlMs, 2000)
+      expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:orderbook:binance:BTC/USD', result, 1000);
+    });
+
+    it('throws and logs on fetch failure', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+      const client = { fetchOrderBook: jest.fn().mockRejectedValue(new Error('exchange down')) };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager });
+
+      await expect(service.getOrderBook('binance', 'BTC/USD')).rejects.toThrow('exchange down');
+      expect(loggerSpy).toHaveBeenCalled();
+      loggerSpy.mockRestore();
+    });
+  });
+
+  describe('calculateRealisticSlippage edge cases', () => {
+    it('returns fixed slippage when order book has empty levels', async () => {
+      const { service } = createService();
+
+      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+        symbol: 'BTC/USD',
+        bids: [],
+        asks: [],
+        timestamp: new Date()
+      });
+
+      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 1, 'BUY');
+
+      expect(result).toEqual({ estimatedPrice: 0, slippageBps: 10, marketImpact: 0 });
+    });
+
+    it('returns high slippage when quantity exceeds available liquidity', async () => {
+      const { service } = createService();
+
+      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+        symbol: 'BTC/USD',
+        bids: [{ price: 100, quantity: 0 }],
+        asks: [{ price: 101, quantity: 0 }],
+        timestamp: new Date()
+      });
+
+      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 10, 'BUY');
+
+      expect(result.slippageBps).toBe(50);
+      expect(result.estimatedPrice).toBe(101);
+    });
+
+    it('uses bids for SELL side slippage', async () => {
+      const { service } = createService();
+
+      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+        symbol: 'BTC/USD',
+        bids: [
+          { price: 100, quantity: 2 },
+          { price: 90, quantity: 2 }
+        ],
+        asks: [],
+        timestamp: new Date()
+      });
+
+      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 3, 'SELL');
+
+      // VWAP = (2*100 + 1*90) / 3 = 96.667
+      expect(result.estimatedPrice).toBeCloseTo(96.667, 2);
+      // Slippage from best bid (100): |96.667 - 100| / 100 * 10000 = 333.33 bps + 4 impact
+      expect(result.slippageBps).toBeCloseTo(337.333, 0);
+    });
+  });
+
+  describe('checkExchangeHealth', () => {
+    it('returns healthy with latency when exchange responds', async () => {
+      const client = { fetchTime: jest.fn().mockResolvedValue(1700000000000) };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn(),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      const { service } = createService({ exchangeManager });
+      const result = await service.checkExchangeHealth('binance');
+
+      expect(result.healthy).toBe(true);
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns unhealthy with error message when exchange fails', async () => {
+      const client = { fetchTime: jest.fn().mockRejectedValue(new Error('connection refused')) };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn(),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      const { service } = createService({ exchangeManager });
+      const result = await service.checkExchangeHealth('binance');
+
+      expect(result.healthy).toBe(false);
+      expect(result.error).toBe('connection refused');
+      expect(result.latencyMs).toBeUndefined();
+    });
+  });
+
+  describe('clearCache', () => {
+    it('deletes price, stale, and orderbook keys for a given symbol', async () => {
+      const cacheManager = {
+        get: jest.fn(),
+        set: jest.fn(),
+        del: jest.fn()
+      };
+
+      const { service } = createService({ cacheManager });
+      await service.clearCache('binance', 'BTC/USDT');
+
+      expect(cacheManager.del).toHaveBeenCalledWith('paper-trading:price:binance:BTC/USDT');
+      expect(cacheManager.del).toHaveBeenCalledWith('paper-trading:price:binance:BTC/USDT:stale');
+      expect(cacheManager.del).toHaveBeenCalledWith('paper-trading:orderbook:binance:BTC/USDT');
+    });
+
+    it('does not delete anything when no symbol provided', async () => {
+      const cacheManager = {
+        get: jest.fn(),
+        set: jest.fn(),
+        del: jest.fn()
+      };
+
+      const { service } = createService({ cacheManager });
+      await service.clearCache('binance');
+
+      expect(cacheManager.del).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -9,6 +9,7 @@ import { paperTradingConfig } from './paper-trading.config';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { toErrorInfo } from '../../shared/error.util';
+import { isTransientError, withRetry } from '../../shared/retry.util';
 import type { User } from '../../users/users.entity';
 
 export interface PriceData {
@@ -64,18 +65,27 @@ export class PaperTradingMarketDataService {
       return cached;
     }
 
-    try {
-      // Format symbol for exchange
-      const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
+    // Format symbol for exchange
+    const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
 
-      // Get client (public if no user)
-      const client = user
-        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-        : await this.exchangeManager.getPublicClient(exchangeSlug);
+    // Get client (public if no user)
+    const client = user
+      ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
+      : await this.exchangeManager.getPublicClient(exchangeSlug);
 
-      // Fetch ticker
-      const ticker = await client.fetchTicker(formattedSymbol);
+    // Fetch ticker with retry
+    const result = await withRetry(() => client.fetchTicker(formattedSymbol), {
+      maxRetries: 3,
+      initialDelayMs: 2000,
+      maxDelayMs: 8000,
+      backoffMultiplier: 2,
+      isRetryable: isTransientError,
+      logger: this.logger,
+      operationName: `fetchTicker(${exchangeSlug}:${symbol})`
+    });
 
+    if (result.success) {
+      const ticker = result.result!;
       const priceData: PriceData = {
         symbol,
         price: ticker.last ?? ticker.close ?? 0,
@@ -88,12 +98,27 @@ export class PaperTradingMarketDataService {
       // Cache the result
       await this.cacheManager.set(cacheKey, priceData, this.cacheTtlMs);
 
+      // Write stale fallback cache with longer TTL
+      const staleKey = `${cacheKey}:stale`;
+      await this.cacheManager.set(staleKey, priceData, 5 * 60 * 1000);
+
       return priceData;
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.error(`Failed to fetch price for ${symbol} from ${exchangeSlug}: ${err.message}`);
-      throw error;
     }
+
+    // All retries exhausted — fall back to stale cache
+    const staleKey = `${cacheKey}:stale`;
+    const stale = await this.cacheManager.get<PriceData>(staleKey);
+    if (stale) {
+      this.logger.warn(
+        `All retries exhausted fetching price for ${symbol} from ${exchangeSlug}. Using stale cached price.`
+      );
+      return { ...stale, source: `${stale.source}:stale` };
+    }
+
+    this.logger.error(
+      `Failed to fetch price for ${symbol} from ${exchangeSlug} after retries, and no stale cache fallback`
+    );
+    throw result.error;
   }
 
   /**
@@ -124,16 +149,27 @@ export class PaperTradingMarketDataService {
       return results;
     }
 
-    try {
-      // Get client
-      const client = user
-        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-        : await this.exchangeManager.getPublicClient(exchangeSlug);
+    // Get client
+    const client = user
+      ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
+      : await this.exchangeManager.getPublicClient(exchangeSlug);
 
-      // Fetch all tickers (more efficient than individual calls)
-      const tickers = await client.fetchTickers(
-        uncachedSymbols.map((s) => this.exchangeManager.formatSymbol(exchangeSlug, s))
-      );
+    // Fetch all tickers with retry
+    const result = await withRetry(
+      () => client.fetchTickers(uncachedSymbols.map((s) => this.exchangeManager.formatSymbol(exchangeSlug, s))),
+      {
+        maxRetries: 3,
+        initialDelayMs: 2000,
+        maxDelayMs: 8000,
+        backoffMultiplier: 2,
+        isRetryable: isTransientError,
+        logger: this.logger,
+        operationName: `fetchTickers(${exchangeSlug})`
+      }
+    );
+
+    if (result.success) {
+      const tickers = result.result!;
 
       for (const symbol of uncachedSymbols) {
         const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
@@ -154,15 +190,41 @@ export class PaperTradingMarketDataService {
           // Cache the result
           const cacheKey = `paper-trading:price:${exchangeSlug}:${symbol}`;
           await this.cacheManager.set(cacheKey, priceData, this.cacheTtlMs);
+
+          // Write stale fallback cache with longer TTL
+          const staleKey = `${cacheKey}:stale`;
+          await this.cacheManager.set(staleKey, priceData, 5 * 60 * 1000);
         }
       }
 
       return results;
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.error(`Failed to fetch prices from ${exchangeSlug}: ${err.message}`);
-      throw error;
     }
+
+    // All retries exhausted — fall back to stale cache
+    this.logger.warn(
+      `All retries exhausted fetching prices from ${exchangeSlug}. ` +
+        `Falling back to stale cached prices for ${uncachedSymbols.length} symbol(s).`
+    );
+
+    let staleMisses = 0;
+    for (const symbol of uncachedSymbols) {
+      const staleKey = `paper-trading:price:${exchangeSlug}:${symbol}:stale`;
+      const stale = await this.cacheManager.get<PriceData>(staleKey);
+      if (stale) {
+        results.set(symbol, { ...stale, source: `${stale.source}:stale` });
+      } else {
+        staleMisses++;
+      }
+    }
+
+    if (staleMisses > 0) {
+      throw new Error(
+        `Failed to fetch prices from ${exchangeSlug} after retries, ` +
+          `and ${staleMisses} symbol(s) have no stale cache fallback`
+      );
+    }
+
+    return results;
   }
 
   /**
@@ -356,6 +418,7 @@ export class PaperTradingMarketDataService {
   async clearCache(exchangeSlug: string, symbol?: string): Promise<void> {
     if (symbol) {
       await this.cacheManager.del(`paper-trading:price:${exchangeSlug}:${symbol}`);
+      await this.cacheManager.del(`paper-trading:price:${exchangeSlug}:${symbol}:stale`);
       await this.cacheManager.del(`paper-trading:orderbook:${exchangeSlug}:${symbol}`);
     }
     // Note: cache-manager doesn't support pattern-based deletion easily

--- a/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
@@ -462,6 +462,26 @@ describe('PaperTradingProcessor', () => {
     expect(paperTradingService.removeTickJobs).toHaveBeenCalledWith('session-nonexistent');
   });
 
+  it('silently returns on subsequent ticks for a missing session (no repeated cleanup)', async () => {
+    const { processor, sessionRepository, paperTradingService } = createProcessor();
+
+    sessionRepository.findOne.mockResolvedValue(null);
+
+    const job = createJob({
+      type: PaperTradingJobType.TICK,
+      sessionId: 'session-gone',
+      userId: 'user-1'
+    });
+
+    await processor.process(job);
+    expect(paperTradingService.removeTickJobs).toHaveBeenCalledTimes(1);
+
+    paperTradingService.removeTickJobs.mockClear();
+
+    await processor.process(job);
+    expect(paperTradingService.removeTickJobs).not.toHaveBeenCalled();
+  });
+
   it('removes tick jobs when session is externally marked as FAILED', async () => {
     const session = {
       id: 'session-failed',
@@ -482,6 +502,35 @@ describe('PaperTradingProcessor', () => {
     await processor.process(job);
 
     expect(paperTradingService.removeTickJobs).toHaveBeenCalledWith('session-failed');
+    expect(engineService.processTick).not.toHaveBeenCalled();
+  });
+
+  it('silently returns on subsequent ticks for a FAILED session (no repeated cleanup)', async () => {
+    const session = {
+      id: 'session-failed-dup',
+      status: PaperTradingStatus.FAILED,
+      initialCapital: 1000
+    };
+
+    const { processor, sessionRepository, paperTradingService, engineService } = createProcessor();
+
+    sessionRepository.findOne.mockResolvedValue(session);
+
+    const job = createJob({
+      type: PaperTradingJobType.TICK,
+      sessionId: 'session-failed-dup',
+      userId: 'user-1'
+    });
+
+    // First tick: should log warning and remove jobs
+    await processor.process(job);
+    expect(paperTradingService.removeTickJobs).toHaveBeenCalledTimes(1);
+
+    paperTradingService.removeTickJobs.mockClear();
+
+    // Second tick: should silently return
+    await processor.process(job);
+    expect(paperTradingService.removeTickJobs).not.toHaveBeenCalled();
     expect(engineService.processTick).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/order/paper-trading/paper-trading.processor.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.ts
@@ -102,6 +102,7 @@ export class PaperTradingProcessor extends WorkerHost {
   private readonly maxConsecutiveErrors: number;
   private readonly maxRetryAttempts: number;
   private readonly retryBackoffMs: number;
+  private readonly cleanedUpSessions = new Set<string>();
 
   constructor(
     @Inject(paperTradingConfig.KEY) private readonly config: ConfigType<typeof paperTradingConfig>,
@@ -206,15 +207,21 @@ export class PaperTradingProcessor extends WorkerHost {
     });
 
     if (!session) {
-      this.logger.warn(`Session ${sessionId} not found, removing tick jobs`);
-      await this.paperTradingService.removeTickJobs(sessionId);
+      if (!this.cleanedUpSessions.has(sessionId)) {
+        this.logger.warn(`Session ${sessionId} not found, removing tick jobs`);
+        await this.paperTradingService.removeTickJobs(sessionId);
+        this.cleanedUpSessions.add(sessionId);
+      }
       return;
     }
 
     // Actively stop ticks if externally marked as FAILED
     if (session.status === PaperTradingStatus.FAILED) {
-      this.logger.warn(`Session ${sessionId} was externally marked as FAILED, removing tick jobs`);
-      await this.paperTradingService.removeTickJobs(sessionId);
+      if (!this.cleanedUpSessions.has(sessionId)) {
+        this.logger.warn(`Session ${sessionId} was externally marked as FAILED, removing tick jobs`);
+        await this.paperTradingService.removeTickJobs(sessionId);
+        this.cleanedUpSessions.add(sessionId);
+      }
       return;
     }
 

--- a/apps/api/src/order/tasks/trade-execution.task.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.ts
@@ -455,6 +455,9 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       current.strength * current.confidence > best.strength * best.confidence ? current : best
     );
 
+    // Per-signal exitConfig takes priority over result-level exitConfig
+    const exitConfig = bestSignal.exitConfig ?? result.exitConfig;
+
     // Resolve trading symbol (e.g. "BTC/USDT") — use default quote currency first
     const symbol = await this.resolveTradingSymbol(bestSignal.coinId);
     if (!symbol) {
@@ -501,7 +504,8 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       allocationPercentage: activation.allocationPercentage || 5.0,
       marketType: marketContext.marketType,
       leverage: marketContext.leverage,
-      positionSide
+      positionSide,
+      exitConfig
     };
   }
 

--- a/apps/api/src/order/utils/exit-config-merge.util.spec.ts
+++ b/apps/api/src/order/utils/exit-config-merge.util.spec.ts
@@ -1,0 +1,93 @@
+import { resolveExitConfig } from './exit-config-merge.util';
+
+import { DEFAULT_EXIT_CONFIG, ExitConfig, StopLossType } from '../interfaces/exit-config.interface';
+
+describe('resolveExitConfig', () => {
+  it('should return DEFAULT_EXIT_CONFIG when called with no layers', () => {
+    expect(resolveExitConfig()).toEqual(DEFAULT_EXIT_CONFIG);
+  });
+
+  it('should skip undefined and empty layers without altering defaults', () => {
+    expect(resolveExitConfig(undefined, {}, undefined)).toEqual(DEFAULT_EXIT_CONFIG);
+  });
+
+  it('should apply a single partial layer over defaults', () => {
+    const result = resolveExitConfig({ enableStopLoss: true, stopLossValue: 5 });
+
+    expect(result.enableStopLoss).toBe(true);
+    expect(result.stopLossValue).toBe(5);
+    // Other defaults preserved
+    expect(result.stopLossType).toBe(DEFAULT_EXIT_CONFIG.stopLossType);
+    expect(result.enableTakeProfit).toBe(DEFAULT_EXIT_CONFIG.enableTakeProfit);
+  });
+
+  it('should apply layers in priority order (last wins)', () => {
+    const userConfig: Partial<ExitConfig> = {
+      enableStopLoss: true,
+      stopLossValue: 3,
+      enableTakeProfit: true,
+      takeProfitValue: 6
+    };
+
+    const signalConfig: Partial<ExitConfig> = {
+      stopLossValue: 2,
+      takeProfitValue: 10
+    };
+
+    const result = resolveExitConfig(userConfig, signalConfig);
+
+    expect(result.enableStopLoss).toBe(true); // from user (not overridden)
+    expect(result.stopLossValue).toBe(2); // signal overrides user
+    expect(result.enableTakeProfit).toBe(true); // from user (not overridden)
+    expect(result.takeProfitValue).toBe(10); // signal overrides user
+  });
+
+  it('should not override lower layers when higher layers omit keys', () => {
+    const userConfig: Partial<ExitConfig> = {
+      enableStopLoss: true,
+      stopLossValue: 5,
+      stopLossType: StopLossType.ATR
+    };
+
+    const signalConfig: Partial<ExitConfig> = {
+      stopLossValue: 3
+      // stopLossType not set — should keep ATR from userConfig
+    };
+
+    const result = resolveExitConfig(userConfig, signalConfig);
+
+    expect(result.stopLossType).toBe(StopLossType.ATR);
+    expect(result.stopLossValue).toBe(3);
+  });
+
+  it('should not override lower layers when higher layers have explicit undefined', () => {
+    const userConfig: Partial<ExitConfig> = {
+      stopLossValue: 5,
+      atrPeriod: 20
+    };
+
+    const signalConfig: Partial<ExitConfig> = {
+      stopLossValue: undefined,
+      atrPeriod: undefined
+    };
+
+    const result = resolveExitConfig(userConfig, signalConfig);
+
+    expect(result.stopLossValue).toBe(5);
+    expect(result.atrPeriod).toBe(20);
+  });
+
+  it('should apply falsy-but-defined values (false, 0)', () => {
+    const layer: Partial<ExitConfig> = {
+      enableStopLoss: false,
+      stopLossValue: 0,
+      useOco: false
+    };
+
+    const result = resolveExitConfig({ enableStopLoss: true, stopLossValue: 5, useOco: true }, layer);
+
+    expect(result.enableStopLoss).toBe(false);
+    expect(result.stopLossValue).toBe(0);
+    expect(result.useOco).toBe(false);
+  });
+});

--- a/apps/api/src/order/utils/exit-config-merge.util.ts
+++ b/apps/api/src/order/utils/exit-config-merge.util.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_EXIT_CONFIG, ExitConfig } from '../interfaces/exit-config.interface';
+
+/**
+ * Merge multiple partial ExitConfig layers into a single resolved ExitConfig.
+ *
+ * Layers are applied in order (lowest-to-highest priority). Undefined values
+ * in higher-priority layers do not override lower layers.
+ *
+ * Typical call pattern:
+ *   resolveExitConfig(userConfig, resultExitConfig, signalExitConfig)
+ *
+ * The system default (DEFAULT_EXIT_CONFIG) is always the base layer.
+ */
+export function resolveExitConfig(...layers: Array<Partial<ExitConfig> | undefined>): ExitConfig {
+  const result = { ...DEFAULT_EXIT_CONFIG };
+
+  for (const layer of layers) {
+    if (!layer) continue;
+    const defined = Object.fromEntries(Object.entries(layer).filter(([, v]) => v !== undefined));
+    Object.assign(result, defined);
+  }
+
+  return result;
+}

--- a/apps/api/src/strategy/live-trading.service.ts
+++ b/apps/api/src/strategy/live-trading.service.ts
@@ -346,7 +346,8 @@ export class LiveTradingService implements OnApplicationShutdown {
             quantity: signal.quantity,
             marketType: 'futures',
             positionSide,
-            leverage: Number(strategy.defaultLeverage) || 1
+            leverage: Number(strategy.defaultLeverage) || 1,
+            exitConfig: signal.exitConfig
           };
 
           await this.tradeExecutionService.executeTradeSignal(tradeSignal);

--- a/apps/api/src/strategy/strategy-executor.service.ts
+++ b/apps/api/src/strategy/strategy-executor.service.ts
@@ -12,6 +12,7 @@ import { AlgorithmContextBuilder } from '../algorithm/services/algorithm-context
 import { CompositeRegimeService } from '../market-regime/composite-regime.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { SignalThrottleService, ThrottleState } from '../order/backtest/shared/throttle';
+import { ExitConfig } from '../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../shared/error.util';
 
 export interface TradingSignal {
@@ -20,6 +21,8 @@ export interface TradingSignal {
   quantity: number;
   price: number;
   reason?: string;
+  /** Strategy-provided exit configuration (per-signal > result-level) */
+  exitConfig?: Partial<ExitConfig>;
 }
 
 export interface MarketData {
@@ -156,7 +159,7 @@ export class StrategyExecutorService {
       surviving.sort((a, b) => b.confidence - a.confidence);
       const best = surviving[0];
 
-      const signal = this.mapAlgorithmSignal(best, context.coins, marketData, availableCapital);
+      const signal = this.mapAlgorithmSignal(best, context.coins, marketData, availableCapital, result.exitConfig);
       if (!signal) {
         this.logger.warn(`Strategy ${strategy.id}: could not map algorithm signal to trading signal`);
         return null;
@@ -255,7 +258,8 @@ export class StrategyExecutorService {
     signal: AlgorithmTradingSignal,
     coins: Array<{ id: string; symbol: string }>,
     marketData: MarketData[],
-    availableCapital: number
+    availableCapital: number,
+    resultExitConfig?: Partial<ExitConfig>
   ): TradingSignal | null {
     const coin = coins.find((c) => c.id === signal.coinId);
     if (!coin) {
@@ -302,12 +306,16 @@ export class StrategyExecutorService {
       }
     }
 
+    // Per-signal exitConfig takes priority over result-level exitConfig
+    const exitConfig = signal.exitConfig ?? resultExitConfig;
+
     return {
       action,
       symbol,
       quantity,
       price,
-      reason: signal.reason
+      reason: signal.reason,
+      exitConfig
     };
   }
 


### PR DESCRIPTION
## Summary

- Extend `AlgorithmResult` and `TradingSignal` interfaces with optional `exitConfig` so strategies can recommend stop-loss/take-profit placement alongside entry signals
- Implement proof-of-concept exit configs in 3 strategies: ATR Trailing Stop, Confluence, and Mean Reversion
- Wire strategy-provided exit configs through both live trading pipelines and the backtest engine with a consistent priority cascade: per-signal > result-level > user default > system default

## Changes

### Interface & Base
- Add optional `exitConfig?: Partial<ExitConfig>` to `AlgorithmResult` and `TradingSignal` interfaces
- Update `BaseAlgorithmStrategy.buildResult()` to pass through exit configs

### Strategy Implementations
- **ATR Trailing Stop**: ATR-based stop loss with configurable multiplier, bounds-clamped parameters
- **Confluence**: Confidence-scaled stop loss (2-4%) with risk-reward take profit (1.5:1 to 3:1)
- **Mean Reversion**: Z-score-scaled take profit (1-8%) with tight ATR-based stop loss (1.5×)

### Config Merging
- New `resolveExitConfig()` utility for multi-layer config merging with undefined-safe semantics
- Backtest engine uses `resolveExitConfig()` for consistent config resolution

### Pipeline Integration
- **Pipeline 1** (LiveTradingService): Pass `exitConfig` through `StrategyExecutorService` → trade signal
- **Pipeline 2** (TradeExecutionTask): Resolve per-signal vs result-level exitConfig, wire to trade execution
- **Backtest engine**: Map strategy exit configs into `BacktestSignal` metadata, pass to `BacktestExitTracker.onBuy()`
- **Paper trading**: Propagate exit configs through processor and market data service
- **Signal throttle**: Preserve exit configs through throttle filtering

### Tests
- `exit-config-merge.util.spec.ts` — layer merging, undefined handling, priority cascade
- `paper-trading-market-data.service.spec.ts` — expanded coverage for exit config propagation
- `paper-trading.processor.spec.ts` — exit config passthrough verification
- `signal-throttle.service.spec.ts` — exit config preservation through throttle

## Test Plan

- [x] All existing tests pass (pre-commit hook verified)
- [x] New unit tests for `resolveExitConfig()` utility
- [x] Signal throttle preserves exit configs
- [x] Paper trading propagates exit configs
- [ ] Strategies without exit configs continue to work identically (backward compatible)
- [ ] Backtest with strategy-provided exit config produces different exit behavior than default

Closes #226