### PR TITLE
refactor(chansey): extract reusable empty-state component

### DIFF
--- a/.claude/commands/sync-branch.md
+++ b/.claude/commands/sync-branch.md
@@ -151,10 +151,24 @@ git diff --name-only --diff-filter=U
 
 # Verify the branch is now up-to-date
 git rev-list --left-right --count origin/master...HEAD
-
-# Quick sanity check - does the project build?
-# (Skip if user passed --no-build)
 ```
+
+### 6.5. Build, Lint & Test
+
+Run build, lint, and test to ensure the sync didn't break anything. **All three must pass before pushing.**
+
+```bash
+# Build the project
+npx nx run-many -t build
+
+# Lint the project
+npx nx run-many -t lint
+
+# Run tests
+npx nx run-many -t test
+```
+
+**If any step fails**: Fix the issues, stage the fixes, and amend or create a new commit before proceeding to push. Do not push broken code.
 
 ### 7. Push Updated Branch
 

--- a/apps/chansey/src/app/coins/coin-detail/coin-detail.component.html
+++ b/apps/chansey/src/app/coins/coin-detail/coin-detail.component.html
@@ -233,7 +233,7 @@
 
       <!-- Description Section -->
       <div class="section">
-        <h2 class="section-title mb-2 text-xl font-semibold md:mb-4 md:text-2xl">About {{ detail.name }}</h2>
+        <h2 class="section-title my-2 text-xl font-semibold md:mb-4 md:text-2xl">About {{ detail.name }}</h2>
         <p-card [pt]="sectionCardPt">
           <!-- T034: Handle missing description -->
           @if (detail.description) {

--- a/apps/chansey/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/chansey/src/app/pages/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
 <div class="dashboard-container">
   @if (userQuery.isPending()) {
-    <div class="flex min-h-96 items-center justify-center">
+    <div class="flex items-center justify-center min-h-64 sm:min-h-96">
       <p-progressSpinner [style]="{ width: '50px', height: '50px' }" strokeWidth="4" />
     </div>
   } @else {
@@ -19,16 +19,15 @@
       </div>
     } @else {
       <p-card class="mb-4">
-        <div class="flex min-h-96 flex-col items-center justify-center p-3 text-center">
-          <p class="text-600 mb-8">Connect your exchanges in the settings to see your balances here.</p>
-          <p-button
-            icon="pi pi-wallet"
-            label="Connect a Wallet"
-            routerLink="/app/settings"
-            [queryParams]="{ tab: 'trading' }"
-            size="large"
-          />
-        </div>
+        <app-empty-state
+          icon="link"
+          message="Connect your exchanges in the settings to see your balances here."
+          actionLabel="Connect Exchange"
+          actionRoute="/app/settings"
+          [actionQueryParams]="{ tab: 'trading' }"
+          actionIcon="pi pi-link"
+          size="large"
+        />
       </p-card>
     }
   }

--- a/apps/chansey/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/chansey/src/app/pages/dashboard/dashboard.component.ts
@@ -1,10 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { RouterModule } from '@angular/router';
 
-import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 
+import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { ExchangeBalanceComponent } from '../../shared/components/exchange-balance/exchange-balance.component';
 import { RecentTransactionsComponent } from '../../shared/components/recent-transactions/recent-transactions.component';
 import { UserAssetsComponent } from '../../shared/components/user-assets/user-assets.component';
@@ -13,10 +12,9 @@ import { AuthService } from '../../shared/services/auth.service';
 @Component({
   selector: 'app-dashboard',
   imports: [
-    RouterModule,
-    ButtonModule,
     CardModule,
     ProgressSpinnerModule,
+    EmptyStateComponent,
     ExchangeBalanceComponent,
     UserAssetsComponent,
     RecentTransactionsComponent

--- a/apps/chansey/src/app/pages/transactions/transactions.component.html
+++ b/apps/chansey/src/app/pages/transactions/transactions.component.html
@@ -1,112 +1,4 @@
 <p-card>
-  <!-- Mobile: filter toggle button (hidden on md+) -->
-  <div class="mt-5 mr-5 mb-3 flex justify-end md:hidden">
-    <p-button
-      [label]="'Filters' + (activeFilterCount() > 0 ? ' (' + activeFilterCount() + ')' : '')"
-      icon="pi pi-filter"
-      [outlined]="true"
-      size="small"
-      [attr.aria-expanded]="filtersVisible()"
-      (onClick)="toggleFilters()"
-    />
-  </div>
-
-  <!-- Filters: always visible on md+, toggled on mobile -->
-  <form
-    [formGroup]="filterForm"
-    class="my-5 gap-3 px-5 md:px-0"
-    [ngClass]="{
-      'hidden md:grid': !filtersVisible(),
-      grid: filtersVisible()
-    }"
-    style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))"
-  >
-    <div>
-      <div class="p-inputgroup w-full">
-        <p-iconfield iconPosition="left" class="ml-auto">
-          <p-inputicon>
-            <i class="pi pi-search"></i>
-          </p-inputicon>
-          <input
-            #searchInput
-            pInputText
-            type="text"
-            (input)="applyGlobalFilter($event)"
-            placeholder="Search Transactions..."
-            fluid
-          />
-          @if (searchText().length > 0) {
-            <p-inputicon>
-              <i
-                class="pi pi-times"
-                role="button"
-                aria-label="Clear search"
-                (click)="clearSearchFilter(); searchInput.value = ''"
-              ></i>
-            </p-inputicon>
-          }
-        </p-iconfield>
-      </div>
-    </div>
-    <div>
-      <p-datepicker
-        formControlName="dateRange"
-        selectionMode="range"
-        [readonlyInput]="true"
-        placeholder="Date Range"
-        dateFormat="M dd, yy"
-        [showIcon]="true"
-        [showClear]="true"
-        fluid
-      />
-    </div>
-    <div>
-      <p-multiSelect
-        [options]="statusOptions"
-        placeholder="Filter by status"
-        formControlName="statuses"
-        optionLabel="label"
-        selectedItemsLabel="{0} statuses selected"
-        (onChange)="applyFilters()"
-        [showClear]="true"
-        display="chip"
-        [filter]="false"
-        [showToggleAll]="false"
-        fluid
-      />
-    </div>
-    <div>
-      <p-multiSelect
-        [options]="sideOptions"
-        placeholder="Filter by side"
-        formControlName="sides"
-        optionLabel="label"
-        selectedItemsLabel="{0} sides selected"
-        (onChange)="applyFilters()"
-        [showClear]="true"
-        display="chip"
-        [filter]="false"
-        [showToggleAll]="false"
-        fluid
-      />
-    </div>
-    <div>
-      <p-multiSelect
-        [options]="typeOptions"
-        placeholder="Filter by type"
-        formControlName="types"
-        optionLabel="label"
-        selectedItemsLabel="{0} types selected"
-        (onChange)="applyFilters()"
-        [showClear]="true"
-        display="chip"
-        [filter]="false"
-        [showToggleAll]="false"
-        fluid
-      />
-    </div>
-  </form>
-
   @if (transactionsQuery.isError()) {
     <div class="p-3 text-center">
       <p class="mb-4 text-lg text-red-500">{{ transactionsQuery.error() }}</p>
@@ -119,198 +11,323 @@
         variant="outlined"
       />
     </div>
-  }
+  } @else if (transactions().length > 0 || isLoading()) {
+    <!-- Mobile: filter toggle button (hidden on md+) -->
+    <div class="mt-5 mr-5 mb-3 flex justify-end md:hidden">
+      <p-button
+        [label]="'Filters' + (activeFilterCount() > 0 ? ' (' + activeFilterCount() + ')' : '')"
+        icon="pi pi-filter"
+        [outlined]="true"
+        size="small"
+        [attr.aria-expanded]="filtersVisible()"
+        (onClick)="toggleFilters()"
+      />
+    </div>
 
-  <p-table
-    #dt
-    [value]="tableData()"
-    [paginator]="true"
-    [rows]="25"
-    [rowHover]="true"
-    [loading]="isLoading()"
-    [rowsPerPageOptions]="[5, 10, 25, 50]"
-    [showCurrentPageReport]="true"
-    [filterDelay]="0"
-    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
-    [globalFilterFields]="[
-      'symbol',
-      'baseCoin.name',
-      'baseCoin.symbol',
-      'quoteCoin.name',
-      'quoteCoin.symbol',
-      'orderId',
-      'clientOrderId',
-      'feeCurrency',
-      'exchange.name',
-      'exchange.slug'
-    ]"
-    [scrollable]="true"
-    dataKey="id"
-    stripedRows
-    [sortField]="'transactTime'"
-    [sortOrder]="-1"
-  >
-    <ng-template pTemplate="header">
-      <tr>
-        <th style="min-width: 120px">Trading Pair</th>
-        <th style="min-width: 120px">Type</th>
-        <th pSortableColumn="transactTime" style="min-width: 160px">Date <p-sortIcon field="transactTime" /></th>
-        <th pSortableColumn="price" style="min-width: 120px" class="text-right">Price</th>
-        <th pSortableColumn="quantity" style="min-width: 120px" class="text-right">Quantity</th>
-        <th pSortableColumn="fee" style="min-width: 120px" class="text-right">Fees</th>
-        <th pSortableColumn="cost" style="min-width: 120px" class="text-right">
-          Total Value <p-sortIcon field="cost" />
-        </th>
-        <th style="min-width: 120px">Exchange</th>
-        <th pSortableColumn="status" style="min-width: 130px">Status <p-sortIcon field="status" /></th>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="loadingbody">
-      <tr>
-        <td>
-          <div class="flex items-center gap-3">
-            <div class="flex -space-x-2">
-              <p-skeleton shape="circle" size="2.5rem" />
-              <p-skeleton shape="circle" size="2.5rem" />
+    <!-- Filters: always visible on md+, toggled on mobile -->
+    <form
+      [formGroup]="filterForm"
+      class="my-5 gap-3 px-5 md:px-0"
+      [ngClass]="{
+        'hidden md:grid': !filtersVisible(),
+        grid: filtersVisible()
+      }"
+      style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))"
+    >
+      <div>
+        <div class="p-inputgroup w-full">
+          <p-iconfield iconPosition="left" class="ml-auto">
+            <p-inputicon>
+              <i class="pi pi-search"></i>
+            </p-inputicon>
+            <input
+              #searchInput
+              pInputText
+              type="text"
+              (input)="applyGlobalFilter($event)"
+              placeholder="Search Transactions..."
+              fluid
+            />
+            @if (searchText().length > 0) {
+              <p-inputicon>
+                <i
+                  class="pi pi-times"
+                  role="button"
+                  aria-label="Clear search"
+                  (click)="clearSearchFilter(); searchInput.value = ''"
+                ></i>
+              </p-inputicon>
+            }
+          </p-iconfield>
+        </div>
+      </div>
+      <div>
+        <p-datepicker
+          formControlName="dateRange"
+          selectionMode="range"
+          [readonlyInput]="true"
+          placeholder="Date Range"
+          dateFormat="M dd, yy"
+          [showIcon]="true"
+          [showClear]="true"
+          fluid
+        />
+      </div>
+      <div>
+        <p-multiSelect
+          [options]="statusOptions"
+          placeholder="Filter by status"
+          formControlName="statuses"
+          optionLabel="label"
+          selectedItemsLabel="{0} statuses selected"
+          (onChange)="applyFilters()"
+          [showClear]="true"
+          display="chip"
+          [filter]="false"
+          [showToggleAll]="false"
+          fluid
+        />
+      </div>
+      <div>
+        <p-multiSelect
+          [options]="sideOptions"
+          placeholder="Filter by side"
+          formControlName="sides"
+          optionLabel="label"
+          selectedItemsLabel="{0} sides selected"
+          (onChange)="applyFilters()"
+          [showClear]="true"
+          display="chip"
+          [filter]="false"
+          [showToggleAll]="false"
+          fluid
+        />
+      </div>
+      <div>
+        <p-multiSelect
+          [options]="typeOptions"
+          placeholder="Filter by type"
+          formControlName="types"
+          optionLabel="label"
+          selectedItemsLabel="{0} types selected"
+          (onChange)="applyFilters()"
+          [showClear]="true"
+          display="chip"
+          [filter]="false"
+          [showToggleAll]="false"
+          fluid
+        />
+      </div>
+    </form>
+
+    <p-table
+      #dt
+      [value]="tableData()"
+      [paginator]="true"
+      [rows]="25"
+      [rowHover]="true"
+      [loading]="isLoading()"
+      [rowsPerPageOptions]="[5, 10, 25, 50]"
+      [showCurrentPageReport]="true"
+      [filterDelay]="0"
+      currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
+      [globalFilterFields]="[
+        'symbol',
+        'baseCoin.name',
+        'baseCoin.symbol',
+        'quoteCoin.name',
+        'quoteCoin.symbol',
+        'orderId',
+        'clientOrderId',
+        'feeCurrency',
+        'exchange.name',
+        'exchange.slug'
+      ]"
+      [scrollable]="true"
+      dataKey="id"
+      stripedRows
+      [sortField]="'transactTime'"
+      [sortOrder]="-1"
+    >
+      <ng-template pTemplate="header">
+        <tr>
+          <th style="min-width: 120px">Trading Pair</th>
+          <th style="min-width: 120px">Type</th>
+          <th pSortableColumn="transactTime" style="min-width: 160px">Date <p-sortIcon field="transactTime" /></th>
+          <th pSortableColumn="price" style="min-width: 120px" class="text-right">Price</th>
+          <th pSortableColumn="quantity" style="min-width: 120px" class="text-right">Quantity</th>
+          <th pSortableColumn="fee" style="min-width: 120px" class="text-right">Fees</th>
+          <th pSortableColumn="cost" style="min-width: 120px" class="text-right">
+            Total Value <p-sortIcon field="cost" />
+          </th>
+          <th style="min-width: 120px">Exchange</th>
+          <th pSortableColumn="status" style="min-width: 130px">Status <p-sortIcon field="status" /></th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="loadingbody">
+        <tr>
+          <td>
+            <div class="flex items-center gap-3">
+              <div class="flex -space-x-2">
+                <p-skeleton shape="circle" size="2.5rem" />
+                <p-skeleton shape="circle" size="2.5rem" />
+              </div>
+              <div class="flex flex-col gap-1">
+                <p-skeleton width="100px" height="1.25rem" />
+                <p-skeleton width="80px" height="1rem" />
+              </div>
             </div>
+          </td>
+          <td>
+            <div class="flex flex-col gap-1">
+              <p-skeleton width="60px" height="2rem" borderRadius="16px" />
+              <p-skeleton width="50px" height="0.875rem" />
+            </div>
+          </td>
+          <td>
             <div class="flex flex-col gap-1">
               <p-skeleton width="100px" height="1.25rem" />
-              <p-skeleton width="80px" height="1rem" />
+              <p-skeleton width="60px" height="1rem" />
             </div>
-          </div>
-        </td>
-        <td>
-          <div class="flex flex-col gap-1">
-            <p-skeleton width="60px" height="2rem" borderRadius="16px" />
-            <p-skeleton width="50px" height="0.875rem" />
-          </div>
-        </td>
-        <td>
-          <div class="flex flex-col gap-1">
-            <p-skeleton width="100px" height="1.25rem" />
-            <p-skeleton width="60px" height="1rem" />
-          </div>
-        </td>
-        <td class="text-right"><p-skeleton width="90px" height="1.25rem" /></td>
-        <td class="text-right"><p-skeleton width="80px" height="1.25rem" /></td>
-        <td class="text-right"><p-skeleton width="80px" height="1.25rem" /></td>
-        <td class="text-right"><p-skeleton width="100px" height="1.25rem" /></td>
-        <td>
-          <div class="flex items-center gap-2">
-            <p-skeleton shape="circle" size="1.5rem" />
-            <p-skeleton width="70px" height="1.25rem" />
-          </div>
-        </td>
-        <td><p-skeleton width="80px" height="2rem" borderRadius="16px" /></td>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-transaction>
-      <tr>
-        <td>
-          <a
-            [routerLink]="transaction.baseCoin?.slug ? ['/app/coins', transaction.baseCoin.slug] : null"
-            [queryParams]="{ from: 'transactions' }"
-            [class.pointer-events-none]="!transaction.baseCoin?.slug"
-            class="flex items-center gap-3 transition-opacity hover:opacity-80"
-          >
-            <div class="flex -space-x-2">
-              <p-avatar
-                [image]="transaction.baseCoin?.image"
-                shape="circle"
-                size="large"
-                class="border-surface min-w-9 border-2 shadow-sm"
-              />
-              @if (transaction.quoteCoin) {
+          </td>
+          <td class="text-right"><p-skeleton width="90px" height="1.25rem" /></td>
+          <td class="text-right"><p-skeleton width="80px" height="1.25rem" /></td>
+          <td class="text-right"><p-skeleton width="80px" height="1.25rem" /></td>
+          <td class="text-right"><p-skeleton width="100px" height="1.25rem" /></td>
+          <td>
+            <div class="flex items-center gap-2">
+              <p-skeleton shape="circle" size="1.5rem" />
+              <p-skeleton width="70px" height="1.25rem" />
+            </div>
+          </td>
+          <td><p-skeleton width="80px" height="2rem" borderRadius="16px" /></td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-transaction>
+        <tr>
+          <td>
+            <a
+              [routerLink]="transaction.baseCoin?.slug ? ['/app/coins', transaction.baseCoin.slug] : null"
+              [queryParams]="{ from: 'transactions' }"
+              [class.pointer-events-none]="!transaction.baseCoin?.slug"
+              class="flex items-center gap-3 transition-opacity hover:opacity-80"
+            >
+              <div class="flex -space-x-2">
                 <p-avatar
-                  [image]="transaction.quoteCoin.image"
+                  [image]="transaction.baseCoin?.image"
                   shape="circle"
                   size="large"
                   class="border-surface min-w-9 border-2 shadow-sm"
                 />
-              }
+                @if (transaction.quoteCoin) {
+                  <p-avatar
+                    [image]="transaction.quoteCoin.image"
+                    shape="circle"
+                    size="large"
+                    class="border-surface min-w-9 border-2 shadow-sm"
+                  />
+                }
+              </div>
+              <div class="flex flex-col">
+                <span class="text-primary-500 hover:text-primary-600 text-lg font-medium">{{
+                  transaction.symbol
+                }}</span>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ transaction.baseCoin?.name }}</span>
+              </div>
+            </a>
+          </td>
+          <td>
+            <div class="flex flex-col items-center gap-0.5">
+              <p-tag [value]="transaction.side" [severity]="getSideSeverity(transaction.side)"></p-tag>
+              <span class="text-xs text-neutral-400">{{ formatType(transaction.type) }}</span>
             </div>
-            <div class="flex flex-col">
-              <span class="text-primary-500 hover:text-primary-600 text-lg font-medium">{{ transaction.symbol }}</span>
-              <span class="text-sm text-gray-500 dark:text-gray-400">{{ transaction.baseCoin?.name }}</span>
-            </div>
-          </a>
-        </td>
-        <td>
-          <div class="flex flex-col items-center gap-0.5">
-            <p-tag [value]="transaction.side" [severity]="getSideSeverity(transaction.side)"></p-tag>
-            <span class="text-xs text-neutral-400">{{ formatType(transaction.type) }}</span>
-          </div>
-        </td>
-        <td class="flex flex-col">
-          <span class="text-lg">{{ transaction.transactTime | date: 'mediumDate' }}</span>
-          <span class="text-sm text-neutral-400">{{ transaction.transactTime | date: 'shortTime' }}</span>
-        </td>
-        <td class="text-right">
-          {{ isUsdQuote(transaction) ? '$' : '' }}{{ transaction.price | number: '1.2-8'
-          }}{{
-            !isUsdQuote(transaction) && transaction.quoteCoin?.symbol
-              ? ' ' + (transaction.quoteCoin.symbol | uppercase)
-              : ''
-          }}
-        </td>
-        <td class="text-right">{{ transaction.quantity | number: '1.2-8' }}</td>
-        <td class="text-right">
-          @if (transaction.fee > 0) {
-            ~{{ isUsdQuote(transaction) ? '$' : '' }}{{ transaction.fee | number: '1.2-6'
+          </td>
+          <td class="flex flex-col">
+            <span class="text-lg">{{ transaction.transactTime | date: 'mediumDate' }}</span>
+            <span class="text-sm text-neutral-400">{{ transaction.transactTime | date: 'shortTime' }}</span>
+          </td>
+          <td class="text-right">
+            {{ isUsdQuote(transaction) ? '$' : '' }}{{ transaction.price | number: '1.2-8'
             }}{{
-              !isUsdQuote(transaction) && (transaction.feeCurrency || transaction.quoteCoin?.symbol)
-                ? ' ' + (transaction.feeCurrency || transaction.quoteCoin?.symbol | uppercase)
+              !isUsdQuote(transaction) && transaction.quoteCoin?.symbol
+                ? ' ' + (transaction.quoteCoin.symbol | uppercase)
                 : ''
             }}
-            @if (getFeePercentage(transaction); as feePercent) {
-              <span class="text-xs text-neutral-400"> ({{ feePercent | number: '1.1-1' }}%)</span>
+          </td>
+          <td class="text-right">{{ transaction.quantity | number: '1.2-8' }}</td>
+          <td class="text-right">
+            @if (transaction.fee > 0) {
+              ~{{ isUsdQuote(transaction) ? '$' : '' }}{{ transaction.fee | number: '1.2-6'
+              }}{{
+                !isUsdQuote(transaction) && (transaction.feeCurrency || transaction.quoteCoin?.symbol)
+                  ? ' ' + (transaction.feeCurrency || transaction.quoteCoin?.symbol | uppercase)
+                  : ''
+              }}
+              @if (getFeePercentage(transaction); as feePercent) {
+                <span class="text-xs text-neutral-400"> ({{ feePercent | number: '1.1-1' }}%)</span>
+              }
+            } @else {
+              —
             }
-          } @else {
-            —
-          }
-        </td>
-        <td class="text-right">
-          {{ isUsdQuote(transaction) ? '$' : '' }}{{ transaction.cost | number: '1.2-8'
-          }}{{
-            !isUsdQuote(transaction) && transaction.quoteCoin?.symbol
-              ? ' ' + (transaction.quoteCoin.symbol | uppercase)
-              : ''
-          }}
-        </td>
-        <td>
-          @if (transaction.exchange) {
-            <div class="flex items-center gap-2">
-              <p-avatar
-                [image]="transaction.exchange.image"
-                shape="circle"
-                size="normal"
-                class="border-surface border shadow-sm"
+          </td>
+          <td class="text-right">
+            {{ isUsdQuote(transaction) ? '$' : '' }}{{ transaction.cost | number: '1.2-8'
+            }}{{
+              !isUsdQuote(transaction) && transaction.quoteCoin?.symbol
+                ? ' ' + (transaction.quoteCoin.symbol | uppercase)
+                : ''
+            }}
+          </td>
+          <td>
+            @if (transaction.exchange) {
+              <div class="flex items-center gap-2">
+                <p-avatar
+                  [image]="transaction.exchange.image"
+                  shape="circle"
+                  size="normal"
+                  class="border-surface border shadow-sm"
+                />
+                <span class="text-sm font-medium">{{ transaction.exchange.name }}</span>
+              </div>
+            } @else {
+              <span class="text-sm text-gray-500 dark:text-gray-400">N/A</span>
+            }
+          </td>
+          <td>
+            <p-tag [value]="transaction.status" [severity]="getStatusSeverity(transaction.status)"></p-tag>
+          </td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="emptymessage">
+        <tr>
+          <td colspan="9" class="p-4">
+            @if (!isLoading()) {
+              <app-empty-state
+                icon="arrow-right-arrow-left"
+                title="No matching transactions"
+                message="Try adjusting your filters or search criteria."
+                [outlined]="true"
               />
-              <span class="text-sm font-medium">{{ transaction.exchange.name }}</span>
-            </div>
-          } @else {
-            <span class="text-sm text-gray-500 dark:text-gray-400">N/A</span>
-          }
-        </td>
-        <td>
-          <p-tag [value]="transaction.status" [severity]="getStatusSeverity(transaction.status)"></p-tag>
-        </td>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="emptymessage">
-      <tr>
-        <td colspan="9" class="p-4">
-          @if (!isLoading()) {
-            <div class="flex items-center gap-2 text-gray-500">
-              <i class="pi pi-inbox text-xl"></i>
-              <span>No transactions found</span>
-            </div>
-          }
-        </td>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="paginatorleft">
-      <div class="text-gray-500">Total Records: {{ transactions().length }}</div>
-    </ng-template>
-  </p-table>
+            }
+          </td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="paginatorleft">
+        @if (transactions().length > 0) {
+          <div class="text-gray-500">Total Records: {{ transactions().length }}</div>
+        }
+      </ng-template>
+    </p-table>
+  } @else {
+    <app-empty-state
+      icon="arrow-right-arrow-left"
+      title="No Transactions Yet"
+      message="Connect your exchanges in the settings to start tracking your trades."
+      actionLabel="Connect Exchange"
+      actionRoute="/app/settings"
+      [actionQueryParams]="{ tab: 'trading' }"
+      actionIcon="pi pi-link"
+      size="large"
+    />
+  }
 </p-card>

--- a/apps/chansey/src/app/pages/transactions/transactions.component.ts
+++ b/apps/chansey/src/app/pages/transactions/transactions.component.ts
@@ -29,7 +29,9 @@ import { Order, OrderSide, OrderStatus, OrderType } from '@chansey/api-interface
 
 import { TransactionsService } from './transactions.service';
 
+import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { formatType, isUsdQuote } from '../../shared/utils/order-format.util';
+import { getSideSeverity, getStatusSeverity } from '../../shared/utils/order-severity.util';
 
 @Component({
   selector: 'app-transactions',
@@ -41,6 +43,7 @@ import { formatType, isUsdQuote } from '../../shared/utils/order-format.util';
     DatePipe,
     DatePickerModule,
     DecimalPipe,
+    EmptyStateComponent,
     IconFieldModule,
     InputIconModule,
     InputTextModule,
@@ -159,30 +162,8 @@ export class TransactionsComponent {
     this.dt?.filterGlobal('', 'contains');
   }
 
-  // Helper method to get appropriate severity for order status
-  getStatusSeverity(status: OrderStatus): 'success' | 'secondary' | 'info' | 'warn' | 'danger' | 'contrast' {
-    switch (status) {
-      case OrderStatus.FILLED:
-        return 'success';
-      case OrderStatus.PARTIALLY_FILLED:
-        return 'info';
-      case OrderStatus.NEW:
-        return 'warn';
-      case OrderStatus.CANCELED:
-      case OrderStatus.EXPIRED:
-      case OrderStatus.REJECTED:
-        return 'danger';
-      case OrderStatus.PENDING_CANCEL:
-        return 'warn';
-      default:
-        return 'info';
-    }
-  }
-
-  // Helper method to get appropriate severity for order side
-  getSideSeverity(side: OrderSide): 'success' | 'danger' {
-    return side === OrderSide.BUY ? 'success' : 'danger';
-  }
+  getStatusSeverity = getStatusSeverity;
+  getSideSeverity = getSideSeverity;
 
   isUsdQuote = isUsdQuote;
   formatType = formatType;

--- a/apps/chansey/src/app/pages/watchlist/watchlist.component.ts
+++ b/apps/chansey/src/app/pages/watchlist/watchlist.component.ts
@@ -35,6 +35,8 @@ export class WatchlistComponent {
     showRemoveAction: true,
     searchPlaceholder: 'Search watchlist...',
     emptyMessage: 'Your watchlist is empty. Add coins from the prices page.',
+    emptyActionLink: '/app/prices',
+    emptyActionLabel: 'Browse Coins',
     cardTitle: 'My Watchlist'
   };
 

--- a/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.html
@@ -101,7 +101,7 @@
   @if (!isLoading()) {
     <p-table
       #dt
-      [paginator]="true"
+      [paginator]="sortedCoins().length > 0"
       [rowHover]="true"
       [rows]="25"
       [showCurrentPageReport]="true"
@@ -116,19 +116,21 @@
       stripedRows
     >
       <ng-template #caption>
-        <div class="flex flex-col items-end">
-          <p-iconfield>
-            <p-inputicon class="pi pi-search" />
-            <input
-              pInputText
-              #searchInput
-              type="text"
-              (input)="applyGlobalFilter($event)"
-              [placeholder]="config().searchPlaceholder"
-              class="w-full md:w-auto"
-            />
-          </p-iconfield>
-        </div>
+        @if (coins().length || searchFilter()) {
+          <div class="flex flex-col items-end">
+            <p-iconfield>
+              <p-inputicon class="pi pi-search" />
+              <input
+                pInputText
+                #searchInput
+                type="text"
+                (input)="applyGlobalFilter($event)"
+                [placeholder]="config().searchPlaceholder"
+                class="w-full md:w-auto"
+              />
+            </p-iconfield>
+          </div>
+        }
       </ng-template>
       <ng-template #header>
         <tr class="whitespace-nowrap">
@@ -240,7 +242,7 @@
             [attr.colspan]="config().showWatchlistToggle || config().showRemoveAction ? 8 : 7"
             class="p-4 text-center"
           >
-            <div class="text-gray-500">
+            <div class="flex flex-col items-center justify-center py-8 text-gray-500">
               @if (searchFilter()) {
                 <i class="pi pi-search mr-2"></i>
                 No coins found matching "{{ searchFilter() }}"
@@ -255,8 +257,12 @@
                   </button>
                 </div>
               } @else {
-                <i class="pi pi-info-circle mr-2"></i>
-                {{ config().emptyMessage }}
+                <app-empty-state
+                  [message]="config().emptyMessage"
+                  [actionRoute]="config().emptyActionLink"
+                  [actionLabel]="config().emptyActionLabel || 'Browse'"
+                  actionIcon="pi pi-search"
+                />
               }
             </div>
           </td>

--- a/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.ts
@@ -10,7 +10,7 @@ import {
   signal,
   viewChild
 } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 
 import { AvatarModule } from 'primeng/avatar';
 import { ButtonModule } from 'primeng/button';
@@ -29,12 +29,15 @@ import { Coin } from '@chansey/api-interfaces';
 import { CounterDirective } from '../../directives/counter/counter.directive';
 import { FormatLargeNumberPipe } from '../../pipes/format-large-number.pipe';
 import { CoinDataService } from '../../services/coin-data.service';
+import { EmptyStateComponent } from '../empty-state/empty-state.component';
 
 export interface CryptoTableConfig {
   showWatchlistToggle?: boolean;
   showRemoveAction?: boolean;
   searchPlaceholder?: string;
   emptyMessage?: string;
+  emptyActionLink?: string;
+  emptyActionLabel?: string;
   cardTitle?: string;
 }
 
@@ -46,11 +49,13 @@ export interface CryptoTableConfig {
     CardModule,
     CounterDirective,
     DecimalPipe,
+    EmptyStateComponent,
     FormatLargeNumberPipe,
     IconFieldModule,
     InputIconModule,
     InputTextModule,
     ProgressBarModule,
+    RouterLink,
     SkeletonModule,
     TableModule,
     TagModule,

--- a/apps/chansey/src/app/shared/components/empty-state/empty-state.component.ts
+++ b/apps/chansey/src/app/shared/components/empty-state/empty-state.component.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { ButtonModule } from 'primeng/button';
+
+@Component({
+  selector: 'app-empty-state',
+  imports: [ButtonModule, RouterLink],
+  template: `
+    <div class="flex flex-col items-center justify-center px-4 py-12 text-center">
+      @if (icon()) {
+        <div class="bg-primary/10 mb-4 rounded-full p-4">
+          <i [class]="'text-primary pi pi-' + icon() + ' !text-4xl'" aria-hidden="true"></i>
+        </div>
+      }
+      @if (title()) {
+        <h3 class="mb-2 text-xl font-semibold text-gray-700 dark:text-gray-300">{{ title() }}</h3>
+      }
+      @if (message()) {
+        <p class="mb-6 max-w-md text-gray-500 dark:text-gray-400">{{ message() }}</p>
+      }
+      @if (actionRoute()) {
+        <p-button
+          [icon]="actionIcon()"
+          [label]="actionLabel()"
+          [routerLink]="actionRoute()"
+          [queryParams]="actionQueryParams()"
+          [outlined]="outlined()"
+          [size]="size()"
+        />
+      }
+      <ng-content />
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class EmptyStateComponent {
+  readonly icon = input<string>();
+  readonly title = input<string>();
+  readonly message = input<string>();
+  readonly actionLabel = input<string>();
+  readonly actionRoute = input<string>();
+  readonly actionQueryParams = input<Record<string, string>>();
+  readonly actionIcon = input<string>();
+  readonly outlined = input(false);
+  readonly size = input<'small' | 'large'>('small');
+}

