### PR TITLE
feat: add OCO order UI with linked pair grouping and visual indicators

### DIFF
--- a/apps/api/src/order/dto/order-response.dto.ts
+++ b/apps/api/src/order/dto/order-response.dto.ts
@@ -261,6 +261,13 @@ export class OrderResponseDto {
   })
   info?: Record<string, unknown>;
 
+  @ApiProperty({
+    description: 'ID of the linked OCO order (one-cancels-other). When one order fills, the linked order cancels.',
+    example: 'b4cc290f-9bf0-4999-8813-bde5e7654003',
+    required: false
+  })
+  ocoLinkedOrderId?: string;
+
   constructor(order: Partial<OrderDto>) {
     Object.assign(this, order);
   }

--- a/apps/chansey/src/app/pages/transactions/transactions.component.html
+++ b/apps/chansey/src/app/pages/transactions/transactions.component.html
@@ -217,19 +217,19 @@
                   [image]="transaction.baseCoin?.image"
                   shape="circle"
                   size="large"
-                  class="border-surface min-w-9 border-2 shadow-sm"
+                  class="min-w-9 border-2 border-surface shadow-sm"
                 />
                 @if (transaction.quoteCoin) {
                   <p-avatar
                     [image]="transaction.quoteCoin.image"
                     shape="circle"
                     size="large"
-                    class="border-surface min-w-9 border-2 shadow-sm"
+                    class="min-w-9 border-2 border-surface shadow-sm"
                   />
                 }
               </div>
               <div class="flex flex-col">
