### PR TITLE
feat(chansey): replace search input with coin autocomplete

### DIFF
--- a/apps/chansey/src/app/layout/app.search.ts
+++ b/apps/chansey/src/app/layout/app.search.ts
@@ -1,33 +1,66 @@
-import { Component, inject } from '@angular/core';
+import { CurrencyPipe } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 
+import { AutoCompleteModule, AutoCompleteSelectEvent } from 'primeng/autocomplete';
 import { AutoFocusModule } from 'primeng/autofocus';
 import { DialogModule } from 'primeng/dialog';
-import { InputTextModule } from 'primeng/inputtext';
+
+import { Coin } from '@chansey/api-interfaces';
+import { queryKeys, useAuthQuery } from '@chansey/shared';
 
 import { LayoutService } from '../shared/services/layout.service';
 
 @Component({
   selector: 'app-search',
   standalone: true,
-  imports: [DialogModule, InputTextModule, AutoFocusModule],
+  imports: [AutoCompleteModule, AutoFocusModule, CurrencyPipe, DialogModule, FormsModule],
   template: ` <p-dialog
     [(visible)]="searchBarActive"
     [breakpoints]="{ '992px': '75vw', '576px': '90vw' }"
+    [style]="{ width: '60vw' }"
     modal
     dismissableMask
-    class="w-1/2"
   >
     <ng-template #headless>
       <div class="search-container">
         <i class="pi pi-search"></i>
-        <input
-          pInputText
-          type="text"
+        <p-autocomplete
+          [ngModel]="selectedCoin()"
+          (ngModelChange)="selectedCoin.set($event)"
+          [suggestions]="coinSuggestions()"
+          (completeMethod)="searchCoins($event)"
+          (onSelect)="onCoinSelect($event)"
+          optionLabel="name"
+          [minLength]="1"
+          placeholder="Search coins..."
           [pAutoFocus]="true"
-          class="p-inputtext search-input"
-          placeholder="Search"
-          (keydown.enter)="toggleSearchBar()"
-        />
+          class="search-autocomplete"
+        >
+          <ng-template #item let-coin>
+            <div class="flex w-full items-center gap-3">
+              @if (coin.image) {
+                <img [src]="coin.image" [alt]="coin.name" class="h-6 w-6 rounded-full" />
+              } @else {
+                <div
+                  class="bg-surface-200 dark:bg-surface-700 flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold"
+                >
+                  {{ coin.symbol?.charAt(0) || '?' }}
+                </div>
+              }
+              <div class="flex flex-col">
+                <span class="font-medium">{{ coin.name }}</span>
+                <span class="text-surface-500 text-xs uppercase">{{ coin.symbol }}</span>
+              </div>
+              @if (coin.currentPrice !== null && coin.currentPrice !== undefined) {
+                <span class="text-surface-500 ml-auto text-sm">{{
+                  coin.currentPrice | currency: 'USD' : 'symbol' : '1.2-2'
+                }}</span>
+              }
+            </div>
+          </ng-template>
+        </p-autocomplete>
       </div>
     </ng-template>
   </p-dialog>`
@@ -35,13 +68,40 @@ import { LayoutService } from '../shared/services/layout.service';
 
 // eslint-disable-next-line @angular-eslint/component-class-suffix
 export class AppSearch {
-  layoutService = inject(LayoutService);
+  private router = inject(Router);
+  private layoutService = inject(LayoutService);
 
-  toggleSearchBar() {
-    this.layoutService.layoutState.update((value) => ({
-      ...value,
-      searchBarActive: !value.searchBarActive
-    }));
+  readonly coinsQuery = useAuthQuery<Coin[]>(() => ({
+    queryKey: queryKeys.coins.lists(),
+    url: '/api/coin',
+    options: { enabled: this.searchBarActive }
+  }));
+
+  selectedCoin = signal<Coin | null>(null);
+  coinSuggestions = signal<Coin[]>([]);
+
+  searchCoins(event: { query: string }): void {
+    const coins = this.coinsQuery.data();
+    if (!coins) {
+      this.coinSuggestions.set([]);
+      return;
+    }
+    const query = event.query.toLowerCase();
+    const suggestions: Coin[] = [];
+    for (const c of coins) {
+      if (c.name.toLowerCase().includes(query) || c.symbol?.toLowerCase()?.includes(query)) {
+        suggestions.push(c);
+        if (suggestions.length >= 10) break;
+      }
+    }
+    this.coinSuggestions.set(suggestions);
+  }
+
+  onCoinSelect(event: AutoCompleteSelectEvent): void {
+    const coin = event.value as Coin;
+    this.searchBarActive = false;
+    this.selectedCoin.set(null);
+    this.router.navigate(['/app/coins', coin.slug]);
   }
 
   get searchBarActive(): boolean {

--- a/apps/chansey/src/app/styles/layout/_search.scss
+++ b/apps/chansey/src/app/styles/layout/_search.scss
@@ -1,35 +1,45 @@
 .search-container {
-    background: var(--surface-overlay);
-    display: flex;
-    align-items: center;
+  background: var(--surface-overlay);
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  padding: 1rem 1.5rem;
+  border-radius: var(--border-radius);
+  gap: 1rem;
+  box-shadow:
+    0px 11px 15px -7px rgba(0, 0, 0, 0.2),
+    0px 24px 38px 3px rgba(0, 0, 0, 0.14),
+    0px 9px 46px 8px rgba(0, 0, 0, 0.12);
+  border: var(--surface-border);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  pointer-events: all;
+
+  > i {
+    color: var(--text-muted-color);
     font-size: 1.5rem;
-    padding: 2rem;
-    border-radius: var(--border-radius);
-    position: relative;
-    box-shadow:
-        0px 11px 15px -7px rgba(0, 0, 0, 0.2),
-        0px 24px 38px 3px rgba(0, 0, 0, 0.14),
-        0px 9px 46px 8px rgba(0, 0, 0, 0.12);
-    border: var(--surface-border);
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
-    pointer-events: all;
+    flex-shrink: 0;
+    position: static;
+    margin: 0;
+  }
 
-    input {
-        appearance: none;
-        font-size: 1.5rem;
-        text-indent: 2.5rem;
-        padding: 0.5rem;
-        width: 100%;
-    }
+  .p-autocomplete.search-autocomplete {
+    flex: 1 1 0%;
+    min-width: 0;
+    width: 100%;
+  }
 
-    i {
-        color: var(--text-muted-color);
-        width: 2rem;
-        font-size: 1.5rem;
-        position: absolute;
-        top: 50%;
-        margin-top: -0.75rem;
-        margin-left: 1rem;
+  .p-autocomplete-input {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    font-size: 1.5rem;
+    padding: 0.5rem 0;
+    width: 100%;
+
+    &:focus {
+      box-shadow: none;
+      border: none;
     }
+  }
 }


### PR DESCRIPTION
## Summary
- Replace the plain text search input with a PrimeNG AutoComplete component that suggests coins by name or symbol
- Display coin image, name, symbol, and current price in the dropdown suggestions
- Navigate to the coin detail page on selection

## Changes
- `apps/chansey/src/app/layout/app.search.ts` - Swap text input for PrimeNG AutoComplete with coin filtering, signal-based state, CurrencyPipe formatting, and reactive query with enabled guard
- `apps/chansey/src/app/styles/layout/_search.scss` - Restyle search container and dropdown for the autocomplete layout

## Test Plan
- [ ] Type a coin name or symbol in the search bar and verify suggestions appear
- [ ] Verify suggestions show coin image, name, symbol, and price
- [ ] Select a suggestion and verify navigation to the coin detail page
- [ ] Verify search works on mobile viewport
- [ ] Verify empty/short input does not trigger suggestions