### PR TITLE
feat(api): add CLS-based request context for automatic audit enrichment

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,7 +1,7 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -21,6 +21,7 @@ import { BalanceModule } from './balance/balance.module';
 import { CategoryModule } from './category/category.module';
 import { CoinModule } from './coin/coin.module';
 import { CoinSelectionModule } from './coin-selection/coin-selection.module';
+import { ClsContextModule } from './common/cls/cls-context.module';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 import { databaseConfig } from './config/database.config';
 import { validateEnv } from './config/env.validation';
@@ -58,6 +59,7 @@ import { TradingModule } from './trading/trading.module';
       load: [databaseConfig, redisConfig]
     }),
     LoggerModule.forRoot(createLoggerConfig()),
+    ClsContextModule,
     StorageModule,
 
     // TypeORM with ConfigService
@@ -142,7 +144,7 @@ import { TradingModule } from './trading/trading.module';
   providers: [
     AppService,
     {
-      provide: 'APP_FILTER',
+      provide: APP_FILTER,
       useClass: GlobalExceptionFilter
     },
     {

--- a/apps/api/src/audit/audit.service.spec.ts
+++ b/apps/api/src/audit/audit.service.spec.ts
@@ -1,0 +1,347 @@
+import { AuditEventType } from '@chansey/api-interfaces';
+
+import { AuditService } from './audit.service';
+import { AuditLog } from './entities/audit-log.entity';
+
+import { RequestContext } from '../common/cls/request-context.service';
+import { CryptoService } from '../common/crypto.service';
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let cryptoService: CryptoService;
+  let mockRepo: any;
+  let mockRequestContext: Partial<RequestContext>;
+
+  beforeEach(() => {
+    cryptoService = new CryptoService();
+
+    mockRepo = {
+      create: jest.fn((data: any) => ({ id: 'audit-1', ...data })),
+      save: jest.fn((entity: any) => Promise.resolve(entity)),
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue([]),
+      createQueryBuilder: jest.fn()
+    };
+
+    mockRequestContext = {
+      userId: 'cls-user-1',
+      ipAddress: '10.0.0.1',
+      userAgent: 'TestAgent/1.0'
+    };
+
+    service = new AuditService(mockRepo, cryptoService, mockRequestContext as RequestContext);
+  });
+
+  describe('createAuditLog — CLS fallback enrichment', () => {
+    const baseDto = {
+      eventType: AuditEventType.STRATEGY_MODIFIED,
+      entityType: 'StrategyConfig',
+      entityId: 'entity-1'
+    } as any;
+
+    it('uses DTO values when provided', async () => {
+      await service.createAuditLog({
+        ...baseDto,
+        userId: 'dto-user',
+        ipAddress: '192.168.1.1',
+        userAgent: 'DtoAgent/2.0'
+      });
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.userId).toBe('dto-user');
+      expect(created.userAgent).toBe('DtoAgent/2.0');
+    });
+
+    it('falls back to CLS values when DTO fields are absent', async () => {
+      await service.createAuditLog(baseDto);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.userId).toBe('cls-user-1');
+      expect(created.userAgent).toBe('TestAgent/1.0');
+    });
+
+    it('handles missing RequestContext gracefully', async () => {
+      const serviceNoCtx = new AuditService(mockRepo, cryptoService, undefined as any);
+
+      await serviceNoCtx.createAuditLog(baseDto);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.userId).toBeUndefined();
+    });
+
+    it('hashes ipAddress when provided via DTO', async () => {
+      await service.createAuditLog({ ...baseDto, ipAddress: '192.168.1.1' });
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.ipAddress).toBe(cryptoService.hashSensitiveData('192.168.1.1'));
+      expect(created.ipAddress).not.toBe('192.168.1.1');
+    });
+
+    it('hashes ipAddress from CLS fallback', async () => {
+      await service.createAuditLog(baseDto);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.ipAddress).toBe(cryptoService.hashSensitiveData('10.0.0.1'));
+    });
+
+    it('sets ipAddress to null when neither DTO nor CLS provides one', async () => {
+      const serviceNoCtx = new AuditService(mockRepo, cryptoService, undefined as any);
+      await serviceNoCtx.createAuditLog(baseDto);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.ipAddress).toBeNull();
+    });
+
+    it('generates correlationId when not provided', async () => {
+      await service.createAuditLog(baseDto);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.correlationId).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('uses provided correlationId', async () => {
+      await service.createAuditLog({ ...baseDto, correlationId: 'corr-123' });
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.correlationId).toBe('corr-123');
+    });
+  });
+
+  describe('createAuditLog — chain hash', () => {
+    const baseDto = {
+      eventType: AuditEventType.STRATEGY_MODIFIED,
+      entityType: 'StrategyConfig',
+      entityId: 'entity-1'
+    } as any;
+
+    it('generates chainHash and saves twice', async () => {
+      await service.createAuditLog(baseDto);
+
+      expect(mockRepo.save).toHaveBeenCalledTimes(2);
+      const secondSave = mockRepo.save.mock.calls[1][0];
+      expect(secondSave.chainHash).toBeDefined();
+      expect(typeof secondSave.chainHash).toBe('string');
+    });
+
+    it('uses previous entry chainHash when available', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({ chainHash: 'prev-hash-abc' });
+
+      await service.createAuditLog(baseDto);
+
+      const secondSave = mockRepo.save.mock.calls[1][0];
+      // Should produce a different chainHash than when previousHash is null
+      mockRepo.findOne.mockResolvedValueOnce(null);
+      mockRepo.save.mockClear();
+      mockRepo.create.mockClear();
+
+      await service.createAuditLog(baseDto);
+      const secondSaveNoPrev = mockRepo.save.mock.calls[1][0];
+
+      expect(secondSave.chainHash).not.toBe(secondSaveNoPrev.chainHash);
+    });
+  });
+
+  describe('integrity hash — includes userId', () => {
+    it('verifies entry created with userId', async () => {
+      await service.createAuditLog({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'entity-1',
+        userId: 'user-42'
+      } as any);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      const auditLog = { ...created, timestamp: created.timestamp } as AuditLog;
+
+      expect(service.verifyIntegrity(auditLog)).toBe(true);
+    });
+
+    it('detects tampering when userId is changed', async () => {
+      await service.createAuditLog({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'entity-1',
+        userId: 'user-42'
+      } as any);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      const auditLog = { ...created } as AuditLog;
+      auditLog.userId = 'tampered-user';
+
+      expect(service.verifyIntegrity(auditLog)).toBe(false);
+    });
+
+    it('detects tampering when eventType is changed', async () => {
+      await service.createAuditLog({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'entity-1'
+      } as any);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      const auditLog = { ...created } as AuditLog;
+      auditLog.eventType = AuditEventType.BACKTEST_COMPLETED;
+
+      expect(service.verifyIntegrity(auditLog)).toBe(false);
+    });
+
+    it('verifies integrity with undefined userId (coerced to null)', async () => {
+      await service.createAuditLog({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'entity-1'
+      } as any);
+
+      // Clear CLS context to get undefined userId
+      const serviceNoCtx = new AuditService(mockRepo, cryptoService, undefined as any);
+      mockRepo.create.mockClear();
+
+      await serviceNoCtx.createAuditLog({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'entity-1'
+      } as any);
+
+      const created = mockRepo.create.mock.calls[0][0];
+      const auditLog = { ...created } as AuditLog;
+
+      expect(serviceNoCtx.verifyIntegrity(auditLog)).toBe(true);
+    });
+  });
+
+  describe('verifyAuditChain', () => {
+    it('returns valid for empty entries', () => {
+      const result = service.verifyAuditChain([]);
+
+      expect(result.valid).toBe(true);
+      expect(result.totalEntries).toBe(0);
+      expect(result.verifiedEntries).toBe(0);
+      expect(result.brokenChainAt).toBeNull();
+      expect(result.tamperedEntries).toEqual([]);
+      expect(result.integrityFailures).toEqual([]);
+    });
+
+    it('validates a single-entry chain', () => {
+      const timestamp = new Date();
+      const integrity = cryptoService.generateAuditIntegrityHash({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'e-1',
+        userId: 'u-1',
+        timestamp
+      });
+      const chainHash = cryptoService.generateChainHash(
+        {
+          id: 'a-1',
+          eventType: AuditEventType.STRATEGY_MODIFIED,
+          entityType: 'StrategyConfig',
+          entityId: 'e-1',
+          timestamp,
+          integrity
+        },
+        null
+      );
+
+      const entry = {
+        id: 'a-1',
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'e-1',
+        userId: 'u-1',
+        timestamp,
+        integrity,
+        chainHash,
+        beforeState: undefined,
+        afterState: undefined,
+        metadata: undefined
+      } as unknown as AuditLog;
+
+      const result = service.verifyAuditChain([entry]);
+
+      expect(result.valid).toBe(true);
+      expect(result.verifiedEntries).toBe(1);
+      expect(result.integrityFailures).toEqual([]);
+    });
+
+    it('detects integrity failure in chain entry', () => {
+      const timestamp = new Date();
+      const integrity = cryptoService.generateAuditIntegrityHash({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'e-1',
+        userId: 'u-1',
+        timestamp
+      });
+      const chainHash = cryptoService.generateChainHash(
+        {
+          id: 'a-1',
+          eventType: AuditEventType.STRATEGY_MODIFIED,
+          entityType: 'StrategyConfig',
+          entityId: 'e-1',
+          timestamp,
+          integrity
+        },
+        null
+      );
+
+      const entry = {
+        id: 'a-1',
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'e-1',
+        userId: 'tampered-user', // tampered
+        timestamp,
+        integrity,
+        chainHash,
+        beforeState: undefined,
+        afterState: undefined,
+        metadata: undefined
+      } as unknown as AuditLog;
+
+      const result = service.verifyAuditChain([entry]);
+
+      expect(result.valid).toBe(false);
+      expect(result.integrityFailures).toContain('a-1');
+    });
+  });
+
+  describe('verifyMultipleEntries', () => {
+    it('returns verified count and failed IDs', async () => {
+      const timestamp = new Date();
+      const goodIntegrity = cryptoService.generateAuditIntegrityHash({
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'e-1',
+        userId: 'u-1',
+        timestamp
+      });
+
+      const goodEntry = {
+        id: 'good-1',
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'e-1',
+        userId: 'u-1',
+        timestamp,
+        integrity: goodIntegrity
+      };
+
+      const badEntry = {
+        id: 'bad-1',
+        eventType: AuditEventType.STRATEGY_MODIFIED,
+        entityType: 'StrategyConfig',
+        entityId: 'e-1',
+        userId: 'tampered',
+        timestamp,
+        integrity: goodIntegrity // integrity doesn't match tampered userId
+      };
+
+      mockRepo.find.mockResolvedValueOnce([goodEntry, badEntry]);
+
+      const result = await service.verifyMultipleEntries(['good-1', 'bad-1']);
+
+      expect(result.verified).toBe(1);
+      expect(result.failed).toEqual(['bad-1']);
+    });
+  });
+});

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { In, Repository } from 'typeorm';
@@ -9,6 +9,7 @@ import { AuditEventType, AuditTrailQuery, CreateAuditLogDto } from '@chansey/api
 
 import { AuditLog } from './entities/audit-log.entity';
 