-                <span class="text-primary-500 hover:text-primary-600 text-lg font-medium">{{
+                <span class="text-lg font-medium text-primary-500 hover:text-primary-600">{{
                   transaction.symbol
                 }}</span>
                 <span class="text-sm text-gray-500 dark:text-gray-400">{{ transaction.baseCoin?.name }}</span>
@@ -238,7 +238,19 @@
           </td>
           <td>
             <div class="flex flex-col items-center gap-0.5">
-              <p-tag [value]="transaction.side" [severity]="getSideSeverity(transaction.side)"></p-tag>
+              <div class="flex items-center gap-1">
+                <p-tag [value]="transaction.side" [severity]="getSideSeverity(transaction.side)"></p-tag>
+                @if (transaction.ocoLinkedOrderId) {
+                  <i
+                    class="pi pi-link text-xs text-blue-500 dark:text-blue-400"
+                    pTooltip="Linked OCO order — when one fills, the other cancels"
+                    tooltipPosition="top"
+                    aria-label="Linked OCO order"
+                    tabindex="0"
+                    role="img"
+                  ></i>
+                }
+              </div>
               <span class="text-xs text-neutral-400">{{ formatType(transaction.type) }}</span>
             </div>
           </td>
@@ -285,7 +297,7 @@
                   [image]="transaction.exchange.image"
                   shape="circle"
                   size="normal"
-                  class="border-surface border shadow-sm"
+                  class="border border-surface shadow-sm"
                 />
                 <span class="text-sm font-medium">{{ transaction.exchange.name }}</span>
               </div>

--- a/apps/chansey/src/app/pages/transactions/transactions.component.ts
+++ b/apps/chansey/src/app/pages/transactions/transactions.component.ts
@@ -24,6 +24,7 @@ import { SelectModule } from 'primeng/select';
 import { SkeletonModule } from 'primeng/skeleton';
 import { Table, TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
 import { EMPTY } from 'rxjs';
 
 import { Order, OrderSide, OrderStatus, OrderType } from '@chansey/api-interfaces';
@@ -56,6 +57,7 @@ import { getSideSeverity, getStatusSeverity } from '../../shared/utils/order-sev
     SkeletonModule,
     TableModule,
     TagModule,
+    TooltipModule,
     UpperCasePipe
   ],
   templateUrl: './transactions.component.html',

--- a/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.html
@@ -1,3 +1,56 @@
+<!-- Shared order card template -->
+<ng-template #orderCard let-order>
+  <!-- Header: Symbol + Side + Status -->
+  <div class="mb-2 flex items-center justify-between">
+    <div class="flex items-center gap-2">
+      <span class="text-sm font-bold text-surface-900 dark:text-surface-50">{{ order.symbol }}</span>
+      <span
+        class="rounded-md px-1.5 py-0.5 text-[11px] font-bold uppercase"
+        [ngClass]="{
+          'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300': order.side === 'BUY',
+          'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300': order.side === 'SELL'
+        }"
+      >
+        {{ order.side }}
+      </span>
+    </div>
+    <span class="rounded-full px-2 py-0.5 text-[11px] font-semibold" [class]="getStatusClass(order.status)">
+      {{ order.status }}
+    </span>
+  </div>
+  <!-- Details -->
+  <div class="grid grid-cols-2 gap-x-4 text-xs">
+    <div class="flex justify-between">
+      <span class="text-surface-500 dark:text-surface-400">Qty</span>
+      <span class="font-medium text-surface-700 tabular-nums dark:text-surface-200">{{
+        order.quantity | number: '1.2-4'
+      }}</span>
+    </div>
+    <div class="flex justify-between">
+      <span class="text-surface-500 dark:text-surface-400">Price</span>
+      <span class="font-medium text-surface-700 tabular-nums dark:text-surface-200">{{
+        order.price | number: '1.2-4'
+      }}</span>
+    </div>
+    @if (order.takeProfitPrice) {
+      <div class="flex justify-between">
+        <span class="text-green-600 dark:text-green-400">TP</span>
+        <span class="font-medium text-surface-700 tabular-nums dark:text-surface-200">{{
+          order.takeProfitPrice | number: '1.2-4'
+        }}</span>
+      </div>
+    }
+    @if (order.stopLossPrice) {
+      <div class="flex justify-between">
+        <span class="text-red-600 dark:text-red-400">SL</span>
+        <span class="font-medium text-surface-700 tabular-nums dark:text-surface-200">{{
+          order.stopLossPrice | number: '1.2-4'
+        }}</span>
+      </div>
+    }
+  </div>
+</ng-template>
+
 @if (orders().length > 0) {
   <div class="mt-5 rounded-xl border border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800">
     <div
@@ -12,53 +65,58 @@
     </div>
     @if (isVisible()) {
       <div class="space-y-2.5 px-4 pb-4">
-        @for (order of orders(); track trackByOrderId($index, order)) {
-          <div class="rounded-xl border border-surface-200 bg-white p-3 dark:border-surface-600 dark:bg-surface-700">
-            <!-- Header: Symbol + Side + Status -->
-            <div class="mb-2 flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <span class="text-sm font-bold text-surface-900 dark:text-surface-50">{{ order.symbol }}</span>
-                <span
-                  class="rounded-md px-1.5 py-0.5 text-[11px] font-bold uppercase"
-                  [ngClass]="{
-                    'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300': order.side === 'BUY',
-                    'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300': order.side === 'SELL'
-                  }"
-                >
-                  {{ order.side }}
-                </span>
+        @for (group of groupedOrders(); track trackByGroupId($index, group)) {
+          @if (group.type === 'oco-pair') {
+            <!-- OCO Pair Wrapper -->
+            <div
+              class="rounded-xl border-2 border-primary-200 bg-primary-50/30 p-2.5 dark:border-primary-800 dark:bg-primary-900/10"
+            >
+              <div class="mb-2 flex items-center gap-1.5 px-1">
+                <i class="pi pi-link text-xs text-primary-600 dark:text-primary-400" aria-hidden="true"></i>
+                <span class="text-xs font-semibold text-primary-700 dark:text-primary-300">Linked OCO Pair</span>
               </div>
-              <span class="rounded-full px-2 py-0.5 text-[11px] font-semibold" [class]="getStatusClass(order.status)">
-                {{ order.status }}
-              </span>
-            </div>
-            <!-- Details -->
-            <div class="mb-3 grid grid-cols-2 gap-x-4 text-xs">
-              <div class="flex justify-between">
-                <span class="text-surface-500 dark:text-surface-400">Qty</span>
-                <span class="font-medium text-surface-700 tabular-nums dark:text-surface-200">{{
-                  order.quantity | number: '1.2-4'
-                }}</span>
+              <div class="space-y-2">
+                @for (order of group.orders; track trackByOrderId($index, order)) {
+                  <div
+                    class="rounded-lg border border-surface-200 bg-white p-3 dark:border-surface-600 dark:bg-surface-700"
+                  >
+                    <ng-container *ngTemplateOutlet="orderCard; context: { $implicit: order }"></ng-container>
+                  </div>
+                }
               </div>
-              <div class="flex justify-between">
-                <span class="text-surface-500 dark:text-surface-400">Price</span>
-                <span class="font-medium text-surface-700 tabular-nums dark:text-surface-200">{{
-                  order.price | number: '1.2-4'
-                }}</span>
+              <!-- Single cancel button for both -->
+              <div class="mt-2">
+                <p-button
+                  icon="pi pi-times"
+                  label="Cancel Both Orders"
+                  severity="danger"
+                  [text]="true"
+                  size="small"
+                  (click)="onCancelOcoPair(group.orders)"
+                  [disabled]="isCancelling()"
+                  styleClass="w-full"
+                />
               </div>
             </div>
-            <!-- Cancel -->
-            <p-button
-              icon="pi pi-times"
-              label="Cancel Order"
-              severity="danger"
-              [text]="true"
-              size="small"
-              (click)="cancelOrder.emit(order.id)"
-              [disabled]="isCancelling()"
-              styleClass="w-full"
-            />
-          </div>
+          } @else {
+            <!-- Standalone Order -->
+            <div class="rounded-xl border border-surface-200 bg-white p-3 dark:border-surface-600 dark:bg-surface-700">
+              <div class="mb-3">
+                <ng-container *ngTemplateOutlet="orderCard; context: { $implicit: group.orders[0] }"></ng-container>
+              </div>
+              <!-- Cancel -->
+              <p-button
+                icon="pi pi-times"
+                label="Cancel Order"
+                severity="danger"
+                [text]="true"
+                size="small"
+                (click)="cancelOrder.emit(group.orders[0].id)"
+                [disabled]="isCancelling()"
+                styleClass="w-full"
+              />
+            </div>
+          }
         }
       </div>
     }

--- a/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.spec.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.spec.ts
@@ -1,0 +1,116 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Order, OrderSide, OrderStatus, OrderType } from '@chansey/api-interfaces';
+
+import { ActiveOrdersComponent } from './active-orders.component';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'order-1',
+    symbol: 'BTC/USD',
+    side: OrderSide.BUY,
+    status: OrderStatus.NEW,
+    quantity: 1,
+    price: 50000,
+    orderType: OrderType.LIMIT,
+    ...overrides
+  } as Order;
+}
+
+describe('ActiveOrdersComponent', () => {
+  let component: ActiveOrdersComponent;
+  let fixture: ComponentFixture<ActiveOrdersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ActiveOrdersComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ActiveOrdersComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('groupedOrders', () => {
+    it('should return empty array for empty orders', () => {
+      fixture.componentRef.setInput('orders', []);
+      fixture.detectChanges();
+      expect(component.groupedOrders()).toEqual([]);
+    });
+
+    it('should group two mutually linked OCO orders into one pair without double-grouping', () => {
+      const orderA = makeOrder({ id: 'a', ocoLinkedOrderId: 'b' });
+      const orderB = makeOrder({ id: 'b', ocoLinkedOrderId: 'a' });
+      fixture.componentRef.setInput('orders', [orderA, orderB]);
+      fixture.detectChanges();
+
+      const groups = component.groupedOrders();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].type).toBe('oco-pair');
+      expect(groups[0].orders.map((o: Order) => o.id).sort()).toEqual(['a', 'b']);
+      expect(groups[0].id).toBe('oco-a-b');
+    });
+
+    it('should fall back to standalone when ocoLinkedOrderId references non-existent order', () => {
+      const order = makeOrder({ id: 'a', ocoLinkedOrderId: 'non-existent' });
+      fixture.componentRef.setInput('orders', [order]);
+      fixture.detectChanges();
+
+      const groups = component.groupedOrders();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].type).toBe('standalone');
+      expect(groups[0].id).toBe('a');
+    });
+
+    it('should pair orders when only one side has ocoLinkedOrderId', () => {
+      const orderA = makeOrder({ id: 'a', ocoLinkedOrderId: 'b' });
+      const orderB = makeOrder({ id: 'b' });
+      fixture.componentRef.setInput('orders', [orderA, orderB]);
+      fixture.detectChanges();
+
+      const groups = component.groupedOrders();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].type).toBe('oco-pair');
+    });
+
+    it('should handle mixed OCO pairs and standalone orders', () => {
+      const orderA = makeOrder({ id: 'a', ocoLinkedOrderId: 'b' });
+      const orderB = makeOrder({ id: 'b', ocoLinkedOrderId: 'a' });
+      const orderC = makeOrder({ id: 'c' });
+      const orderD = makeOrder({ id: 'd' });
+      fixture.componentRef.setInput('orders', [orderA, orderB, orderC, orderD]);
+      fixture.detectChanges();
+
+      const groups = component.groupedOrders();
+      expect(groups).toHaveLength(3);
+      expect(groups.map((g) => g.type)).toEqual(['oco-pair', 'standalone', 'standalone']);
+    });
+
+    it('should only pair the first linker when two orders both link to the same target', () => {
+      const orderA = makeOrder({ id: 'a', ocoLinkedOrderId: 'c' });
+      const orderB = makeOrder({ id: 'b', ocoLinkedOrderId: 'c' });
+      const orderC = makeOrder({ id: 'c' });
+      fixture.componentRef.setInput('orders', [orderA, orderB, orderC]);
+      fixture.detectChanges();
+
+      const groups = component.groupedOrders();
+      // A pairs with C first; B falls to standalone since C is already processed
+      expect(groups).toHaveLength(2);
+      expect(groups[0].type).toBe('oco-pair');
+      expect(groups[0].orders.map((o: Order) => o.id)).toEqual(['a', 'c']);
+      expect(groups[1].type).toBe('standalone');
+      expect(groups[1].orders[0].id).toBe('b');
+    });
+  });
+
+  describe('onCancelOcoPair', () => {
+    it('should emit order IDs', () => {
+      const spy = jest.fn();
+      component.cancelOcoPair.subscribe(spy);
+
+      const orders = [makeOrder({ id: 'x' }), makeOrder({ id: 'y' })];
+      component.onCancelOcoPair(orders);
+
+      expect(spy).toHaveBeenCalledWith(['x', 'y']);
+    });
+  });
+});

