### PR TITLE
feat: separate watched coins from trading coins with dedicated UI

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -12,9 +12,9 @@ Create a GitHub issue: $ARGUMENTS
 
 - Remote URL: !`git remote get-url origin 2>/dev/null || echo "not a git repo"`
 - Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
-- Available labels: !`gh label list --json name --jq '.[].name' 2>/dev/null | tr '\n' ', ' | sed 's/,$//'`
+- Available labels: !`gh label list --json name --jq '[.[].name] | join(", ")' 2>/dev/null`
 - Available projects:
-  !`gh project list --owner braxtondiggs --format json --jq '.projects[] | "\(.number): \(.title)"' 2>/dev/null | tr '\n' ', ' | sed 's/,$//'`
+  !`gh project list --owner braxtondiggs --format json --jq '[.projects[] | "\(.number): \(.title)"] | join(", ")' 2>/dev/null`
 
 ## Task Overview
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,7 @@
   "prettier.configPath": ".prettierrc",
   "editor.codeActionsOnSave": {
     "source.addMissingImports": "explicit",
-    "source.organizeImports": "always",
-    "source.fixAll": "explicit"
+    "source.fixAll.eslint": "always"
   },
   "vsicons.presets.angular": true,
   "tailwindCSS.experimental.classRegex": [["className=\"([^\"\\\\]*)\"", "\"([^\"]*)\""]],

--- a/apps/api/src/coin-selection/coin-selection-type.enum.ts
+++ b/apps/api/src/coin-selection/coin-selection-type.enum.ts
@@ -1,4 +1,5 @@
 export enum CoinSelectionType {
   MANUAL = 'MANUAL',
-  AUTOMATIC = 'AUTOMATIC'
+  AUTOMATIC = 'AUTOMATIC',
+  WATCHED = 'WATCHED'
 }

--- a/apps/api/src/coin-selection/coin-selection.controller.ts
+++ b/apps/api/src/coin-selection/coin-selection.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpStatus,
   Param,
+  ParseEnumPipe,
   ParseUUIDPipe,
   Patch,
   Post,
@@ -39,7 +40,7 @@ export class CoinSelectionController {
     name: 'type',
     required: false,
     enum: CoinSelectionType,
-    description: 'Filter coin selection items by type (MANUAL or AUTOMATIC)',
+    description: 'Filter coin selection items by type (MANUAL, AUTOMATIC, or WATCHED)',
     example: CoinSelectionType.MANUAL
   })
   @ApiResponse({
@@ -47,7 +48,10 @@ export class CoinSelectionController {
     description: 'List of coin selection items retrieved successfully.',
     type: [CoinSelectionResponseDto]
   })
-  async getCoinSelections(@GetUser() user: User, @Query('type') type?: CoinSelectionType) {
+  async getCoinSelections(
+    @GetUser() user: User,
+    @Query('type', new ParseEnumPipe(CoinSelectionType, { optional: true })) type?: CoinSelectionType
+  ) {
     return this.coinSelection.getCoinSelectionsByUser(user, [CoinSelectionRelations.COIN], type);
   }
 

--- a/apps/api/src/coin-selection/coin-selection.entity.ts
+++ b/apps/api/src/coin-selection/coin-selection.entity.ts
@@ -38,7 +38,7 @@ export class CoinSelection {
     example: CoinSelectionType.MANUAL,
     enum: CoinSelectionType
   })
-  type: string;
+  type: CoinSelectionType;
 
   @CreateDateColumn({ type: 'timestamptz', select: false })
   createdAt: Date;

--- a/apps/api/src/coin-selection/coin-selection.module.ts
+++ b/apps/api/src/coin-selection/coin-selection.module.ts
@@ -9,15 +9,13 @@ import { CoinSelectionHistoricalPriceTask } from './tasks/coin-selection-histori
 
 import { CoinModule } from '../coin/coin.module';
 import { OHLCModule } from '../ohlc/ohlc.module';
-import { SharedCacheModule } from '../shared-cache.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([CoinSelection]),
     BullModule.registerQueue({ name: 'coin-selection-queue' }),
     forwardRef(() => CoinModule),
-    forwardRef(() => OHLCModule),
-    SharedCacheModule
+    forwardRef(() => OHLCModule)
   ],
   controllers: [CoinSelectionController],
   providers: [CoinSelectionService, CoinSelectionHistoricalPriceTask],

--- a/apps/api/src/coin-selection/coin-selection.service.spec.ts
+++ b/apps/api/src/coin-selection/coin-selection.service.spec.ts
@@ -99,7 +99,8 @@ describe('CoinSelectionService', () => {
       expect(result).toEqual([{ id: 'selection-1' }]);
       expect(selectionRepo.find).toHaveBeenCalledWith({
         where: { user: { id: mockUser.id }, type: CoinSelectionType.MANUAL },
-        relations: ['coin']
+        relations: ['coin'],
+        order: { coin: { name: 'ASC' } }
       });
     });
   });

--- a/apps/api/src/coin-selection/coin-selection.service.ts
+++ b/apps/api/src/coin-selection/coin-selection.service.ts
@@ -23,6 +23,10 @@ export class CoinSelectionService {
     @Inject(forwardRef(() => OHLCService)) private readonly ohlcService: OHLCService
   ) {}
 