+import { RequestContext } from '../common/cls/request-context.service';
 import { CryptoService } from '../common/crypto.service';
 
 /**
@@ -22,7 +23,8 @@ export class AuditService {
   constructor(
     @InjectRepository(AuditLog)
     private readonly auditLogRepository: Repository<AuditLog>,
-    private readonly cryptoService: CryptoService
+    private readonly cryptoService: CryptoService,
+    @Optional() private readonly requestContext?: RequestContext
   ) {}
 
   /**
@@ -32,11 +34,17 @@ export class AuditService {
   async createAuditLog(dto: CreateAuditLogDto): Promise<AuditLog> {
     const timestamp = new Date();
 
-    // Generate integrity hash
+    // Fallback to CLS values when dto fields are not provided
+    const effectiveUserId = dto.userId ?? this.requestContext?.userId;
+    const effectiveIpAddress = dto.ipAddress ?? this.requestContext?.ipAddress;
+    const effectiveUserAgent = dto.userAgent ?? this.requestContext?.userAgent;
+
+    // Generate integrity hash (includes userId for non-repudiation)
     const integrity = this.cryptoService.generateAuditIntegrityHash({
       eventType: dto.eventType,
       entityType: dto.entityType,
       entityId: dto.entityId,
+      userId: effectiveUserId,
       timestamp,
       beforeState: dto.beforeState,
       afterState: dto.afterState,
@@ -44,21 +52,21 @@ export class AuditService {
     });
 
     // Hash IP address for privacy
-    const hashedIpAddress = dto.ipAddress ? this.cryptoService.hashSensitiveData(dto.ipAddress) : null;
+    const hashedIpAddress = effectiveIpAddress ? this.cryptoService.hashSensitiveData(effectiveIpAddress) : null;
 
     const auditLog = this.auditLogRepository.create({
       eventType: dto.eventType,
       entityType: dto.entityType,
       entityId: dto.entityId,
-      userId: dto.userId,
+      userId: effectiveUserId,
       timestamp,
       beforeState: dto.beforeState,
       afterState: dto.afterState,
       metadata: dto.metadata,
-      correlationId: dto.correlationId || randomUUID(),
+      correlationId: dto.correlationId ?? this.requestContext?.requestId ?? randomUUID(),
       integrity,
       ipAddress: hashedIpAddress,
-      userAgent: dto.userAgent
+      userAgent: effectiveUserAgent
     });
 
     // Save first to get the ID, then generate and update chain hash
@@ -158,6 +166,7 @@ export class AuditService {
       eventType: auditLog.eventType,
       entityType: auditLog.entityType,
       entityId: auditLog.entityId,
+      userId: auditLog.userId,
       timestamp: auditLog.timestamp,
       beforeState: auditLog.beforeState,
       afterState: auditLog.afterState,

--- a/apps/api/src/common/cls/cls-context.interceptor.spec.ts
+++ b/apps/api/src/common/cls/cls-context.interceptor.spec.ts
@@ -1,0 +1,52 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+
+import { of } from 'rxjs';
+
+import { ClsContextInterceptor } from './cls-context.interceptor';
+import { RequestContext } from './request-context.service';
+
+describe('ClsContextInterceptor', () => {
+  let interceptor: ClsContextInterceptor;
+  let requestContext: RequestContext;
+  let next: CallHandler;
+
+  beforeEach(() => {
+    requestContext = {
+      userId: undefined,
+      requestId: undefined,
+      ipAddress: undefined,
+      userAgent: undefined
+    } as any as RequestContext;
+
+    interceptor = new ClsContextInterceptor(requestContext);
+    next = { handle: jest.fn().mockReturnValue(of('result')) };
+  });
+
+  const createExecutionContext = (user?: { id: string }): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ user })
+      })
+    }) as unknown as ExecutionContext;
+
+  it('sets userId and forwards the response observable for authenticated requests', () => {
+    const ctx = createExecutionContext({ id: 'user-123' });
+
+    const result$ = interceptor.intercept(ctx, next);
+
+    expect(requestContext.userId).toBe('user-123');
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    expect(result$).toBeDefined();
+  });
+
+  it('skips userId assignment for unauthenticated requests', () => {
+    const setUserIdSpy = jest.fn();
+    Object.defineProperty(requestContext, 'userId', { set: setUserIdSpy, configurable: true });
+    const ctx = createExecutionContext(undefined);
+
+    interceptor.intercept(ctx, next);
+
+    expect(setUserIdSpy).not.toHaveBeenCalled();
+    expect(next.handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/common/cls/cls-context.interceptor.ts
+++ b/apps/api/src/common/cls/cls-context.interceptor.ts
@@ -1,0 +1,33 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+
+import { FastifyRequest } from 'fastify';
+import { Observable } from 'rxjs';
+
+import { RequestContext } from './request-context.service';
+
+/**
+ * Populates CLS context with the authenticated user's ID.
+ *
+ * **Execution order matters:**
+ * 1. ClsMiddleware runs first — sets requestId, ipAddress, userAgent.
+ * 2. Guards run next (e.g., JwtAuthGuard) — attach `request.user`.
+ *    If the guard rejects (401), this interceptor never runs, so userId
+ *    will be undefined in CLS. GlobalExceptionFilter still has requestId,
+ *    ipAddress, and userAgent from step 1.
+ * 3. This interceptor runs — copies `request.user.id` into CLS.
+ */
+@Injectable()
+export class ClsContextInterceptor implements NestInterceptor {
+  constructor(private readonly requestContext: RequestContext) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<FastifyRequest>();
+    const user = (request as FastifyRequest & { user?: { id: string } }).user;
+
+    if (user) {
+      this.requestContext.userId = user.id;
+    }
+
+    return next.handle();
+  }
+}