--- a/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.ts
@@ -1,11 +1,17 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
 
 import { Order } from '@chansey/api-interfaces';
 
 import { getStatusClass } from '../crypto-trading.utils';
+
+export interface GroupedOrder {
+  type: 'oco-pair' | 'standalone';
+  orders: Order[];
+  id: string;
+}
 
 @Component({
   selector: 'app-active-orders',
@@ -20,10 +26,50 @@ export class ActiveOrdersComponent {
   isCancelling = input(false);
 
   cancelOrder = output<string>();
+  cancelOcoPair = output<string[]>();
 
   readonly getStatusClass = getStatusClass;
 
+  groupedOrders = computed<GroupedOrder[]>(() => {
+    const orders = this.orders();
+    const orderMap = new Map(orders.map((o) => [o.id, o]));
+    const result: GroupedOrder[] = [];
+    const processed = new Set<string>();
+
+    for (const order of orders) {
+      if (processed.has(order.id)) continue;
+
+      if (order.ocoLinkedOrderId) {
+        const linked = orderMap.get(order.ocoLinkedOrderId);
+        if (linked && !processed.has(linked.id)) {
+          processed.add(order.id);
+          processed.add(linked.id);
+          const [firstId, secondId] = [order.id, linked.id].sort();
+          result.push({
+            type: 'oco-pair',
+            orders: [order, linked],
+            id: `oco-${firstId}-${secondId}`
+          });
+          continue;
+        }
+      }
+
+      processed.add(order.id);
+      result.push({ type: 'standalone', orders: [order], id: order.id });
+    }
+
+    return result;
+  });
+
+  trackByGroupId(_index: number, group: GroupedOrder) {
+    return group.id;
+  }
+
   trackByOrderId(_index: number, order: Order) {
     return order.id;
+  }
+
+  onCancelOcoPair(orders: Order[]): void {
+    this.cancelOcoPair.emit(orders.map((o) => o.id));
   }
 }

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.html
@@ -151,7 +151,7 @@
     <div
       class="mb-5 flex items-center justify-between rounded-xl border border-surface-200 bg-surface-50 px-4 py-3 dark:border-surface-700 dark:bg-surface-800"
     >
-      <span class="text-sm font-bold text-surface-800 dark:text-surface-100">
+      <span class="text-sm font-bold text-surface-800 uppercase dark:text-surface-100">
         {{ selectedPair()?.baseAsset?.symbol }}/{{ selectedPair()?.quoteAsset?.symbol }}
       </span>
       <div class="flex items-center gap-2.5">
@@ -278,6 +278,7 @@
     [isVisible]="showActiveOrders()"
     [isCancelling]="cancelOrderMutation.isPending()"
     (cancelOrder)="cancelOrder($event)"
+    (cancelOcoPair)="cancelOcoPair($event)"
   />
 
   <p-confirmDialog />

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.spec.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.spec.ts
@@ -463,6 +463,42 @@ describe('CryptoTradingComponent', () => {
     });
   });
 
