### PR TITLE
feat: add market limits and precision constraints to trading UI

### DIFF
--- a/apps/api/src/order/dto/order-preview.dto.ts
+++ b/apps/api/src/order/dto/order-preview.dto.ts
@@ -148,4 +148,19 @@ export class OrderPreviewDto {
     required: false
   })
   supportedOrderTypes?: OrderType[];
+
+  @ApiProperty({ description: 'Minimum order quantity', required: false })
+  minQuantity?: number;
+
+  @ApiProperty({ description: 'Maximum order quantity', required: false })
+  maxQuantity?: number;
+
+  @ApiProperty({ description: 'Minimum order value in quote currency', required: false })
+  minCost?: number;
+
+  @ApiProperty({ description: 'Quantity step size (precision)', required: false })
+  quantityStep?: number;
+
+  @ApiProperty({ description: 'Price step size (precision)', required: false })
+  priceStep?: number;
 }

--- a/apps/api/src/order/order.service.ts
+++ b/apps/api/src/order/order.service.ts
@@ -30,6 +30,7 @@ import { Exchange } from '../exchange/exchange.entity';
 import { ExchangeService } from '../exchange/exchange.service';
 import { mapCcxtError } from '../shared/ccxt-error-mapper.util';
 import { toErrorInfo } from '../shared/error.util';
+import { extractMarketLimits } from '../shared/precision.util';
 import { User } from '../users/users.entity';
 
 /** CCXT order creation parameters */