--- a/apps/api/src/common/cls/cls-context.module.ts
+++ b/apps/api/src/common/cls/cls-context.module.ts
@@ -1,0 +1,30 @@
+import { Global, Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+
+import { ClsModule } from 'nestjs-cls';
+
+import { randomUUID } from 'crypto';
+
+import { ClsContextInterceptor } from './cls-context.interceptor';
+import { CLS_IP_ADDRESS, CLS_REQUEST_ID, CLS_USER_AGENT } from './cls.constants';
+import { RequestContext } from './request-context.service';
+
+@Global()
+@Module({
+  imports: [
+    ClsModule.forRoot({
+      global: true,
+      middleware: {
+        mount: true,
+        setup: (cls, req) => {
+          cls.set(CLS_REQUEST_ID, req.id ?? randomUUID());
+          cls.set(CLS_IP_ADDRESS, req.ip);
+          cls.set(CLS_USER_AGENT, req.headers['user-agent']);
+        }
+      }
+    })
+  ],
+  providers: [RequestContext, { provide: APP_INTERCEPTOR, useClass: ClsContextInterceptor }],
+  exports: [RequestContext]
+})
+export class ClsContextModule {}

--- a/apps/api/src/common/cls/cls.constants.ts
+++ b/apps/api/src/common/cls/cls.constants.ts
@@ -1,0 +1,4 @@
+export const CLS_USER_ID = 'cls_user_id';
+export const CLS_REQUEST_ID = 'cls_request_id';
+export const CLS_IP_ADDRESS = 'cls_ip_address';
+export const CLS_USER_AGENT = 'cls_user_agent';

--- a/apps/api/src/common/cls/index.ts
+++ b/apps/api/src/common/cls/index.ts
@@ -1,0 +1,4 @@
+export * from './cls.constants';
+export * from './cls-context.interceptor';
+export * from './cls-context.module';
+export * from './request-context.service';

--- a/apps/api/src/common/cls/request-context.service.ts
+++ b/apps/api/src/common/cls/request-context.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+
+import { ClsService } from 'nestjs-cls';
+
+import { CLS_IP_ADDRESS, CLS_REQUEST_ID, CLS_USER_AGENT, CLS_USER_ID } from './cls.constants';
+
+@Injectable()
+export class RequestContext {
+  constructor(private readonly cls: ClsService) {}
+
+  get userId(): string | undefined {
+    return this.cls.isActive() ? this.cls.get(CLS_USER_ID) : undefined;
+  }
+
+  set userId(value: string) {
+    this.cls.set(CLS_USER_ID, value);
+  }
+
+  get requestId(): string | undefined {
+    return this.cls.isActive() ? this.cls.get(CLS_REQUEST_ID) : undefined;
+  }
+
+  set requestId(value: string) {
+    this.cls.set(CLS_REQUEST_ID, value);
+  }
+
+  get ipAddress(): string | undefined {
+    return this.cls.isActive() ? this.cls.get(CLS_IP_ADDRESS) : undefined;
+  }
+
+  set ipAddress(value: string) {
+    this.cls.set(CLS_IP_ADDRESS, value);
+  }
+
+  get userAgent(): string | undefined {
+    return this.cls.isActive() ? this.cls.get(CLS_USER_AGENT) : undefined;
+  }
+
+  set userAgent(value: string) {
+    this.cls.set(CLS_USER_AGENT, value);
+  }
+}

--- a/apps/api/src/common/crypto.service.ts
+++ b/apps/api/src/common/crypto.service.ts
@@ -35,6 +35,7 @@ export class CryptoService {
     eventType: string;
     entityType: string;
     entityId: string;
+    userId?: string | null;
     timestamp: Date;
     beforeState?: any;
     afterState?: any;
@@ -44,6 +45,7 @@ export class CryptoService {
       eventType: auditEntry.eventType,
       entityType: auditEntry.entityType,
       entityId: auditEntry.entityId,
+      userId: auditEntry.userId || null,
       timestamp: auditEntry.timestamp.toISOString(),
       beforeState: auditEntry.beforeState || null,
       afterState: auditEntry.afterState || null,
@@ -60,6 +62,7 @@ export class CryptoService {
     eventType: string;
     entityType: string;
     entityId: string;
+    userId?: string | null;
     timestamp: Date;
     beforeState?: any;
     afterState?: any;

--- a/apps/api/src/common/filters/global-exception.filter.ts
+++ b/apps/api/src/common/filters/global-exception.filter.ts
@@ -1,8 +1,9 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger, Optional } from '@nestjs/common';
 import { MESSAGES } from '@nestjs/core/constants';
 
 import { FastifyReply, FastifyRequest } from 'fastify';
 
+import { RequestContext } from '../cls/request-context.service';
 import { AppException, ErrorCode } from '../exceptions';
 
 /**
@@ -24,6 +25,8 @@ export interface ErrorResponse {
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(GlobalExceptionFilter.name);
+
+  constructor(@Optional() private readonly requestContext?: RequestContext) {}
 
   catch(exception: unknown, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
@@ -132,11 +135,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
    * Logs errors with appropriate severity based on status code.
    */
   private logError(errorResponse: ErrorResponse, exception: unknown): void {
-    const logContext = {
+    const logContext: Record<string, unknown> = {
       code: errorResponse.code,
       statusCode: errorResponse.statusCode,
       path: errorResponse.path,
-      context: errorResponse.context
+      context: errorResponse.context,
+      requestId: this.requestContext?.requestId,
+      userId: this.requestContext?.userId
     };
 
     // Log 5xx errors as errors, 4xx as warnings

--- a/apps/api/src/common/index.ts
+++ b/apps/api/src/common/index.ts
@@ -1,2 +1,3 @@
+export * from './cls';
 export * from './exceptions';
 export * from './filters';

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -22,6 +22,8 @@ async function bootstrap(): Promise<void> {
     new FastifyAdapter({
       // Disable Fastify's built-in logger since we're using Pino via nestjs-pino
       logger: false,
+      // Trust Railway's reverse proxy so req.ip returns the real client IP
+      trustProxy: true,
       // Router options moved here to comply with Fastify v6 (fixes FSTDEP022 warning)
       routerOptions: {
         ignoreTrailingSlash: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "date-fns": "^4.1.0",
         "decimal.js": "^10.6.0",
         "minio": "^8.0.6",
+        "nestjs-cls": "^6.2.0",
         "nestjs-pino": "^4.5.0",
         "ngx-image-cropper": "^9.1.5",
         "passport": "^0.7.0",
@@ -35963,6 +35964,21 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
+    },
+    "node_modules/nestjs-cls": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/nestjs-cls/-/nestjs-cls-6.2.0.tgz",
+      "integrity": "sha512-b2Remha7gV5gId3ezjr2tupjqqgYK7/JqjqX6oZ0ZIDFATUggKH1/32+ul2lOe7FepnHasDONDoePuWEE64cug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@nestjs/common": ">= 10 < 12",
+        "@nestjs/core": ">= 10 < 12",
+        "reflect-metadata": "*",
+        "rxjs": ">= 7"
+      }
     },
     "node_modules/nestjs-pino": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "date-fns": "^4.1.0",
     "decimal.js": "^10.6.0",
     "minio": "^8.0.6",
+    "nestjs-cls": "^6.2.0",
     "nestjs-pino": "^4.5.0",
     "ngx-image-cropper": "^9.1.5",
     "passport": "^0.7.0",


### PR DESCRIPTION
## Summary
- Add `nestjs-cls` integration with a `RequestContext` service that stores userId, requestId, ipAddress, and userAgent per request via continuation-local storage
- Audit logs are automatically enriched with CLS context values as fallbacks, eliminating the need for callers to manually pass request metadata
- Error logs in `GlobalExceptionFilter` now include requestId and userId for improved observability

## Changes
- **CLS module** (`cls-context.module.ts`) — Configures `nestjs-cls` middleware to capture requestId, IP, and user-agent at request entry
- **ClsContextInterceptor** — Runs after auth guards to copy `request.user.id` into CLS context
- **RequestContext service** — Type-safe getter/setter facade over CLS store, globally exported
- **AuditService** — Falls back to CLS values for userId, ipAddress, userAgent when not explicitly provided; includes userId in integrity hash for non-repudiation
- **CryptoService** — Updated integrity hash to include userId field
- **GlobalExceptionFilter** — Injects RequestContext to log requestId and userId with errors; fixed `APP_FILTER` provider token
- **main.ts** — Enable `trustProxy` on Fastify adapter for correct client IP behind Railway proxy
- **Tests** — Comprehensive AuditService tests (CLS fallback, chain hash, integrity verification) and ClsContextInterceptor tests

## Test Plan
- [x] AuditService unit tests cover CLS fallback, integrity hash with userId, chain hash verification, and tamper detection
- [x] ClsContextInterceptor tests verify userId assignment for authenticated and unauthenticated requests
- [ ] Verify audit logs contain correct userId/IP/userAgent when created from HTTP request context
- [ ] Verify error logs include requestId and userId

Closes #289