+  /**
+   * Returns all coin selections across all users. Internal/system-use only.
+   * Used by AlgorithmContextBuilder for background algorithm execution.
+   */
   async getCoinSelections(): Promise<CoinSelection[]> {
     return await this.coinSelection.find({
       relations: ['coin']
@@ -61,7 +65,8 @@ export class CoinSelectionService {
 
     const selections = await this.coinSelection.find({
       where: whereConditions,
-      relations
+      relations,
+      order: relations?.includes(CoinSelectionRelations.COIN) ? { coin: { name: 'ASC' } } : { createdAt: 'ASC' }
     });
     return selections;
   }
@@ -128,6 +133,13 @@ export class CoinSelectionService {
   async getManualCoinSelectionSymbols(user: User): Promise<string[]> {
     const items = await this.getCoinSelectionsByUser(user, [CoinSelectionRelations.COIN], CoinSelectionType.MANUAL);
     return items.map((p) => p.coin.symbol.toUpperCase());
+  }
+
+  async bulkDeleteAutomaticSelections(userId: string) {
+    return this.coinSelection.delete({
+      user: { id: userId },
+      type: CoinSelectionType.AUTOMATIC
+    });
   }
 
   async deleteCoinSelectionItem(selectionId: string, userId: string) {

--- a/apps/api/src/coin-selection/dto/coin-selection-response.dto.ts
+++ b/apps/api/src/coin-selection/dto/coin-selection-response.dto.ts
@@ -1,7 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { CreateCoinSelectionDto } from './create-coin-selection.dto';
-
 import { CoinResponseDto } from '../../coin/dto/coin-response.dto';
 import { UserResponseDto } from '../../users/dto';
 import { CoinSelectionType } from '../coin-selection-type.enum';
@@ -18,7 +16,7 @@ export class CoinSelectionResponseDto {
     example: CoinSelectionType.MANUAL,
     enum: CoinSelectionType
   })
-  type: string;
+  type: CoinSelectionType;
 
   @ApiProperty({
     description: 'Coin associated with this selection item',
@@ -44,7 +42,7 @@ export class CoinSelectionResponseDto {
   })
   updatedAt: Date;
 
-  constructor(partial: Partial<CreateCoinSelectionDto>) {
+  constructor(partial: Partial<CoinSelectionResponseDto>) {
     Object.assign(this, partial);
   }
 }

--- a/apps/api/src/coin-selection/dto/update-coin-selection.dto.ts
+++ b/apps/api/src/coin-selection/dto/update-coin-selection.dto.ts
@@ -1,5 +1,5 @@
-import { PartialType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 
 import { CreateCoinSelectionDto } from './create-coin-selection.dto';
 
-export class UpdateCoinSelectionDto extends PartialType(CreateCoinSelectionDto) {}
+export class UpdateCoinSelectionDto extends PartialType(OmitType(CreateCoinSelectionDto, ['coinId'] as const)) {}

--- a/apps/api/src/coin/coin.controller.ts
+++ b/apps/api/src/coin/coin.controller.ts
@@ -72,6 +72,20 @@ export class CoinController {
     return this.coin.getCoinsWithCurrentPrices();
   }
 
+  @Get('suggested')
+  @ApiOperation({
+    summary: 'Get suggested coins',
+    description: 'Retrieves the suggested coins for the authenticated user based on their risk profile.'
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'List of suggested coins retrieved successfully.',
+    type: [Coin]
+  })
+  suggestedCoins(@GetUser() user: User) {
+    return this.coin.getCoinsByRiskLevel(user);
+  }
+
   @Get(':id')
   @ApiParam({
     name: 'id',
@@ -161,20 +175,6 @@ export class CoinController {
   })
   getCoinHistoricalData(@Param('id', new ParseUUIDPipe()) id: string): Promise<any> {
     return this.coin.getCoinHistoricalData(id);
-  }
-
-  @Get('suggested')
-  @ApiOperation({
-    summary: 'Get suggested coins',
-    description: 'Retrieves the suggested coins for the authenticated user based on their risk profile.'
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: 'List of suggested coins retrieved successfully.',
-    type: [Coin]
-  })
-  suggestedCoins(@GetUser() user: User) {
-    return this.coin.getCoinsByRiskLevel(user);
   }
 }
 

--- a/apps/api/src/migrations/1741700000000-add-watched-coin-selection-type.ts
+++ b/apps/api/src/migrations/1741700000000-add-watched-coin-selection-type.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWatchedCoinSelectionType1741700000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Adding a new enum value requires running outside of a transaction in PostgreSQL
+    await queryRunner.query(`COMMIT`);
+    await queryRunner.query(`ALTER TYPE coin_selection_type_enum ADD VALUE IF NOT EXISTS 'WATCHED'`);
+    await queryRunner.query(`BEGIN`);
+
+    // Migrate existing MANUAL records for non-custom-risk users to WATCHED
+    // These are "watch only" selections that were previously conflated with trading selections
+    await queryRunner.query(`
+      UPDATE coin_selection cs
+      SET type = 'WATCHED'
+      FROM "user" u
+      LEFT JOIN risk r ON u."coinRiskId" = r.id
+      WHERE cs."userId" = u.id
+        AND cs.type = 'MANUAL'
+        AND (r.level IS NULL OR r.level != 6)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert WATCHED records back to MANUAL
+    await queryRunner.query(`
+      UPDATE coin_selection
+      SET type = 'MANUAL'
+      WHERE type = 'WATCHED'
+    `);
+
+    // Note: PostgreSQL does not support removing enum values
+    // The WATCHED value will remain in the enum but won't be used
+  }
+}

--- a/apps/api/src/risk/risk.constants.ts
+++ b/apps/api/src/risk/risk.constants.ts
@@ -1,1 +1,1 @@
-export { CUSTOM_RISK_LEVEL, DEFAULT_RISK_LEVEL, MIN_WATCHLIST_COINS } from '@chansey/api-interfaces';
+export { CUSTOM_RISK_LEVEL, DEFAULT_RISK_LEVEL, MIN_TRADING_COINS } from '@chansey/api-interfaces';

--- a/apps/api/src/risk/risk.service.ts
+++ b/apps/api/src/risk/risk.service.ts
@@ -1,10 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Not, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { CreateRiskDto, UpdateRiskDto } from './dto';
-import { CUSTOM_RISK_LEVEL } from './risk.constants';
 import { Risk } from './risk.entity';
 
 @Injectable()
@@ -16,7 +15,6 @@ export class RiskService {
 
   async findAll(): Promise<Risk[]> {
     return this.riskRepository.find({
-      where: { level: Not(CUSTOM_RISK_LEVEL) },
       order: { level: 'ASC' }
     });
   }

--- a/apps/api/src/tasks/backtest-orchestration.service.ts
+++ b/apps/api/src/tasks/backtest-orchestration.service.ts
@@ -31,7 +31,7 @@ import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backte
 import { BacktestService } from '../order/backtest/backtest.service';
 import { CreateBacktestDto } from '../order/backtest/dto/backtest.dto';
 import { MarketDataSet } from '../order/backtest/market-data-set.entity';
-import { CUSTOM_RISK_LEVEL, MIN_WATCHLIST_COINS } from '../risk/risk.constants';
+import { CUSTOM_RISK_LEVEL, MIN_TRADING_COINS } from '../risk/risk.constants';
 import { toErrorInfo } from '../shared/error.util';
 import { User } from '../users/users.entity';
 import { UsersService } from '../users/users.service';
@@ -96,16 +96,16 @@ export class BacktestOrchestrationService {
 
       this.logger.log(`Orchestrating backtests for user ${userId} with risk level ${riskLevel}`);
 
-      // For custom risk users, resolve watchlist coins and validate minimum count
+      // For custom risk users, resolve trading coins and validate minimum count
       let coinSymbolFilter: string[] | undefined;
       if (user.coinRisk?.level === CUSTOM_RISK_LEVEL) {
         coinSymbolFilter = await this.coinSelectionService.getManualCoinSelectionSymbols(user);
-        if (coinSymbolFilter.length < MIN_WATCHLIST_COINS) {
+        if (coinSymbolFilter.length < MIN_TRADING_COINS) {
           this.logger.warn(
-            `User ${userId} has < ${MIN_WATCHLIST_COINS} watchlist coins (${coinSymbolFilter.length}), skipping orchestration`
+            `User ${userId} has < ${MIN_TRADING_COINS} trading coins (${coinSymbolFilter.length}), skipping orchestration`
           );
           result.errors.push(
-            `Insufficient watchlist coins: ${coinSymbolFilter.length} (minimum ${MIN_WATCHLIST_COINS} required)`
+            `Insufficient trading coins: ${coinSymbolFilter.length} (minimum ${MIN_TRADING_COINS} required)`
           );
           return result;
         }

--- a/apps/api/src/tasks/pipeline-orchestration.service.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.ts
@@ -28,7 +28,7 @@ import { buildParameterSpace } from '../optimization/utils/parameter-space-build
 import { Pipeline } from '../pipeline/entities/pipeline.entity';
 import { PipelineStage, PipelineStatus } from '../pipeline/interfaces';
 import { PipelineOrchestratorService } from '../pipeline/services/pipeline-orchestrator.service';
-import { CUSTOM_RISK_LEVEL, MIN_WATCHLIST_COINS } from '../risk/risk.constants';
+import { CUSTOM_RISK_LEVEL, MIN_TRADING_COINS } from '../risk/risk.constants';
 import { toErrorInfo } from '../shared/error.util';
 import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
 import { User } from '../users/users.entity';
@@ -174,15 +174,15 @@ export class PipelineOrchestrationService {
 
       this.logger.log(`Orchestrating pipelines for user ${userId} with risk level ${riskLevel}`);
 
-      // For custom risk users, validate minimum watchlist coins
+      // For custom risk users, validate minimum trading coins
       if (user.coinRisk?.level === CUSTOM_RISK_LEVEL) {
-        const watchlistSymbols = await this.coinSelectionService.getManualCoinSelectionSymbols(user);
-        if (watchlistSymbols.length < MIN_WATCHLIST_COINS) {
+        const tradingCoinSymbols = await this.coinSelectionService.getManualCoinSelectionSymbols(user);
+        if (tradingCoinSymbols.length < MIN_TRADING_COINS) {
           this.logger.warn(
-            `User ${userId} has < ${MIN_WATCHLIST_COINS} watchlist coins (${watchlistSymbols.length}), skipping pipeline orchestration`
+            `User ${userId} has < ${MIN_TRADING_COINS} trading coins (${tradingCoinSymbols.length}), skipping pipeline orchestration`
           );
           result.errors.push(
-            `Insufficient watchlist coins: ${watchlistSymbols.length} (minimum ${MIN_WATCHLIST_COINS} required)`
+            `Insufficient trading coins: ${tradingCoinSymbols.length} (minimum ${MIN_TRADING_COINS} required)`
           );
           return result;
         }

--- a/apps/api/src/users/tasks/users.task.ts
+++ b/apps/api/src/users/tasks/users.task.ts
@@ -76,14 +76,6 @@ export class UsersTaskService extends WorkerHost implements OnModuleInit {
       this.logger.log(`Removed outdated selection update job for risk ${risk.level} (was: ${existingJob.pattern})`);
     }
 
-    // Also clean up any legacy portfolio-update jobs
-    const legacyJobName = `portfolio-update-risk-${risk.level}`;
-    const legacyJob = existingJobs.find((job) => job.name === legacyJobName);
-    if (legacyJob) {
-      await this.userQueue.removeRepeatableByKey(legacyJob.key);
-      this.logger.log(`Removed legacy portfolio update job for risk ${risk.level}`);
-    }
-
     // Schedule new job
     await this.userQueue.add(
       jobName,

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_OPPORTUNITY_SELLING_CONFIG,
   OpportunitySellingUserConfig
 } from '../order/interfaces/opportunity-selling.interface';
-import { CUSTOM_RISK_LEVEL, DEFAULT_RISK_LEVEL, MIN_WATCHLIST_COINS } from '../risk/risk.constants';
+import { CUSTOM_RISK_LEVEL, DEFAULT_RISK_LEVEL, MIN_TRADING_COINS } from '../risk/risk.constants';
 import { Risk } from '../risk/risk.entity';
 import { toErrorInfo } from '../shared/error.util';
 import { RiskPoolMappingService } from '../strategy/risk-pool-mapping.service';
@@ -102,14 +102,14 @@ export class UsersService {
         riskChanged = true;
       }
 
-      // Validate watchlist count for custom risk level
-      // Skip when user is SWITCHING TO custom (they're building their watchlist)
+      // Validate trading coin count for custom risk level
+      // Skip when user is SWITCHING TO custom (they're building their trading coins)
       const isSwitchingToCustom = !!coinRisk && updatedUser.coinRisk?.level === CUSTOM_RISK_LEVEL;
       if (updatedUser.coinRisk?.level === CUSTOM_RISK_LEVEL && !isSwitchingToCustom) {
-        const watchlistSymbols = await this.coinSelection.getManualCoinSelectionSymbols(updatedUser);
-        if (watchlistSymbols.length < MIN_WATCHLIST_COINS) {
+        const tradingCoinSymbols = await this.coinSelection.getManualCoinSelectionSymbols(updatedUser);
+        if (tradingCoinSymbols.length < MIN_TRADING_COINS) {
           throw new BadRequestException(
-            `Custom coin selection requires at least ${MIN_WATCHLIST_COINS} coins in your watchlist (currently ${watchlistSymbols.length})`
+            `Custom coin selection requires at least ${MIN_TRADING_COINS} trading coins (currently ${tradingCoinSymbols.length})`
           );
         }
       }
@@ -193,14 +193,9 @@ export class UsersService {
   }
 
   async updateCoinSelectionByUserRisk(user: User) {
-    const selections = await this.coinSelection.getCoinSelectionsByUser(user);
-    const automaticSelections = selections.filter((s) => s.type === CoinSelectionType.AUTOMATIC);
+    await this.coinSelection.bulkDeleteAutomaticSelections(user.id);
 
-    await Promise.all(
-      automaticSelections.map((selection) => this.coinSelection.deleteCoinSelectionItem(selection.id, user.id))
-    );
-
-    // Custom risk users manage their own coins via watchlist
+    // Custom risk users manage their own trading coins manually
     if (user.coinRisk?.level === CUSTOM_RISK_LEVEL) return;
 
     const coinCount = user.coinRisk?.coinCount ?? DEFAULT_COIN_COUNTS[user.coinRisk?.level ?? DEFAULT_RISK_LEVEL] ?? 10;

--- a/apps/chansey/src/app/app.routes.ts
+++ b/apps/chansey/src/app/app.routes.ts
@@ -79,6 +79,11 @@ export const appRoutes: Route[] = [
         data: { breadcrumb: 'Watchlist' }
       },
       {
+        path: 'trading-coins',
+        loadComponent: () => import('./pages/trading-coins').then((c) => c.TradingCoinsComponent),
+        data: { breadcrumb: 'Trading Coins' }
+      },
+      {
         path: 'coins',
         children: [
           { path: '', redirectTo: '/app/prices', pathMatch: 'full' },

--- a/apps/chansey/src/app/coins/coin-detail/coin-detail.component.ts
+++ b/apps/chansey/src/app/coins/coin-detail/coin-detail.component.ts
@@ -63,9 +63,9 @@ export class CoinDetailComponent {
   private userQuery = this.authService.useUser();
 
   // Watchlist state
-  watchlistQuery = this.coinDataService.useWatchlist();
-  private addToWatchlistMutation = this.coinDataService.useAddToWatchlist();
-  private removeFromWatchlistMutation = this.coinDataService.useRemoveFromWatchlist();
+  watchlistQuery = this.coinDataService.useWatchedCoins();
+  private addToWatchedMutation = this.coinDataService.useAddToWatchedCoins();
+  private removeFromWatchedMutation = this.coinDataService.useRemoveFromWatchedCoins();
   processingWatchlist = signal(false);
 
   // Tighter card body padding on mobile for section cards
@@ -138,7 +138,7 @@ export class CoinDetailComponent {
       const item = (this.watchlistQuery.data() || []).find((i) => i.coin.id === detail.id);
       if (!item) return;
       this.processingWatchlist.set(true);
-      this.removeFromWatchlistMutation.mutate(item.id, {
+      this.removeFromWatchedMutation.mutate(item.id, {
         onSuccess: () => {
           this.processingWatchlist.set(false);
           this.messageService.add({
@@ -154,8 +154,8 @@ export class CoinDetailComponent {
       });
     } else {
       this.processingWatchlist.set(true);
-      this.addToWatchlistMutation.mutate(
-        { coinId: detail.id, type: CoinSelectionType.MANUAL },
+      this.addToWatchedMutation.mutate(
+        { coinId: detail.id, type: CoinSelectionType.WATCHED },
         {
           onSuccess: () => {
             this.processingWatchlist.set(false);

--- a/apps/chansey/src/app/layout/app.menu.ts
+++ b/apps/chansey/src/app/layout/app.menu.ts
@@ -54,8 +54,8 @@ export class AppMenu {
   model = computed<MenuItem[]>(() => {
     const items: MenuItem[] = [
       {
-        label: 'Portfolio Hub',
-        icon: 'pi pi-fw pi-briefcase',
+        label: 'Trading',
+        icon: 'pi pi-fw pi-chart-line',
         items: [
           {
             label: 'Dashboard',
@@ -76,6 +76,11 @@ export class AppMenu {
             label: 'Watchlist',
             icon: 'pi pi-fw pi-star',
             routerLink: ['/app/watchlist']
+          },
+          {
+            label: 'Trading Coins',
+            icon: 'pi pi-fw pi-chart-bar',
+            routerLink: ['/app/trading-coins']
           }
         ]
       },

--- a/apps/chansey/src/app/pages/prices/prices.component.html
+++ b/apps/chansey/src/app/pages/prices/prices.component.html
@@ -1,4 +1,4 @@
-<p-toast></p-toast>
+<p-toast />
 
 <app-crypto-table
   [coins]="coins()"
@@ -7,4 +7,4 @@
   [watchlistCoinIds]="watchlistCoinIds()"
   [processingCoinId]="processingCoinId()"
   (toggleWatchlist)="onToggleWatchlist($event)"
-></app-crypto-table>
+/>

--- a/apps/chansey/src/app/pages/prices/prices.component.ts
+++ b/apps/chansey/src/app/pages/prices/prices.component.ts
@@ -21,16 +21,16 @@ export class PricesComponent {
   private readonly messageService = inject(MessageService);
 
   readonly coinsQuery = this.coinDataService.useCoins();
-  readonly watchlistQuery = this.coinDataService.useWatchlist();
-  readonly addToWatchlistMutation = this.coinDataService.useAddToWatchlist();
-  readonly removeFromWatchlistMutation = this.coinDataService.useRemoveFromWatchlist();
+  readonly watchedCoinsQuery = this.coinDataService.useWatchedCoins();
+  readonly addToWatchedMutation = this.coinDataService.useAddToWatchedCoins();
+  readonly removeFromWatchedMutation = this.coinDataService.useRemoveFromWatchedCoins();
 
   readonly isLoading = computed(() => this.coinsQuery.isPending());
   readonly coins = computed(() => this.coinsQuery.data() || []);
 
   readonly watchlistCoinIds = computed(() => {
-    const watchlistItems = this.watchlistQuery.data() || [];
-    return new Set(watchlistItems.map((item) => item.coin.id));
+    const watchedItems = this.watchedCoinsQuery.data() || [];
+    return new Set(watchedItems.map((item) => item.coin.id));
   });
 
   readonly tableConfig: CryptoTableConfig = {
@@ -52,11 +52,8 @@ export class PricesComponent {
 
   private addToWatchlist(coin: Coin): void {
     this.processingCoinId.set(coin.id);
-    this.addToWatchlistMutation.mutate(
-      {
-        coinId: coin.id,
-        type: CoinSelectionType.MANUAL
-      },
+    this.addToWatchedMutation.mutate(
+      { coinId: coin.id, type: CoinSelectionType.WATCHED },
       {
         onSuccess: () => {
           this.processingCoinId.set(null);
@@ -66,7 +63,7 @@ export class PricesComponent {
             detail: `${coin.name} has been added to your watchlist`
           });
         },
-        onError: (error) => {
+        onError: (error: Error) => {
           this.processingCoinId.set(null);
           this.messageService.add({
             severity: 'error',
@@ -79,16 +76,16 @@ export class PricesComponent {
   }
 
   private removeFromWatchlist(coin: Coin): void {
-    const watchlistData = this.watchlistQuery.data() || [];
-    const portfolioItem = watchlistData.find((item) => item.coin.id === coin.id);
+    const watchedData = this.watchedCoinsQuery.data() || [];
+    const watchedItem = watchedData.find((item) => item.coin.id === coin.id);
 
-    if (!portfolioItem) {
+    if (!watchedItem) {
       this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Coin not found in watchlist' });
       return;
     }
 
     this.processingCoinId.set(coin.id);
-    this.removeFromWatchlistMutation.mutate(portfolioItem.id, {
+    this.removeFromWatchedMutation.mutate(watchedItem.id, {
       onSuccess: () => {
         this.processingCoinId.set(null);
         this.messageService.add({

--- a/apps/chansey/src/app/pages/trading-coins/index.ts
+++ b/apps/chansey/src/app/pages/trading-coins/index.ts
@@ -1,0 +1,1 @@
+export * from './trading-coins.component';

--- a/apps/chansey/src/app/pages/trading-coins/trading-coins.component.html
+++ b/apps/chansey/src/app/pages/trading-coins/trading-coins.component.html
@@ -1,0 +1,53 @@
+<p-toast />
+<p-confirmDialog />
+
+@if (!isCustomCoinSelection()) {
+  <p-message severity="info" class="mb-4 block">
+    <ng-template #container let-closable="closable">
+      <div class="flex w-full items-center justify-between gap-3 p-3">
+        <div class="flex items-center gap-2">
+          <i class="pi pi-info-circle"></i>
+          <span>
+            Your trading coins are auto-selected based on your risk level
+            @if (userRiskLevel(); as level) {
+              (Level {{ level }})
+            }
+            .
+          </span>
+        </div>
+        <p-button
+          label="Settings"
+          icon="pi pi-cog"
+          routerLink="/app/settings"
+          [queryParams]="{ tab: 'trading' }"
+          severity="info"
+          [outlined]="true"
+          size="large"
+        />
+      </div>
+    </ng-template>
+  </p-message>
+}
+
+@if (isCustomCoinSelection() && showInsufficientCoinsWarning()) {
+  <p-message severity="warn" class="mb-4 block">
+    <ng-template #container let-closable="closable">
+      <div class="flex flex-wrap items-center gap-2 p-3">
+        <i class="pi pi-exclamation-triangle"></i>
+        <span>
+          <strong>Trading Paused</strong> - Add {{ coinsNeeded() }} more coin(s) to resume trading. Custom coin
+          selection requires at least {{ MIN_TRADING_COINS }} coins.
+        </span>
+        <a routerLink="/app/prices" class="font-semibold text-primary hover:underline">Browse Coins</a>
+      </div>
+    </ng-template>
+  </p-message>
+}
+
+<app-crypto-table
+  [coins]="tradingCoins()"
+  [isLoading]="isLoading()"
+  [config]="isCustomCoinSelection() ? customTableConfig : autoTableConfig"
+  [processingCoinId]="processingCoinId()"
+  (removeCoin)="onRemoveCoin($event)"
+/>

--- a/apps/chansey/src/app/pages/trading-coins/trading-coins.component.ts
+++ b/apps/chansey/src/app/pages/trading-coins/trading-coins.component.ts
@@ -1,0 +1,204 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { MessageModule } from 'primeng/message';
+import { ToastModule } from 'primeng/toast';
+
+import { Coin, CUSTOM_RISK_LEVEL, MIN_TRADING_COINS } from '@chansey/api-interfaces';
+
+import { CryptoTableComponent, CryptoTableConfig } from '../../shared/components/crypto-table/crypto-table.component';
+import { AuthService } from '../../shared/services/auth.service';
+import { CoinDataService } from '../../shared/services/coin-data.service';
+import { RisksService } from '../admin/risks/risks.service';
+import { SettingsService } from '../user/settings/settings.service';
+
+@Component({
+  selector: 'app-trading-coins',
+  imports: [ButtonModule, ConfirmDialogModule, CryptoTableComponent, MessageModule, RouterLink, ToastModule],
+  providers: [ConfirmationService, MessageService],
+  templateUrl: './trading-coins.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TradingCoinsComponent {
+  readonly processingCoinId = signal<string | null>(null);
+  private readonly coinDataService = inject(CoinDataService);
+  private readonly messageService = inject(MessageService);
+  private readonly confirmationService = inject(ConfirmationService);
+  private readonly authService = inject(AuthService);
+  private readonly risksService = inject(RisksService);
+  private readonly settingsService = inject(SettingsService);
+
+  readonly userQuery = this.authService.useUser();
+  readonly risksQuery = this.risksService.useRisks();
+  readonly updateProfileMutation = this.settingsService.useUpdateProfileMutation();
+
+  // Trading coins (MANUAL type) for custom users
+  readonly tradingCoinsQuery = this.coinDataService.useTradingCoins();
+  readonly removeFromTradingMutation = this.coinDataService.useRemoveFromTradingCoins();
+
+  // Auto-selected coins for auto users
+  readonly autoSelectedCoinsQuery = this.coinDataService.useAutoSelectedCoins();
+
+  readonly isCustomCoinSelection = computed(() => {
+    const user = this.userQuery.data();
+    return user?.coinRisk?.level === CUSTOM_RISK_LEVEL;
+  });
+
+  readonly userRiskLevel = computed(() => this.userQuery.data()?.coinRisk?.level ?? null);
+
+  /** Level 3 (Moderate) risk for auto-demote fallback */
+  readonly level3Risk = computed(() => this.risksQuery.data()?.find((r) => r.level === 3) ?? null);
+
+  /** True until we know the user's mode AND the relevant coin query has resolved */
+  readonly isLoading = computed(() => {
+    if (this.userQuery.isPending()) return true;
+    return this.isCustomCoinSelection() ? this.tradingCoinsQuery.isPending() : this.autoSelectedCoinsQuery.isPending();
+  });
+
+  readonly tradingCoins = computed(() => {
+    if (this.userQuery.isPending()) return [];
+    if (this.isCustomCoinSelection()) {
+      return (this.tradingCoinsQuery.data() || []).map((item) => item.coin);
+    }
+    return (this.autoSelectedCoinsQuery.data() || []).map((item) => item.coin);
+  });
+
+  readonly tradingCoinCount = computed(() =>
+    this.isCustomCoinSelection() ? (this.tradingCoinsQuery.data() ?? []).length : 0
+  );
+
+  readonly showInsufficientCoinsWarning = computed(
+    () => this.isCustomCoinSelection() && this.tradingCoinCount() < MIN_TRADING_COINS
+  );
+
+  readonly coinsNeeded = computed(() => Math.max(0, MIN_TRADING_COINS - this.tradingCoinCount()));
+
+  readonly MIN_TRADING_COINS = MIN_TRADING_COINS;
+
+  readonly customTableConfig: CryptoTableConfig = {
+    showWatchlistToggle: false,
+    showRemoveAction: true,
+    removeTooltip: 'Remove from trading coins',
+    searchPlaceholder: 'Search trading coins...',
+    emptyMessage: 'No trading coins selected. Add coins to start trading.',
+    emptyActionLink: '/app/prices',
+    emptyActionLabel: 'Browse Coins',
+    cardTitle: 'My Trading Coins'
+  };
+
+  readonly autoTableConfig: CryptoTableConfig = {
+    showWatchlistToggle: false,
+    showRemoveAction: false,
+    searchPlaceholder: 'Search trading coins...',
+    emptyMessage: 'No coins auto-selected yet. Check your risk level in Settings.',
+    emptyActionLink: '/app/settings',
+    emptyActionLabel: 'Go to Settings',
+    cardTitle: 'My Trading Coins'
+  };
+
+  onRemoveCoin(coin: Coin): void {
+    const tradingData = this.tradingCoinsQuery.data() || [];
+    const selectionItem = tradingData.find((item) => item.coin.id === coin.id);
+
+    if (!selectionItem) {
+      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Coin not found in trading coins' });
+      return;
+    }
+
+    if (this.tradingCoinCount() <= MIN_TRADING_COINS) {
+      const remainingAfterRemoval = this.tradingCoinCount() - 1;
+      this.confirmationService.confirm({
+        message:
+          remainingAfterRemoval < MIN_TRADING_COINS
+            ? `Removing ${coin.name} will leave you with ${remainingAfterRemoval} coin(s). Custom coin selection requires at least ${MIN_TRADING_COINS} coins, so you'll be switched back to auto mode (Moderate).`
+            : `Are you sure you want to remove ${coin.name} from your trading coins?`,
+        header: `Remove ${coin.name}?`,
+        icon: 'pi pi-exclamation-triangle',
+        acceptButtonStyleClass: 'p-button-danger',
+        rejectButtonStyleClass: 'p-button-secondary',
+        accept: () => {
+          if (remainingAfterRemoval < MIN_TRADING_COINS) {
+            this.performRemovalWithDemote(coin, selectionItem.id);
+          } else {
+            this.performRemoval(coin, selectionItem.id);
+          }
+        }
+      });
+    } else {
+      this.performRemoval(coin, selectionItem.id);
+    }
+  }
+
+  private performRemoval(coin: Coin, selectionId: string): void {
+    this.processingCoinId.set(coin.id);
+    this.removeFromTradingMutation.mutate(selectionId, {
+      onSuccess: () => {
+        this.processingCoinId.set(null);
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Removed from Trading Coins',
+          detail: `${coin.name} has been removed from your trading coins`
+        });
+      },
+      onError: (error: Error) => {
+        this.processingCoinId.set(null);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: error.message || 'Failed to remove coin from trading coins'
+        });
+      }
+    });
+  }
+
+  /**
+   * Remove coin AND switch user back to auto mode (level 3 - Moderate)
+   * Used when removing would drop trading coins below MIN_TRADING_COINS
+   */
+  private performRemovalWithDemote(coin: Coin, selectionId: string): void {
+    const level3 = this.level3Risk();
+    if (!level3) {
+      this.performRemoval(coin, selectionId);
+      return;
+    }
+
+    this.processingCoinId.set(coin.id);
+
+    this.removeFromTradingMutation.mutate(selectionId, {
+      onSuccess: () => {
+        this.updateProfileMutation.mutate(
+          { coinRisk: level3.id },
+          {
+            onSuccess: () => {
+              this.processingCoinId.set(null);
+              this.messageService.add({
+                severity: 'info',
+                summary: 'Switched to Auto Mode',
+                detail: `${coin.name} removed. You've been switched to auto coin selection (Moderate).`
+              });
+            },
+            onError: () => {
+              this.processingCoinId.set(null);
+              this.messageService.add({
+                severity: 'warn',
+                summary: 'Coin Removed',
+                detail: `${coin.name} removed, but couldn't switch modes. Please check settings.`
+              });
+            }
+          }
+        );
+      },
+      onError: (error: Error) => {
+        this.processingCoinId.set(null);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: error.message || 'Failed to remove coin'
+        });
+      }
+    });
+  }
+}