@@ -559,6 +560,13 @@ export class OrderService {
       const estimatedFee = estimatedCost * feeRate;
       const totalRequired = dto.side === OrderSide.BUY ? estimatedCost + estimatedFee : estimatedCost;
 
+      // Extract market limits
+      const extracted = extractMarketLimits(market, exchange.precisionMode);
+      const limits = {
+        ...extracted,
+        maxQuantity: market?.limits?.amount?.max ?? Infinity
+      };
+
       // Get user balance
       const balances = await exchange.fetchBalance();
       const [baseCurrency, quoteCurrency] = dto.symbol.split('/');
@@ -587,6 +595,21 @@ export class OrderService {
         warnings.push(
           `Insufficient ${balanceCurrency} balance. Available: ${availableBalance.toFixed(8)}, Required: ${required.toFixed(8)}`
         );
+      }
+
+      // Minimum quantity warning
+      if (limits.minQuantity > 0 && dto.quantity < limits.minQuantity) {
+        warnings.push(`Minimum quantity is ${limits.minQuantity} ${baseCurrency}`);
+      }
+
+      // Maximum quantity warning
+      if (limits.maxQuantity < Infinity && dto.quantity > limits.maxQuantity) {
+        warnings.push(`Maximum quantity is ${limits.maxQuantity} ${baseCurrency}`);
+      }
+
+      // Minimum notional (order value) warning
+      if (limits.minCost > 0 && estimatedCost < limits.minCost) {
+        warnings.push(`Minimum order value is ${limits.minCost} ${quoteCurrency}`);
       }
 
       // Calculate slippage for market orders
@@ -628,7 +651,12 @@ export class OrderService {
         estimatedSlippage,
         warnings,
         exchange: exchangeKey.exchange.name,
-        supportedOrderTypes
+        supportedOrderTypes,
+        minQuantity: limits.minQuantity > 0 ? limits.minQuantity : undefined,
+        maxQuantity: limits.maxQuantity < Infinity ? limits.maxQuantity : undefined,
+        minCost: limits.minCost > 0 ? limits.minCost : undefined,
+        quantityStep: limits.quantityStep > 0 ? limits.quantityStep : undefined,
+        priceStep: limits.priceStep > 0 ? limits.priceStep : undefined
       };
 
       return preview;

--- a/apps/api/src/shared/index.ts
+++ b/apps/api/src/shared/index.ts
@@ -2,6 +2,14 @@ export { cleanExchangeMessage, mapCcxtError } from './ccxt-error-mapper.util';
 export { LOCK_DEFAULTS, LOCK_KEYS, LOCK_REDIS_DB } from './distributed-lock.constants';
 export { DistributedLockService, LockInfo, LockOptions, LockResult } from './distributed-lock.service';
 export { isUniqueConstraintViolation, toErrorInfo } from './error.util';
+export {
+  CCXT_DECIMAL_PLACES,
+  CCXT_SIGNIFICANT_DIGITS,
+  CCXT_TICK_SIZE,
+  extractMarketLimits,
+  MarketLimitsResult,
+  precisionToStepSize
+} from './precision.util';
 export { LOCK_REDIS, lockRedisProvider } from './lock-redis.provider';
 export { forceRemoveJob } from './queue.util';
 export { SharedLockModule } from './shared-lock.module';

--- a/apps/api/src/shared/precision.util.spec.ts
+++ b/apps/api/src/shared/precision.util.spec.ts
@@ -1,0 +1,90 @@
+import {
+  CCXT_DECIMAL_PLACES,
+  CCXT_SIGNIFICANT_DIGITS,
+  CCXT_TICK_SIZE,
+  extractMarketLimits,
+  precisionToStepSize
+} from './precision.util';
+
+describe('precisionToStepSize', () => {
+  it('returns the value directly for TICK_SIZE mode', () => {
+    expect(precisionToStepSize(0.001, CCXT_TICK_SIZE)).toBe(0.001);
+    expect(precisionToStepSize(0.01, CCXT_TICK_SIZE)).toBe(0.01);
+    expect(precisionToStepSize(1, CCXT_TICK_SIZE)).toBe(1);
+  });
+
+  it.each([
+    [2, CCXT_DECIMAL_PLACES, 0.01],
+    [8, CCXT_DECIMAL_PLACES, 1e-8],
+    [0, CCXT_DECIMAL_PLACES, 1],
+    [3, CCXT_SIGNIFICANT_DIGITS, 0.001],
+    [1, CCXT_SIGNIFICANT_DIGITS, 0.1]
+  ])('converts count %d (mode %d) to step size %f', (value, mode, expected) => {
+    expect(precisionToStepSize(value, mode)).toBeCloseTo(expected);
+  });
+
+  it.each([null, undefined])('returns 0 when precision value is %s', (value) => {
+    expect(precisionToStepSize(value, CCXT_DECIMAL_PLACES)).toBe(0);
+    expect(precisionToStepSize(value, CCXT_TICK_SIZE)).toBe(0);
+  });
+
+  it.each([undefined, null, 999])('falls back to DECIMAL_PLACES when mode is %s', (mode) => {
+    expect(precisionToStepSize(2, mode)).toBeCloseTo(0.01);
+  });
+});
+
+describe('extractMarketLimits', () => {
+  it('returns zeroes for null/undefined market', () => {
+    const expected = { minQuantity: 0, maxQuantity: 0, minCost: 0, quantityStep: 0, priceStep: 0 };
+    expect(extractMarketLimits(null, CCXT_DECIMAL_PLACES)).toEqual(expected);
+    expect(extractMarketLimits(undefined, CCXT_TICK_SIZE)).toEqual(expected);
+  });
+
+  it('extracts limits using TICK_SIZE mode', () => {
+    const market = {
+      limits: { amount: { min: 0.001, max: 9000 }, cost: { min: 10 } },
+      precision: { amount: 0.001, price: 0.01 }
+    };
+    expect(extractMarketLimits(market, CCXT_TICK_SIZE)).toEqual({
+      minQuantity: 0.001,
+      maxQuantity: 9000,
+      minCost: 10,
+      quantityStep: 0.001,
+      priceStep: 0.01
+    });
+  });
+
+  it('extracts limits using DECIMAL_PLACES mode', () => {
+    const market = {
+      limits: { amount: { min: 0.01, max: 5000 }, cost: { min: 5 } },
+      precision: { amount: 3, price: 2 }
+    };
+    const result = extractMarketLimits(market, CCXT_DECIMAL_PLACES);
+    expect(result.minQuantity).toBe(0.01);
+    expect(result.maxQuantity).toBe(5000);
+    expect(result.minCost).toBe(5);
+    expect(result.quantityStep).toBeCloseTo(0.001);
+    expect(result.priceStep).toBeCloseTo(0.01);
+  });
+
+  it('preserves explicit 0 limits via nullish coalescing', () => {
+    const market = {
+      limits: { amount: { min: 0, max: 0 }, cost: { min: 0 } },
+      precision: { amount: 2, price: 2 }
+    };
+    const result = extractMarketLimits(market, CCXT_DECIMAL_PLACES);
+    expect(result.minQuantity).toBe(0);
+    expect(result.maxQuantity).toBe(0);
+    expect(result.minCost).toBe(0);
+  });
+
+  it('defaults missing nested keys to 0 without throwing', () => {
+    const market = { limits: { amount: { min: 1 } }, precision: {} };
+    const result = extractMarketLimits(market, CCXT_TICK_SIZE);
+    expect(result.minQuantity).toBe(1);
+    expect(result.maxQuantity).toBe(0);
+    expect(result.minCost).toBe(0);
+    expect(result.quantityStep).toBe(0);
+    expect(result.priceStep).toBe(0);
+  });
+});

--- a/apps/api/src/shared/precision.util.ts
+++ b/apps/api/src/shared/precision.util.ts
@@ -1,0 +1,56 @@
+/**
+ * CCXT precision mode constants.
+ * @see https://docs.ccxt.com/#/README?id=precision-mode
+ */
+export const CCXT_DECIMAL_PLACES = 2;
+export const CCXT_SIGNIFICANT_DIGITS = 3;
+export const CCXT_TICK_SIZE = 4;
+
+export interface MarketLimitsResult {
+  minQuantity: number;
+  maxQuantity: number;
+  minCost: number;
+  quantityStep: number;
+  priceStep: number;
+}
+
+/**
+ * Convert a CCXT precision value to a step size, respecting the exchange's precision mode.
+ *
+ * - TICK_SIZE (e.g. Binance): the value *is* the step (e.g. 0.001)
+ * - DECIMAL_PLACES / SIGNIFICANT_DIGITS: the value is a count → step = 10^(-n)
+ * - null / undefined: returns 0 (unknown)
+ */
+export function precisionToStepSize(
+  precisionValue: number | undefined | null,
+  precisionMode: number | undefined | null
+): number {
+  if (precisionValue == null) return 0;
+  if (precisionMode === CCXT_TICK_SIZE) return precisionValue;
+  if (precisionMode === CCXT_DECIMAL_PLACES || precisionMode === CCXT_SIGNIFICANT_DIGITS)
+    return Math.pow(10, -precisionValue);
+  // Unknown or missing mode — fall back to DECIMAL_PLACES behaviour
+  return Math.pow(10, -precisionValue);
+}
+
+/**
+ * Extract normalised market limits from a CCXT market object.
+ *
+ * @param market  - a CCXT market (may be undefined/null)
+ * @param precisionMode - `exchange.precisionMode` (TICK_SIZE | DECIMAL_PLACES | …)
+ */
+export function extractMarketLimits(
+  market:
+    | { limits?: Record<string, Record<string, number | undefined>>; precision?: Record<string, number | undefined> }
+    | undefined
+    | null,
+  precisionMode: number | undefined | null
+): MarketLimitsResult {
+  return {
+    minQuantity: market?.limits?.amount?.min ?? 0,
+    maxQuantity: market?.limits?.amount?.max ?? 0,
+    minCost: market?.limits?.cost?.min ?? 0,
+    quantityStep: precisionToStepSize(market?.precision?.amount, precisionMode),
+    priceStep: precisionToStepSize(market?.precision?.price, precisionMode)
+  };
+}

--- a/apps/api/src/trading/dto/index.ts
+++ b/apps/api/src/trading/dto/index.ts
@@ -1,3 +1,4 @@
+export * from './market-limits.dto';
 export * from './order-book.dto';
 export * from './ticker.dto';
 export * from './trading-balance.dto';

--- a/apps/api/src/trading/dto/market-limits.dto.ts
+++ b/apps/api/src/trading/dto/market-limits.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MarketLimitsDto {
+  @ApiProperty({ description: 'Minimum order quantity', example: 0.001 })
+  minQuantity: number;
+
+  @ApiProperty({ description: 'Maximum order quantity', example: 9000 })
+  maxQuantity: number;
+
+  @ApiProperty({ description: 'Minimum order value in quote currency', example: 10 })
+  minCost: number;
+
+  @ApiProperty({ description: 'Quantity step size (precision)', example: 0.00001 })
+  quantityStep: number;
+
+  @ApiProperty({ description: 'Price step size (precision)', example: 0.01 })
+  priceStep: number;
+}

--- a/apps/api/src/trading/trading.controller.ts
+++ b/apps/api/src/trading/trading.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, HttpStatus, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, HttpStatus, ParseUUIDPipe, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-import { OrderBookDto, TickerDto, TradingBalanceDto } from './dto';
+import { MarketLimitsDto, OrderBookDto, TickerDto, TradingBalanceDto } from './dto';
 import { TradingService } from './trading.service';
 
 import GetUser from '../authentication/decorator/get-user.decorator';
@@ -89,5 +89,36 @@ export class TradingController {
   })
   async getTicker(@Query('symbol') symbol: string, @Query('exchangeId') exchangeId?: string): Promise<TickerDto> {
     return this.tradingService.getTicker(symbol, exchangeId);
+  }
+
+  @Get('market-limits')
+  @ApiOperation({
+    summary: 'Get market limits for a trading pair',
+    description:
+      'Returns minimum/maximum quantity, minimum notional value, and precision for a trading pair on a specific exchange'
+  })
+  @ApiQuery({
+    name: 'symbol',
+    description: 'Trading pair symbol (e.g., BTC/USDT)',
+    required: true,
+    type: String
+  })
+  @ApiQuery({
+    name: 'exchangeKeyId',
+    description: 'Exchange key ID for the user',
+    required: true,
+    type: String
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully retrieved market limits',
+    type: MarketLimitsDto
+  })
+  async getMarketLimits(
+    @GetUser() user: User,
+    @Query('symbol') symbol: string,
+    @Query('exchangeKeyId', new ParseUUIDPipe()) exchangeKeyId: string
+  ): Promise<MarketLimitsDto> {
+    return this.tradingService.getMarketLimits(symbol, exchangeKeyId, user);
   }
 }