--- a/apps/chansey/src/app/shared/components/index.ts
+++ b/apps/chansey/src/app/shared/components/index.ts
@@ -2,6 +2,7 @@ export * from './auth-illustrations';
 export * from './auth-messages';
 export * from './auth-page-shell';
 export * from './crypto-table/crypto-table.component';
+export * from './empty-state/empty-state.component';
 export * from './exchange-balance/exchange-balance.component';
 export * from './image-crop/image-crop.component';
 export * from './lazy-image/lazy-image.component';

--- a/apps/chansey/src/app/shared/components/recent-transactions/recent-transactions.component.html
+++ b/apps/chansey/src/app/shared/components/recent-transactions/recent-transactions.component.html
@@ -1,6 +1,6 @@
 <p-card class="recent-transactions-container">
   <ng-template pTemplate="header">
-    <div class="flex items-center justify-between border-b border-gray-100 p-4 dark:border-neutral-700">
+    <div class="flex items-center justify-between p-4 border-b border-gray-100 dark:border-neutral-700">
       <div class="flex items-center gap-4">
         <i class="pi pi-history text-primary"></i>
         <h2 class="m-0 text-xl font-semibold">Recent Transactions</h2>
@@ -21,7 +21,7 @@
   @if (transactionsQuery.isPending()) {
     <div class="mb-3 overflow-hidden">
       <!-- Skeleton for table header -->
-      <div class="mb-2 flex rounded-t border-b border-gray-100 p-3 dark:border-neutral-700">
+      <div class="flex p-3 mb-2 border-b border-gray-100 rounded-t dark:border-neutral-700">
         <p-skeleton width="120px" height="1.25rem" class="mr-6"></p-skeleton>
         <p-skeleton width="100px" height="1.25rem" class="mr-6"></p-skeleton>
         <p-skeleton width="120px" height="1.25rem" class="mr-6"></p-skeleton>
@@ -29,8 +29,8 @@
       </div>
       <!-- Skeleton for table rows -->
       @for (i of skeletonRows(); track i) {
-        <div class="mb-2 flex border-b border-gray-50 p-3 dark:border-neutral-700">
-          <div class="mr-6 flex items-center">
+        <div class="flex p-3 mb-2 border-b border-gray-50 dark:border-neutral-700">
+          <div class="flex items-center mr-6">
             <p-skeleton shape="circle" size="2.5rem" class="mr-2"></p-skeleton>
             <p-skeleton width="120px" height="1.25rem"></p-skeleton>
           </div>
@@ -44,14 +44,12 @@
 
   <!-- Empty state -->
   @if (!transactionsQuery.isPending() && transactions().length === 0) {
-    <div class="m-3 flex flex-col items-center justify-center rounded-lg bg-gray-50/30 px-4 py-12 dark:bg-gray-800/20">
-      <div class="bg-primary/10 mb-4 rounded-full p-4">
-        <i class="text-primary pi pi-wallet text-4xl!"></i>
-      </div>
-      <h3 class="mb-2 text-2xl font-medium">No transactions yet</h3>
-      <p class="mb-6 max-w-md text-center">
-        You haven't made any transactions yet.<br />Start trading to see your activity here.
-      </p>
+    <div class="m-3 rounded-lg bg-gray-50/30 dark:bg-gray-800/20">
+      <app-empty-state
+        icon="wallet"
+        title="No transactions yet"
+        message="You haven't made any transactions yet. Start trading to see your activity here."
+      />
     </div>
   }
 
@@ -81,10 +79,10 @@
                   [image]="transaction.baseCoin?.image"
                   shape="circle"
                   size="large"
-                  class="mr-2 min-w-10 shadow-sm"
+                  class="mr-2 shadow-sm min-w-10"
                 />
                 <div class="flex flex-col">
-                  <span class="text-primary-500 hover:text-primary-600 font-medium">{{ transaction.symbol }}</span>
+                  <span class="font-medium text-primary-500 hover:text-primary-600">{{ transaction.symbol }}</span>
                   <span class="text-xs text-gray-500 dark:text-gray-400">{{ transaction.baseCoin?.name }}</span>
                 </div>
               </a>

--- a/apps/chansey/src/app/shared/components/recent-transactions/recent-transactions.component.ts
+++ b/apps/chansey/src/app/shared/components/recent-transactions/recent-transactions.component.ts
@@ -9,10 +9,10 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 
-import { OrderSide, OrderStatus } from '@chansey/api-interfaces';
-
 import { TransactionsService } from '../../../pages/transactions/transactions.service';
 import { formatType, isUsdQuote } from '../../utils/order-format.util';
+import { getSideSeverity, getStatusSeverity } from '../../utils/order-severity.util';
+import { EmptyStateComponent } from '../empty-state/empty-state.component';
 
 @Component({
   selector: 'app-recent-transactions',
@@ -22,11 +22,12 @@ import { formatType, isUsdQuote } from '../../utils/order-format.util';
     CardModule,
     DatePipe,
     DecimalPipe,
-    UpperCasePipe,
+    EmptyStateComponent,
     RouterModule,
     SkeletonModule,
     TableModule,
-    TagModule
+    TagModule,
+    UpperCasePipe
   ],
   templateUrl: './recent-transactions.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -44,30 +45,8 @@ export class RecentTransactionsComponent {
   transactions = computed(() => this.transactionsQuery.data()?.slice(0, this.limit()) || []);
   skeletonRows = computed(() => Array.from({ length: Math.min(this.limit(), 4) }, (_, i) => i));
 
-  // Helper method to get appropriate severity for order status
-  getStatusSeverity(status: OrderStatus): 'success' | 'secondary' | 'info' | 'warn' | 'danger' | 'contrast' {
-    switch (status) {
-      case OrderStatus.FILLED:
-        return 'success';
-      case OrderStatus.PARTIALLY_FILLED:
-        return 'info';
-      case OrderStatus.NEW:
-        return 'warn';
-      case OrderStatus.CANCELED:
-      case OrderStatus.EXPIRED:
-      case OrderStatus.REJECTED:
-        return 'danger';
-      case OrderStatus.PENDING_CANCEL:
-        return 'warn';
-      default:
-        return 'info';
-    }
-  }
-
-  // Helper method to get appropriate severity for order side
-  getSideSeverity(side: OrderSide): 'success' | 'danger' {
-    return side === OrderSide.BUY ? 'success' : 'danger';
-  }
+  getStatusSeverity = getStatusSeverity;
+  getSideSeverity = getSideSeverity;
 
   isUsdQuote = isUsdQuote;
   formatType = formatType;

--- a/apps/chansey/src/app/shared/components/user-assets/user-assets.component.html
+++ b/apps/chansey/src/app/shared/components/user-assets/user-assets.component.html
@@ -1,6 +1,6 @@
 <p-card class="user-assets-container">
   <ng-template pTemplate="header">
-    <div class="flex items-center justify-between border-b border-gray-100 p-4 dark:border-neutral-700">
+    <div class="flex items-center justify-between p-4 border-b border-gray-100 dark:border-neutral-700">
       <div class="flex items-center gap-4">
         <i class="pi pi-wallet text-primary"></i>
         <h2 class="m-0 text-xl font-semibold">Your Assets</h2>
@@ -12,7 +12,7 @@
   @if (assetsQuery.isPending()) {
     <div class="mb-3 overflow-hidden">
       <!-- Skeleton for table header -->
-      <div class="mb-2 flex rounded-t border-b border-gray-100 p-3 dark:border-neutral-700">
+      <div class="flex p-3 mb-2 border-b border-gray-100 rounded-t dark:border-neutral-700">
         <p-skeleton width="120px" height="1.25rem" class="mr-6"></p-skeleton>
         <p-skeleton width="100px" height="1.25rem" class="mr-6"></p-skeleton>
         <p-skeleton width="120px" height="1.25rem" class="mr-6"></p-skeleton>
@@ -20,8 +20,8 @@
       </div>
       <!-- Skeleton for table rows -->
       @for (i of skeletonRows(); track i) {
-        <div class="mb-2 flex border-b border-gray-50 p-3 dark:border-neutral-700">
-          <div class="mr-6 flex items-center">
+        <div class="flex p-3 mb-2 border-b border-gray-50 dark:border-neutral-700">
+          <div class="flex items-center mr-6">
             <p-skeleton shape="circle" size="2.5rem" class="mr-2"></p-skeleton>
             <p-skeleton width="120px" height="1.25rem"></p-skeleton>
           </div>
@@ -35,14 +35,12 @@
 
   <!-- Empty state -->
   @if (!assetsQuery.isPending() && assets().length === 0) {
-    <div class="m-3 flex flex-col items-center justify-center rounded-lg bg-gray-50/30 px-4 py-12 dark:bg-gray-800/20">
-      <div class="bg-primary/10 mb-4 rounded-full p-4">
-        <i class="text-primary pi pi-dollar text-4xl!"></i>
-      </div>
-      <h3 class="mb-2 text-2xl font-medium">No assets yet</h3>
-      <p class="mb-6 max-w-md text-center">
-        You haven't purchased any assets yet.<br />Start trading to build your portfolio.
-      </p>
+    <div class="m-3 rounded-lg bg-gray-50/30 dark:bg-gray-800/20">
+      <app-empty-state
+        icon="dollar"
+        title="No assets yet"
+        message="You haven't purchased any assets yet. Start trading to build your portfolio."
+      />
     </div>
   }
 
@@ -88,9 +86,9 @@
                 [class.pointer-events-none]="!asset.slug"
                 class="flex items-center gap-1 transition-opacity hover:opacity-80"
               >
-                <p-avatar [image]="asset.image" shape="circle" size="large" class="mr-2 min-w-10 shadow-sm" />
+                <p-avatar [image]="asset.image" shape="circle" size="large" class="mr-2 shadow-sm min-w-10" />
                 <div class="flex flex-col">
-                  <span class="text-primary-500 hover:text-primary-600 font-medium">{{ asset.name }}</span>
+                  <span class="font-medium text-primary-500 hover:text-primary-600">{{ asset.name }}</span>
                   <span class="text-xs text-gray-500 uppercase dark:text-gray-400">{{ asset.symbol }}</span>
                 </div>
               </a>

--- a/apps/chansey/src/app/shared/components/user-assets/user-assets.component.ts
+++ b/apps/chansey/src/app/shared/components/user-assets/user-assets.component.ts
@@ -13,6 +13,8 @@ import { TagModule } from 'primeng/tag';
 
 import { UserAssetsService } from './user-assets.service';
 
+import { EmptyStateComponent } from '../empty-state/empty-state.component';
+
 @Component({
   selector: 'app-user-assets',
   imports: [
@@ -21,6 +23,7 @@ import { UserAssetsService } from './user-assets.service';
     CardModule,
     CurrencyPipe,
     DecimalPipe,
+    EmptyStateComponent,
     PaginatorModule,
     ProgressSpinnerModule,
     RouterModule,

--- a/apps/chansey/src/app/shared/utils/order-severity.util.ts
+++ b/apps/chansey/src/app/shared/utils/order-severity.util.ts
@@ -1,0 +1,26 @@
+import { OrderSide, OrderStatus } from '@chansey/api-interfaces';
+
+type TagSeverity = 'success' | 'secondary' | 'info' | 'warn' | 'danger' | 'contrast';
+
+export function getStatusSeverity(status: OrderStatus): TagSeverity {
+  switch (status) {
+    case OrderStatus.FILLED:
+      return 'success';
+    case OrderStatus.PARTIALLY_FILLED:
+      return 'info';
+    case OrderStatus.NEW:
+      return 'warn';
+    case OrderStatus.CANCELED:
+    case OrderStatus.EXPIRED:
+    case OrderStatus.REJECTED:
+      return 'danger';
+    case OrderStatus.PENDING_CANCEL:
+      return 'warn';
+    default:
+      return 'info';
+  }
+}
+
+export function getSideSeverity(side: OrderSide): 'success' | 'danger' {
+  return side === OrderSide.BUY ? 'success' : 'danger';
+}


### PR DESCRIPTION
## Summary

- Extract a shared `EmptyStateComponent` with configurable icon, title, message, and action button
- Replace inline empty state markup across dashboard, transactions, recent-transactions, user-assets, and watchlist
- Extract duplicated order severity helpers into a shared `order-severity.util.ts`

## Changes

- **New**: `empty-state.component.ts` — reusable empty state with icon, title, message, and optional action link
- **New**: `order-severity.util.ts` — shared `getStatusSeverity`/`getSideSeverity` helpers
- **Updated**: Dashboard, transactions, recent-transactions, user-assets — use `EmptyStateComponent` instead of inline markup
- **Updated**: `crypto-table` — added `emptyActionLink`/`emptyActionLabel` inputs for configurable empty state; hide filters/pagination when no data
- **Updated**: Transactions — hide filters and pagination when no data exists

## Test Plan

- [ ] Dashboard shows empty states correctly for assets, recent transactions, and portfolio sections
- [ ] Transactions page shows empty state when no orders exist, filters/pagination hidden
- [ ] Watchlist shows empty state with "Browse Coins" action link
- [ ] All empty state action buttons navigate correctly
- [ ] No visual regressions in components that were refactored