+  describe('cancelOcoPair', () => {
+    it('should call mutation with only the first order ID', () => {
+      component.cancelOcoPair(['order-1', 'order-2']);
+
+      expect(cancelOrderResult.mutate).toHaveBeenCalledTimes(1);
+      expect(cancelOrderResult.mutate).toHaveBeenCalledWith('order-1', expect.any(Object));
+    });
+
+    it('should show success toast on success', () => {
+      component.cancelOcoPair(['order-1', 'order-2']);
+
+      const callbacks = cancelOrderResult.mutate.mock.calls[0][1];
+      callbacks.onSuccess();
+
+      expect(mockMessageService.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'success', summary: 'OCO Pair Cancelled' })
+      );
+    });
+
+    it('should show error toast on failure', () => {
+      component.cancelOcoPair(['order-1', 'order-2']);
+
+      const callbacks = cancelOrderResult.mutate.mock.calls[0][1];
+      callbacks.onError(new Error('Exchange unavailable'));
+
+      expect(mockMessageService.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error', detail: 'Exchange unavailable' })
+      );
+    });
+
+    it('should do nothing for empty array', () => {
+      component.cancelOcoPair([]);
+      expect(cancelOrderResult.mutate).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getStatusClass (utility)', () => {
     it.each([
       [OrderStatus.NEW, 'bg-blue-100'],

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
@@ -16,7 +16,6 @@ import { debounceTime, Subject, takeUntil } from 'rxjs';
 import {
   Exchange,
   ExchangeKey,
-  Order,
   OrderPreview,
   OrderSide,
   OrderType,
@@ -326,6 +325,27 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
           severity: 'error',
           summary: 'Cancellation Failed',
           detail: error.message || 'Failed to cancel order'
+        });
+      }
+    });
+  }
+
+  cancelOcoPair(orderIds: string[]) {
+    if (orderIds.length === 0) return;
+    // Cancel first order only — exchange automatically cancels the linked OCO order
+    this.cancelOrderMutation.mutate(orderIds[0], {
+      onSuccess: () => {
+        this.messageService.add({
+          severity: 'success',
+          summary: 'OCO Pair Cancelled',
+          detail: 'Both linked OCO orders cancelled successfully'
+        });
+      },
+      onError: (error: Error) => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Cancellation Failed',
+          detail: error.message || 'Failed to cancel OCO orders'
         });
       }
     });

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.html
@@ -174,8 +174,91 @@
     </div>
   }
 