--- a/apps/api/src/trading/trading.module.ts
+++ b/apps/api/src/trading/trading.module.ts
@@ -5,10 +5,11 @@ import { TradingService } from './trading.service';
 
 import { BalanceModule } from '../balance/balance.module';
 import { CoinModule } from '../coin/coin.module';
+import { ExchangeKeyModule } from '../exchange/exchange-key/exchange-key.module';
 import { ExchangeModule } from '../exchange/exchange.module';
 
 @Module({
-  imports: [BalanceModule, CoinModule, ExchangeModule],
+  imports: [BalanceModule, CoinModule, ExchangeKeyModule, ExchangeModule],
   controllers: [TradingController],
   providers: [TradingService],
   exports: [TradingService]

--- a/apps/api/src/trading/trading.service.spec.ts
+++ b/apps/api/src/trading/trading.service.spec.ts
@@ -1,0 +1,476 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TradingService } from './trading.service';
+
+import { BalanceService } from '../balance/balance.service';
+import { CoinService } from '../coin/coin.service';
+import { ExchangeKeyService } from '../exchange/exchange-key/exchange-key.service';
+import { ExchangeManagerService } from '../exchange/exchange-manager.service';
+import { ExchangeService } from '../exchange/exchange.service';
+import { CCXT_DECIMAL_PLACES, CCXT_TICK_SIZE } from '../shared/precision.util';
+
+describe('TradingService', () => {
+  let service: TradingService;
+  let balanceService: jest.Mocked<BalanceService>;
+  let coinService: jest.Mocked<CoinService>;
+  let exchangeKeyService: jest.Mocked<ExchangeKeyService>;
+  let exchangeService: jest.Mocked<ExchangeService>;
+  let exchangeManagerService: jest.Mocked<ExchangeManagerService>;
+
+  const mockUser = { id: 'user-1' } as any;
+  const mockCoin = { id: 'coin-1', name: 'Bitcoin', symbol: 'BTC', slug: 'bitcoin' } as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradingService,
+        {
+          provide: BalanceService,
+          useValue: { getUserBalances: jest.fn() }
+        },
+        {
+          provide: CoinService,
+          useValue: { getCoinBySymbol: jest.fn() }
+        },
+        {
+          provide: ExchangeKeyService,
+          useValue: { findOne: jest.fn() }
+        },
+        {
+          provide: ExchangeService,
+          useValue: { findOne: jest.fn() }
+        },
+        {
+          provide: ExchangeManagerService,
+          useValue: { getExchangeService: jest.fn(), getPublicClient: jest.fn() }
+        }
+      ]
+    }).compile();
+
+    service = module.get(TradingService);
+    balanceService = module.get(BalanceService);
+    coinService = module.get(CoinService);
+    exchangeKeyService = module.get(ExchangeKeyService);
+    exchangeService = module.get(ExchangeService);
+    exchangeManagerService = module.get(ExchangeManagerService);
+  });
+
+  // ---------------------------------------------------------------------------
+  // getMarketLimits
+  // ---------------------------------------------------------------------------
+  describe('getMarketLimits', () => {
+    const exchangeKeyId = '00000000-0000-0000-0000-000000000001';
+
+    function setupMocks(opts: { market?: any; precisionMode?: number; exchangeKey?: any }) {
+      const { market, precisionMode = CCXT_DECIMAL_PLACES, exchangeKey } = opts;
+
+      exchangeKeyService.findOne.mockResolvedValue(
+        exchangeKey ?? {
+          id: exchangeKeyId,
+          exchange: { slug: 'binance_us', name: 'Binance US' }
+        }
+      );
+
+      const mockClient = {
+        markets: market !== undefined ? { 'BTC/USDT': market } : null,
+        precisionMode,
+        loadMarkets: jest.fn().mockImplementation(async function (this: any) {
+          this.markets = { 'BTC/USDT': market };
+        })
+      };
+
+      exchangeManagerService.getExchangeService.mockReturnValue({
+        getClient: jest.fn().mockResolvedValue(mockClient)
+      } as any);
+    }
+
+    it('returns limits for a valid symbol with DECIMAL_PLACES mode', async () => {
+      setupMocks({
+        market: {
+          limits: { amount: { min: 0.001, max: 9000 }, cost: { min: 10 } },
+          precision: { amount: 3, price: 2 }
+        },
+        precisionMode: CCXT_DECIMAL_PLACES
+      });
+
+      const result = await service.getMarketLimits('BTC/USDT', exchangeKeyId, mockUser);
+      expect(result.minQuantity).toBe(0.001);
+      expect(result.maxQuantity).toBe(9000);
+      expect(result.minCost).toBe(10);
+      expect(result.quantityStep).toBeCloseTo(0.001);
+      expect(result.priceStep).toBeCloseTo(0.01);
+    });
+
+    it('returns limits for a valid symbol with TICK_SIZE mode', async () => {
+      setupMocks({
+        market: {
+          limits: { amount: { min: 0.001, max: 9000 }, cost: { min: 10 } },
+          precision: { amount: 0.001, price: 0.01 }
+        },
+        precisionMode: CCXT_TICK_SIZE
+      });
+
+      const result = await service.getMarketLimits('BTC/USDT', exchangeKeyId, mockUser);
+      expect(result.quantityStep).toBe(0.001);
+      expect(result.priceStep).toBe(0.01);
+    });
+
+    it('throws NotFoundException when exchange key is not found', async () => {
+      exchangeKeyService.findOne.mockResolvedValue(null as any);
+
+      await expect(service.getMarketLimits('BTC/USDT', exchangeKeyId, mockUser)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException for unavailable symbol', async () => {
+      setupMocks({
+        market: {
+          limits: { amount: { min: 0.001 }, cost: { min: 10 } },
+          precision: { amount: 3, price: 2 }
+        }
+      });
+
+      await expect(service.getMarketLimits('ETH/USDT', exchangeKeyId, mockUser)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for invalid symbol format', async () => {
+      await expect(service.getMarketLimits('BTCUSDT', exchangeKeyId, mockUser)).rejects.toThrow(BadRequestException);
+    });
+
+    it('calls loadMarkets when client.markets is null', async () => {
+      const market = {
+        limits: { amount: { min: 0.01, max: 100 }, cost: { min: 1 } },
+        precision: { amount: 2, price: 2 }
+      };
+
+      exchangeKeyService.findOne.mockResolvedValue({
+        id: exchangeKeyId,
+        exchange: { slug: 'binance_us', name: 'Binance US' }
+      } as any);
+
+      const loadMarkets = jest.fn().mockImplementation(async function (this: any) {
+        this.markets = { 'BTC/USDT': market };
+      });
+
+      const mockClient = { markets: null, precisionMode: CCXT_DECIMAL_PLACES, loadMarkets };
+
+      exchangeManagerService.getExchangeService.mockReturnValue({
+        getClient: jest.fn().mockResolvedValue(mockClient)
+      } as any);
+
+      await service.getMarketLimits('BTC/USDT', exchangeKeyId, mockUser);
+      expect(loadMarkets).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTradingBalances
+  // ---------------------------------------------------------------------------
+  describe('getTradingBalances', () => {
+    function setupExchangeClient(balances: Record<string, any>) {
+      exchangeService.findOne.mockResolvedValue({ slug: 'binance_us', name: 'Binance US' } as any);
+      exchangeManagerService.getExchangeService.mockReturnValue({
+        getClient: jest.fn().mockResolvedValue({
+          fetchBalance: jest.fn().mockResolvedValue(balances)
+        })
+      } as any);
+    }
+
+    it('returns CCXT balances when exchangeId is provided', async () => {
+      setupExchangeClient({
+        BTC: { free: 1.5, used: 0.5, total: 2 },
+        info: {},
+        free: {},
+        used: {},
+        total: {}
+      });
+      coinService.getCoinBySymbol.mockResolvedValue(mockCoin);
+
+      const result = await service.getTradingBalances(mockUser, 'exchange-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        coin: { id: 'coin-1', name: 'Bitcoin', symbol: 'BTC', slug: 'bitcoin' },
+        available: 1.5,
+        locked: 0.5,
+        total: 2
+      });
+    });
+
+    it('skips CCXT meta keys (info, free, used, total, timestamp, datetime)', async () => {
+      setupExchangeClient({
+        BTC: { free: 1, used: 0, total: 1 },
+        info: { someData: true },
+        free: { BTC: 1 },
+        used: { BTC: 0 },
+        total: { BTC: 1 },
+        timestamp: 12345,
+        datetime: '2024-01-01'
+      });
+      coinService.getCoinBySymbol.mockResolvedValue(mockCoin);
+
+      const result = await service.getTradingBalances(mockUser, 'exchange-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].coin.symbol).toBe('BTC');
+    });
+
+    it('skips assets with zero or negative total balance', async () => {
+      setupExchangeClient({
+        BTC: { free: 0, used: 0, total: 0 },
+        ETH: { free: -1, used: 0, total: -1 }
+      });
+      coinService.getCoinBySymbol.mockResolvedValue(mockCoin);
+
+      const result = await service.getTradingBalances(mockUser, 'exchange-1');
+      expect(result).toHaveLength(0);
+    });
+
+    it('skips assets where coin is not found in database', async () => {
+      setupExchangeClient({
+        UNKNOWN: { free: 10, used: 0, total: 10 }
+      });
+      coinService.getCoinBySymbol.mockResolvedValue(null as any);
+
+      const result = await service.getTradingBalances(mockUser, 'exchange-1');
+      expect(result).toHaveLength(0);
+    });
+
+    it('falls back to DB balances when CCXT fetch fails', async () => {
+      exchangeService.findOne.mockRejectedValue(new Error('Exchange not found'));
+      balanceService.getUserBalances.mockResolvedValue({
+        current: [
+          {
+            id: 'exchange-1',
+            balances: [{ asset: 'BTC', free: '2.0', locked: '0.5' }]
+          }
+        ]
+      } as any);
+      coinService.getCoinBySymbol.mockResolvedValue(mockCoin);
+
+      const result = await service.getTradingBalances(mockUser, 'exchange-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].available).toBe(2);
+      expect(result[0].locked).toBe(0.5);
+      expect(result[0].total).toBe(2.5);
+    });
+
+    it('uses DB balances when no exchangeId is provided', async () => {
+      balanceService.getUserBalances.mockResolvedValue({
+        current: [
+          {
+            id: 'ex-1',
+            balances: [{ asset: 'BTC', free: '1.0', locked: '0.0' }]
+          }
+        ]
+      } as any);
+      coinService.getCoinBySymbol.mockResolvedValue(mockCoin);
+
+      const result = await service.getTradingBalances(mockUser);
+      expect(result).toHaveLength(1);
+      expect(result[0].total).toBe(1);
+    });
+
+    it('throws NotFoundException when exchangeId filter yields no results from DB', async () => {
+      balanceService.getUserBalances.mockResolvedValue({ current: [] } as any);
+
+      await expect(service.getTradingBalances(mockUser, 'nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getOrderBook
+  // ---------------------------------------------------------------------------
+  describe('getOrderBook', () => {
+    function setupPublicClient(overrides: Partial<Record<string, any>> = {}) {
+      const mockClient = {
+        markets: {
+          'BTC/USDT': { active: true, ...overrides.marketOverrides }
+        },
+        loadMarkets: jest.fn(),
+        fetchOrderBook: jest.fn().mockResolvedValue({
+          bids: [[50000, 1.5]],
+          asks: [[50100, 2.0]],
+          datetime: '2024-01-01T00:00:00Z',
+          ...overrides.orderBook
+        }),
+        ...overrides.client
+      };
+      exchangeManagerService.getPublicClient.mockResolvedValue(mockClient as any);
+      return mockClient;
+    }
+
+    it('returns mapped order book for a valid symbol', async () => {
+      setupPublicClient();
+
+      const result = await service.getOrderBook('BTC/USDT');
+
+      expect(result.bids).toHaveLength(1);
+      expect(result.bids[0]).toEqual({ price: 50000, quantity: 1.5, total: 75000 });
+      expect(result.asks).toHaveLength(1);
+      expect(result.asks[0]).toEqual({ price: 50100, quantity: 2.0, total: 100200 });
+      expect(result.lastUpdated).toEqual(new Date('2024-01-01T00:00:00Z'));
+    });
+
+    it('uses current date when datetime is missing', async () => {
+      setupPublicClient({ orderBook: { bids: [], asks: [], datetime: null } });
+
+      const before = Date.now();
+      const result = await service.getOrderBook('BTC/USDT');
+      const after = Date.now();
+
+      expect(result.lastUpdated.getTime()).toBeGreaterThanOrEqual(before);
+      expect(result.lastUpdated.getTime()).toBeLessThanOrEqual(after);
+    });
+
+    it('throws BadRequestException for invalid symbol format', async () => {
+      await expect(service.getOrderBook('BTCUSDT')).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when symbol is not available on exchange', async () => {
+      setupPublicClient();
+
+      await expect(service.getOrderBook('ETH/USDT')).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when market is suspended', async () => {
+      const mockClient = {
+        markets: { 'BTC/USDT': { active: false } },
+        loadMarkets: jest.fn(),
+        fetchOrderBook: jest.fn()
+      };
+      exchangeManagerService.getPublicClient.mockResolvedValue(mockClient as any);
+
+      await expect(service.getOrderBook('BTC/USDT')).rejects.toThrow(BadRequestException);
+    });
+
+    it('loads markets when not yet loaded', async () => {
+      const loadMarkets = jest.fn().mockImplementation(async function (this: any) {
+        this.markets = { 'BTC/USDT': { active: true } };
+      });
+      const mockClient = {
+        markets: null,
+        loadMarkets,
+        fetchOrderBook: jest.fn().mockResolvedValue({ bids: [], asks: [], datetime: null })
+      };
+      exchangeManagerService.getPublicClient.mockResolvedValue(mockClient as any);
+
+      await service.getOrderBook('BTC/USDT');
+      expect(loadMarkets).toHaveBeenCalled();
+    });
+
+    it('wraps non-BadRequestException errors', async () => {
+      const mockClient = {
+        markets: { 'BTC/USDT': { active: true } },
+        loadMarkets: jest.fn(),
+        fetchOrderBook: jest.fn().mockRejectedValue(new Error('Insufficient funds'))
+      };
+      exchangeManagerService.getPublicClient.mockResolvedValue(mockClient as any);
+
+      await expect(service.getOrderBook('BTC/USDT')).rejects.toThrow(BadRequestException);
+    });
+
+    it('uses specific exchange when exchangeId is provided', async () => {
+      exchangeService.findOne.mockResolvedValue({ slug: 'coinbase', name: 'Coinbase' } as any);
+      exchangeManagerService.getExchangeService.mockReturnValue({
+        getClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': { active: true } },
+          loadMarkets: jest.fn(),
+          fetchOrderBook: jest.fn().mockResolvedValue({ bids: [], asks: [], datetime: null })
+        })
+      } as any);
+
+      const result = await service.getOrderBook('BTC/USDT', 'exchange-1');
+      expect(result.bids).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTicker
+  // ---------------------------------------------------------------------------
+  describe('getTicker', () => {
+    function setupTicker(tickerData: Record<string, any> = {}) {
+      const mockClient = {
+        fetchTicker: jest.fn().mockResolvedValue({
+          last: 50000,
+          change: 500,
+          percentage: 1.01,
+          high: 51000,
+          low: 49000,
+          baseVolume: 1000,
+          quoteVolume: 50000000,
+          open: 49500,
+          previousClose: 49400,
+          datetime: '2024-01-01T00:00:00Z',
+          ...tickerData
+        })
+      };
+      exchangeManagerService.getPublicClient.mockResolvedValue(mockClient as any);
+      return mockClient;
+    }
+
+    it('returns all ticker fields when present', async () => {
+      setupTicker();
+
+      const result = await service.getTicker('BTC/USDT');
+
+      expect(result).toEqual({
+        symbol: 'BTC/USDT',
+        price: 50000,
+        priceChange: 500,
+        priceChangePercent: 1.01,
+        high24h: 51000,
+        low24h: 49000,
+        volume24h: 1000,
+        quoteVolume24h: 50000000,
+        openPrice: 49500,
+        prevClosePrice: 49400,
+        lastUpdated: new Date('2024-01-01T00:00:00Z')
+      });
+    });
+
+    it('returns undefined for null optional fields', async () => {
+      setupTicker({
+        change: null,
+        percentage: null,
+        high: null,
+        low: null,
+        baseVolume: null,
+        quoteVolume: null,
+        open: null,
+        previousClose: null
+      });
+
+      const result = await service.getTicker('BTC/USDT');
+
+      expect(result.price).toBe(50000);
+      expect(result.priceChange).toBeUndefined();
+      expect(result.priceChangePercent).toBeUndefined();
+      expect(result.high24h).toBeUndefined();
+      expect(result.low24h).toBeUndefined();
+      expect(result.volume24h).toBeUndefined();
+      expect(result.quoteVolume24h).toBeUndefined();
+      expect(result.openPrice).toBeUndefined();
+      expect(result.prevClosePrice).toBeUndefined();
+    });
+
+    it('defaults price to 0 when last is null', async () => {
+      setupTicker({ last: null });
+
+      const result = await service.getTicker('BTC/USDT');
+      expect(result.price).toBe(0);
+    });
+
+    it('throws BadRequestException for invalid symbol format', async () => {
+      await expect(service.getTicker('BTCUSDT')).rejects.toThrow(BadRequestException);
+    });
+
+    it('re-throws errors from exchange', async () => {
+      const mockClient = {
+        fetchTicker: jest.fn().mockRejectedValue(new Error('Exchange down'))
+      };
+      exchangeManagerService.getPublicClient.mockResolvedValue(mockClient as any);
+
+      await expect(service.getTicker('BTC/USDT')).rejects.toThrow('Exchange down');
+    });
+  });
+});

--- a/apps/api/src/trading/trading.service.ts
+++ b/apps/api/src/trading/trading.service.ts
@@ -2,15 +2,17 @@ import { BadRequestException, Injectable, Logger, NotFoundException } from '@nes
 
 import * as ccxt from 'ccxt';
 
-import { OrderBookDto, TickerDto, TradingBalanceDto } from './dto';
+import { MarketLimitsDto, OrderBookDto, TickerDto, TradingBalanceDto } from './dto';
 
 import { BalanceService } from '../balance/balance.service';
 import { Coin } from '../coin/coin.entity';
 import { CoinService } from '../coin/coin.service';
 import { CCXT_BALANCE_META_KEYS } from '../exchange/ccxt-balance.util';
+import { ExchangeKeyService } from '../exchange/exchange-key/exchange-key.service';
 import { ExchangeManagerService } from '../exchange/exchange-manager.service';
 import { ExchangeService } from '../exchange/exchange.service';
 import { toErrorInfo } from '../shared/error.util';
+import { extractMarketLimits } from '../shared/precision.util';
 import { withRateLimitRetryThrow } from '../shared/retry.util';
 import { User } from '../users/users.entity';
 
@@ -22,6 +24,7 @@ export class TradingService {
   constructor(
     private readonly balanceService: BalanceService,
     private readonly coinService: CoinService,
+    private readonly exchangeKeyService: ExchangeKeyService,
     private readonly exchangeService: ExchangeService,
     private readonly exchangeManagerService: ExchangeManagerService
   ) {}
@@ -124,6 +127,32 @@ export class TradingService {
     }
   }
 
+  async getMarketLimits(symbol: string, exchangeKeyId: string, user: User): Promise<MarketLimitsDto> {
+    this.validateSymbol(symbol);
+
+    const exchangeKey = await this.exchangeKeyService.findOne(exchangeKeyId, user.id);
+    if (!exchangeKey?.exchange) {
+      throw new NotFoundException('Exchange key not found');
+    }
+
+    const service = this.exchangeManagerService.getExchangeService(exchangeKey.exchange.slug);
+    const client = await service.getClient(user);
+
+    if (!client.markets) {
+      await withRateLimitRetryThrow(() => client.loadMarkets(), {
+        logger: this.logger,
+        operationName: 'loadMarkets'
+      });
+    }
+
+    const market = client.markets[symbol];
+    if (!market) {
+      throw new BadRequestException(`Trading pair ${symbol} is not available on ${exchangeKey.exchange.name}`);
+    }
+
+    return extractMarketLimits(market, client.precisionMode);
+  }
+
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
@@ -143,7 +172,7 @@ export class TradingService {
         const exchange = await this.exchangeService.findOne(exchangeId);
         const service = this.exchangeManagerService.getExchangeService(exchange.slug);
         return { client: await service.getClient(), name: exchange.name };
-      } catch (error: unknown) {
+      } catch (_error: unknown) {
         this.logger.warn(`Failed to get exchange client for ${exchangeId}, falling back to public client`);
       }
     }

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.html
@@ -235,6 +235,7 @@
               [hasSufficientBalance]="buyHasSufficientBalance()"
               [fallbackTotal]="buyTotalWithFees()"
               [fallbackNet]="0"
+              [marketLimits]="marketLimits()"
               (submitOrder)="onSubmitOrder('BUY')"
               (percentageChange)="onBuyPercentageChange($event)"
             />
@@ -254,6 +255,7 @@
               [hasSufficientBalance]="sellHasSufficientBalance()"
               [fallbackTotal]="0"
               [fallbackNet]="sellNetAmount()"
+              [marketLimits]="marketLimits()"
               (submitOrder)="onSubmitOrder('SELL')"
               (percentageChange)="onSellPercentageChange($event)"
             />

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.spec.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.spec.ts
@@ -68,11 +68,14 @@ const createOrderResult = createMockMutationResult();
 const previewOrderResult = createMockMutationResult();
 const cancelOrderResult = createMockMutationResult();
 
+const marketLimitsResult = createMockQueryResult<any>(null);
+
 const mockTradingQueryService = {
   useTradingPairs: jest.fn(() => tradingPairsResult),
   useBalances: jest.fn(() => balancesResult),
   useActiveOrders: jest.fn(() => activeOrdersResult),
-  useOrderBook: jest.fn(() => orderBookResult)
+  useOrderBook: jest.fn(() => orderBookResult),
+  useMarketLimits: jest.fn(() => marketLimitsResult)
 };
 
 const mockTradingMutationService = {

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
@@ -16,6 +16,7 @@ import { debounceTime, Subject, takeUntil } from 'rxjs';
 import {
   Exchange,
   ExchangeKey,
+  MarketLimits,
   OrderPreview,
   OrderSide,
   OrderType,
@@ -151,6 +152,9 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
     return userExchange?.id || null;
   });
 
+  marketLimitsQuery = this.tradingQueryService.useMarketLimits(this.selectedSymbol, this.selectedExchangeKeyId);
+  marketLimits = computed<MarketLimits | null>(() => this.marketLimitsQuery.data() ?? null);
+
   exchangeOptions = computed(() => {
     const supportedExchanges = this.exchangeQuery.data();
     const userExchanges = this.userQuery.data()?.exchanges;
@@ -227,6 +231,14 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
         this.showOrderBook.set(true);
       }
     });
+
+    effect(() => {
+      const limits = this.marketLimits();
+      if (limits && this.buyOrderForm && this.sellOrderForm) {
+        this.applyMarketLimitsValidators(this.buyOrderForm, limits);
+        this.applyMarketLimitsValidators(this.sellOrderForm, limits);
+      }
+    });
   }
 
   ngOnInit() {
@@ -247,7 +259,7 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
   onPairChange(event: { value: string }) {
     const symbol = event.value;
     this.selectedPairValue.set(symbol);
-    const pair = this.tradingPairsQuery.data()?.find((p) => p.symbol.toUpperCase() === symbol.toUpperCase());
+    const pair = this.tradingPairsQuery.data()?.find((p) => p.symbol?.toUpperCase() === symbol?.toUpperCase());
     if (pair) {
       this.tradingStateService.setSelectedPair(pair);
       this.triggerPreview('BUY');
@@ -526,6 +538,18 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
         /* Preview failures are non-critical */
       }
     });
+  }
+
+  private applyMarketLimitsValidators(form: FormGroup, limits: MarketLimits) {
+    const quantityControl = form.get('quantity');
+    if (!quantityControl) return;
+
+    const validators = [Validators.required, Validators.min(limits.minQuantity > 0 ? limits.minQuantity : 0.00000001)];
+    if (limits.maxQuantity > 0) {
+      validators.push(Validators.max(limits.maxQuantity));
+    }
+    quantityControl.setValidators(validators);
+    quantityControl.updateValueAndValidity({ emitEvent: false });
   }
 
   private setQuantityPercentage(side: 'BUY' | 'SELL', percentage: number) {

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.html
@@ -45,7 +45,8 @@
         formControlName="quantity"
         mode="decimal"
         [minFractionDigits]="2"
-        [maxFractionDigits]="8"
+        [maxFractionDigits]="marketLimits()?.quantityStep ? countDecimals(marketLimits()!.quantityStep) : 8"
+        [step]="marketLimits()?.quantityStep && marketLimits()!.quantityStep > 0 ? marketLimits()!.quantityStep : 1"
         class="w-full"
         [class.ng-invalid]="isFieldInvalid('quantity')"
         [class.ng-dirty]="isFieldInvalid('quantity')"
@@ -59,6 +60,20 @@
     </p-floatlabel>
     @if (isFieldInvalid('quantity')) {
       <small class="p-error" role="alert">{{ getFieldError('quantity') }}</small>
+    }
+    @if (marketLimits()?.minQuantity || marketLimits()?.minCost) {
+      <div class="mt-1 text-xs text-surface-400">
+        @if (marketLimits()?.minQuantity) {
+          Min: {{ marketLimits()?.minQuantity }} {{ selectedPair()?.baseAsset?.symbol | uppercase }}
+        }
+        @if (marketLimits()?.minQuantity && marketLimits()?.minCost) {
+          &middot;
+        }
+        @if (marketLimits()?.minCost) {
+          Min value: {{ marketLimits()?.minCost | number: '1.2-2' }}
+          {{ selectedPair()?.quoteAsset?.symbol | uppercase }}
+        }
+      </div>
     }
     <!-- Percentage Buttons -->
     <div>
@@ -85,7 +100,8 @@
           formControlName="price"
           mode="decimal"
           [minFractionDigits]="2"
-          [maxFractionDigits]="8"
+          [maxFractionDigits]="marketLimits()?.priceStep ? countDecimals(marketLimits()!.priceStep) : 8"
+          [step]="marketLimits()?.priceStep && marketLimits()!.priceStep > 0 ? marketLimits()!.priceStep : 1"
           class="w-full"
           [class.ng-invalid]="isFieldInvalid('price')"
           [class.ng-dirty]="isFieldInvalid('price')"
@@ -364,13 +380,26 @@
     }
   </div>
 
+  @if (isBelowMinCost()) {
+    <p-message severity="warn" size="small">
+      Order value is below the minimum of {{ marketLimits()?.minCost }}
+      {{ selectedPair()?.quoteAsset?.symbol | uppercase }}
+    </p-message>
+  }
+
   <p-button
     type="submit"
     [label]="buttonLabel()"
     [icon]="buttonIcon()"
     [severity]="buttonSeverity()"
     styleClass="w-full"
-    [disabled]="form().invalid || isSubmitting() || !selectedPair() || (orderPreview() && !hasSufficientBalance())"
+    [disabled]="
+      form().invalid ||
+      isSubmitting() ||
+      !selectedPair() ||
+      (orderPreview() && !hasSufficientBalance()) ||
+      isBelowMinCost()
+    "
     [loading]="isSubmitting()"
   />
 </form>

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.ts
@@ -9,7 +9,7 @@ import { MessageModule } from 'primeng/message';
 import { SelectModule } from 'primeng/select';
 import { SelectButtonModule } from 'primeng/selectbutton';
 
-import { OrderPreview, OrderType, TickerPair, TrailingType } from '@chansey/api-interfaces';
+import { MarketLimits, OrderPreview, OrderType, TickerPair, TrailingType } from '@chansey/api-interfaces';
 
 @Component({
   selector: 'app-order-form',
@@ -42,6 +42,7 @@ export class OrderFormComponent {
   hasSufficientBalance = input.required<boolean>();
   fallbackTotal = input.required<number>();
   fallbackNet = input.required<number>();
+  marketLimits = input<MarketLimits | null>(null);
 
   // Outputs
   submitOrder = output<void>();
@@ -49,6 +50,21 @@ export class OrderFormComponent {
 
   // Derived from side
   isBuy = computed(() => this.side() === 'BUY');
+
+  isBelowMinCost = computed(() => {
+    const limits = this.marketLimits();
+    const pair = this.selectedPair();
+    const quantity = this.form().get('quantity')?.value;
+    if (!limits?.minCost || !quantity) return false;
+
+    const orderType = this.form().get('type')?.value;
+    const customPrice = this.form().get('price')?.value;
+    const useLimitPrice = (orderType === OrderType.LIMIT || orderType === OrderType.STOP_LIMIT) && customPrice > 0;
+    const price = useLimitPrice ? customPrice : pair?.currentPrice;
+    if (!price) return false;
+
+    return quantity * price < limits.minCost;
+  });
 
   // Color theme classes derived from side
   summaryBorderClass = computed(() =>
@@ -122,10 +138,31 @@ export class OrderFormComponent {
     if (field.errors['required']) return 'This field is required';
     if (field.errors['min']) {
       const minValue = field.errors['min'].min;
+      if (fieldName === 'quantity' && this.marketLimits()?.minQuantity) {
+        const symbol = this.selectedPair()?.baseAsset?.symbol?.toUpperCase() || '';
+        return `Minimum is ${minValue} ${symbol}`;
+      }
       const formatted = minValue < 0.0001 ? minValue.toFixed(8) : minValue;
       return `Minimum value is ${formatted}`;
     }
+    if (field.errors['max']) {
+      const maxValue = field.errors['max'].max;
+      if (fieldName === 'quantity' && this.marketLimits()?.maxQuantity) {
+        const symbol = this.selectedPair()?.baseAsset?.symbol?.toUpperCase() || '';
+        return `Maximum is ${maxValue} ${symbol}`;
+      }
+      return `Maximum value is ${maxValue}`;
+    }
     return 'Invalid value';
+  }
+
+  countDecimals(value: number): number {
+    if (Math.floor(value) === value || !isFinite(value)) return 0;
+    const s = String(value);
+    if (s.includes('e-')) {
+      return parseInt(s.split('e-')[1], 10);
+    }
+    return s.split('.')[1]?.length || 0;
   }
 
   onSubmit(): void {

--- a/apps/chansey/src/app/shared/services/trading/trading-query.service.ts
+++ b/apps/chansey/src/app/shared/services/trading/trading-query.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Signal } from '@angular/core';
 
-import { Balance, Order, OrderStatus, TickerPair } from '@chansey/api-interfaces';
+import { Balance, MarketLimits, Order, OrderStatus, TickerPair } from '@chansey/api-interfaces';
 import { FREQUENT_POLICY, queryKeys, STANDARD_POLICY, TIME, useAuthQuery } from '@chansey/shared';
 
 import { OrderBook } from './trading.types';
@@ -109,6 +109,21 @@ export class TradingQueryService {
         refetchOnWindowFocus: false,
         retry: 2
       }
+    });
+  }
+
+  /**
+   * Get market limits for a trading pair on a specific exchange
+   */
+  useMarketLimits(symbol: Signal<string | null>, exchangeKeyId: Signal<string | null>) {
+    return useAuthQuery<MarketLimits>(() => {
+      const sym = symbol();
+      const keyId = exchangeKeyId();
+      return {
+        queryKey: queryKeys.trading.marketLimits(sym, keyId),
+        url: `/api/trading/market-limits?symbol=${encodeURIComponent(sym || '')}&exchangeKeyId=${keyId}`,
+        options: { cachePolicy: STANDARD_POLICY, enabled: !!sym && !!keyId }
+      };
     });
   }
 

--- a/libs/api-interfaces/src/lib/order/order.interface.ts
+++ b/libs/api-interfaces/src/lib/order/order.interface.ts
@@ -188,6 +188,14 @@ export interface OrderSyncStatus {
   hasActiveExchangeKeys: boolean;
 }
 
+export interface MarketLimits {
+  minQuantity: number;
+  maxQuantity: number;
+  minCost: number;
+  quantityStep: number;
+  priceStep: number;
+}
+
 export interface OrderPreview {
   symbol: string;
   side: OrderSide;
@@ -211,6 +219,11 @@ export interface OrderPreview {
   warnings: string[];
   exchange: string;
   supportedOrderTypes?: OrderType[];
+  minQuantity?: number;
+  maxQuantity?: number;
+  minCost?: number;
+  quantityStep?: number;
+  priceStep?: number;
 }
 
 /**

--- a/libs/shared/src/lib/query/query-keys.ts
+++ b/libs/shared/src/lib/query/query-keys.ts
@@ -195,7 +195,9 @@ export const queryKeys = {
     ticker: (symbol: string, exchangeId?: string) =>
       exchangeId
         ? ([...queryKeys.trading.all, 'ticker', symbol, exchangeId] as const)
-        : ([...queryKeys.trading.all, 'ticker', symbol] as const)
+        : ([...queryKeys.trading.all, 'ticker', symbol] as const),
+    marketLimits: (symbol?: string | null, exchangeKeyId?: string | null) =>
+      [...queryKeys.trading.all, 'market-limits', symbol ?? '', exchangeKeyId ?? ''] as const
   },
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `GET /trading/market-limits` endpoint to fetch min/max quantity, min cost, and step sizes from exchange via CCXT
- Apply dynamic form validators and input precision based on exchange-reported limits
- Display min quantity and min notional hints in order form with warnings when below minimums

## Changes

### API
- **Trading endpoint**: New `GET /trading/market-limits` endpoint returning exchange market limits via CCXT
- **Market limits DTO**: `MarketLimitsDto` with min/max quantity, min cost, and step sizes
- **Order preview**: Added market limit fields to `OrderPreviewDto` with quantity/cost validation warnings
- **Precision util**: New `precision.util.ts` with unit tests for consistent decimal handling
- **Trading service tests**: Comprehensive test suite (476 lines) covering market limits and order preview

### Frontend
- **Order form**: Dynamic validators, step precision, and min quantity/notional hints from exchange limits
- **Crypto trading component**: Wired up `useMarketLimits` TanStack Query for real-time limit data
- **Warning display**: Inline warning message and disabled submit when below minimum cost
- **Shared interfaces**: `MarketLimits` interface and query key for frontend caching

### Shared
- **api-interfaces**: Added `MarketLimits` interface to shared library
- **query-keys**: Added market limits query key

## Test Plan

- [ ] `GET /trading/market-limits?exchange=binance&symbol=BTC/USDT` returns valid limits
- [ ] Order form shows min quantity and min cost hints
- [ ] Submit button disabled when order is below minimum cost
- [ ] Input step size matches exchange precision rules
- [ ] Order preview includes limit warnings when applicable
- [ ] Unit tests pass: `nx test api` and `nx test chansey`