### PR TITLE
refactor(api): add rate-limit-aware retry across exchange calls

### DIFF
--- a/apps/api/src/algorithm/scripts/added-to-exchange-binance.service.ts
+++ b/apps/api/src/algorithm/scripts/added-to-exchange-binance.service.ts
@@ -4,6 +4,7 @@ import * as ccxt from 'ccxt';
 
 import { BinanceUSService } from '../../exchange/binance/binance-us.service';
 import { toErrorInfo } from '../../shared/error.util';
+import { withRateLimitRetryThrow } from '../../shared/retry.util';
 
 @Injectable()
 export class AddedtoExchangeBinanceService {
@@ -33,7 +34,10 @@ export class AddedtoExchangeBinanceService {
 
   private async checkForNewListings() {
     // Get all current markets
-    const markets = await this.client.fetchMarkets();
+    const markets = await withRateLimitRetryThrow(() => this.client.fetchMarkets(), {
+      logger: this.logger,
+      operationName: 'fetchMarkets'
+    });
     const currentSymbols = markets.flatMap((market) => (market?.symbol ? [market.symbol] : []));
 
     // Compare with previously known symbols (you'd need to store this somewhere)
@@ -70,7 +74,10 @@ export class AddedtoExchangeBinanceService {
       const formattedSymbol = symbol.includes('/') ? symbol : symbol.replace(/([A-Z0-9]{3,})([A-Z0-9]{3,})$/, '$1/$2');
 
       // Get current market price
-      const ticker = await this.client.fetchTicker(formattedSymbol);
+      const ticker = await withRateLimitRetryThrow(() => this.client.fetchTicker(formattedSymbol), {
+        logger: this.logger,
+        operationName: `fetchTicker(${formattedSymbol})`
+      });
       const price = ticker.last ?? 0;
 
       // Calculate quantity based on USDT amount

--- a/apps/api/src/category/tasks/category-sync.task.ts
+++ b/apps/api/src/category/tasks/category-sync.task.ts
@@ -5,9 +5,10 @@ import { CronExpression } from '@nestjs/schedule';
 
 import { AxiosError } from 'axios';
 import { Job, Queue } from 'bullmq';
-import { firstValueFrom, retry, timeout } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 
 import { toErrorInfo } from '../../shared/error.util';
+import { withRateLimitRetryThrow } from '../../shared/retry.util';
 import { CategoryService } from '../category.service';
 
 @Processor('category-queue')
@@ -92,12 +93,14 @@ export class CategorySyncTask extends WorkerHost implements OnModuleInit {
   }
 
   private async fetchCategories() {
-    return firstValueFrom(
-      this.http
-        .get('https://api.coingecko.com/api/v3/coins/categories/list', {
-          timeout: 10000
-        })
-        .pipe(timeout(12000), retry({ count: 3, delay: 1000 }))
+    return withRateLimitRetryThrow(
+      () =>
+        firstValueFrom(
+          this.http.get('https://api.coingecko.com/api/v3/coins/categories/list', {
+            timeout: 10000
+          })
+        ),
+      { operationName: 'fetchCategories' }
     );
   }
 

--- a/apps/api/src/exchange/base-exchange.service.ts
+++ b/apps/api/src/exchange/base-exchange.service.ts
@@ -11,6 +11,7 @@ import { EXCHANGE_KEY_SERVICE, EXCHANGE_SERVICE, IExchangeKeyService, IExchangeS
 
 import { AssetBalanceDto } from '../balance/dto/balance-response.dto';
 import { toErrorInfo } from '../shared/error.util';
+import { withRateLimitRetryThrow } from '../shared/retry.util';
 import { User } from '../users/users.entity';
 
 /**
@@ -283,7 +284,10 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
     try {
       const formattedSymbol = this.formatSymbol(symbol);
       const client = await this.getClient(user);
-      const ticker = await client.fetchTicker(formattedSymbol);
+      const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(formattedSymbol), {
+        logger: this.logger,
+        operationName: `fetchTicker(${symbol})`
+      });
 
       return ticker.last ?? 0;
     } catch (error: unknown) {
@@ -326,7 +330,10 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
   async validateKeys(apiKey: string, apiSecret: string): Promise<void> {
     const client = await this.getTemporaryClient(apiKey, apiSecret);
     try {
-      await client.fetchBalance();
+      await withRateLimitRetryThrow(() => client.fetchBalance(), {
+        logger: this.logger,
+        operationName: 'validateKeys'
+      });
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`${this.constructor.name} API key validation failed: ${err.message}`, err.stack);

--- a/apps/api/src/exchange/binance/binance-us.service.ts
+++ b/apps/api/src/exchange/binance/binance-us.service.ts
@@ -7,6 +7,12 @@ import * as https from 'https';
 
 import { AssetBalanceDto } from '../../balance/dto/balance-response.dto';
 import { toErrorInfo } from '../../shared/error.util';
+import {
+  isAuthenticationError,
+  isTransientError,
+  withRateLimitRetry,
+  withRateLimitRetryThrow
+} from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
 import { CCXT_BALANCE_META_KEYS } from '../ccxt-balance.util';
@@ -50,7 +56,10 @@ export class BinanceUSService extends BaseExchangeService {
   async getFreeBalance(user: User) {
     try {
       const client = await this.getClient(user);
-      const balanceData = await client.fetchBalance();
+      const balanceData = await withRateLimitRetryThrow(() => client.fetchBalance(), {
+        logger: this.logger,
+        operationName: 'getFreeBalance'
+      });
 
       const balances: AssetBalanceDto[] = [];
 
@@ -94,9 +103,11 @@ export class BinanceUSService extends BaseExchangeService {
     });
 
     try {
-      // Try to fetch balance - this will throw an error if the keys are invalid
-      await client.fetchBalance();
-      return true;
+      const result = await withRateLimitRetry(() => client.fetchBalance(), {
+        operationName: 'validateApiKeys',
+        isRetryable: (err) => isTransientError(err) && !isAuthenticationError(err)
+      });
+      return result.success;
     } catch {
       return false;
     } finally {

--- a/apps/api/src/exchange/coinbase-exchange/coinbase-exchange.service.ts
+++ b/apps/api/src/exchange/coinbase-exchange/coinbase-exchange.service.ts
@@ -5,6 +5,7 @@ import * as ccxt from 'ccxt';
 
 import { AssetBalanceDto } from '../../balance/dto/balance-response.dto';
 import { toErrorInfo } from '../../shared/error.util';
+import { withRateLimitRetryThrow } from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
 import { CCXT_BALANCE_META_KEYS } from '../ccxt-balance.util';
@@ -38,7 +39,10 @@ export class CoinbaseExchangeService extends BaseExchangeService {
       const formattedSymbol = symbol.includes('/') ? symbol : symbol.replace('-', '/');
 
       const client = await this.getClient();
-      const ticker = await client.fetchTicker(formattedSymbol);
+      const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(formattedSymbol), {
+        logger: this.logger,
+        operationName: `getPrice(${symbol})`
+      });
 
       // Return in the format expected by existing code
       return {
@@ -65,7 +69,10 @@ export class CoinbaseExchangeService extends BaseExchangeService {
   async getBalance(user: User): Promise<AssetBalanceDto[]> {
     try {
       const client = await this.getClient(user);
-      const balances = await client.fetchBalance();
+      const balances = await withRateLimitRetryThrow(() => client.fetchBalance(), {
+        logger: this.logger,
+        operationName: 'getBalance'
+      });
 
       const assetBalances: AssetBalanceDto[] = [];
 

--- a/apps/api/src/exchange/coinbase/coinbase.service.ts
+++ b/apps/api/src/exchange/coinbase/coinbase.service.ts
@@ -7,6 +7,12 @@ import * as https from 'https';
 
 import { AssetBalanceDto } from '../../balance/dto/balance-response.dto';
 import { toErrorInfo } from '../../shared/error.util';
+import {
+  isAuthenticationError,
+  isTransientError,
+  withRateLimitRetry,
+  withRateLimitRetryThrow
+} from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
 import { CCXT_BALANCE_META_KEYS } from '../ccxt-balance.util';
@@ -57,7 +63,10 @@ export class CoinbaseService extends BaseExchangeService {
       const formattedSymbol = symbol.includes('/') ? symbol : symbol.replace('-', '/');
 
       const client = await this.getCoinbaseClient();
-      const ticker = await client.fetchTicker(formattedSymbol);
+      const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(formattedSymbol), {
+        logger: this.logger,
+        operationName: `getPrice(${symbol})`
+      });
 
       // Return in the format expected by existing code
       return {
@@ -116,9 +125,11 @@ export class CoinbaseService extends BaseExchangeService {
     });
 
     try {
-      // Try to fetch balance - this will throw an error if the keys are invalid
-      await client.fetchBalance();
-      return true;
+      const result = await withRateLimitRetry(() => client.fetchBalance(), {
+        operationName: 'validateApiKeys',
+        isRetryable: (err) => isTransientError(err) && !isAuthenticationError(err)
+      });
+      return result.success;
     } catch (error: unknown) {
       return false;
     } finally {
@@ -165,14 +176,20 @@ export class CoinbaseService extends BaseExchangeService {
   async getFuturesPositions(user: User, symbol?: string): Promise<ccxt.Position[]> {
     const exchange = await this.getClient(user);
     const symbols = symbol ? [symbol] : undefined;
-    return exchange.fetchPositions(symbols);
+    return withRateLimitRetryThrow(() => exchange.fetchPositions(symbols), {
+      logger: this.logger,
+      operationName: 'getFuturesPositions'
+    });
   }
 
   async getBalance(user: User): Promise<AssetBalanceDto[]> {
     try {
       const client = await this.getCoinbaseClient(user);
       this.logger.log(`Fetching Coinbase balance for user ${user.id}...`);
-      const balances = await client.fetchBalance();
+      const balances = await withRateLimitRetryThrow(() => client.fetchBalance(), {
+        logger: this.logger,
+        operationName: 'getBalance'
+      });
       this.logger.debug(`Fetched Coinbase balance for user ${user.id}: ${JSON.stringify(balances)}`);
 
       const assetBalances: AssetBalanceDto[] = [];

--- a/apps/api/src/exchange/kraken/kraken.service.ts
+++ b/apps/api/src/exchange/kraken/kraken.service.ts
@@ -7,6 +7,12 @@ import * as https from 'https';
 
 import { AssetBalanceDto } from '../../balance/dto/balance-response.dto';
 import { toErrorInfo } from '../../shared/error.util';
+import {
+  isAuthenticationError,
+  isTransientError,
+  withRateLimitRetry,
+  withRateLimitRetryThrow
+} from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
 import { CCXT_BALANCE_META_KEYS } from '../ccxt-balance.util';
@@ -50,7 +56,10 @@ export class KrakenService extends BaseExchangeService {
   async getFreeBalance(user: User) {
     try {
       const client = await this.getClient(user);
-      const balanceData = await client.fetchBalance();
+      const balanceData = await withRateLimitRetryThrow(() => client.fetchBalance(), {
+        logger: this.logger,
+        operationName: 'getFreeBalance'
+      });
 
       const balances: AssetBalanceDto[] = [];
 
@@ -99,9 +108,11 @@ export class KrakenService extends BaseExchangeService {
     });
 
     try {
-      // Try to fetch balance - this will throw an error if the keys are invalid
-      await client.fetchBalance();
-      return true;
+      const result = await withRateLimitRetry(() => client.fetchBalance(), {
+        operationName: 'validateApiKeys',
+        isRetryable: (err) => isTransientError(err) && !isAuthenticationError(err)
+      });
+      return result.success;
     } catch {
       return false;
     } finally {

--- a/apps/api/src/ohlc/services/exchange-ohlc.service.spec.ts
+++ b/apps/api/src/ohlc/services/exchange-ohlc.service.spec.ts
@@ -1,6 +1,7 @@
 import { ExchangeOHLCService } from './exchange-ohlc.service';
 
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import * as retryUtil from '../../shared/retry.util';
 
 const createClient = (overrides: Partial<any> = {}) => ({
   has: { fetchOHLCV: true },
@@ -15,6 +16,8 @@ describe('ExchangeOHLCService', () => {
   let exchangeManager: jest.Mocked<ExchangeManagerService>;
   let configService: { get: jest.Mock };
 
+  let withRateLimitRetryThrowSpy: jest.SpyInstance;
+
   beforeEach(() => {
     exchangeManager = {
       getPublicClient: jest.fn()
@@ -22,9 +25,15 @@ describe('ExchangeOHLCService', () => {
     configService = { get: jest.fn() };
 
     service = new ExchangeOHLCService(exchangeManager, configService as any);
+
+    // Mock withRateLimitRetryThrow to execute operation once without retry delays
+    withRateLimitRetryThrowSpy = jest
+      .spyOn(retryUtil, 'withRateLimitRetryThrow')
+      .mockImplementation(async (fn) => fn());
   });
 
   afterEach(() => {
+    withRateLimitRetryThrowSpy.mockRestore();
     jest.clearAllMocks();
   });
 
@@ -58,17 +67,14 @@ describe('ExchangeOHLCService', () => {
     expect(result.candles?.[0].open).toBe(1);
   });
 
-  it('fetchOHLCWithRetry retries on rate limit and succeeds', async () => {
+  it('fetchOHLCWithRetry delegates to fetchOHLC', async () => {
     const fetchSpy = jest
       .spyOn(service, 'fetchOHLC')
-      .mockResolvedValueOnce({ success: false, error: 'rate limit exceeded' })
-      .mockResolvedValueOnce({ success: true, candles: [] });
+      .mockResolvedValueOnce({ success: true, candles: [], exchangeSlug: 'binance_us' });
 
-    jest.spyOn(service as any, 'sleep').mockResolvedValue(undefined);
+    const result = await service.fetchOHLCWithRetry('binance_us', 'BTC/USD', 0, 500);
 
-    const result = await service.fetchOHLCWithRetry('binance_us', 'BTC/USD', 0, 500, 2);
-
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result.success).toBe(true);
   });
 
@@ -89,8 +95,6 @@ describe('ExchangeOHLCService', () => {
       .mockResolvedValueOnce({ success: false, error: 'fail1' })
       .mockResolvedValueOnce({ success: false, error: 'fail2' })
       .mockResolvedValueOnce({ success: false, error: 'fail3' });
-
-    jest.spyOn(service as any, 'sleep').mockResolvedValue(undefined);
 
     const result = await service.fetchOHLCWithFallback('BTC/USD', 0, 500);
 

--- a/apps/api/src/ohlc/services/exchange-ohlc.service.ts
+++ b/apps/api/src/ohlc/services/exchange-ohlc.service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { DEFAULT_QUOTE_CURRENCY, EXCHANGE_QUOTE_CURRENCY, USD_QUOTE_CURRENCIES } from '../../exchange/constants';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { formatSymbolForExchange } from '../../exchange/utils';
+import { withRateLimitRetryThrow } from '../../shared/retry.util';
 
 export interface OHLCRawData {
   timestamp: number; // Unix ms
@@ -25,8 +26,6 @@ export interface OHLCFetchResult {
 export class ExchangeOHLCService {
   private readonly logger = new Logger(ExchangeOHLCService.name);
   private readonly EXCHANGE_PRIORITY: string[];
-  private readonly MAX_RETRIES = 3;
-  private readonly INITIAL_BACKOFF_MS = 2000;
 
   constructor(
     private readonly exchangeManager: ExchangeManagerService,
@@ -65,7 +64,7 @@ export class ExchangeOHLCService {
       errors.push(`${exchangeSlug}: ${result.error}`);
 
       // Add delay between exchange attempts to avoid rate limiting
-      await this.sleep(500);
+      await new Promise((resolve) => setTimeout(resolve, 500));
     }
 
     return {
@@ -75,56 +74,11 @@ export class ExchangeOHLCService {
   }
 
   /**
-   * Fetch OHLC data from a specific exchange with retry logic
+   * Fetch OHLC data from a specific exchange with retry logic.
+   * Retry is handled inside fetchOHLC via withRateLimitRetryThrow.
    */
-  async fetchOHLCWithRetry(
-    exchangeSlug: string,
-    symbol: string,
-    since: number,
-    limit = 500,
-    retries = this.MAX_RETRIES
-  ): Promise<OHLCFetchResult> {
-    let lastError = '';
-    let backoffMs = this.INITIAL_BACKOFF_MS;
-
-    for (let attempt = 1; attempt <= retries; attempt++) {
-      try {
-        const result = await this.fetchOHLC(exchangeSlug, symbol, since, limit);
-
-        if (result.success) {
-          return result;
-        }
-
-        lastError = result.error || 'Unknown error';
-
-        // Check if it's a rate limit error
-        if (lastError.toLowerCase().includes('rate limit')) {
-          this.logger.warn(
-            `Rate limit hit on ${exchangeSlug}, waiting ${backoffMs}ms before retry ${attempt}/${retries}`
-          );
-          await this.sleep(backoffMs);
-          backoffMs *= 2; // Exponential backoff
-        } else if (attempt < retries) {
-          // Other errors - shorter delay
-          await this.sleep(backoffMs);
-          backoffMs *= 2;
-        }
-      } catch (error: unknown) {
-        lastError = error instanceof Error ? error.message : 'Unknown error';
-        this.logger.warn(`OHLC fetch attempt ${attempt}/${retries} failed for ${exchangeSlug}: ${lastError}`);
-
-        if (attempt < retries) {
-          await this.sleep(backoffMs);
-          backoffMs *= 2;
-        }
-      }
-    }
-
-    return {
-      success: false,
-      exchangeSlug,
-      error: lastError
-    };
+  async fetchOHLCWithRetry(exchangeSlug: string, symbol: string, since: number, limit = 500): Promise<OHLCFetchResult> {
+    return this.fetchOHLC(exchangeSlug, symbol, since, limit);
   }
 
   /**
@@ -147,7 +101,10 @@ export class ExchangeOHLCService {
 
       // Load markets if not already loaded
       if (!client.markets) {
-        await client.loadMarkets();
+        await withRateLimitRetryThrow(() => client.loadMarkets(), {
+          logger: this.logger,
+          operationName: `loadMarkets(${exchangeSlug})`
+        });
       }
 
       // Check if the symbol exists on this exchange
@@ -162,7 +119,10 @@ export class ExchangeOHLCService {
 
       // Fetch OHLCV data (Open, High, Low, Close, Volume)
       // Format: [[timestamp, open, high, low, close, volume], ...]
-      const ohlcv = await client.fetchOHLCV(formattedSymbol, '1h', since, limit);
+      const ohlcv = await withRateLimitRetryThrow(() => client.fetchOHLCV(formattedSymbol, '1h', since, limit), {
+        logger: this.logger,
+        operationName: `fetchOHLCV(${exchangeSlug}:${symbol})`
+      });
 
       if (!ohlcv || ohlcv.length === 0) {
         return {
@@ -221,7 +181,10 @@ export class ExchangeOHLCService {
       const client = await this.exchangeManager.getPublicClient(exchangeSlug);
 
       if (!client.markets) {
-        await client.loadMarkets();
+        await withRateLimitRetryThrow(() => client.loadMarkets(), {
+          logger: this.logger,
+          operationName: `loadMarkets(${exchangeSlug})`
+        });
       }
 
       const symbols: string[] = [];
@@ -249,12 +212,5 @@ export class ExchangeOHLCService {
       this.logger.warn(`Failed to get available symbols for ${baseAsset} on ${exchangeSlug}: ${error}`);
       return [];
     }
-  }
-
-  /**
-   * Sleep helper for delays
-   */
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/apps/api/src/ohlc/services/realtime-ticker.service.ts
+++ b/apps/api/src/ohlc/services/realtime-ticker.service.ts
@@ -7,6 +7,7 @@ import { CoinService } from '../../coin/coin.service';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { formatSymbolForExchange } from '../../exchange/utils';
 import { toErrorInfo } from '../../shared/error.util';
+import { withRateLimitRetryThrow } from '../../shared/retry.util';
 
 export interface TickerPrice {
   coinId: string;
@@ -168,7 +169,10 @@ export class RealtimeTickerService {
 
         // Load markets if not loaded
         if (!client.markets) {
-          await client.loadMarkets();
+          await withRateLimitRetryThrow(() => client.loadMarkets(), {
+            logger: this.logger,
+            operationName: `loadMarkets(${exchangeSlug})`
+          });
         }
 
         // Check if symbol exists
@@ -178,7 +182,10 @@ export class RealtimeTickerService {
         }
 
         // Fetch ticker
-        const ticker = await client.fetchTicker(formattedSymbol);
+        const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(formattedSymbol), {
+          logger: this.logger,
+          operationName: `fetchTicker(${exchangeSlug}:${tradingSymbol})`
+        });
 
         if (ticker && ticker.last) {
           return {

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -28,16 +28,19 @@ const createService = (overrides: Partial<{ cacheManager: any; exchangeManager: 
 };
 
 describe('PaperTradingMarketDataService', () => {
-  let withRetrySpy: jest.SpyInstance;
+  let withRateLimitRetrySpy: jest.SpyInstance;
+  let withRateLimitRetryThrowSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Spy on withRetry to avoid real delays in tests
-    withRetrySpy = jest.spyOn(retryUtil, 'withRetry');
+    // Spy on rate-limit-aware retry wrappers to avoid real delays in tests
+    withRateLimitRetrySpy = jest.spyOn(retryUtil, 'withRateLimitRetry');
+    withRateLimitRetryThrowSpy = jest.spyOn(retryUtil, 'withRateLimitRetryThrow');
   });
 
   afterEach(() => {
-    withRetrySpy.mockRestore();
+    withRateLimitRetrySpy.mockRestore();
+    withRateLimitRetryThrowSpy.mockRestore();
   });
 
   it('returns cached price data when available', async () => {
@@ -82,7 +85,7 @@ describe('PaperTradingMarketDataService', () => {
       getPublicClient: jest.fn().mockResolvedValue(client)
     };
 
-    withRetrySpy.mockResolvedValue({
+    withRateLimitRetrySpy.mockResolvedValue({
       success: true,
       result: ticker,
       attempts: 1,
@@ -204,9 +207,8 @@ describe('PaperTradingMarketDataService', () => {
     it('returns empty array when fetch throws', async () => {
       const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
 
-      const client = {
-        fetchOHLCV: jest.fn().mockRejectedValue(new Error('network error'))
-      };
+      // Mock withRateLimitRetryThrow to throw immediately (avoid real retry delays)
+      withRateLimitRetryThrowSpy.mockRejectedValue(new Error('network error'));
 
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
@@ -215,7 +217,7 @@ describe('PaperTradingMarketDataService', () => {
 
       const exchangeManager = {
         formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
-        getPublicClient: jest.fn().mockResolvedValue(client)
+        getPublicClient: jest.fn().mockResolvedValue({})
       };
 
       const { service } = createService({ cacheManager, exchangeManager });
@@ -244,7 +246,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue(client)
       };
 
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: true,
         result: ticker,
         attempts: 2,
@@ -255,12 +257,10 @@ describe('PaperTradingMarketDataService', () => {
       const result = await service.getCurrentPrice('binance', 'BTC/USDT');
 
       expect(result.price).toBe(45000);
-      expect(withRetrySpy).toHaveBeenCalledWith(
+      expect(withRateLimitRetrySpy).toHaveBeenCalledWith(
         expect.any(Function),
         expect.objectContaining({
-          maxRetries: 3,
-          initialDelayMs: 2000,
-          isRetryable: retryUtil.isTransientError
+          operationName: expect.stringContaining('fetchTicker')
         })
       );
     });
@@ -291,7 +291,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTicker: jest.fn() })
       };
 
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: false,
         error: new Error('ETIMEDOUT'),
         attempts: 4,
@@ -320,7 +320,7 @@ describe('PaperTradingMarketDataService', () => {
       };
 
       const timeoutError = new Error('ETIMEDOUT');
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: false,
         error: timeoutError,
         attempts: 4,
@@ -353,7 +353,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue(client)
       };
 
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: true,
         result: tickers,
         attempts: 2,
@@ -401,7 +401,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: false,
         error: new Error('ETIMEDOUT'),
         attempts: 4,
@@ -443,7 +443,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: false,
         error: new Error('ETIMEDOUT'),
         attempts: 4,
@@ -485,7 +485,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: true,
         result: tickers,
         attempts: 1,
@@ -517,7 +517,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRetrySpy.mockResolvedValue({
+      withRateLimitRetrySpy.mockResolvedValue({
         success: true,
         result: tickers,
         attempts: 1,

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -9,7 +9,7 @@ import { paperTradingConfig } from './paper-trading.config';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { toErrorInfo } from '../../shared/error.util';
-import { isTransientError, withRetry } from '../../shared/retry.util';
+import { withRateLimitRetry, withRateLimitRetryThrow } from '../../shared/retry.util';
 import type { User } from '../../users/users.entity';
 
 export interface PriceData {
@@ -74,12 +74,7 @@ export class PaperTradingMarketDataService {
       : await this.exchangeManager.getPublicClient(exchangeSlug);
 
     // Fetch ticker with retry
-    const result = await withRetry(() => client.fetchTicker(formattedSymbol), {
-      maxRetries: 3,
-      initialDelayMs: 2000,
-      maxDelayMs: 8000,
-      backoffMultiplier: 2,
-      isRetryable: isTransientError,
+    const result = await withRateLimitRetry(() => client.fetchTicker(formattedSymbol), {
       logger: this.logger,
       operationName: `fetchTicker(${exchangeSlug}:${symbol})`
     });
@@ -155,14 +150,9 @@ export class PaperTradingMarketDataService {
       : await this.exchangeManager.getPublicClient(exchangeSlug);
 
     // Fetch all tickers with retry
-    const result = await withRetry(
+    const result = await withRateLimitRetry(
       () => client.fetchTickers(uncachedSymbols.map((s) => this.exchangeManager.formatSymbol(exchangeSlug, s))),
       {
-        maxRetries: 3,
-        initialDelayMs: 2000,
-        maxDelayMs: 8000,
-        backoffMultiplier: 2,
-        isRetryable: isTransientError,
         logger: this.logger,
         operationName: `fetchTickers(${exchangeSlug})`
       }
@@ -246,7 +236,10 @@ export class PaperTradingMarketDataService {
         ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
         : await this.exchangeManager.getPublicClient(exchangeSlug);
 
-      const rawOrderBook = await client.fetchOrderBook(formattedSymbol, depth);
+      const rawOrderBook = await withRateLimitRetryThrow(() => client.fetchOrderBook(formattedSymbol, depth), {
+        logger: this.logger,
+        operationName: `fetchOrderBook(${exchangeSlug}:${symbol})`
+      });
 
       const orderBook: OrderBook = {
         symbol,
@@ -367,7 +360,10 @@ export class PaperTradingMarketDataService {
         ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
         : await this.exchangeManager.getPublicClient(exchangeSlug);
 
-      const ohlcv = await client.fetchOHLCV(formattedSymbol, timeframe, undefined, limit);
+      const ohlcv = await withRateLimitRetryThrow(
+        () => client.fetchOHLCV(formattedSymbol, timeframe, undefined, limit),
+        { logger: this.logger, operationName: `fetchOHLCV(${exchangeSlug}:${symbol})` }
+      );
 
       const candles = ohlcv.map((candle) => ({
         avg: candle[4] as number, // close price — representative price for indicators
@@ -397,7 +393,17 @@ export class PaperTradingMarketDataService {
 
     try {
       const client = await this.exchangeManager.getPublicClient(exchangeSlug);
-      await client.fetchTime();
+      const result = await withRateLimitRetry(() => client.fetchTime(), {
+        logger: this.logger,
+        operationName: `checkExchangeHealth(${exchangeSlug})`
+      });
+
+      if (!result.success) {
+        return {
+          healthy: false,
+          error: result.error?.message
+        };
+      }
 
       return {
         healthy: true,

--- a/apps/api/src/order/services/order-sync.service.ts
+++ b/apps/api/src/order/services/order-sync.service.ts
@@ -18,6 +18,7 @@ import { ExchangeManagerService } from '../../exchange/exchange-manager.service'
 import { ExchangeService } from '../../exchange/exchange.service';
 import { MetricsService } from '../../metrics/metrics.service';
 import { toErrorInfo } from '../../shared/error.util';
+import { withRateLimitRetry, withRateLimitRetryThrow } from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { OrderTransitionReason } from '../entities/order-status-history.entity';
 import { Order, OrderSide, OrderStatus } from '../order.entity';
@@ -51,19 +52,24 @@ export class OrderSyncService {
 
     try {
       const since = lastSyncTime ? new Date(lastSyncTime).getTime() : undefined;
-      const markets = await client.loadMarkets();
+      const markets = await withRateLimitRetryThrow(() => client.loadMarkets(), {
+        logger: this.logger,
+        operationName: 'loadMarkets (fetchHistoricalOrders)'
+      });
       this.logger.log(`Fetching historical orders since: ${since}`);
       this.logger.log(`Available markets: ${Object.keys(markets).join(', ')}`);
       const allOrders: ccxt.Order[] = [];
 
       for (const symbol of Object.keys(markets)) {
-        try {
-          const symbolOrders = await client.fetchOrders(symbol, since);
-          this.logger.log(`Fetched ${symbolOrders.length} orders for ${symbol}`);
-          allOrders.push(...symbolOrders);
-        } catch (error: unknown) {
-          const err = toErrorInfo(error);
-          this.logger.log(`Failed to fetch orders for ${symbol}: ${err.message}`);
+        const result = await withRateLimitRetry(() => client.fetchOrders(symbol, since), {
+          logger: this.logger,
+          operationName: `fetchOrders(${symbol})`
+        });
+        if (result.success) {
+          this.logger.log(`Fetched ${result.result!.length} orders for ${symbol}`);
+          allOrders.push(...result.result!);
+        } else {
+          this.logger.log(`Failed to fetch orders for ${symbol}: ${result.error!.message}`);
         }
       }
 
@@ -89,19 +95,24 @@ export class OrderSyncService {
         return [];
       }
 
-      const markets = await client.loadMarkets();
+      const markets = await withRateLimitRetryThrow(() => client.loadMarkets(), {
+        logger: this.logger,
+        operationName: 'loadMarkets (fetchMyTrades)'
+      });
       this.logger.log(`Fetching historical trades since: ${since}`);
       this.logger.log(`Available markets: ${Object.keys(markets).join(', ')}`);
       const allTrades: ccxt.Trade[] = [];
 
       for (const symbol of Object.keys(markets)) {
-        try {
-          const symbolTrades = await client.fetchMyTrades(symbol, since);
-          this.logger.log(`Fetched ${symbolTrades.length} trades for ${symbol}`);
-          allTrades.push(...symbolTrades);
-        } catch (error: unknown) {
-          const err = toErrorInfo(error);
-          this.logger.log(`Failed to fetch trades for ${symbol}: ${err.message}`);
+        const result = await withRateLimitRetry(() => client.fetchMyTrades(symbol, since), {
+          logger: this.logger,
+          operationName: `fetchMyTrades(${symbol})`
+        });
+        if (result.success) {
+          this.logger.log(`Fetched ${result.result!.length} trades for ${symbol}`);
+          allTrades.push(...result.result!);
+        } else {
+          this.logger.log(`Failed to fetch trades for ${symbol}: ${result.error!.message}`);
         }
       }
 

--- a/apps/api/src/order/services/position-management.service.ts
+++ b/apps/api/src/order/services/position-management.service.ts
@@ -15,7 +15,7 @@ import { ExchangeManagerService } from '../../exchange/exchange-manager.service'
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
 import { CircuitBreakerService, CircuitOpenError } from '../../shared/circuit-breaker.service';
 import { toErrorInfo } from '../../shared/error.util';
-import { isTransientError, withRetry } from '../../shared/retry.util';
+import { extractRetryAfterMs, isRateLimitError, isTransientError, withRetry } from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import {
   calculateStopLossPrice as computeSL,
@@ -116,13 +116,18 @@ export class PositionManagementService {
       throw error;
     }
 
-    // Execute with retry
+    // Execute with retry (rate-limit-aware delays)
     const result = await withRetry(operation, {
       maxRetries: 3,
       initialDelayMs: 1000,
       maxDelayMs: 10000,
       backoffMultiplier: 2,
       isRetryable: isTransientError,
+      onRetry: (error, _attempt, defaultDelay) => {
+        if (isRateLimitError(error)) {
+          return extractRetryAfterMs(error) ?? Math.max(defaultDelay, 5000);
+        }
+      },
       logger: this.logger,
       operationName: `${operationName} (${exchangeSlug})`
     });

--- a/apps/api/src/order/services/trade-execution.service.ts
+++ b/apps/api/src/order/services/trade-execution.service.ts
@@ -30,6 +30,7 @@ import { Exchange } from '../../exchange/exchange.entity';
 import { NOTIFICATION_EVENTS } from '../../notification/interfaces/notification-events.interface';
 import { PriceSummary } from '../../ohlc/ohlc-candle.entity';
 import { toErrorInfo } from '../../shared/error.util';
+import { withRateLimitRetryThrow } from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { DEFAULT_SLIPPAGE_LIMITS, slippageLimitsConfig, SlippageLimitsConfig } from '../config/slippage-limits.config';
 import { OrderTransitionReason } from '../entities/order-status-history.entity';
@@ -146,7 +147,10 @@ export class TradeExecutionService {
       const exchangeClient = await this.exchangeManagerService.getExchangeClient(exchangeKey.exchange.slug, user);
 
       // Load markets
-      await exchangeClient.loadMarkets();
+      await withRateLimitRetryThrow(() => exchangeClient.loadMarkets(), {
+        logger: this.logger,
+        operationName: 'loadMarkets'
+      });
 
       // Verify symbol exists
       if (!exchangeClient.markets[signal.symbol]) {
@@ -157,7 +161,10 @@ export class TradeExecutionService {
       // await this.verifyFunds(exchangeClient, signal);
 
       // CAPTURE EXPECTED PRICE BEFORE EXECUTION (for slippage calculation)
-      const ticker = await exchangeClient.fetchTicker(signal.symbol);
+      const ticker = await withRateLimitRetryThrow(() => exchangeClient.fetchTicker(signal.symbol), {
+        logger: this.logger,
+        operationName: `fetchTicker(${signal.symbol})`
+      });
       const expectedPrice = signal.action === 'BUY' ? ticker.ask || ticker.last || 0 : ticker.bid || ticker.last || 0;
 
       this.logger.debug(
@@ -624,7 +631,10 @@ export class TradeExecutionService {
   ): Promise<number> {
     try {
       // Fetch order book with limited depth for efficiency
-      const orderBook = await exchangeClient.fetchOrderBook(symbol, 20);
+      const orderBook = await withRateLimitRetryThrow(() => exchangeClient.fetchOrderBook(symbol, 20), {
+        logger: this.logger,
+        operationName: `fetchOrderBook(${symbol})`
+      });
 
       // Use asks for BUY orders, bids for SELL orders
       const relevantSide = action === 'BUY' ? orderBook.asks : orderBook.bids;

--- a/apps/api/src/portfolio/coin-alert.service.ts
+++ b/apps/api/src/portfolio/coin-alert.service.ts
@@ -4,6 +4,8 @@ import { ConfigService } from '@nestjs/config';
 
 import { firstValueFrom } from 'rxjs';
 
+import { withRateLimitRetryThrow } from '../shared/retry.util';
+
 @Injectable()
 export class CoinAlertService {
   private BASE_URL = 'https://api.cryptocurrencyalerting.com/v1/alert-conditions';
@@ -24,7 +26,10 @@ export class CoinAlertService {
   }
 
   async get(type: AlertType = 'percent_price') {
-    const { data } = await firstValueFrom(this.http.get(this.BASE_URL, { ...this.auth, params: { type } }));
+    const { data } = await withRateLimitRetryThrow(
+      () => firstValueFrom(this.http.get(this.BASE_URL, { ...this.auth, params: { type } })),
+      { operationName: 'getCoinAlerts' }
+    );
     return data;
   }
 

--- a/apps/api/src/shared/index.ts
+++ b/apps/api/src/shared/index.ts
@@ -17,9 +17,15 @@ export {
 } from './circuit-breaker.service';
 export {
   DEFAULT_RETRY_OPTIONS,
+  extractRetryAfterMs,
+  isAuthenticationError,
+  isRateLimitError,
   isTransientError,
+  RATE_LIMIT_RETRY_OPTIONS,
   RetryOptions,
   RetryResult,
+  withRateLimitRetry,
+  withRateLimitRetryThrow,
   withRetry,
   withRetryThrow
 } from './retry.util';

--- a/apps/api/src/shared/retry.util.spec.ts
+++ b/apps/api/src/shared/retry.util.spec.ts
@@ -1,6 +1,16 @@
 import { Logger } from '@nestjs/common';
 
-import { isTransientError, withRetry, withRetryThrow } from './retry.util';
+import {
+  extractRetryAfterMs,
+  isAuthenticationError,
+  isRateLimitError,
+  isTransientError,
+  rateLimitAwareDelay,
+  withRateLimitRetry,
+  withRateLimitRetryThrow,
+  withRetry,
+  withRetryThrow
+} from './retry.util';
 
 describe('retry.util', () => {
   describe('isTransientError', () => {
@@ -8,6 +18,7 @@ describe('retry.util', () => {
       expect(isTransientError(new Error('ECONNRESET'))).toBe(true);
       expect(isTransientError(new Error('ECONNREFUSED'))).toBe(true);
       expect(isTransientError(new Error('ETIMEDOUT'))).toBe(true);
+      expect(isTransientError(new Error('ENOTFOUND'))).toBe(true);
       expect(isTransientError(new Error('socket hang up'))).toBe(true);
       expect(isTransientError(new Error('fetch failed'))).toBe(true);
     });
@@ -22,6 +33,7 @@ describe('retry.util', () => {
       expect(isTransientError(new Error('503 Service Unavailable'))).toBe(true);
       expect(isTransientError(new Error('502 Bad Gateway'))).toBe(true);
       expect(isTransientError(new Error('504 Gateway Timeout'))).toBe(true);
+      expect(isTransientError(new Error('temporarily unavailable'))).toBe(true);
     });
 
     it('should identify CCXT-specific errors as transient', () => {
@@ -32,12 +44,23 @@ describe('retry.util', () => {
       const exchangeNotAvailable = new Error('Exchange not available');
       exchangeNotAvailable.name = 'ExchangeNotAvailable';
       expect(isTransientError(exchangeNotAvailable)).toBe(true);
+
+      const requestTimeout = new Error('Request timed out');
+      requestTimeout.name = 'RequestTimeout';
+      expect(isTransientError(requestTimeout)).toBe(true);
     });
 
     it('should not identify business errors as transient', () => {
       expect(isTransientError(new Error('Invalid order'))).toBe(false);
       expect(isTransientError(new Error('Insufficient balance'))).toBe(false);
       expect(isTransientError(new Error('Invalid API key'))).toBe(false);
+    });
+
+    it('should not false-positive on status code substrings', () => {
+      expect(isTransientError(new Error('Order #42900 not found'))).toBe(false);
+      expect(isTransientError(new Error('Order #50300 processed'))).toBe(false);
+      expect(isTransientError(new Error('Order #50200 processed'))).toBe(false);
+      expect(isTransientError(new Error('Order #50400 processed'))).toBe(false);
     });
   });
 
@@ -114,6 +137,16 @@ describe('retry.util', () => {
       expect(operation).toHaveBeenCalledTimes(1);
     });
 
+    it('should wrap non-Error thrown values', async () => {
+      const operation = jest.fn().mockRejectedValue('string error');
+
+      const result = await withRetry(operation, { maxRetries: 0 });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toBe('string error');
+    });
+
     it('should log retry attempts when logger provided', async () => {
       const mockLogger = { warn: jest.fn(), error: jest.fn() } as unknown as Logger;
       const operation = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce('success');
@@ -130,6 +163,24 @@ describe('retry.util', () => {
       await promise;
 
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('testOp failed (attempt 1/4)'));
+    });
+
+    it('should log error on final failure when logger provided', async () => {
+      const mockLogger = { warn: jest.fn(), error: jest.fn() } as unknown as Logger;
+      const operation = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+
+      const promise = withRetry(operation, {
+        maxRetries: 1,
+        initialDelayMs: 10,
+        isRetryable: isTransientError,
+        logger: mockLogger,
+        operationName: 'testOp'
+      });
+
+      await jest.runAllTimersAsync();
+      await promise;
+
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('testOp failed after 2 attempts'));
     });
 
     it('should track total delay time', async () => {
@@ -183,6 +234,294 @@ describe('retry.util', () => {
       });
 
       const expectation = expect(promise).rejects.toThrow('ECONNRESET');
+      await jest.runAllTimersAsync();
+      await expectation;
+    });
+  });
+
+  describe('isRateLimitError', () => {
+    it.each([
+      [
+        'RateLimitExceeded class',
+        () => {
+          class RateLimitExceeded extends Error {
+            constructor() {
+              super('rate limit');
+            }
+          }
+          return new RateLimitExceeded();
+        }
+      ],
+      [
+        'DDoSProtection class',
+        () => {
+          class DDoSProtection extends Error {
+            constructor() {
+              super('ddos protection');
+            }
+          }
+          return new DDoSProtection();
+        }
+      ],
+      [
+        'error.name = RateLimitExceeded',
+        () => {
+          const e = new Error('some message');
+          e.name = 'RateLimitExceeded';
+          return e;
+        }
+      ],
+      [
+        'error.name = DDoSProtection',
+        () => {
+          const e = new Error('some message');
+          e.name = 'DDoSProtection';
+          return e;
+        }
+      ]
+    ])('should detect %s', (_label, makeError) => {
+      expect(isRateLimitError(makeError())).toBe(true);
+    });
+
+    it('should detect rate limit string patterns in message', () => {
+      expect(isRateLimitError(new Error('rate limit exceeded'))).toBe(true);
+      expect(isRateLimitError(new Error('too many requests'))).toBe(true);
+      expect(isRateLimitError(new Error('HTTP 429 Too Many Requests'))).toBe(true);
+    });
+
+    it('should return false for non-rate-limit errors', () => {
+      expect(isRateLimitError(new Error('ECONNRESET'))).toBe(false);
+      expect(isRateLimitError(new Error('ETIMEDOUT'))).toBe(false);
+      expect(isRateLimitError(new Error('503 Service Unavailable'))).toBe(false);
+      expect(isRateLimitError(new Error('Invalid order'))).toBe(false);
+    });
+
+    it('should not false-positive on 429 as a substring', () => {
+      expect(isRateLimitError(new Error('Order #42900 not found'))).toBe(false);
+    });
+  });
+
+  describe('isAuthenticationError', () => {
+    it.each([
+      [
+        'AuthenticationError class',
+        () => {
+          class AuthenticationError extends Error {}
+          return new AuthenticationError('bad key');
+        }
+      ],
+      [
+        'PermissionDenied class',
+        () => {
+          class PermissionDenied extends Error {}
+          return new PermissionDenied('denied');
+        }
+      ],
+      [
+        'AccountSuspended class',
+        () => {
+          class AccountSuspended extends Error {}
+          return new AccountSuspended('suspended');
+        }
+      ],
+      [
+        'error.name = AuthenticationError',
+        () => {
+          const e = new Error('bad key');
+          e.name = 'AuthenticationError';
+          return e;
+        }
+      ]
+    ])('should detect %s', (_label, makeError) => {
+      expect(isAuthenticationError(makeError())).toBe(true);
+    });
+
+    it('should return false for non-auth errors', () => {
+      expect(isAuthenticationError(new Error('rate limit exceeded'))).toBe(false);
+      expect(isAuthenticationError(new Error('ECONNRESET'))).toBe(false);
+    });
+  });
+
+  describe('extractRetryAfterMs', () => {
+    it('should parse Retry-After header value in seconds', () => {
+      expect(extractRetryAfterMs(new Error('Retry-After: 5'))).toBe(5000);
+      expect(extractRetryAfterMs(new Error('retry-after: 10'))).toBe(10000);
+    });
+
+    it('should parse "retry after N seconds" pattern', () => {
+      expect(extractRetryAfterMs(new Error('Please retry after 30 seconds'))).toBe(30000);
+    });
+
+    it('should return null for zero-second Retry-After', () => {
+      expect(extractRetryAfterMs(new Error('Retry-After: 0'))).toBeNull();
+    });
+
+    it('should cap at maximum of 120000ms', () => {
+      expect(extractRetryAfterMs(new Error('Retry-After: 300'))).toBe(120000);
+    });
+
+    it('should return null when no Retry-After hint found', () => {
+      expect(extractRetryAfterMs(new Error('ECONNRESET'))).toBeNull();
+      expect(extractRetryAfterMs(new Error('rate limit exceeded'))).toBeNull();
+    });
+  });
+
+  describe('rateLimitAwareDelay', () => {
+    it('should return Retry-After delay for rate limit errors when header present', () => {
+      const error = new Error('rate limit exceeded, Retry-After: 10');
+      const delay = rateLimitAwareDelay(error, 1, 5000);
+
+      expect(delay).toBe(10000); // 10s from header > 5s default
+    });
+
+    it('should return preset delay for rate limit errors without Retry-After', () => {
+      const error = new Error('rate limit exceeded');
+      const delay = rateLimitAwareDelay(error, 1, 2000);
+
+      // Should use max of RATE_LIMIT_RETRY_OPTIONS.initialDelayMs (5000) and defaultDelay (2000)
+      expect(delay).toBe(5000);
+    });
+
+    it('should return undefined for non-rate-limit errors', () => {
+      const error = new Error('ECONNRESET');
+      const delay = rateLimitAwareDelay(error, 1, 1000);
+
+      expect(delay).toBeUndefined();
+    });
+  });
+
+  describe('onRetry callback in withRetry', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should use custom delay when onRetry returns a number', async () => {
+      const onRetry = jest.fn().mockReturnValue(42);
+      const operation = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce('success');
+
+      const promise = withRetry(operation, {
+        maxRetries: 3,
+        initialDelayMs: 10,
+        isRetryable: isTransientError,
+        onRetry
+      });
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(onRetry).toHaveBeenCalledWith(expect.any(Error), 1, expect.any(Number));
+      expect(result.totalDelayMs).toBe(42);
+    });
+
+    it('should use default delay when onRetry returns void', async () => {
+      const onRetry = jest.fn().mockReturnValue(undefined);
+      const operation = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce('success');
+
+      const promise = withRetry(operation, {
+        maxRetries: 3,
+        initialDelayMs: 100,
+        backoffMultiplier: 1,
+        maxDelayMs: 1000,
+        isRetryable: isTransientError,
+        onRetry
+      });
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(onRetry).toHaveBeenCalled();
+      expect(result.totalDelayMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe('withRateLimitRetry', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should retry rate limit errors with longer delays', async () => {
+      const error = new Error('rate limit exceeded');
+      const operation = jest.fn().mockRejectedValueOnce(error).mockResolvedValueOnce('recovered');
+
+      const promise = withRateLimitRetry(operation);
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('recovered');
+      expect(result.attempts).toBe(2);
+      // Rate limit delay should be at least 5000ms (the preset initialDelayMs)
+      expect(result.totalDelayMs).toBeGreaterThanOrEqual(5000 * 0.75); // accounting for jitter
+    });
+
+    it('should also retry non-rate-limit transient errors', async () => {
+      const operation = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce('recovered');
+
+      const promise = withRateLimitRetry(operation);
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('recovered');
+    });
+
+    it('should fail after max retries', async () => {
+      const error = new Error('rate limit exceeded');
+      const operation = jest.fn().mockRejectedValue(error);
+
+      const promise = withRateLimitRetry(operation);
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(error);
+      expect(result.attempts).toBe(4); // initial + 3 retries
+    });
+  });
+
+  describe('withRateLimitRetryThrow', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should succeed on retry after rate limit', async () => {
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('rate limit exceeded'))
+        .mockResolvedValueOnce('recovered');
+
+      const promise = withRateLimitRetryThrow(operation);
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe('recovered');
+    });
+
+    it('should throw on final failure', async () => {
+      const error = new Error('rate limit exceeded');
+      const operation = jest.fn().mockRejectedValue(error);
+
+      const promise = withRateLimitRetryThrow(operation);
+
+      const expectation = expect(promise).rejects.toThrow('rate limit exceeded');
       await jest.runAllTimersAsync();
       await expectation;
     });

--- a/apps/api/src/shared/retry.util.ts
+++ b/apps/api/src/shared/retry.util.ts
@@ -18,6 +18,12 @@ export interface RetryOptions {
   logger?: Logger;
   /** Operation name for logging */
   operationName?: string;
+  /**
+   * Callback invoked before each retry sleep.
+   * If it returns a number, that value is used as the delay (in ms) instead of the default.
+   * If it returns void/undefined, the default calculated delay is used.
+   */
+  onRetry?: (error: Error, attempt: number, defaultDelayMs: number) => number | void;
 }
 
 /**
@@ -34,7 +40,7 @@ export interface RetryResult<T> {
 /**
  * Default retry options
  */
-export const DEFAULT_RETRY_OPTIONS: Required<Omit<RetryOptions, 'logger' | 'operationName'>> = {
+export const DEFAULT_RETRY_OPTIONS: Required<Omit<RetryOptions, 'logger' | 'operationName' | 'onRetry'>> = {
   maxRetries: 3,
   initialDelayMs: 1000,
   maxDelayMs: 30000,
@@ -67,7 +73,7 @@ export function isTransientError(error: Error): boolean {
   if (
     message.includes('rate limit') ||
     message.includes('too many requests') ||
-    message.includes('429') ||
+    /\b429\b/.test(message) ||
     name.includes('ratelimit')
   ) {
     return true;
@@ -75,9 +81,9 @@ export function isTransientError(error: Error): boolean {
 
   // Temporary server errors
   if (
-    message.includes('503') ||
-    message.includes('502') ||
-    message.includes('504') ||
+    /\b503\b/.test(message) ||
+    /\b502\b/.test(message) ||
+    /\b504\b/.test(message) ||
     message.includes('service unavailable') ||
     message.includes('bad gateway') ||
     message.includes('gateway timeout') ||
@@ -100,6 +106,66 @@ export function isTransientError(error: Error): boolean {
 }
 
 /**
+ * Check if an error is specifically a rate limit error (subset of transient errors).
+ * Detects CCXT RateLimitExceeded/DDoSProtection and HTTP 429 patterns.
+ */
+export function isRateLimitError(error: Error): boolean {
+  const constructorName = error.constructor?.name || '';
+  const errorName = error.name || '';
+  const message = error.message?.toLowerCase() || '';
+
+  // CCXT class hierarchy: RateLimitExceeded, DDoSProtection
+  if (
+    constructorName === 'RateLimitExceeded' ||
+    constructorName === 'DDoSProtection' ||
+    errorName === 'RateLimitExceeded' ||
+    errorName === 'DDoSProtection'
+  ) {
+    return true;
+  }
+
+  // String fallback for name (case-insensitive)
+  const nameLower = (constructorName + errorName).toLowerCase();
+  if (nameLower.includes('ratelimitexceeded') || nameLower.includes('ddosprotection')) {
+    return true;
+  }
+
+  // String fallback for message
+  if (message.includes('rate limit') || message.includes('too many requests') || /\b429\b/.test(message)) {
+    return true;
+  }
+
+  return false;
+}
+
+/** Check if a CCXT error is an authentication/permission error (never retryable). */
+export function isAuthenticationError(error: Error): boolean {
+  const name = (error.constructor?.name || '') + (error.name || '');
+  return /AuthenticationError|PermissionDenied|AccountSuspended/i.test(name);
+}
+
+/**
+ * Extract a Retry-After hint from an error message (in milliseconds).
+ * Parses numeric seconds from patterns like "Retry-After: 5" or "retry after 10 seconds".
+ * Bounds result to 1000ms–120000ms.
+ * Returns null if no hint is found.
+ */
+export function extractRetryAfterMs(error: Error): number | null {
+  const message = error.message || '';
+
+  // Match patterns: "Retry-After: 5", "retry-after 10", "retry after 30 seconds"
+  const match = message.match(/retry[- ]?after[:\s]*(\d+)/i);
+  if (!match) return null;
+
+  const seconds = parseInt(match[1], 10);
+  if (isNaN(seconds) || seconds <= 0) return null;
+
+  const ms = seconds * 1000;
+  // Bound to 1s–120s
+  return Math.max(1000, Math.min(ms, 120000));
+}
+
+/**
  * Sleep for a specified duration
  */
 function sleep(ms: number): Promise<void> {
@@ -109,7 +175,10 @@ function sleep(ms: number): Promise<void> {
 /**
  * Calculate delay with exponential backoff and jitter
  */
-function calculateDelay(attempt: number, options: Required<Omit<RetryOptions, 'logger' | 'operationName'>>): number {
+function calculateDelay(
+  attempt: number,
+  options: Required<Omit<RetryOptions, 'logger' | 'operationName' | 'onRetry'>>
+): number {
   const exponentialDelay = options.initialDelayMs * Math.pow(options.backoffMultiplier, attempt);
   const cappedDelay = Math.min(exponentialDelay, options.maxDelayMs);
   // Add jitter (±25%) to prevent thundering herd
@@ -170,7 +239,16 @@ export async function withRetry<T>(operation: () => Promise<T>, options: RetryOp
       const shouldRetry = attempt < opts.maxRetries && opts.isRetryable(lastError);
 
       if (shouldRetry) {
-        const delay = calculateDelay(attempt, opts);
+        let delay = calculateDelay(attempt, opts);
+
+        // Allow onRetry callback to override the delay
+        if (opts.onRetry) {
+          const customDelay = opts.onRetry(lastError, attempt + 1, delay);
+          if (typeof customDelay === 'number') {
+            delay = customDelay;
+          }
+        }
+
         totalDelayMs += delay;
 
         if (opts.logger) {
@@ -218,4 +296,59 @@ export async function withRetryThrow<T>(operation: () => Promise<T>, options: Re
   }
 
   throw result.error;
+}
+
+/**
+ * onRetry callback that uses longer delays for rate limit errors.
+ * If the error is a rate limit, uses the Retry-After header hint or the preset initial delay (whichever is longer).
+ * For non-rate-limit errors, returns undefined to use the default delay.
+ */
+export function rateLimitAwareDelay(error: Error, _attempt: number, defaultDelayMs: number): number | void {
+  if (isRateLimitError(error)) {
+    const retryAfter = extractRetryAfterMs(error);
+    const rateLimitDelay = retryAfter ?? RATE_LIMIT_RETRY_OPTIONS.initialDelayMs ?? 5000;
+    return Math.max(rateLimitDelay, defaultDelayMs);
+  }
+}
+
+/**
+ * Retry options tuned for exchange rate limit errors.
+ * Uses 5s initial delay with 3x backoff (vs default 1s/2x).
+ * Still retries all transient errors, but rate limits get longer delays via onRetry.
+ */
+export const RATE_LIMIT_RETRY_OPTIONS: Partial<RetryOptions> = {
+  initialDelayMs: 5000,
+  backoffMultiplier: 3,
+  maxDelayMs: 60000,
+  maxRetries: 3,
+  isRetryable: isTransientError,
+  onRetry: rateLimitAwareDelay
+};
+
+/**
+ * Execute an async operation with rate-limit-aware retry logic.
+ * Merges caller options with RATE_LIMIT_RETRY_OPTIONS presets.
+ *
+ * @param operation - The async operation to execute
+ * @param options - Additional retry options (merged over rate limit defaults)
+ * @returns RetryResult with success status, result/error, and metrics
+ */
+export async function withRateLimitRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<RetryResult<T>> {
+  return withRetry(operation, { ...RATE_LIMIT_RETRY_OPTIONS, ...options });
+}
+
+/**
+ * Execute an async operation with rate-limit-aware retry, throwing on final failure.
+ * Convenience wrapper that throws instead of returning RetryResult.
+ *
+ * @param operation - The async operation to execute
+ * @param options - Additional retry options (merged over rate limit defaults)
+ * @returns The operation result
+ * @throws The last error if all retries fail
+ */
+export async function withRateLimitRetryThrow<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  return withRetryThrow(operation, { ...RATE_LIMIT_RETRY_OPTIONS, ...options });
 }

--- a/apps/api/src/trading/trading.service.ts
+++ b/apps/api/src/trading/trading.service.ts
@@ -11,6 +11,7 @@ import { CCXT_BALANCE_META_KEYS } from '../exchange/ccxt-balance.util';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
 import { ExchangeService } from '../exchange/exchange.service';
 import { toErrorInfo } from '../shared/error.util';
+import { withRateLimitRetryThrow } from '../shared/retry.util';
 import { User } from '../users/users.entity';
 
 @Injectable()
@@ -51,7 +52,10 @@ export class TradingService {
       const { client, name: exchangeName } = await this.resolveExchangeClient(exchangeId);
 
       if (!client.markets) {
-        await client.loadMarkets();
+        await withRateLimitRetryThrow(() => client.loadMarkets(), {
+          logger: this.logger,
+          operationName: 'loadMarkets'
+        });
       }
 
       if (!client.markets[symbol]) {
@@ -67,7 +71,10 @@ export class TradingService {
         );
       }
 
-      const orderBook = await client.fetchOrderBook(symbol, 10);
+      const orderBook = await withRateLimitRetryThrow(() => client.fetchOrderBook(symbol, 10), {
+        logger: this.logger,
+        operationName: `fetchOrderBook(${symbol})`
+      });
 
       return {
         bids: orderBook.bids.map(([price, quantity]) => this.toOrderBookEntry(price, quantity)),
@@ -92,7 +99,10 @@ export class TradingService {
 
     try {
       const { client } = await this.resolveExchangeClient(exchangeId);
-      const ticker = await client.fetchTicker(symbol);
+      const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(symbol), {
+        logger: this.logger,
+        operationName: `fetchTicker(${symbol})`
+      });
 
       return {
         symbol,
@@ -154,7 +164,10 @@ export class TradingService {
       const exchange = await this.exchangeService.findOne(exchangeId);
       const service = this.exchangeManagerService.getExchangeService(exchange.slug);
       const client = await service.getClient(user);
-      const ccxtBalances = await client.fetchBalance();
+      const ccxtBalances = await withRateLimitRetryThrow(() => client.fetchBalance(), {
+        logger: this.logger,
+        operationName: 'fetchBalance'
+      });
 
       const balances: TradingBalanceDto[] = [];
 


### PR DESCRIPTION
## Summary

- Add rate-limit-aware retry utilities to centralize exchange API retry logic
- Wrap all CCXT exchange API calls with rate-limit-aware retry, replacing ad-hoc patterns
- Add `onRetry` callback hook to `withRetry` for custom delay strategies

## Changes

**New retry utilities** (`apps/api/src/shared/retry.util.ts`):
- `isRateLimitError()` — detects CCXT rate-limit exceptions
- `extractRetryAfterMs()` — parses `Retry-After` headers from exchange responses
- `rateLimitAwareDelay()` — delays using exchange-provided backoff or exponential fallback
- `withRateLimitRetry()` / `withRateLimitRetryThrow()` — convenience wrappers for exchange calls

**Adopted across all exchange services** (20 files):
- Exchange services (Binance US, Coinbase, Kraken, base exchange)
- OHLC services (exchange OHLC, realtime ticker)
- Order services (order sync, position management, trade execution)
- Paper trading market data service
- Trading service, category sync, coin alert, algorithm scripts

**Cleanup**:
- Removed duplicate ad-hoc retry logic from `ExchangeOHLCService`

## Test Plan

- [x] 341+ lines of new tests in `retry.util.spec.ts`
- [x] All 2353 existing tests pass
- [x] Lint passes (0 errors)
- [x] Build passes

Closes #249