--- a/apps/chansey/src/app/pages/user/settings/components/trading-settings/trading-settings.component.html
+++ b/apps/chansey/src/app/pages/user/settings/components/trading-settings/trading-settings.component.html
@@ -1,6 +1,6 @@
 <!-- Risk Profile -->
 @if (risksQuery.isPending()) {
-  <div class="border-surface-200 dark:border-surface-700 rounded-lg border p-4">
+  <div class="rounded-lg border border-surface-200 p-4 dark:border-surface-700">
     <p-skeleton width="180px" height="1.5rem" styleClass="mb-4" />
     <p-skeleton width="100%" height="3rem" styleClass="mt-2" />
     <p-skeleton width="100%" height="3rem" styleClass="mt-2" />
@@ -21,21 +21,140 @@
       @if (risksQuery.isError()) {
         <p class="text-sm text-red-500">Failed to load risk profiles. Please try again later.</p>
       }
-      <div class="flex flex-col gap-4 py-3">
-        <p-floatlabel variant="on" class="flex flex-wrap">
-          <p-select
-            id="coinRisk"
-            formControlName="coinRisk"
-            [options]="risksQuery.data()"
-            [loading]="risksQuery.isLoading() || risksQuery.isPending()"
-            optionLabel="name"
-            optionValue="id"
-            placeholder="Select Coin Risk Profile"
-            class="w-full"
+      <div class="flex flex-col gap-6 py-4">
+        <!-- Coin Selection Mode Toggle -->
+        <div class="flex flex-col gap-1">
+          <p-selectbutton
+            [options]="coinSelectionOptions"
+            [ngModel]="coinSelectionMode()"
+            (ngModelChange)="onModeChange($event)"
+            [ngModelOptions]="{ standalone: true }"
+            optionLabel="label"
+            optionValue="value"
             size="large"
+            fluid
+            class="coin-selection-toggle"
           />
-          <label for="coinRisk">Portfolio Pool</label>
-        </p-floatlabel>
+        </div>
+
+        <!-- "Pick for me" mode: show Auto-Select Coins dropdown (levels 1-5) -->
+        @if (coinSelectionMode() === 'auto') {
+          <div class="flex flex-col gap-5">
+            <p-floatlabel variant="on" class="flex flex-wrap">
+              <p-select
+                id="coinRisk"
+                formControlName="coinRisk"
+                [options]="autoRisks()"
+                [loading]="risksQuery.isLoading() || risksQuery.isPending()"
+                optionLabel="name"
+                optionValue="id"
+                class="w-full"
+                size="large"
+              >
+                <ng-template #selectedItem let-risk>
+                  <span>{{ risk.name }}</span>
+                </ng-template>
+                <ng-template #item let-risk>
+                  <div class="flex flex-col gap-1 py-1">
+                    <span class="font-medium">{{ risk.name }}</span>
+                    <span class="text-xs text-muted-color">{{ getCriteriaDescription(risk.level) }}</span>
+                  </div>
+                </ng-template>
+              </p-select>
+              <label for="coinRisk">Auto-Select Coins</label>
+            </p-floatlabel>
+
+            <!-- Preview panel showing coins that will be selected -->
+            @if (previewCoins().length > 0) {
+              <div class="rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+                <div class="mb-2 flex items-center gap-2 text-sm text-muted-color">
+                  <span>Type of coins that may be selected for trading:</span>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  @for (coin of previewCoins(); track coin.id) {
+                    <p-chip styleClass="pl-0 pr-3">
+                      <img [src]="coin.image" [alt]="coin.symbol" class="mr-2 ml-0 h-6 w-6 rounded-full" />
+                      <span class="text-sm font-medium uppercase">{{ coin.symbol }}</span>
+                    </p-chip>
+                  }
+                </div>
+              </div>
+            } @else if (coinPreviewQuery.isError()) {
+              <div class="rounded-lg bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+                <i class="pi pi-exclamation-triangle mr-2"></i>
+                Failed to load preview
+              </div>
+            } @else if (coinPreviewQuery.isFetching() && previewRiskLevel()) {
+              <div class="rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+                <div class="flex items-center gap-2 text-sm text-muted-color">
+                  <i class="pi pi-spin pi-spinner text-xs"></i>
+                  <span>Loading preview...</span>
+                </div>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- "I'll choose my own" mode: show trading coins summary -->
+        @if (coinSelectionMode() === 'manual') {
+          <div class="flex flex-col gap-5">
+            @if (tradingCoinCount() === 0) {
+              <p-message severity="info" icon="pi pi-info-circle">
+                No trading coins selected. Search below to add coins you'd like to trade, or
+                <a routerLink="/app/trading-coins" class="font-semibold text-primary">Browse Trading Coins</a> to get
+                started.
+              </p-message>
+            } @else if (manualModeBlocked()) {
+              <p-message severity="warn" icon="pi pi-exclamation-triangle">
+                You need at least {{ MIN_TRADING_COINS }} trading coins to enable manual coin selection ({{
+                  coinsNeeded()
+                }}
+                more needed).
+              </p-message>
+            }
+            <p-floatlabel variant="on">
+              <p-autocomplete
+                id="tradingCoins"
+                class="trading-coins-autocomplete"
+                [ngModel]="tradingCoinObjects()"
+                [ngModelOptions]="{ standalone: true }"
+                [multiple]="true"
+                [suggestions]="tradingCoinSuggestions"
+                (completeMethod)="searchTradingCoins($event)"
+                (onSelect)="onTradingCoinSelect($event)"
+                (onUnselect)="onTradingCoinUnselect($event)"
+                optionLabel="name"
+                fluid
+                size="large"
+                dropdown
+              >
+                <ng-template #item let-coin>
+                  <div class="flex items-center gap-2">
+                    @if (coin.image) {
+                      <img [src]="coin.image" [alt]="coin.name" class="h-5 w-5 rounded-full" />
+                    }
+                    <span>{{ coin.name }}</span>
+                    <span class="text-xs text-surface-500 uppercase">{{ coin.symbol }}</span>
+                  </div>
+                </ng-template>
+                <ng-template #selectedItem let-coin>
+                  <div class="flex items-center gap-1">
+                    @if (coin.image) {
+                      <img [src]="coin.image" [alt]="coin.symbol" class="h-4 w-4 rounded-full" />
+                    }
+                    <span class="text-xs font-medium uppercase">{{ coin.symbol }}</span>
+                  </div>
+                </ng-template>
+              </p-autocomplete>
+              <label for="tradingCoins">Trading Coins</label>
+            </p-floatlabel>
+            <span class="-mt-3 ml-2 text-xs text-muted-color"
+              >We recommend at least 3 coins for proper diversification. View and manage your selections on the
+              <a routerLink="/app/trading-coins" class="font-semibold text-primary">Trading Coins</a> page.</span
+            >
+          </div>
+        }
+
         <p-floatlabel variant="on" class="flex flex-wrap">
           <p-select
             id="calculationRiskLevel"
@@ -43,23 +162,29 @@
             [options]="calculationRiskOptions"
             optionLabel="label"
             optionValue="value"
-            placeholder="Select Trading Style"
             class="w-full"
             size="large"
-          />
+          >
+            <ng-template #item let-option>
+              <div class="flex flex-col gap-1 py-1">
+                <span class="font-medium">{{ option.label }}</span>
+                <span class="text-xs text-muted-color">{{ option.description }}</span>
+              </div>
+            </ng-template>
+          </p-select>
           <label for="calculationRiskLevel">Trading Style</label>
         </p-floatlabel>
         @if (tradingStyleProfile(); as profile) {
-          <p-panel class="mt-2 block">
+          <p-panel class="block">
             <ng-template #header>
-              <div class="flex items-center gap-2">
-                <i class="pi pi-shield text-primary"></i>
+              <div class="flex items-center gap-2 pt-3">
+                <i class="pi pi-chart-bar text-primary"></i>
                 <span class="font-medium">Risk Summary</span>
               </div>
             </ng-template>
-            <div class="grid grid-cols-2 gap-3">
+            <div class="mt-1 grid grid-cols-2 gap-4">
               <div class="flex flex-col gap-1">
-                <span class="text-muted-color text-xs">Capital Allocation</span>
+                <span class="text-xs text-muted-color">Capital Allocation</span>
                 <div class="flex items-center gap-2">
                   <span class="text-lg font-semibold">{{ profile.capitalAllocation }}%</span>
                 </div>
@@ -71,7 +196,7 @@
                 />
               </div>
               <div class="flex flex-col gap-1">
-                <span class="text-muted-color text-xs">Max Single Position</span>
+                <span class="text-xs text-muted-color">Max Single Position</span>
                 <div class="flex items-center gap-2">
                   <span class="text-lg font-semibold">{{ profile.maxSinglePosition }}%</span>
                 </div>
@@ -83,7 +208,7 @@
                 />
               </div>
               <div class="flex flex-col gap-1">
-                <span class="text-muted-color text-xs">Daily Loss Limit</span>
+                <span class="text-xs text-muted-color">Daily Loss Limit</span>
                 <div class="flex items-center gap-2">
                   <span class="text-lg font-semibold">{{ profile.dailyLossLimit }}%</span>
                 </div>
@@ -95,7 +220,7 @@
                 />
               </div>
               <div class="flex flex-col gap-1">
-                <span class="text-muted-color text-xs">Bear Market Capital</span>
+                <span class="text-xs text-muted-color">Bear Market Capital</span>
                 <div class="flex items-center gap-2">
                   <span class="text-lg font-semibold">{{ profile.bearMarketCapital }}%</span>
                 </div>
@@ -107,7 +232,7 @@
                 />
               </div>
             </div>
-            <p class="text-muted-color mt-3 mb-0 text-xs">How your trading style affects risk controls</p>
+            <p class="mt-4 mb-0 text-xs text-muted-color">How your trading style affects risk controls</p>
           </p-panel>
         }
         <div class="flex justify-end pt-2">
@@ -115,8 +240,9 @@
             label="Save Risk Profile"
             icon="pi pi-save"
             [loading]="updateProfileMutation.isPending()"
-            [disabled]="!riskForm.valid || !riskForm.dirty"
+            [disabled]="!riskForm.valid || !hasRiskChanges() || manualModeBlocked()"
             (click)="saveRiskProfile()"
+            size="large"
           />
         </div>
       </div>
@@ -140,7 +266,7 @@
 
 <!-- Opportunity Selling -->
 @if (opportunitySellingQuery.isPending()) {
-  <div class="border-surface-200 dark:border-surface-700 mt-3 rounded-lg border p-4">
+  <div class="mt-3 rounded-lg border border-surface-200 p-4 dark:border-surface-700">
     <p-skeleton width="180px" height="1.5rem" styleClass="mb-4" />
     <div class="flex items-center justify-between py-3">
       <p-skeleton width="200px" height="1.25rem" />
@@ -148,7 +274,7 @@
     </div>
     <p-skeleton width="100%" height="2.5rem" styleClass="mt-2" />
   </div>
-  <div class="border-surface-200 dark:border-surface-700 mt-3 rounded-lg border p-4">
+  <div class="mt-3 rounded-lg border border-surface-200 p-4 dark:border-surface-700">
     <p-skeleton width="150px" height="1.5rem" styleClass="mb-4" />
     <div class="flex items-center justify-between py-3">
       <p-skeleton width="180px" height="1.25rem" />
@@ -214,7 +340,7 @@
                     <img [src]="coin.image" [alt]="coin.name" class="h-5 w-5 rounded-full" />
                   }
                   <span>{{ coin.name }}</span>
-                  <span class="text-surface-500 text-xs uppercase">{{ coin.symbol }}</span>
+                  <span class="text-xs text-surface-500 uppercase">{{ coin.symbol }}</span>
                 </div>
               </ng-template>
             </p-autocomplete>
@@ -225,7 +351,7 @@
           <div class="flex flex-col gap-2">
             <div class="flex items-center justify-between">
               <label class="text-900 font-semibold">Max Sell Limit</label>
-              <span class="text-primary font-semibold"
+              <span class="font-semibold text-primary"
                 >{{ opportunitySellingForm.get('maxLiquidationPercent')?.value }}%</span
               >
             </div>

--- a/apps/chansey/src/app/pages/user/settings/components/trading-settings/trading-settings.component.ts
+++ b/apps/chansey/src/app/pages/user/settings/components/trading-settings/trading-settings.component.ts
@@ -1,28 +1,45 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';
+import { ChipModule } from 'primeng/chip';
 import { FloatLabel } from 'primeng/floatlabel';
+import { MessageModule } from 'primeng/message';
 import { PanelModule } from 'primeng/panel';
 import { ProgressBar } from 'primeng/progressbar';
 import { SelectModule } from 'primeng/select';
+import { SelectButtonModule } from 'primeng/selectbutton';
 import { SkeletonModule } from 'primeng/skeleton';
 import { SliderModule } from 'primeng/slider';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
 
 import {
   Coin,
+  CoinSelectionType,
+  CUSTOM_RISK_LEVEL,
   Exchange,
   ExchangeKey,
+  MIN_TRADING_COINS,
   Risk,
   TRADING_STYLE_PROFILES,
   TradingStyleProfile
 } from '@chansey/api-interfaces';
 
+/** Human-readable descriptions of coin selection criteria per risk level */
+const RISK_CRITERIA: Record<number, string> = {
+  1: 'High-volume, established coins with stable track records',
+  2: 'Balanced selection favoring stability over growth',
+  3: 'Mix of established and emerging coins',
+  4: 'Growth-oriented coins with higher potential',
+  5: 'Top-ranked trending coins for maximum growth'
+};
+
 import { AuthService } from '../../../../../shared/services/auth.service';
+import { CoinDataService } from '../../../../../shared/services/coin-data.service';
 import { ExchangeService } from '../../../../../shared/services/exchange.service';
 import { RisksService } from '../../../../admin/risks/risks.service';
 import { SettingsService } from '../../settings.service';
@@ -37,20 +54,42 @@ import { SaveStatusIndicatorComponent } from '../save-status-indicator/save-stat
   imports: [
     AutoCompleteModule,
     ButtonModule,
+    ChipModule,
     ExchangeIntegrationsComponent,
     FloatLabel,
     FormsModule,
+    MessageModule,
     PanelModule,
     ProgressBar,
     ReactiveFormsModule,
+    RouterLink,
     SaveStatusIndicatorComponent,
+    SelectButtonModule,
     SelectModule,
     SkeletonModule,
     SliderModule,
     ToggleSwitchModule
   ],
   templateUrl: './trading-settings.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: `
+    ::ng-deep .coin-selection-toggle .p-togglebutton-checked {
+      background: var(--p-primary-color) !important;
+      border-color: var(--p-primary-color) !important;
+    }
+    ::ng-deep .coin-selection-toggle .p-togglebutton-checked .p-togglebutton-content {
+      background: transparent !important;
+      color: var(--p-primary-contrast-color) !important;
+    }
+    ::ng-deep .trading-coins-autocomplete .p-autocomplete-chip {
+      background: var(--p-primary-color) !important;
+      border-color: var(--p-primary-color) !important;
+    }
+    ::ng-deep .trading-coins-autocomplete .p-autocomplete-chip .p-chip-label,
+    ::ng-deep .trading-coins-autocomplete .p-autocomplete-chip .p-chip-remove-icon {
+      color: var(--p-primary-contrast-color) !important;
+    }
+  `
 })
 export class TradingSettingsComponent {
   private fb = inject(FormBuilder);
@@ -58,6 +97,7 @@ export class TradingSettingsComponent {
   private confirmationService = inject(ConfirmationService);
   private settingsService = inject(SettingsService);
   private authService = inject(AuthService);
+  private coinDataService = inject(CoinDataService);
   private riskService = inject(RisksService);
   private exchangeService = inject(ExchangeService);
 
@@ -67,6 +107,11 @@ export class TradingSettingsComponent {
   readonly updateOpportunitySellingMutation = this.settingsService.useUpdateOpportunitySellingMutation();
   readonly futuresTradingQuery = this.settingsService.useFuturesTradingQuery();
   readonly updateFuturesTradingMutation = this.settingsService.useUpdateFuturesTradingMutation();
+
+  // Trading coins
+  readonly tradingCoinsQuery = this.coinDataService.useTradingCoins();
+  readonly addToTradingMutation = this.coinDataService.useAddToTradingCoins();
+  readonly removeFromTradingMutation = this.coinDataService.useRemoveFromTradingCoins();
 
   // Risk profile
   readonly risksQuery = this.riskService.useRisks();
@@ -78,6 +123,59 @@ export class TradingSettingsComponent {
   readonly deleteExchangeKeyMutation = this.settingsService.useDeleteExchangeKeyMutation();
 
   user = computed(() => this.userQuery.data());
+
+  // Coin selection mode
+  coinSelectionMode = signal<'auto' | 'manual'>('auto');
+  readonly coinSelectionOptions = [
+    { label: 'Pick for me', value: 'auto' },
+    { label: "I'll choose my own", value: 'manual' }
+  ];
+
+  level6Risk = computed(() => this.risksQuery.data()?.find((r) => r.level === CUSTOM_RISK_LEVEL) ?? null);
+  autoRisks = computed(() => this.risksQuery.data()?.filter((r) => r.level >= 1 && r.level <= 5) ?? []);
+
+  /** Track selected auto-risk level for preview (null when in manual mode) */
+  previewRiskLevel = signal<number | null>(null);
+  readonly coinPreviewQuery = this.coinDataService.useCoinPreview(this.previewRiskLevel);
+  previewCoins = computed(() => (this.coinSelectionMode() === 'auto' ? (this.coinPreviewQuery.data() ?? []) : []));
+  tradingCoinItems = computed(() => this.tradingCoinsQuery.data() ?? []);
+  /** Tracks pending add/remove coin IDs to handle race between mutation settlement and query refetch */
+  private pendingTradingAdds = signal<Set<string>>(new Set());
+  private pendingTradingRemoves = signal<Set<string>>(new Set());
+  /** Count includes pending adds not yet in query data, excludes pending removes still in query data */
+  tradingCoinCount = computed(() => {
+    const queryData = this.tradingCoinsQuery.data() ?? [];
+    const actualIds = new Set(queryData.map((w) => w.coin.id));
+    const pendingAddsNotInData = [...this.pendingTradingAdds()].filter((id) => !actualIds.has(id)).length;
+    const pendingRemovesStillInData = [...this.pendingTradingRemoves()].filter((id) => actualIds.has(id)).length;
+    return queryData.length + pendingAddsNotInData - pendingRemovesStillInData;
+  });
+
+  tradingCoinObjects = computed(() => this.tradingCoinItems().map((w) => w.coin));
+  tradingCoinSuggestions: Coin[] = [];
+
+  readonly MIN_TRADING_COINS = MIN_TRADING_COINS;
+
+  /** True when form values differ from saved user data */
+  hasRiskChanges = computed(() => {
+    const userData = this.user();
+    if (!userData) return false;
+    const coinRiskId = this.selectedCoinRiskId();
+    const calcLevel = this.selectedCalcRiskLevel();
+    const savedCoinRiskId = userData.coinRisk?.id || '';
+    const savedCalcLevel = userData.calculationRiskLevel ?? userData.coinRisk?.level ?? null;
+    const savedMode = userData.coinRisk?.level === CUSTOM_RISK_LEVEL ? 'manual' : 'auto';
+    const modeChanged = this.coinSelectionMode() !== savedMode;
+    return modeChanged || coinRiskId !== savedCoinRiskId || calcLevel !== savedCalcLevel;
+  });
+
+  /** True when manual mode is selected but trading coins fewer than required */
+  manualModeBlocked = computed(
+    () => this.coinSelectionMode() === 'manual' && this.tradingCoinCount() < MIN_TRADING_COINS
+  );
+
+  /** How many more coins the user needs to add */
+  coinsNeeded = computed(() => Math.max(0, MIN_TRADING_COINS - this.tradingCoinCount()));
 
   readonly futuresAutoSave = createAutoSave(() => this.doSaveFutures());
   readonly opportunityToggleAutoSave = createAutoSave(() => this.doSaveOpportunityToggle());
@@ -115,11 +213,11 @@ export class TradingSettingsComponent {
   });
 
   calculationRiskOptions = [
-    { label: 'Ultra Conservative', value: 1 },
-    { label: 'Conservative', value: 2 },
-    { label: 'Moderate', value: 3 },
-    { label: 'Growth', value: 4 },
-    { label: 'Aggressive', value: 5 }
+    { label: 'Conservative', value: 1, description: 'Minimal risk, smaller positions, tight loss limits' },
+    { label: 'Moderately Conservative', value: 2, description: 'Low risk with slightly larger allocations' },
+    { label: 'Moderate', value: 3, description: 'Balanced risk and position sizing' },
+    { label: 'Moderately Aggressive', value: 4, description: 'Higher allocations, wider loss tolerance' },
+    { label: 'Aggressive', value: 5, description: 'Maximum allocations, highest risk tolerance' }
   ];
 
   selectedCoinRiskId = signal<string | null>(null);
@@ -130,14 +228,20 @@ export class TradingSettingsComponent {
 
   tradingStyleProfile = computed<TradingStyleProfile | null>(() => {
     const calcRisk = this.selectedCalcRiskLevel();
+    if (calcRisk) return TRADING_STYLE_PROFILES[calcRisk] ?? TRADING_STYLE_PROFILES[3];
+    // Fallback: derive from coin risk level
     const risks = this.risksQuery.data();
     const selectedId = this.selectedCoinRiskId();
     if (!risks || !selectedId) return null;
     const selected = risks.find((r: Risk) => r.id === selectedId);
     if (!selected) return null;
-    const level = calcRisk ?? selected.level;
-    return TRADING_STYLE_PROFILES[level] ?? TRADING_STYLE_PROFILES[3];
+    return TRADING_STYLE_PROFILES[selected.level] ?? TRADING_STYLE_PROFILES[3];
   });
+
+  /** Get human-readable criteria description for a risk level */
+  getCriteriaDescription(level: number): string {
+    return RISK_CRITERIA[level] ?? '';
+  }
 
   // Exchange forms
   exchangeForms = signal<Record<string, ExchangeFormState>>({});
@@ -158,7 +262,16 @@ export class TradingSettingsComponent {
     this.riskForm
       .get('calculationRiskLevel')
       ?.valueChanges.pipe(takeUntilDestroyed())
-      .subscribe((v) => this.selectedCalcRiskLevel.set(v));
+      .subscribe((v) => {
+        this.selectedCalcRiskLevel.set(v);
+        // In auto mode, keep Auto-Select Coins in sync with Trading Style
+        if (this.coinSelectionMode() === 'auto' && v >= 1 && v <= 5) {
+          const matchingRisk = this.autoRisks().find((r) => r.level === v);
+          if (matchingRisk && this.riskForm.get('coinRisk')?.value !== matchingRisk.id) {
+            this.riskForm.get('coinRisk')?.setValue(matchingRisk.id);
+          }
+        }
+      });
 
     // Populate risk form from user data
     effect(() => {
@@ -166,12 +279,38 @@ export class TradingSettingsComponent {
       if (userData && !this.riskForm.dirty) {
         const coinRiskObj = userData.coinRisk;
         const calcLevel = userData.calculationRiskLevel ?? coinRiskObj?.level ?? null;
-        this.riskForm.patchValue({
-          coinRisk: coinRiskObj?.id || '',
-          calculationRiskLevel: calcLevel
-        });
+        this.riskForm.patchValue(
+          {
+            coinRisk: coinRiskObj?.id || '',
+            calculationRiskLevel: calcLevel
+          },
+          { emitEvent: false }
+        );
         this.selectedCoinRiskId.set(coinRiskObj?.id || null);
         this.selectedCalcRiskLevel.set(calcLevel);
+
+        // Detect coin selection mode from saved risk level
+        this.coinSelectionMode.set(coinRiskObj?.level === CUSTOM_RISK_LEVEL ? 'manual' : 'auto');
+
+        // Set preview level for auto mode
+        if (coinRiskObj?.level !== CUSTOM_RISK_LEVEL && coinRiskObj?.level) {
+          this.previewRiskLevel.set(coinRiskObj.level);
+        }
+      }
+    });
+
+    // Sync preview risk level when selection changes
+    effect(() => {
+      const selectedId = this.selectedCoinRiskId();
+      const risks = this.risksQuery.data();
+      const mode = this.coinSelectionMode();
+      if (mode === 'auto' && selectedId && risks) {
+        const risk = risks.find((r: Risk) => r.id === selectedId);
+        if (risk && risk.level >= 1 && risk.level <= 5) {
+          this.previewRiskLevel.set(risk.level);
+        }
+      } else if (mode === 'manual') {
+        this.previewRiskLevel.set(null);
       }
     });
 
@@ -258,6 +397,81 @@ export class TradingSettingsComponent {
         return updated;
       });
     });
+  }
+
+  // --- Coin Selection Mode ---
+
+  onModeChange(mode: 'auto' | 'manual'): void {
+    this.coinSelectionMode.set(mode);
+    this.riskForm.markAsDirty(); // prevent user-data effect from overwriting
+    if (mode === 'manual') {
+      const level6 = this.level6Risk();
+      if (level6) {
+        this.riskForm.get('coinRisk')?.setValue(level6.id);
+      }
+    } else {
+      const userData = this.user();
+      const savedRisk = userData?.coinRisk;
+      const savedCalcLevel = userData?.calculationRiskLevel;
+      // In auto mode, both dropdowns must match — use calculationRiskLevel to pick the auto risk
+      const matchingRisk = savedCalcLevel ? this.autoRisks().find((r) => r.level === savedCalcLevel) : null;
+      const fallback = savedRisk?.level !== CUSTOM_RISK_LEVEL ? savedRisk : null;
+      const restoreRisk = matchingRisk ?? fallback ?? this.autoRisks().find((r) => r.level === 3);
+      if (restoreRisk) {
+        this.riskForm.get('coinRisk')?.setValue(restoreRisk.id);
+        // Subscription will auto-sync calculationRiskLevel to match
+      }
+    }
+  }
+
+  searchTradingCoins(event: { query: string }): void {
+    const coins = this.coinsQuery.data();
+    if (!coins) {
+      this.tradingCoinSuggestions = [];
+      return;
+    }
+    const query = event.query.toLowerCase();
+    const tradingSlugs = new Set(this.tradingCoinItems().map((w) => w.coin.slug));
+    this.tradingCoinSuggestions = coins
+      .filter(
+        (c) =>
+          !tradingSlugs.has(c.slug) && (c.name.toLowerCase().includes(query) || c.symbol.toLowerCase().includes(query))
+      )
+      .slice(0, 10);
+  }
+
+  onTradingCoinSelect(event: { value: Coin }): void {
+    const coin = event.value;
+    if (!coin?.id) return;
+    this.pendingTradingAdds.update((set) => new Set([...set, coin.id]));
+    this.addToTradingMutation.mutate(
+      { coinId: coin.id, type: CoinSelectionType.MANUAL },
+      {
+        onSettled: () =>
+          this.pendingTradingAdds.update((set) => {
+            const newSet = new Set(set);
+            newSet.delete(coin.id);
+            return newSet;
+          })
+      }
+    );
+  }
+
+  onTradingCoinUnselect(event: { value: Coin }): void {
+    const coin = event.value;
+    if (!coin?.id) return;
+    this.pendingTradingRemoves.update((set) => new Set([...set, coin.id]));
+    const item = this.tradingCoinItems().find((w) => w.coin.id === coin.id);
+    if (item) {
+      this.removeFromTradingMutation.mutate(item.id, {
+        onSettled: () =>
+          this.pendingTradingRemoves.update((set) => {
+            const newSet = new Set(set);
+            newSet.delete(coin.id);
+            return newSet;
+          })
+      });
+    }
   }
 
   // --- Opportunity Selling ---
@@ -378,7 +592,7 @@ export class TradingSettingsComponent {
   // --- Risk Profile ---
 
   saveRiskProfile(): void {
-    if (!this.riskForm.valid || !this.riskForm.dirty) return;
+    if (!this.riskForm.valid || !this.hasRiskChanges() || this.manualModeBlocked()) return;
 
     const formData = this.riskForm.getRawValue();
     const userData = this.user();
@@ -386,7 +600,13 @@ export class TradingSettingsComponent {
 
     if (userData) {
       const coinRiskObj = userData.coinRisk;
-      if (formData.coinRisk !== (coinRiskObj?.id || '')) {
+      // If switching to manual mode, ensure we send the level-6 risk ID
+      if (this.coinSelectionMode() === 'manual') {
+        const level6 = this.level6Risk();
+        if (level6 && level6.id !== (coinRiskObj?.id || '')) {
+          updatedFields['coinRisk'] = level6.id;
+        }
+      } else if (formData.coinRisk !== (coinRiskObj?.id || '')) {
         updatedFields['coinRisk'] = formData.coinRisk;
       }
       const currentCalcLevel = userData.calculationRiskLevel ?? coinRiskObj?.level ?? null;

--- a/apps/chansey/src/app/pages/watchlist/watchlist.component.html
+++ b/apps/chansey/src/app/pages/watchlist/watchlist.component.html
@@ -5,6 +5,5 @@
   [isLoading]="isLoading()"
   [config]="tableConfig"
   [processingCoinId]="processingCoinId()"
-  coinLinkFrom="watchlist"
   (removeCoin)="onRemoveCoin($event)"
 />

--- a/apps/chansey/src/app/pages/watchlist/watchlist.component.ts
+++ b/apps/chansey/src/app/pages/watchlist/watchlist.component.ts
@@ -20,8 +20,8 @@ export class WatchlistComponent {
   private readonly coinDataService = inject(CoinDataService);
   private readonly messageService = inject(MessageService);
 
-  readonly watchlistQuery = this.coinDataService.useWatchlist();
-  readonly removeFromWatchlistMutation = this.coinDataService.useRemoveFromWatchlist();
+  readonly watchlistQuery = this.coinDataService.useWatchedCoins();
+  readonly removeFromWatchlistMutation = this.coinDataService.useRemoveFromWatchedCoins();
 
   readonly isLoading = computed(() => this.watchlistQuery.isPending());
 
@@ -33,8 +33,9 @@ export class WatchlistComponent {
   readonly tableConfig: CryptoTableConfig = {
     showWatchlistToggle: false,
     showRemoveAction: true,
+    removeTooltip: 'Remove from watchlist',
     searchPlaceholder: 'Search watchlist...',
-    emptyMessage: 'Your watchlist is empty. Add coins from the prices page.',
+    emptyMessage: 'Your watchlist is empty. Star coins on the prices page to track them here.',
     emptyActionLink: '/app/prices',
     emptyActionLabel: 'Browse Coins',
     cardTitle: 'My Watchlist'
@@ -42,15 +43,15 @@ export class WatchlistComponent {
 
   onRemoveCoin(coin: Coin): void {
     const watchlistData = this.watchlistQuery.data() || [];
-    const portfolioItem = watchlistData.find((item) => item.coin.id === coin.id);
+    const selectionItem = watchlistData.find((item) => item.coin.id === coin.id);
 
-    if (!portfolioItem) {
+    if (!selectionItem) {
       this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Coin not found in watchlist' });
       return;
     }
 
     this.processingCoinId.set(coin.id);
-    this.removeFromWatchlistMutation.mutate(portfolioItem.id, {
+    this.removeFromWatchlistMutation.mutate(selectionItem.id, {
       onSuccess: () => {
         this.processingCoinId.set(null);
         this.messageService.add({

--- a/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.html
@@ -180,7 +180,7 @@
                   severity="danger"
                   (click)="onRemoveCoin(coin); $event.stopPropagation()"
                   [disabled]="isCoinProcessing(coin.id)"
-                  pTooltip="Remove from watchlist"
+                  pTooltip="{{ config().removeTooltip || 'Remove' }}"
                   tooltipPosition="top"
                 />
               }
@@ -191,7 +191,7 @@
             <div class="flex items-center gap-3 transition-opacity hover:opacity-80">
               <p-avatar [image]="coin.image" shape="circle" size="large" class="min-w-10 shadow-sm" />
               <div class="flex flex-col">
-                <span class="text-primary-500 hover:text-primary-600 text-lg font-medium">{{ coin.name }}</span>
+                <span class="text-lg font-medium text-primary-500 hover:text-primary-600">{{ coin.name }}</span>
                 <span class="text-sm text-gray-500 uppercase dark:text-gray-400">{{ coin.symbol }}</span>
               </div>
             </div>
@@ -250,7 +250,7 @@
                   Try adjusting your search terms or
                   <button
                     type="button"
-                    class="text-primary-500 hover:text-primary-600 underline"
+                    class="text-primary-500 underline hover:text-primary-600"
                     (click)="clearSearch()"
                   >
                     clear the search

--- a/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-table/crypto-table.component.ts
@@ -10,7 +10,7 @@ import {
   signal,
   viewChild
 } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 
 import { AvatarModule } from 'primeng/avatar';
 import { ButtonModule } from 'primeng/button';
@@ -34,6 +34,7 @@ import { EmptyStateComponent } from '../empty-state/empty-state.component';
 export interface CryptoTableConfig {
   showWatchlistToggle?: boolean;
   showRemoveAction?: boolean;
+  removeTooltip?: string;
   searchPlaceholder?: string;
   emptyMessage?: string;
   emptyActionLink?: string;
@@ -55,7 +56,6 @@ export interface CryptoTableConfig {
     InputIconModule,
     InputTextModule,
     ProgressBarModule,
-    RouterLink,
     SkeletonModule,
     TableModule,
     TagModule,

--- a/apps/chansey/src/app/shared/services/coin-data.service.ts
+++ b/apps/chansey/src/app/shared/services/coin-data.service.ts
@@ -13,10 +13,26 @@ export class CoinDataService {
     });
   }
 
-  useWatchlist() {
-    return useAuthQuery<CoinSelectionItem[]>(queryKeys.coins.watchlist(), '/api/coin-selections?type=MANUAL', {
+  useWatchedCoins() {
+    return useAuthQuery<CoinSelectionItem[]>(queryKeys.coins.watchedCoins(), '/api/coin-selections?type=WATCHED', {
       cachePolicy: FREQUENT_POLICY
     });
+  }
+
+  useTradingCoins() {
+    return useAuthQuery<CoinSelectionItem[]>(queryKeys.coins.tradingCoins(), '/api/coin-selections?type=MANUAL', {
+      cachePolicy: FREQUENT_POLICY
+    });
+  }
+
+  useAutoSelectedCoins() {
+    return useAuthQuery<CoinSelectionItem[]>(
+      queryKeys.coins.autoSelectedCoins(),
+      '/api/coin-selections?type=AUTOMATIC',
+      {
+        cachePolicy: FREQUENT_POLICY
+      }
+    );
   }
 
   usePrices(coins: Signal<string>) {
@@ -38,15 +54,27 @@ export class CoinDataService {
     });
   }
 
-  useAddToWatchlist() {
+  useAddToWatchedCoins() {
     return useAuthMutation<{ id: string }, CreateCoinSelectionDto>('/api/coin-selections', 'POST', {
-      invalidateQueries: [queryKeys.coins.watchlist()]
+      invalidateQueries: [queryKeys.coins.watchedCoins()]
     });
   }
 
-  useRemoveFromWatchlist() {
+  useRemoveFromWatchedCoins() {
     return useAuthMutation<void, string>((selectionId: string) => `/api/coin-selections/${selectionId}`, 'DELETE', {
-      invalidateQueries: [queryKeys.coins.watchlist()]
+      invalidateQueries: [queryKeys.coins.watchedCoins()]
+    });
+  }
+
+  useAddToTradingCoins() {
+    return useAuthMutation<{ id: string }, CreateCoinSelectionDto>('/api/coin-selections', 'POST', {
+      invalidateQueries: [queryKeys.coins.tradingCoins()]
+    });
+  }
+
+  useRemoveFromTradingCoins() {
+    return useAuthMutation<void, string>((selectionId: string) => `/api/coin-selections/${selectionId}`, 'DELETE', {
+      invalidateQueries: [queryKeys.coins.tradingCoins()]
     });
   }
 
@@ -58,7 +86,7 @@ export class CoinDataService {
     return useAuthQuery<Coin[]>(() => {
       const level = riskLevel();
       return {
-        queryKey: ['coins', 'preview', level],
+        queryKey: queryKeys.coins.preview(level),
         url: `/api/coins/preview?riskLevel=${level}&limit=5`,
         options: {
           cachePolicy: STANDARD_POLICY,

--- a/libs/api-interfaces/src/lib/coin-selection/coin-selection-type.enum.ts
+++ b/libs/api-interfaces/src/lib/coin-selection/coin-selection-type.enum.ts
@@ -1,4 +1,5 @@
 export enum CoinSelectionType {
   MANUAL = 'MANUAL',
-  AUTOMATIC = 'AUTOMATIC'
+  AUTOMATIC = 'AUTOMATIC',
+  WATCHED = 'WATCHED'
 }

--- a/libs/api-interfaces/src/lib/risk/risk.interface.ts
+++ b/libs/api-interfaces/src/lib/risk/risk.interface.ts
@@ -96,8 +96,8 @@ export const DEFAULT_RISK_LEVEL = 3;
 /** Risk level indicating custom/user-defined coin selection */
 export const CUSTOM_RISK_LEVEL = 6;
 
-/** Minimum coins required in watchlist for custom risk level users */
-export const MIN_WATCHLIST_COINS = 3;
+/** Minimum coins required for trading for custom risk level users */
+export const MIN_TRADING_COINS = 3;
 
 export function getEffectiveCalculationRisk(
   coinRiskLevel: number | undefined | null,

--- a/libs/shared/src/lib/query/query-keys.spec.ts
+++ b/libs/shared/src/lib/query/query-keys.spec.ts
@@ -6,7 +6,9 @@ describe('query-keys', () => {
     expect(queryKeys.coins.lists()).toEqual(['coins', 'list']);
     expect(queryKeys.coins.list({ category: 'defi' })).toEqual(['coins', 'list', { category: 'defi' }]);
     expect(queryKeys.coins.list()).toEqual(queryKeys.coins.lists());
-    expect(queryKeys.coins.watchlist()).toEqual(['coins', 'watchlist']);
+    expect(queryKeys.coins.watchedCoins()).toEqual(['coins', 'watched-coins']);
+    expect(queryKeys.coins.tradingCoins()).toEqual(['coins', 'trading-coins']);
+    expect(queryKeys.coins.autoSelectedCoins()).toEqual(['coins', 'auto-selected-coins']);
     expect(queryKeys.coins.detail('btc')).toEqual(['coins', 'detail', 'btc']);
     expect(queryKeys.coins.chart('eth', '24h')).toEqual(['coins', 'detail', 'eth', 'chart', '24h']);
     expect(queryKeys.coins.holdings('ada')).toEqual(['coins', 'detail', 'ada', 'holdings']);

--- a/libs/shared/src/lib/query/query-keys.ts
+++ b/libs/shared/src/lib/query/query-keys.ts
@@ -44,11 +44,14 @@ export const queryKeys = {
     lists: () => [...queryKeys.coins.all, 'list'] as const,
     list: (filters?: { category?: string; search?: string }) =>
       filters ? ([...queryKeys.coins.lists(), filters] as const) : queryKeys.coins.lists(),
-    watchlist: () => [...queryKeys.coins.all, 'watchlist'] as const,
+    watchedCoins: () => [...queryKeys.coins.all, 'watched-coins'] as const,
+    tradingCoins: () => [...queryKeys.coins.all, 'trading-coins'] as const,
+    autoSelectedCoins: () => [...queryKeys.coins.all, 'auto-selected-coins'] as const,
     detail: (slug: string) => [...queryKeys.coins.all, 'detail', slug] as const,
     price: (slug: string) => [...queryKeys.coins.detail(slug), 'price'] as const,
     chart: (slug: string, period: string) => [...queryKeys.coins.detail(slug), 'chart', period] as const,
-    holdings: (slug: string) => [...queryKeys.coins.detail(slug), 'holdings'] as const
+    holdings: (slug: string) => [...queryKeys.coins.detail(slug), 'holdings'] as const,
+    preview: (level: number | null) => [...queryKeys.coins.all, 'preview', level] as const
   },
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `WATCHED` coin selection type to distinguish bookmarked coins from actively traded coins
- Create dedicated Trading Coins page showing user's active trading selections
- Overhaul trading settings with auto/manual mode toggle, coin preview panel, and inline coin management

## Changes

### Backend
- **`WATCHED` coin selection type** — new enum value + DB migration
- **Coin selection service** — split queries by type (watched vs trading), bulk delete for automatic selections, alphabetical ordering
- **Route fixes** — `/suggested` moved above `:id` to prevent param shadowing, `ParseEnumPipe` validation for type query param
- **Risk service** — expose `isCustomRiskLevel()` helper
- **Renamed constants** — `MIN_WATCHLIST_COINS` → `MIN_TRADING_COINS`
- **Eager loading removal** — explicit coin relation loading replaces `eager: true`

### Frontend
- **Trading Coins page** — new page at `/app/trading-coins` showing active selections with auto-demote behavior
- **Trading Settings** — auto/manual mode toggle, coin preview panel, autocomplete for adding coins
- **Watchlist** — renamed service methods to `watched`/`trading` coin variants with separate query keys
- **Navigation** — updated menu with Trading Coins entry

### Shared
- **`CoinSelectionType`** — added `WATCHED` value
- **Query keys** — new `coinSelections` and `coins.preview` keys

## Test Plan

- [ ] `nx test api` passes
- [ ] `/coin-selections` CRUD works for AUTO, MANUAL, and WATCHED types
- [ ] Trading Coins page displays active selections correctly
- [ ] Trading settings auto/manual toggle persists risk level
- [ ] Watchlist shows only WATCHED coins

## Related Issues

Closes #273