### PR TITLE
fix(api): add explicit enumName to all entity enum columns for TypeORM synchronize

### DIFF
--- a/apps/api/src/config/database.config.ts
+++ b/apps/api/src/config/database.config.ts
@@ -17,6 +17,8 @@ export const databaseConfig = registerAs(
     migrations: [join(__dirname, '../migrations/*.{ts,js}')],
     migrationsTableName: 'migration',
     migrationsRun: process.env.NODE_ENV === 'production',
+    // DEVELOPMENT ONLY - auto-sync schema changes (entities must use unique enumName per table)
+    // For production: Use migrations: npx nx g @nx/nest:migration --project=api --name=<name>
     synchronize: process.env.NODE_ENV !== 'production',
     logging: process.env.NODE_ENV !== 'production',
     uuidExtension: 'pgcrypto',

--- a/apps/api/src/order/backtest/backtest.entity.ts
+++ b/apps/api/src/order/backtest/backtest.entity.ts
@@ -66,13 +66,13 @@ export class Backtest {
 
   @IsEnum(BacktestType)
   @IsNotEmpty()
-  @Column({ type: 'enum', enum: BacktestType })
+  @Column({ type: 'enum', enum: BacktestType, enumName: 'backtest_type_enum' })
   @ApiProperty({ description: 'Type of backtest', enum: BacktestType })
   type: BacktestType;
 
   @IsEnum(BacktestStatus)
   @IsNotEmpty()
-  @Column({ type: 'enum', enum: BacktestStatus, default: BacktestStatus.PENDING })
+  @Column({ type: 'enum', enum: BacktestStatus, enumName: 'backtest_status_enum', default: BacktestStatus.PENDING })
   @Index()
   @ApiProperty({ description: 'Current status of the backtest', enum: BacktestStatus })
   status: BacktestStatus;
@@ -282,13 +282,13 @@ export class BacktestTrade {
 
   @IsEnum(TradeType)
   @IsNotEmpty()
-  @Column({ type: 'enum', enum: TradeType })
+  @Column({ type: 'enum', enum: TradeType, enumName: 'backtest_trade_type_enum' })
   @ApiProperty({ description: 'Type of trade', enum: TradeType })
   type: TradeType;
 
   @IsEnum(TradeStatus)
   @IsNotEmpty()
-  @Column({ type: 'enum', enum: TradeStatus, default: TradeStatus.EXECUTED })
+  @Column({ type: 'enum', enum: TradeStatus, enumName: 'backtest_trade_status_enum', default: TradeStatus.EXECUTED })
   @ApiProperty({ description: 'Status of the trade', enum: TradeStatus })
   status: TradeStatus;
 
@@ -464,7 +464,7 @@ export class BacktestSignal {
   timestamp: Date;
 
   @IsEnum(SignalType)
-  @Column({ type: 'enum', enum: SignalType })
+  @Column({ type: 'enum', enum: SignalType, enumName: 'backtest_signal_type_enum' })
   @ApiProperty({ description: 'Signal classification', enum: SignalType })
   signalType: SignalType;
 
@@ -474,7 +474,7 @@ export class BacktestSignal {
   instrument: string;
 
   @IsEnum(SignalDirection)
-  @Column({ type: 'enum', enum: SignalDirection })
+  @Column({ type: 'enum', enum: SignalDirection, enumName: 'backtest_signal_direction_enum' })
   @ApiProperty({ description: 'Directional intent of the signal', enum: SignalDirection })
   direction: SignalDirection;
 
@@ -542,12 +542,12 @@ export class SimulatedOrderFill {
   id: string;
 
   @IsEnum(SimulatedOrderType)
-  @Column({ type: 'enum', enum: SimulatedOrderType })
+  @Column({ type: 'enum', enum: SimulatedOrderType, enumName: 'simulated_order_type_enum' })
   @ApiProperty({ description: 'Simulated order type', enum: SimulatedOrderType })
   orderType: SimulatedOrderType;
 
   @IsEnum(SimulatedOrderStatus)
-  @Column({ type: 'enum', enum: SimulatedOrderStatus })
+  @Column({ type: 'enum', enum: SimulatedOrderStatus, enumName: 'simulated_order_status_enum' })
   @ApiProperty({ description: 'Fill completion status', enum: SimulatedOrderStatus })
   status: SimulatedOrderStatus;
 

--- a/apps/api/src/order/backtest/market-data-set.entity.ts
+++ b/apps/api/src/order/backtest/market-data-set.entity.ts
@@ -43,7 +43,7 @@ export class MarketDataSet {
   label: string;
 
   @IsEnum(MarketDataSource)
-  @Column({ type: 'enum', enum: MarketDataSource })
+  @Column({ type: 'enum', enum: MarketDataSource, enumName: 'market_data_source_enum' })
   @ApiProperty({ description: 'Origin of the dataset', enum: MarketDataSource })
   source: MarketDataSource;
 
@@ -52,7 +52,7 @@ export class MarketDataSet {
   instrumentUniverse: string[];
 
   @IsEnum(MarketDataTimeframe)
-  @Column({ type: 'enum', enum: MarketDataTimeframe })
+  @Column({ type: 'enum', enum: MarketDataTimeframe, enumName: 'market_data_timeframe_enum' })
   @ApiProperty({ description: 'Granularity of the dataset', enum: MarketDataTimeframe })
   timeframe: MarketDataTimeframe;
 

--- a/apps/api/src/order/entities/order-status-history.entity.ts
+++ b/apps/api/src/order/entities/order-status-history.entity.ts
@@ -38,7 +38,7 @@ export class OrderStatusHistory {
   @Column({
     type: 'enum',
     enum: OrderStatus,
-    enumName: 'order_status_enum',
+    enumName: 'order_history_from_status_enum',
     nullable: true,
     comment: 'Previous status (null for initial creation)'
   })
@@ -47,7 +47,7 @@ export class OrderStatusHistory {
   @Column({
     type: 'enum',
     enum: OrderStatus,
-    enumName: 'order_status_enum',
+    enumName: 'order_history_to_status_enum',
     comment: 'New status after transition'
   })
   toStatus: OrderStatus;
@@ -61,6 +61,7 @@ export class OrderStatusHistory {
   @Column({
     type: 'enum',
     enum: OrderTransitionReason,
+    enumName: 'order_transition_reason_enum',
     comment: 'Reason code for the status change'
   })
   reason: OrderTransitionReason;

--- a/apps/api/src/order/order.entity.ts
+++ b/apps/api/src/order/order.entity.ts
@@ -295,7 +295,8 @@ export class Order {
 
   @Column({
     type: 'enum',
-    enum: OrderStatus
+    enum: OrderStatus,
+    enumName: 'order_status_enum'
   })
   @IsEnum(OrderStatus)
   @IsNotEmpty()
@@ -308,7 +309,8 @@ export class Order {
 
   @Column({
     type: 'enum',
-    enum: OrderSide
+    enum: OrderSide,
+    enumName: 'order_side_enum'
   })
   @ApiProperty({
     description: 'Side of the order',
@@ -319,7 +321,8 @@ export class Order {
 
   @Column({
     type: 'enum',
-    enum: OrderType
+    enum: OrderType,
+    enumName: 'order_type_enum'
   })
   @ApiProperty({
     description: 'Type of the order',
@@ -446,6 +449,7 @@ export class Order {
     type: 'enum',
     name: 'trailing_type',
     enum: TrailingType,
+    enumName: 'trailing_type_enum',
     nullable: true
   })
   @IsEnum(TrailingType)

--- a/apps/api/src/order/paper-trading/entities/paper-trading-order.entity.ts
+++ b/apps/api/src/order/paper-trading/entities/paper-trading-order.entity.ts
@@ -48,17 +48,27 @@ export class PaperTradingOrder {
   id: string;
 
   @IsEnum(PaperTradingOrderSide)
-  @Column({ type: 'enum', enum: PaperTradingOrderSide })
+  @Column({ type: 'enum', enum: PaperTradingOrderSide, enumName: 'paper_trading_order_side_enum' })
   @ApiProperty({ description: 'Order side', enum: PaperTradingOrderSide })
   side: PaperTradingOrderSide;
 
   @IsEnum(PaperTradingOrderType)
-  @Column({ type: 'enum', enum: PaperTradingOrderType, default: PaperTradingOrderType.MARKET })
+  @Column({
+    type: 'enum',
+    enum: PaperTradingOrderType,
+    enumName: 'paper_trading_order_type_enum',
+    default: PaperTradingOrderType.MARKET
+  })
   @ApiProperty({ description: 'Order type', enum: PaperTradingOrderType, default: 'MARKET' })
   orderType: PaperTradingOrderType;
 
   @IsEnum(PaperTradingOrderStatus)
-  @Column({ type: 'enum', enum: PaperTradingOrderStatus, default: PaperTradingOrderStatus.PENDING })
+  @Column({
+    type: 'enum',
+    enum: PaperTradingOrderStatus,
+    enumName: 'paper_trading_order_status_enum',
+    default: PaperTradingOrderStatus.PENDING
+  })
   @ApiProperty({ description: 'Order status', enum: PaperTradingOrderStatus, default: 'PENDING' })
   status: PaperTradingOrderStatus;
 

--- a/apps/api/src/order/paper-trading/entities/paper-trading-session.entity.ts
+++ b/apps/api/src/order/paper-trading/entities/paper-trading-session.entity.ts
@@ -59,7 +59,12 @@ export class PaperTradingSession {
   description?: string;
 
   @IsEnum(PaperTradingStatus)
-  @Column({ type: 'enum', enum: PaperTradingStatus, default: PaperTradingStatus.ACTIVE })
+  @Column({
+    type: 'enum',
+    enum: PaperTradingStatus,
+    enumName: 'paper_trading_session_status_enum',
+    default: PaperTradingStatus.ACTIVE
+  })
   @ApiProperty({ description: 'Current status of the session', enum: PaperTradingStatus })
   status: PaperTradingStatus;
 

--- a/apps/api/src/order/paper-trading/entities/paper-trading-signal.entity.ts
+++ b/apps/api/src/order/paper-trading/entities/paper-trading-signal.entity.ts
@@ -40,12 +40,12 @@ export class PaperTradingSignal {
   id: string;
 
   @IsEnum(PaperTradingSignalType)
-  @Column({ type: 'enum', enum: PaperTradingSignalType })
+  @Column({ type: 'enum', enum: PaperTradingSignalType, enumName: 'paper_trading_signal_type_enum' })
   @ApiProperty({ description: 'Type of signal', enum: PaperTradingSignalType })
   signalType: PaperTradingSignalType;
 
   @IsEnum(PaperTradingSignalDirection)
-  @Column({ type: 'enum', enum: PaperTradingSignalDirection })
+  @Column({ type: 'enum', enum: PaperTradingSignalDirection, enumName: 'paper_trading_signal_direction_enum' })
   @ApiProperty({ description: 'Direction of the signal', enum: PaperTradingSignalDirection })
   direction: PaperTradingSignalDirection;
 


### PR DESCRIPTION
## Summary

- Fix TypeORM `synchronize` failures when multiple tables share the same PostgreSQL enum type
- Give every enum column a unique `enumName` per table so no two tables reference the same PostgreSQL enum type

## Problem

TypeORM's `synchronize` fails when multiple tables share the same PostgreSQL enum type (via `enumName`). During schema sync, it renames the old enum to `_old`, migrates one table's column, then tries to `DROP` the `_old` type while other tables still reference it — causing a cascade failure.

## Changes

- `apps/api/src/config/database.config.ts` — Config update for synchronize behavior
- `apps/api/src/order/backtest/backtest.entity.ts` — Unique enumNames for backtest enums
- `apps/api/src/order/backtest/market-data-set.entity.ts` — Unique enumName for market data set enums
- `apps/api/src/order/entities/order-status-history.entity.ts` — Unique enumName for order status history enums
- `apps/api/src/order/order.entity.ts` — Unique enumName for order enums
- `apps/api/src/order/paper-trading/entities/paper-trading-order.entity.ts` — Unique enumNames for paper trading order enums
- `apps/api/src/order/paper-trading/entities/paper-trading-session.entity.ts` — Unique enumName for paper trading session enums
- `apps/api/src/order/paper-trading/entities/paper-trading-signal.entity.ts` — Unique enumName for paper trading signal enums

## Test Plan

- [ ] TypeORM synchronize runs without enum-related errors
- [ ] Existing enum values remain intact after synchronize
- [ ] No runtime behavior changes — `enumName` only affects schema sync