-  <!-- Take Profit Price -->
-  @if (shouldShowTakeProfitField()) {
+  <!-- OCO Linked Orders Panel -->
+  @if (isOcoOrder()) {
+    <div
+      class="space-y-3 rounded-lg border border-primary-200 bg-primary-50/50 p-3 dark:border-primary-800 dark:bg-primary-900/20"
+    >
+      <div class="flex items-center gap-2 text-sm font-semibold text-primary-800 dark:text-primary-200">
+        <i class="pi pi-link text-xs" aria-hidden="true"></i>
+        <span>Linked Orders (OCO)</span>
+      </div>
+      <p class="text-xs leading-relaxed text-primary-700 dark:text-primary-300">
+        Set a take-profit price above and a stop-loss price below the current price. When one triggers, the other
+        automatically cancels.
+      </p>
+      <!-- Mini price diagram -->
+      <div
+        class="flex flex-col items-center gap-0.5 rounded-md border border-dashed border-primary-300 bg-white/60 px-3 py-2 text-xs dark:border-primary-700 dark:bg-surface-800/60"
+      >
+        <div class="flex items-center gap-1.5 font-medium text-green-600 dark:text-green-400">
+          <i class="pi pi-arrow-up text-[10px]" aria-hidden="true"></i>
+          <span>Take Profit</span>
+        </div>
+        <div class="h-3 border-l border-dashed border-surface-300 dark:border-surface-600"></div>
+        <div class="flex items-center gap-1.5 font-semibold text-surface-600 dark:text-surface-300">
+          <i class="pi pi-minus text-[10px]" aria-hidden="true"></i>
+          <span>Current Price</span>
+        </div>
+        <div class="h-3 border-l border-dashed border-surface-300 dark:border-surface-600"></div>
+        <div class="flex items-center gap-1.5 font-medium text-red-600 dark:text-red-400">
+          <i class="pi pi-arrow-down text-[10px]" aria-hidden="true"></i>
+          <span>Stop Loss</span>
+        </div>
+      </div>
+      <!-- Take Profit input -->
+      <div class="space-y-2">
+        <p-floatlabel variant="on">
+          <p-inputnumber
+            [inputId]="side() + 'TakeProfitPrice'"
+            formControlName="takeProfitPrice"
+            mode="decimal"
+            [minFractionDigits]="2"
+            [maxFractionDigits]="8"
+            class="w-full"
+            [class.ng-invalid]="isFieldInvalid('takeProfitPrice')"
+            [class.ng-dirty]="isFieldInvalid('takeProfitPrice')"
+          />
+          <label [for]="side() + 'TakeProfitPrice'">
+            Take Profit
+            @if (selectedPair()?.quoteAsset?.symbol) {
+              <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
+            }
+          </label>
+        </p-floatlabel>
+        @if (isFieldInvalid('takeProfitPrice')) {
+          <small class="p-error" role="alert">{{ getFieldError('takeProfitPrice') }}</small>
+        }
+      </div>
+      <!-- Stop Loss input -->
+      <div class="space-y-2">
+        <p-floatlabel variant="on">
+          <p-inputnumber
+            [inputId]="side() + 'StopLossPrice'"
+            formControlName="stopLossPrice"
+            mode="decimal"
+            [minFractionDigits]="2"
+            [maxFractionDigits]="8"
+            class="w-full"
+            [class.ng-invalid]="isFieldInvalid('stopLossPrice')"
+            [class.ng-dirty]="isFieldInvalid('stopLossPrice')"
+          />
+          <label [for]="side() + 'StopLossPrice'">
+            Stop Loss
+            @if (selectedPair()?.quoteAsset?.symbol) {
+              <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
+            }
+          </label>
+        </p-floatlabel>
+        @if (isFieldInvalid('stopLossPrice')) {
+          <small class="p-error" role="alert">{{ getFieldError('stopLossPrice') }}</small>
+        }
+      </div>
+    </div>
+  }
+
+  <!-- Take Profit Price (standalone, non-OCO) -->
+  @if (isTakeProfitOnly()) {
     <div class="space-y-2">
       <p-floatlabel variant="on">
         <p-inputnumber
@@ -198,34 +281,6 @@
       @if (isFieldInvalid('takeProfitPrice')) {
         <small class="p-error" role="alert">{{ getFieldError('takeProfitPrice') }}</small>
       }
-    </div>
-  }
-
-  <!-- Stop Loss Price (for OCO) -->
-  @if (shouldShowStopLossField()) {
-    <div class="space-y-2">
-      <p-floatlabel variant="on">
-        <p-inputnumber
-          [inputId]="side() + 'StopLossPrice'"
-          formControlName="stopLossPrice"
-          mode="decimal"
-          [minFractionDigits]="2"
-          [maxFractionDigits]="8"
-          class="w-full"
-          [class.ng-invalid]="isFieldInvalid('stopLossPrice')"
-          [class.ng-dirty]="isFieldInvalid('stopLossPrice')"
-        />
-        <label [for]="side() + 'StopLossPrice'">
-          Stop Loss
-          @if (selectedPair()?.quoteAsset?.symbol) {
-            <span>({{ selectedPair()?.quoteAsset?.symbol | uppercase }})</span>
-          }
-        </label>
-      </p-floatlabel>
-      @if (isFieldInvalid('stopLossPrice')) {
-        <small class="p-error" role="alert">{{ getFieldError('stopLossPrice') }}</small>
-      }
-      <p-message severity="info" size="small"> OCO: When one order executes, the other cancels </p-message>
     </div>
   }
 

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.ts
@@ -95,13 +95,20 @@ export class OrderFormComponent {
     return this.form().get('type')?.value === OrderType.TRAILING_STOP;
   }
 
+  isOcoOrder(): boolean {
+    return this.form().get('type')?.value === OrderType.OCO;
+  }
+
+  isTakeProfitOnly(): boolean {
+    return this.form().get('type')?.value === OrderType.TAKE_PROFIT;
+  }
+
   shouldShowTakeProfitField(): boolean {
-    const type = this.form().get('type')?.value;
-    return type === OrderType.TAKE_PROFIT || type === OrderType.OCO;
+    return this.isTakeProfitOnly() || this.isOcoOrder();
   }
 
   shouldShowStopLossField(): boolean {
-    return this.form().get('type')?.value === OrderType.OCO;
+    return this.isOcoOrder();
   }
 
   isFieldInvalid(fieldName: string): boolean {

--- a/libs/api-interfaces/src/lib/order/exchange-order-support.ts
+++ b/libs/api-interfaces/src/lib/order/exchange-order-support.ts
@@ -1,24 +1,35 @@
 import { ExchangeOrderTypeSupport, OrderType, TimeInForce } from './order.interface';
 
+/** Shared config for Binance US variants */
+const BINANCE_US_CONFIG = {
+  supportedTypes: [
+    OrderType.MARKET,
+    OrderType.LIMIT,
+    OrderType.STOP_LOSS,
+    OrderType.STOP_LIMIT,
+    OrderType.TAKE_PROFIT,
+    OrderType.OCO
+  ],
+  supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
+  hasOcoSupport: true,
+  hasTrailingStopSupport: false
+};
+
+/** Shared config for Coinbase Pro variants (coinbasepro, gdax, coinbaseexchange) */
+const COINBASE_PRO_CONFIG = {
+  supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
+  supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
+  hasOcoSupport: false,
+  hasTrailingStopSupport: false
+};
+
 /**
  * Exchange-specific order type support configuration
  * This is the single source of truth for what order types each exchange supports
  */
 export const EXCHANGE_ORDER_TYPE_SUPPORT: Record<string, ExchangeOrderTypeSupport> = {
-  binanceus: {
-    exchangeSlug: 'binanceus',
-    supportedTypes: [
-      OrderType.MARKET,
-      OrderType.LIMIT,
-      OrderType.STOP_LOSS,
-      OrderType.STOP_LIMIT,
-      OrderType.TAKE_PROFIT,
-      OrderType.OCO
-    ],
-    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC, TimeInForce.FOK],
-    hasOcoSupport: true,
-    hasTrailingStopSupport: false
-  },
+  binanceus: { exchangeSlug: 'binanceus', ...BINANCE_US_CONFIG },
+  binance_us: { exchangeSlug: 'binance_us', ...BINANCE_US_CONFIG },
   binance: {
     exchangeSlug: 'binance',
     supportedTypes: [
@@ -34,27 +45,10 @@ export const EXCHANGE_ORDER_TYPE_SUPPORT: Record<string, ExchangeOrderTypeSuppor
     hasOcoSupport: true,
     hasTrailingStopSupport: true
   },
-  coinbase: {
-    exchangeSlug: 'coinbase',
-    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
-    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
-    hasOcoSupport: false,
-    hasTrailingStopSupport: false
-  },
-  coinbasepro: {
-    exchangeSlug: 'coinbasepro',
-    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
-    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
-    hasOcoSupport: false,
-    hasTrailingStopSupport: false
-  },
-  coinbaseexchange: {
-    exchangeSlug: 'coinbaseexchange',
-    supportedTypes: [OrderType.MARKET, OrderType.LIMIT, OrderType.STOP_LOSS],
-    supportedTimeInForce: [TimeInForce.GTC, TimeInForce.IOC],
-    hasOcoSupport: false,
-    hasTrailingStopSupport: false
-  },
+  coinbase: { exchangeSlug: 'coinbase', ...COINBASE_PRO_CONFIG },
+  coinbasepro: { exchangeSlug: 'coinbasepro', ...COINBASE_PRO_CONFIG },
+  gdax: { exchangeSlug: 'gdax', ...COINBASE_PRO_CONFIG },
+  coinbaseexchange: { exchangeSlug: 'coinbaseexchange', ...COINBASE_PRO_CONFIG },
   kraken: {
     exchangeSlug: 'kraken',
     supportedTypes: [


### PR DESCRIPTION
## Summary
- Add dedicated OCO (One-Cancels-Other) order panel in the order form with take-profit/stop-loss inputs and a visual price diagram
- Group linked OCO orders in the active orders view with paired visual treatment and bulk cancel
- Show OCO link indicator on the transactions list with tooltip

## Changes

### Order Form
- Replace separate TP/SL fields with a unified OCO panel when OCO order type is selected
- Add mini price diagram showing TP → Current Price → SL relationship
- Extract `isOcoOrder()` and `isTakeProfitOnly()` helpers in order form component

### Active Orders
- Add `groupedOrders` computed signal that pairs OCO-linked orders into groups
- Render OCO pairs in a visually distinct wrapper with link icon and "Cancel Both Orders" button
- Extract shared `#orderCard` template to reduce duplication between paired and standalone cards

### Transactions
- Add OCO link icon with tooltip on orders that have `ocoLinkedOrderId`

### API & Shared Libs
- Add `ocoLinkedOrderId` field to `OrderResponseDto`
- Add `binance_us` and `gdax` exchange order support configs
- Refactor exchange-order-support with shared config constants (`BINANCE_US_CONFIG`, `COINBASE_PRO_CONFIG`)

### Tests
- Add unit tests for `ActiveOrdersComponent` OCO grouping logic (6 test cases)
- Add unit tests for `CryptoTradingComponent.cancelOcoPair` method (4 test cases)

## Test Plan
- [ ] Select OCO order type in order form — verify dedicated panel with TP/SL inputs and price diagram appears
- [ ] Place OCO orders — verify they appear grouped in active orders with link icon
- [ ] Cancel OCO pair — verify both orders are cancelled with single action
- [ ] Verify standalone orders still display and cancel individually
- [ ] Check transactions list shows link icon on OCO-linked orders
- [ ] Unit tests pass: `nx test chansey`