### PR TITLE
feat: polish trading UI with depth bars, validation, and accessibility

### DIFF
--- a/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.html
@@ -1,11 +1,11 @@
 <!-- Shared order card template -->
 <ng-template #orderCard let-order>
-  <!-- Header: Symbol + Side + Status -->
+  <!-- Header: Symbol + Side + Type + Status -->
   <div class="mb-2 flex items-center justify-between">
     <div class="flex items-center gap-2">
       <span class="text-sm font-bold text-surface-900 dark:text-surface-50">{{ order.symbol }}</span>
       <span
-        class="rounded-md px-1.5 py-0.5 text-[11px] font-bold uppercase"
+        class="rounded-md px-1.5 py-0.5 text-xs font-bold uppercase"
         [ngClass]="{
           'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300': order.side === 'BUY',
           'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300': order.side === 'SELL'
@@ -13,9 +13,14 @@
       >
         {{ order.side }}
       </span>
+      <span
+        class="rounded-md bg-surface-100 px-1.5 py-0.5 text-xs font-medium text-surface-600 dark:bg-surface-600 dark:text-surface-300"
+      >
+        {{ formatOrderType(order.type) }}
+      </span>
     </div>
-    <span class="rounded-full px-2 py-0.5 text-[11px] font-semibold" [class]="getStatusClass(order.status)">
-      {{ order.status }}
+    <span class="rounded-full px-2 py-0.5 text-xs font-semibold" [class]="getStatusClass(order.status)">
+      {{ formatStatus(order.status) }}
     </span>
   </div>
   <!-- Details -->
@@ -60,6 +65,8 @@
       <div class="flex items-center gap-1">
         <span
           class="rounded-full bg-primary-100 px-2 py-0.5 text-xs font-bold text-primary-700 dark:bg-primary-800 dark:text-primary-200"
+          aria-live="polite"
+          [attr.aria-label]="orders().length + ' active orders'"
         >
           {{ orders().length }}
         </span>
@@ -70,25 +77,36 @@
           size="small"
           (click)="refresh.emit()"
           [loading]="isRefreshing()"
+          ariaLabel="Refresh active orders"
         />
       </div>
     </div>
     @if (isVisible()) {
-      <div class="space-y-2.5 px-4 pb-4">
+      <div class="space-y-2.5 px-4 pb-4" role="list" aria-label="Active orders list">
         @for (group of groupedOrders(); track trackByGroupId($index, group)) {
           @if (group.type === 'oco-pair') {
             <!-- OCO Pair Wrapper -->
             <div
-              class="rounded-xl border-2 border-primary-200 bg-primary-50/30 p-2.5 dark:border-primary-800 dark:bg-primary-900/10"
+              role="listitem"
+              class="rounded-xl border-2 border-primary-200 bg-primary-50/30 p-3 dark:border-primary-800 dark:bg-primary-900/10"
             >
               <div class="mb-2 flex items-center gap-1.5 px-1">
                 <i class="pi pi-link text-xs text-primary-600 dark:text-primary-400" aria-hidden="true"></i>
-                <span class="text-xs font-semibold text-primary-700 dark:text-primary-300">Linked OCO Pair</span>
+                <span
+                  class="text-xs font-semibold text-primary-700 dark:text-primary-300"
+                  pTooltip="These two orders are linked — when one fills, the other is automatically canceled."
+                  tooltipPosition="top"
+                  >Linked Pair</span
+                >
               </div>
               <div class="space-y-2">
                 @for (order of group.orders; track trackByOrderId($index, order)) {
                   <div
-                    class="rounded-lg border border-surface-200 bg-white p-3 dark:border-surface-600 dark:bg-surface-700"
+                    class="rounded-lg border border-surface-200 bg-surface-0 p-2.5 dark:border-surface-600 dark:bg-surface-700"
+                    [ngClass]="{
+                      'border-l-3 border-l-green-500 dark:border-l-green-400': order.side === 'BUY',
+                      'border-l-3 border-l-red-500 dark:border-l-red-400': order.side === 'SELL'
+                    }"
                   >
                     <ng-container *ngTemplateOutlet="orderCard; context: { $implicit: order }"></ng-container>
                   </div>
@@ -100,31 +118,40 @@
                   icon="pi pi-times"
                   label="Cancel Both Orders"
                   severity="danger"
-                  [text]="true"
+                  [outlined]="true"
                   size="small"
                   (click)="onCancelOcoPair(group.orders)"
                   [disabled]="isCancelling()"
                   styleClass="w-full"
+                  [attr.aria-label]="'Cancel linked ' + group.orders[0].symbol + ' orders'"
                 />
               </div>
             </div>
           } @else {
             <!-- Standalone Order -->
-            <div class="rounded-xl border border-surface-200 bg-white p-3 dark:border-surface-600 dark:bg-surface-700">
-              <div class="mb-3">
-                <ng-container *ngTemplateOutlet="orderCard; context: { $implicit: group.orders[0] }"></ng-container>
-              </div>
+            <div
+              role="listitem"
+              class="rounded-xl border border-surface-200 bg-surface-0 p-3 dark:border-surface-600 dark:bg-surface-700"
+              [ngClass]="{
+                'border-l-3 border-l-green-500 dark:border-l-green-400': group.orders[0].side === 'BUY',
+                'border-l-3 border-l-red-500 dark:border-l-red-400': group.orders[0].side === 'SELL'
+              }"
+            >
+              <ng-container *ngTemplateOutlet="orderCard; context: { $implicit: group.orders[0] }"></ng-container>
               <!-- Cancel -->
-              <p-button
-                icon="pi pi-times"
-                label="Cancel Order"
-                severity="danger"
-                [text]="true"
-                size="small"
-                (click)="cancelOrder.emit(group.orders[0].id)"
-                [disabled]="isCancelling()"
-                styleClass="w-full"
-              />
+              <div class="mt-2">
+                <p-button
+                  icon="pi pi-times"
+                  label="Cancel Order"
+                  severity="danger"
+                  [outlined]="true"
+                  size="small"
+                  (click)="cancelOrder.emit(group.orders[0].id)"
+                  [disabled]="isCancelling()"
+                  styleClass="w-full"
+                  [attr.aria-label]="'Cancel ' + group.orders[0].symbol + ' order'"
+                />
+              </div>
             </div>
           }
         }

--- a/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/active-orders/active-orders.component.ts
@@ -2,10 +2,11 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { Order } from '@chansey/api-interfaces';
 
-import { getStatusClass } from '../crypto-trading.utils';
+import { formatOrderType, formatStatus, getStatusClass } from '../crypto-trading.utils';
 
 export interface GroupedOrder {
   type: 'oco-pair' | 'standalone';
@@ -16,7 +17,7 @@ export interface GroupedOrder {
 @Component({
   selector: 'app-active-orders',
   standalone: true,
-  imports: [CommonModule, ButtonModule],
+  imports: [CommonModule, ButtonModule, TooltipModule],
   templateUrl: './active-orders.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -32,6 +33,8 @@ export class ActiveOrdersComponent {
   refresh = output();
 
   readonly getStatusClass = getStatusClass;
+  readonly formatOrderType = formatOrderType;
+  readonly formatStatus = formatStatus;
 
   groupedOrders = computed<GroupedOrder[]>(() => {
     const orders = this.orders();

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.component.ts
@@ -687,19 +687,22 @@ export class CryptoTradingComponent implements OnInit, OnDestroy {
 
     if (limits.priceStep > 0) {
       this.applyPriceStepValidator(form, limits.priceStep);
-      form.get('price')?.updateValueAndValidity({ emitEvent: false });
     }
   }
 
   private applyPriceStepValidator(form: FormGroup, priceStep: number): void {
-    const priceControl = form.get('price');
-    if (!priceControl || priceStep <= 0) return;
-    const validators: ValidatorFn[] = [];
-    if (priceControl.hasValidator(Validators.required)) {
-      validators.push(Validators.required, Validators.min(0.00000001));
+    if (priceStep <= 0) return;
+    const priceControls = ['price', 'stopPrice', 'takeProfitPrice', 'stopLossPrice'];
+    for (const name of priceControls) {
+      const control = form.get(name);
+      if (!control) continue;
+      const validators: ValidatorFn[] = [Validators.min(0.00000001), stepSizeValidator(priceStep)];
+      if (control.hasValidator(Validators.required)) {
+        validators.unshift(Validators.required);
+      }
+      control.setValidators(validators);
+      control.updateValueAndValidity({ emitEvent: false });
     }
-    validators.push(stepSizeValidator(priceStep));
-    priceControl.setValidators(validators);
   }
 
   private setQuantityPercentage(side: 'BUY' | 'SELL', percentage: number) {

--- a/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.utils.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/crypto-trading.utils.ts
@@ -78,11 +78,12 @@ export function findBalance(
 export function getAvailableBuyBalance(
   balances: Balance[] | undefined,
   pair: TickerPair | null,
-  preview: OrderPreview | null
+  preview: OrderPreview | null,
+  orderType?: OrderType
 ): number {
   const balance = findBalance(balances, pair, 'BUY');
   if (!balance) return 0;
-  const feeRate = getFeeRate(preview);
+  const feeRate = orderType ? getFeeRateForOrderType(orderType, preview) : getFeeRate(preview);
   return new Decimal(balance.available).div(new Decimal(1).plus(new Decimal(feeRate))).toNumber();
 }
 
@@ -124,6 +125,32 @@ export function getStatusClass(status: OrderStatus): string {
     [OrderStatus.EXPIRED]: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200'
   };
   return classes[status] || 'bg-gray-100 text-gray-800';
+}
+
+export function formatOrderType(type: OrderType): string {
+  const labels: Record<OrderType, string> = {
+    [OrderType.MARKET]: 'Market',
+    [OrderType.LIMIT]: 'Limit',
+    [OrderType.STOP_LOSS]: 'Stop Loss',
+    [OrderType.STOP_LIMIT]: 'Stop Limit',
+    [OrderType.TRAILING_STOP]: 'Trailing Stop',
+    [OrderType.TAKE_PROFIT]: 'Take Profit',
+    [OrderType.OCO]: 'OCO'
+  };
+  return labels[type] || type;
+}
+
+export function formatStatus(status: OrderStatus): string {
+  const labels: Record<OrderStatus, string> = {
+    [OrderStatus.NEW]: 'New',
+    [OrderStatus.PARTIALLY_FILLED]: 'Partial Fill',
+    [OrderStatus.FILLED]: 'Filled',
+    [OrderStatus.CANCELED]: 'Canceled',
+    [OrderStatus.PENDING_CANCEL]: 'Canceling',
+    [OrderStatus.REJECTED]: 'Rejected',
+    [OrderStatus.EXPIRED]: 'Expired'
+  };
+  return labels[status] || status;
 }
 
 export function trackByPrice(_index: number, item: OrderBookEntry) {

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-book/order-book.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-book/order-book.component.html
@@ -1,7 +1,7 @@
 @if (orderBookData()) {
-  <div class="mt-6 rounded-xl border border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800">
+  <div class="mt-5 rounded-xl border border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800">
     @if (isVisible()) {
-      <div class="flex items-center justify-between px-4 pt-3 pb-1">
+      <div class="flex min-h-[44px] items-center justify-between px-4 pt-3 pb-1">
         <span class="font-display text-sm font-bold tracking-tight text-surface-700 dark:text-surface-200">
           Order Book
         </span>
@@ -12,70 +12,103 @@
           size="small"
           (click)="refresh.emit()"
           [loading]="isRefreshing()"
+          ariaLabel="Refresh order book"
         />
       </div>
-      <div class="grid grid-cols-2 gap-4 px-4 pb-4">
-        <!-- Asks (Sell orders) -->
-        <div>
-          <div class="mb-1 text-[11px] font-bold tracking-wider text-red-500 uppercase dark:text-red-400">
-            Sell Orders
+      @if (topAsks().length || topBids().length) {
+        <div class="grid grid-cols-2 gap-4 px-4 pb-4">
+          <!-- Asks (Sell orders) -->
+          <div>
+            <div class="mb-1 text-[11px] font-bold tracking-wider text-red-500 uppercase dark:text-red-400">
+              Sell Orders
+            </div>
+            <div class="mb-2 flex justify-between text-[11px] font-semibold text-surface-400">
+              <span>Price</span>
+              <span>Amount</span>
+            </div>
+            <div class="space-y-0.5">
+              @for (ask of topAsksWithDepth(); track trackByPrice($index, ask)) {
+                <div class="relative overflow-hidden rounded-md px-2 py-1">
+                  <div
+                    class="absolute inset-y-0 right-0 bg-red-500/10 dark:bg-red-400/10"
+                    [style.width.%]="ask.depthPercent"
+                  ></div>
+                  <div class="relative flex justify-between text-xs tabular-nums">
+                    <span class="font-medium text-red-600 dark:text-red-400">{{ ask.price | number: '1.2-6' }}</span>
+                    <span class="text-surface-500 dark:text-surface-400">{{ ask.quantity | number: '1.2-4' }}</span>
+                  </div>
+                </div>
+              }
+            </div>
           </div>
-          <div class="mb-2 flex justify-between text-[11px] font-semibold text-surface-400">
-            <span>Price</span>
-            <span>Amount</span>
-          </div>
-          <div class="space-y-0.5">
-            @for (ask of topAsks(); track trackByPrice($index, ask)) {
-              <div
-                class="flex justify-between rounded-md px-2 py-1 text-xs tabular-nums odd:bg-surface-100 dark:odd:bg-surface-700/50"
-              >
-                <span class="font-medium text-red-600 dark:text-red-400">{{ ask.price | number: '1.2-6' }}</span>
-                <span class="text-surface-500 dark:text-surface-400">{{ ask.quantity | number: '1.2-4' }}</span>
-              </div>
-            }
+          <!-- Bids (Buy orders) -->
+          <div>
+            <div class="mb-1 text-[11px] font-bold tracking-wider text-green-500 uppercase dark:text-green-400">
+              Buy Orders
+            </div>
+            <div class="mb-2 flex justify-between text-[11px] font-semibold text-surface-400">
+              <span>Price</span>
+              <span>Amount</span>
+            </div>
+            <div class="space-y-0.5">
+              @for (bid of topBidsWithDepth(); track trackByPrice($index, bid)) {
+                <div class="relative overflow-hidden rounded-md px-2 py-1">
+                  <div
+                    class="absolute inset-y-0 left-0 bg-green-500/10 dark:bg-green-400/10"
+                    [style.width.%]="bid.depthPercent"
+                  ></div>
+                  <div class="relative flex justify-between text-xs tabular-nums">
+                    <span class="font-medium text-green-600 dark:text-green-400">{{
+                      bid.price | number: '1.2-6'
+                    }}</span>
+                    <span class="text-surface-500 dark:text-surface-400">{{ bid.quantity | number: '1.2-4' }}</span>
+                  </div>
+                </div>
+              }
+            </div>
           </div>
         </div>
-        <!-- Bids (Buy orders) -->
-        <div>
-          <div class="mb-1 text-[11px] font-bold tracking-wider text-green-500 uppercase dark:text-green-400">
-            Buy Orders
+        <!-- Spread indicator -->
+        @if (spread(); as spread) {
+          <div
+            class="mx-4 mb-4 flex items-center justify-center gap-2 rounded-lg border border-surface-200 bg-surface-100 px-3 py-1.5 text-[11px] text-surface-500 dark:border-surface-700 dark:bg-surface-700/50 dark:text-surface-400"
+          >
+            <span class="font-semibold tracking-wider uppercase">Spread</span>
+            <span class="tabular-nums">{{ spread.value | number: '1.2-6' }}</span>
+            <span class="tabular-nums">({{ spread.percent | number: '1.2-2' }}%)</span>
           </div>
-          <div class="mb-2 flex justify-between text-[11px] font-semibold text-surface-400">
-            <span>Price</span>
-            <span>Amount</span>
-          </div>
-          <div class="space-y-0.5">
-            @for (bid of topBids(); track trackByPrice($index, bid)) {
-              <div
-                class="flex justify-between rounded-md px-2 py-1 text-xs tabular-nums odd:bg-surface-100 dark:odd:bg-surface-700/50"
-              >
-                <span class="font-medium text-green-600 dark:text-green-400">{{ bid.price | number: '1.2-6' }}</span>
-                <span class="text-surface-500 dark:text-surface-400">{{ bid.quantity | number: '1.2-4' }}</span>
-              </div>
-            }
-          </div>
+        }
+      } @else {
+        <div class="px-4 pb-4 text-center text-sm text-surface-400 dark:text-surface-500">
+          No orders available for this pair.
         </div>
-      </div>
+      }
     }
   </div>
 }
 <!-- Order Book Loading -->
 @if (!orderBookData() && isLoading()) {
-  <div class="mt-6 rounded-xl border border-surface-200 bg-surface-50 p-4 dark:border-surface-700 dark:bg-surface-800">
+  <div class="mt-5 rounded-xl border border-surface-200 bg-surface-50 p-4 dark:border-surface-700 dark:bg-surface-800">
     <div class="font-display mb-3 text-sm font-bold tracking-tight text-surface-700 dark:text-surface-200">
       Order Book
     </div>
     <div class="grid grid-cols-2 gap-4">
-      <div class="space-y-1.5">
-        @for (_ of [1, 2, 3, 4, 5]; track $index) {
-          <p-skeleton height="1.25rem" />
-        }
-      </div>
-      <div class="space-y-1.5">
-        @for (_ of [1, 2, 3, 4, 5]; track $index) {
-          <p-skeleton height="1.25rem" />
-        }
-      </div>
+      @for (col of [0, 1]; track col) {
+        <div>
+          <div class="mb-1">
+            <p-skeleton width="5rem" height="0.75rem" />
+          </div>
+          <div class="mb-2 flex justify-between">
+            <p-skeleton width="2rem" height="0.6rem" />
+            <p-skeleton width="2.5rem" height="0.6rem" />
+          </div>
+          <div class="space-y-1.5">
+            @for (_ of [1, 2, 3, 4, 5]; track $index) {
+              <p-skeleton height="1.25rem" />
+            }
+          </div>
+        </div>
+      }
     </div>
   </div>
 }

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-book/order-book.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-book/order-book.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 
+import { Decimal } from 'decimal.js';
 import { ButtonModule } from 'primeng/button';
 import { SkeletonModule } from 'primeng/skeleton';
 
@@ -19,12 +20,40 @@ export class OrderBookComponent {
   isLoading = input(false);
   isVisible = input(false);
   isRefreshing = input(false);
-  showToggle = input(true);
 
   refresh = output();
 
   topBids = computed(() => this.orderBookData()?.bids.slice(0, 5) || []);
   topAsks = computed(() => this.orderBookData()?.asks.slice(0, 5) || []);
+
+  spread = computed(() => {
+    const asks = this.topAsks();
+    const bids = this.topBids();
+    if (!asks.length || !bids.length) return null;
+    const bestAsk = asks[0].price;
+    const bestBid = bids[0].price;
+    const diff = new Decimal(bestAsk).minus(bestBid);
+    return {
+      value: diff.toNumber(),
+      percent: diff.div(bestAsk).times(100).toNumber()
+    };
+  });
+
+  /** Max quantity across all visible rows, used for depth bar scaling */
+  private maxQuantity = computed(() => {
+    const all = [...this.topAsks(), ...this.topBids()];
+    return Math.max(...all.map((e) => e.quantity), 0);
+  });
+
+  topAsksWithDepth = computed(() => {
+    const max = this.maxQuantity();
+    return this.topAsks().map((a) => ({ ...a, depthPercent: max > 0 ? (a.quantity / max) * 100 : 0 }));
+  });
+
+  topBidsWithDepth = computed(() => {
+    const max = this.maxQuantity();
+    return this.topBids().map((b) => ({ ...b, depthPercent: max > 0 ? (b.quantity / max) * 100 : 0 }));
+  });
 
   readonly trackByPrice = trackByPrice;
 }

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/exit-config/exit-config.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/exit-config/exit-config.component.html
@@ -1,68 +1,80 @@
 <!-- Exit Strategy Collapsible Panel -->
-<div class="rounded-lg border border-surface-200 dark:border-surface-700" [formGroup]="form()">
+<div
+  class="mb-4 rounded-xl border border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-800"
+  [formGroup]="form()"
+>
   <!-- Header Toggle -->
   <button
     type="button"
-    class="flex w-full items-center justify-between px-3 py-2 text-sm font-semibold text-surface-700 transition-colors hover:bg-surface-100 dark:text-surface-200 dark:hover:bg-surface-800"
+    class="flex min-h-[44px] w-full items-center justify-between rounded-t-xl px-4 py-2.5 text-sm font-semibold text-surface-700 transition-colors hover:bg-surface-100 focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:outline-none dark:text-surface-200 dark:hover:bg-surface-800"
     (click)="toggleExpanded()"
     [attr.aria-expanded]="isExpanded()"
     aria-controls="exitConfigPanel"
   >
     <div class="flex items-center gap-2">
       <i class="pi pi-shield text-xs" aria-hidden="true"></i>
-      <span>Exit Strategy</span>
-      @if (
-        form().get('enableStopLoss')?.value ||
-        form().get('enableTakeProfit')?.value ||
-        form().get('enableTrailingStop')?.value
-      ) {
+      <span class="font-display tracking-tight">Exit Strategy</span>
+      @if (activeStrategyCount(); as count) {
         <span
-          class="rounded-full bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-300"
+          class="rounded-full bg-primary-100 px-2 py-0.5 text-[11px] font-semibold text-primary-700 dark:bg-primary-800 dark:text-primary-200"
         >
-          Active
+          {{ count }} Active
         </span>
       }
     </div>
     <i
-      class="pi text-xs transition-transform duration-200"
-      [class.pi-chevron-down]="!isExpanded()"
-      [class.pi-chevron-up]="isExpanded()"
+      class="pi pi-chevron-down text-xs transition-transform duration-200"
+      [class.rotate-180]="isExpanded()"
       aria-hidden="true"
     ></i>
   </button>
 
   <!-- Expanded Content -->
   @if (isExpanded()) {
-    <div id="exitConfigPanel" class="space-y-3 border-t border-surface-200 px-3 py-3 dark:border-surface-700">
+    <div
+      @slideDown
+      id="exitConfigPanel"
+      class="space-y-3 border-t border-surface-200 px-4 py-3 dark:border-surface-700"
+      role="region"
+      aria-label="Exit strategy configuration"
+    >
       <!-- Stop Loss Section -->
-      <div class="space-y-2">
+      <div
+        class="space-y-2 transition-all duration-200"
+        [class.border-l-2]="form().get('enableStopLoss')?.value"
+        [class.border-l-red-500]="form().get('enableStopLoss')?.value"
+        [class.pl-3]="form().get('enableStopLoss')?.value"
+      >
         <div class="flex items-center justify-between">
           <label class="flex items-center gap-1.5 text-xs font-medium text-surface-600 dark:text-surface-300">
             <i class="pi pi-arrow-down text-[10px] text-red-500" aria-hidden="true"></i>
             Stop Loss
           </label>
-          <p-toggleswitch formControlName="enableStopLoss" />
+          <p-toggleswitch formControlName="enableStopLoss" ariaLabel="Enable stop loss" />
         </div>
         @if (form().get('enableStopLoss')?.value) {
-          <div class="grid grid-cols-2 gap-2">
-            <p-select
-              formControlName="stopLossType"
-              [options]="stopLossTypeOptions"
-              optionLabel="label"
-              optionValue="value"
-              class="w-full"
-              appendTo="body"
-            />
-            <p-inputnumber
-              formControlName="stopLossValue"
-              mode="decimal"
-              [min]="0"
-              [max]="limits.STOP_LOSS_MAX"
-              [minFractionDigits]="2"
-              [maxFractionDigits]="4"
-              [suffix]="' ' + stopLossValueSuffix()"
-              class="w-full"
-            />
+          <div @slideDown>
+            <p-inputgroup>
+              <p-inputnumber
+                formControlName="stopLossValue"
+                mode="decimal"
+                [min]="0"
+                [max]="limits.STOP_LOSS_MAX"
+                [minFractionDigits]="2"
+                [maxFractionDigits]="4"
+                class="w-full"
+              />
+              <p-inputgroup-addon class="!p-0">
+                <button
+                  type="button"
+                  class="cursor-pointer px-2 py-1 text-xs font-semibold text-surface-600 hover:text-surface-900 dark:text-surface-300 dark:hover:text-surface-100"
+                  (click)="stopLossMenu.toggle($event)"
+                >
+                  {{ stopLossButtonLabel() }}
+                </button>
+              </p-inputgroup-addon>
+            </p-inputgroup>
+            <p-menu #stopLossMenu [model]="stopLossMenuItems" [popup]="true" appendTo="body" styleClass="!min-w-fit" />
           </div>
           @if (stopLossHelperText()) {
             <p class="text-xs text-surface-500 dark:text-surface-400">{{ stopLossHelperText() }}</p>
@@ -71,43 +83,47 @@
       </div>
 
       <!-- Take Profit Section -->
-      <div class="space-y-2">
+      <div
+        class="space-y-2 transition-all duration-200"
+        [class.border-l-2]="form().get('enableTakeProfit')?.value"
+        [class.border-l-green-500]="form().get('enableTakeProfit')?.value"
+        [class.pl-3]="form().get('enableTakeProfit')?.value"
+      >
         <div class="flex items-center justify-between">
           <label class="flex items-center gap-1.5 text-xs font-medium text-surface-600 dark:text-surface-300">
             <i class="pi pi-arrow-up text-[10px] text-green-500" aria-hidden="true"></i>
             Take Profit
           </label>
-          <p-toggleswitch formControlName="enableTakeProfit" />
+          <p-toggleswitch formControlName="enableTakeProfit" ariaLabel="Enable take profit" />
         </div>
         @if (form().get('enableTakeProfit')?.value) {
-          <div class="grid grid-cols-2 gap-2">
-            <p-select
-              formControlName="takeProfitType"
-              [options]="getTakeProfitTypeOptions()"
-              optionLabel="label"
-              optionValue="value"
-              optionDisabled="disabled"
-              class="w-full"
+          <div @slideDown>
+            <p-inputgroup>
+              <p-inputnumber
+                formControlName="takeProfitValue"
+                mode="decimal"
+                [min]="0"
+                [max]="limits.TAKE_PROFIT_MAX"
+                [minFractionDigits]="2"
+                [maxFractionDigits]="4"
+                class="w-full"
+              />
+              <p-inputgroup-addon class="!p-0">
+                <button
+                  type="button"
+                  class="cursor-pointer px-2 py-1 text-xs font-semibold text-surface-600 hover:text-surface-900 dark:text-surface-300 dark:hover:text-surface-100"
+                  (click)="takeProfitMenu.toggle($event)"
+                >
+                  {{ takeProfitButtonLabel() }}
+                </button>
+              </p-inputgroup-addon>
+            </p-inputgroup>
+            <p-menu
+              #takeProfitMenu
+              [model]="takeProfitMenuItems"
+              [popup]="true"
               appendTo="body"
-            >
-              <ng-template pTemplate="item" let-option>
-                <div [class.opacity-40]="option.value === 'risk_reward' && isRiskRewardDisabled()">
-                  {{ option.label }}
-                  @if (option.value === 'risk_reward' && isRiskRewardDisabled()) {
-                    <span class="text-[10px]">(enable SL)</span>
-                  }
-                </div>
-              </ng-template>
-            </p-select>
-            <p-inputnumber
-              formControlName="takeProfitValue"
-              mode="decimal"
-              [min]="0"
-              [max]="limits.TAKE_PROFIT_MAX"
-              [minFractionDigits]="2"
-              [maxFractionDigits]="4"
-              [suffix]="' ' + takeProfitValueSuffix()"
-              class="w-full"
+              styleClass="!min-w-fit"
             />
           </div>
           @if (takeProfitHelperText()) {
@@ -117,75 +133,113 @@
       </div>
 
       <!-- Trailing Stop Section -->
-      <div class="space-y-2">
+      <div
+        class="space-y-2 transition-all duration-200"
+        [class.border-l-2]="form().get('enableTrailingStop')?.value"
+        [class.border-l-primary-500]="form().get('enableTrailingStop')?.value"
+        [class.pl-3]="form().get('enableTrailingStop')?.value"
+      >
         <div class="flex items-center justify-between">
           <label class="flex items-center gap-1.5 text-xs font-medium text-surface-600 dark:text-surface-300">
             <i class="pi pi-chart-line text-[10px] text-primary-500" aria-hidden="true"></i>
             Trailing Stop
           </label>
-          <p-toggleswitch formControlName="enableTrailingStop" />
+          <p-toggleswitch formControlName="enableTrailingStop" ariaLabel="Enable trailing stop" />
         </div>
         @if (form().get('enableTrailingStop')?.value) {
-          <div class="grid grid-cols-2 gap-2">
-            <p-select
-              formControlName="trailingType"
-              [options]="exitTrailingTypeOptions"
-              optionLabel="label"
-              optionValue="value"
-              class="w-full"
-              appendTo="body"
-            />
-            <p-inputnumber
-              formControlName="trailingValue"
-              mode="decimal"
-              [min]="0"
-              [max]="limits.TRAILING_VALUE_MAX"
-              [minFractionDigits]="2"
-              [maxFractionDigits]="4"
-              class="w-full"
-            />
-          </div>
-          <div class="grid grid-cols-2 gap-2">
-            <p-select
-              formControlName="trailingActivation"
-              [options]="trailingActivationOptions"
-              optionLabel="label"
-              optionValue="value"
-              class="w-full"
-              appendTo="body"
-            />
-            @if (!isTrailingActivationImmediate()) {
+          <div @slideDown class="space-y-2">
+            <!-- Trailing value row -->
+            <p-inputgroup>
               <p-inputnumber
-                formControlName="trailingActivationValue"
+                formControlName="trailingValue"
                 mode="decimal"
                 [min]="0"
-                [max]="limits.TRAILING_ACTIVATION_MAX"
+                [max]="limits.TRAILING_VALUE_MAX"
                 [minFractionDigits]="2"
                 [maxFractionDigits]="4"
                 class="w-full"
-                [placeholder]="form().get('trailingActivation')?.value === 'price' ? 'Price' : '% Gain'"
               />
+              <p-inputgroup-addon class="!p-0">
+                <button
+                  type="button"
+                  class="cursor-pointer px-2 py-1 text-xs font-semibold text-surface-600 hover:text-surface-900 dark:text-surface-300 dark:hover:text-surface-100"
+                  (click)="trailingValueMenu.toggle($event)"
+                >
+                  {{ trailingValueButtonLabel() }}
+                </button>
+              </p-inputgroup-addon>
+            </p-inputgroup>
+            <p-menu
+              #trailingValueMenu
+              [model]="trailingValueMenuItems"
+              [popup]="true"
+              appendTo="body"
+              styleClass="!min-w-fit"
+            />
+
+            <!-- Trailing activation row -->
+            @if (isTrailingActivationImmediate()) {
+              <button
+                type="button"
+                class="flex w-full cursor-pointer items-center justify-between rounded-md border border-surface-300 px-3 py-2 text-xs font-medium text-surface-600 hover:bg-surface-100 dark:border-surface-600 dark:text-surface-300 dark:hover:bg-surface-700"
+                (click)="trailingActivationMenu.toggle($event)"
+              >
+                Immediately
+                <i class="pi pi-chevron-down text-[10px]" aria-hidden="true"></i>
+              </button>
+            } @else {
+              <p-inputgroup>
+                <p-inputnumber
+                  formControlName="trailingActivationValue"
+                  mode="decimal"
+                  [min]="0"
+                  [max]="limits.TRAILING_ACTIVATION_MAX"
+                  [minFractionDigits]="2"
+                  [maxFractionDigits]="4"
+                  class="w-full"
+                  [placeholder]="form().get('trailingActivation')?.value === 'price' ? 'Price' : '% Gain'"
+                />
+                <p-inputgroup-addon class="!p-0">
+                  <button
+                    type="button"
+                    class="cursor-pointer px-2 py-1 text-xs font-semibold text-surface-600 hover:text-surface-900 dark:text-surface-300 dark:hover:text-surface-100"
+                    (click)="trailingActivationMenu.toggle($event)"
+                  >
+                    {{ trailingActivationButtonLabel() }}
+                  </button>
+                </p-inputgroup-addon>
+              </p-inputgroup>
             }
+            <p-menu
+              #trailingActivationMenu
+              [model]="trailingActivationMenuItems"
+              [popup]="true"
+              appendTo="body"
+              styleClass="!min-w-fit"
+            />
+
+            <p class="text-xs text-surface-500 dark:text-surface-400">
+              Stop price automatically adjusts as the market moves in your favor
+            </p>
           </div>
-          <p class="text-xs text-surface-500 dark:text-surface-400">
-            Stop price automatically adjusts as the market moves in your favor
-          </p>
         }
       </div>
 
       <!-- OCO Toggle -->
       @if (showOcoToggle()) {
-        <div class="flex items-center justify-between rounded-md bg-surface-50 px-3 py-2 dark:bg-surface-800">
-          <label
-            class="flex items-center gap-1.5 text-xs font-medium text-surface-600 dark:text-surface-300"
-            pTooltip="When one order fills, the other is automatically cancelled"
-            tooltipPosition="top"
-          >
+        <div class="flex items-center justify-between rounded-md bg-surface-50 px-3 py-2.5 dark:bg-surface-800">
+          <label class="flex items-center gap-1.5 text-xs font-medium text-surface-600 dark:text-surface-300">
             <i class="pi pi-link text-[10px]" aria-hidden="true"></i>
             Link as OCO
-            <i class="pi pi-info-circle text-[10px] text-surface-400" aria-hidden="true"></i>
+            <i
+              class="pi pi-info-circle text-[10px] text-surface-400"
+              pTooltip="When one order fills, the other is automatically cancelled"
+              tooltipPosition="top"
+              tabindex="0"
+              aria-label="OCO info: When one order fills, the other is automatically cancelled"
+            ></i>
           </label>
-          <p-toggleswitch formControlName="useOco" />
+          <p-toggleswitch formControlName="useOco" ariaLabel="Link as OCO pair" />
         </div>
       }
     </div>

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/exit-config/exit-config.component.spec.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/exit-config/exit-config.component.spec.ts
@@ -85,12 +85,21 @@ describe('ExitConfigComponent', () => {
     });
   });
 
-  describe('isRiskRewardDisabled', () => {
-    it('should return true when SL is disabled, false when enabled', () => {
-      expect(component.isRiskRewardDisabled()).toBe(true);
+  describe('stopLossButtonLabel', () => {
+    it('should return % for PERCENTAGE type', () => {
+      form.get('stopLossType')?.setValue(StopLossType.PERCENTAGE);
+      expect(component.stopLossButtonLabel()).toBe('%');
+    });
 
-      form.get('enableStopLoss')?.setValue(true);
-      expect(component.isRiskRewardDisabled()).toBe(false);
+    it('should return quote symbol for FIXED type with selected pair', () => {
+      fixture.componentRef.setInput('selectedPair', mockPair);
+      form.get('stopLossType')?.setValue(StopLossType.FIXED);
+      expect(component.stopLossButtonLabel()).toBe('USDT');
+    });
+
+    it('should return $ for FIXED type without selected pair', () => {
+      form.get('stopLossType')?.setValue(StopLossType.FIXED);
+      expect(component.stopLossButtonLabel()).toBe('$');
     });
   });
 
@@ -246,60 +255,58 @@ describe('ExitConfigComponent', () => {
     });
   });
 
-  describe('getTakeProfitTypeOptions', () => {
-    it('should return Risk:Reward as disabled when SL is off', () => {
+  describe('takeProfitMenuItems', () => {
+    it('should have Risk:Reward disabled when SL is off', () => {
       form.get('enableStopLoss')?.setValue(false);
-      const options = component.getTakeProfitTypeOptions();
-      const rr = options.find((o) => o.value === TakeProfitType.RISK_REWARD);
+      const rr = component.takeProfitMenuItems.find((i) => i.label === 'Risk:Reward');
       expect(rr?.disabled).toBe(true);
     });
 
-    it('should return Risk:Reward as enabled when SL is on', () => {
+    it('should have Risk:Reward enabled when SL is on', () => {
       form.get('enableStopLoss')?.setValue(true);
-      const options = component.getTakeProfitTypeOptions();
-      const rr = options.find((o) => o.value === TakeProfitType.RISK_REWARD);
+      const rr = component.takeProfitMenuItems.find((i) => i.label === 'Risk:Reward');
       expect(rr?.disabled).toBe(false);
     });
   });
 
-  describe('stopLossValueSuffix', () => {
+  describe('takeProfitButtonLabel', () => {
     it('should return % for PERCENTAGE type', () => {
-      form.get('stopLossType')?.setValue(StopLossType.PERCENTAGE);
-      expect(component.stopLossValueSuffix()).toBe('%');
+      form.get('takeProfitType')?.setValue(TakeProfitType.PERCENTAGE);
+      expect(component.takeProfitButtonLabel()).toBe('%');
     });
 
-    it('should return quote asset symbol for FIXED type with a selected pair', () => {
+    it('should return R:R for RISK_REWARD type', () => {
+      form.get('takeProfitType')?.setValue(TakeProfitType.RISK_REWARD);
+      expect(component.takeProfitButtonLabel()).toBe('R:R');
+    });
+
+    it('should return quote symbol for FIXED type with selected pair', () => {
       fixture.componentRef.setInput('selectedPair', mockPair);
-      form.get('stopLossType')?.setValue(StopLossType.FIXED);
-      expect(component.stopLossValueSuffix()).toBe('USDT');
+      form.get('takeProfitType')?.setValue(TakeProfitType.FIXED);
+      expect(component.takeProfitButtonLabel()).toBe('USDT');
     });
 
-    it('should return empty string for FIXED type without a selected pair', () => {
-      form.get('stopLossType')?.setValue(StopLossType.FIXED);
-      expect(component.stopLossValueSuffix()).toBe('');
+    it('should return $ for FIXED type without selected pair', () => {
+      form.get('takeProfitType')?.setValue(TakeProfitType.FIXED);
+      expect(component.takeProfitButtonLabel()).toBe('$');
     });
   });
 
-  describe('takeProfitValueSuffix', () => {
+  describe('trailingValueButtonLabel', () => {
     it('should return % for PERCENTAGE type', () => {
-      form.get('takeProfitType')?.setValue(TakeProfitType.PERCENTAGE);
-      expect(component.takeProfitValueSuffix()).toBe('%');
+      form.get('trailingType')?.setValue(ExitTrailingType.PERCENTAGE);
+      expect(component.trailingValueButtonLabel()).toBe('%');
     });
 
-    it('should return :1 for RISK_REWARD type', () => {
-      form.get('takeProfitType')?.setValue(TakeProfitType.RISK_REWARD);
-      expect(component.takeProfitValueSuffix()).toBe(':1');
-    });
-
-    it('should return quote asset symbol for FIXED type with a selected pair', () => {
+    it('should return quote symbol for AMOUNT type with selected pair', () => {
       fixture.componentRef.setInput('selectedPair', mockPair);
-      form.get('takeProfitType')?.setValue(TakeProfitType.FIXED);
-      expect(component.takeProfitValueSuffix()).toBe('USDT');
+      form.get('trailingType')?.setValue(ExitTrailingType.AMOUNT);
+      expect(component.trailingValueButtonLabel()).toBe('USDT');
     });
 
-    it('should return empty string for FIXED type without a selected pair', () => {
-      form.get('takeProfitType')?.setValue(TakeProfitType.FIXED);
-      expect(component.takeProfitValueSuffix()).toBe('');
+    it('should return $ for AMOUNT type without selected pair', () => {
+      form.get('trailingType')?.setValue(ExitTrailingType.AMOUNT);
+      expect(component.trailingValueButtonLabel()).toBe('$');
     });
   });
 
@@ -311,7 +318,7 @@ describe('ExitConfigComponent', () => {
     });
 
     it.each([
-      { side: 'BUY' as const, expected: 'Sells if price drops 2% below your entry' },
+      { side: 'BUY' as const, expected: 'Automatically sells if price falls 2% from your buy price' },
       { side: 'SELL' as const, expected: 'Buys back if price rises 2% above your entry' }
     ])('should return percentage text for $side side', ({ side, expected }) => {
       fixture.componentRef.setInput('side', side);
@@ -351,7 +358,7 @@ describe('ExitConfigComponent', () => {
     it('should return risk reward text', () => {
       form.get('takeProfitType')?.setValue(TakeProfitType.RISK_REWARD);
       form.get('takeProfitValue')?.setValue(3);
-      expect(component.takeProfitHelperText()).toBe('Targets 3:1 reward relative to your stop loss distance');
+      expect(component.takeProfitHelperText()).toBe('Aims for 3x the gain compared to your stop loss risk');
     });
 
     it.each([

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/exit-config/exit-config.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/exit-config/exit-config.component.ts
@@ -1,30 +1,55 @@
+import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
+import { MenuItem } from 'primeng/api';
+import { InputGroupModule } from 'primeng/inputgroup';
+import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { InputNumberModule } from 'primeng/inputnumber';
-import { SelectModule } from 'primeng/select';
+import { MenuModule } from 'primeng/menu';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
 import { startWith } from 'rxjs';
 
-import { StopLossType, TakeProfitType, TickerPair, TrailingActivationType } from '@chansey/api-interfaces';
-
 import {
-  EXIT_CONFIG_LIMITS,
-  EXIT_TRAILING_TYPE_OPTIONS,
-  STOP_LOSS_TYPE_OPTIONS,
-  TAKE_PROFIT_TYPE_OPTIONS,
-  TRAILING_ACTIVATION_OPTIONS
-} from '../../crypto-trading.constants';
+  ExitTrailingType,
+  StopLossType,
+  TakeProfitType,
+  TickerPair,
+  TrailingActivationType
+} from '@chansey/api-interfaces';
+
+import { EXIT_CONFIG_LIMITS } from '../../crypto-trading.constants';
 
 @Component({
   selector: 'app-exit-config',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, InputNumberModule, SelectModule, ToggleSwitchModule, TooltipModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    InputGroupModule,
+    InputGroupAddonModule,
+    InputNumberModule,
+    MenuModule,
+    ToggleSwitchModule,
+    TooltipModule
+  ],
   templateUrl: './exit-config.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [
+    trigger('slideDown', [
+      transition(':enter', [
+        style({ height: '0', opacity: 0, overflow: 'hidden' }),
+        animate('200ms ease-out', style({ height: '*', opacity: 1 }))
+      ]),
+      transition(':leave', [
+        style({ height: '*', opacity: 1, overflow: 'hidden' }),
+        animate('150ms ease-in', style({ height: '0', opacity: 0 }))
+      ])
+    ])
+  ]
 })
 export class ExitConfigComponent implements OnInit {
   form = input.required<FormGroup>();
@@ -33,13 +58,72 @@ export class ExitConfigComponent implements OnInit {
 
   isExpanded = signal(false);
 
-  stopLossTypeOptions = STOP_LOSS_TYPE_OPTIONS;
-  exitTrailingTypeOptions = EXIT_TRAILING_TYPE_OPTIONS;
-  trailingActivationOptions = TRAILING_ACTIVATION_OPTIONS;
-
   readonly limits = EXIT_CONFIG_LIMITS;
 
+  // Stable menu item arrays — built once, mutated in place to avoid reference churn
+  readonly stopLossMenuItems: MenuItem[] = [
+    {
+      label: 'Percentage',
+      command: () => this.form().get('stopLossType')?.setValue(StopLossType.PERCENTAGE)
+    },
+    {
+      label: 'Fixed Price',
+      command: () => this.form().get('stopLossType')?.setValue(StopLossType.FIXED)
+    }
+  ];
+
+  readonly takeProfitMenuItems: MenuItem[] = [
+    {
+      label: 'Percentage',
+      command: () => this.form().get('takeProfitType')?.setValue(TakeProfitType.PERCENTAGE)
+    },
+    {
+      label: 'Fixed Price',
+      command: () => this.form().get('takeProfitType')?.setValue(TakeProfitType.FIXED)
+    },
+    {
+      label: 'Risk:Reward',
+      disabled: true,
+      command: () => this.form().get('takeProfitType')?.setValue(TakeProfitType.RISK_REWARD)
+    }
+  ];
+
+  readonly trailingValueMenuItems: MenuItem[] = [
+    {
+      label: 'Percentage',
+      command: () => this.form().get('trailingType')?.setValue(ExitTrailingType.PERCENTAGE)
+    },
+    {
+      label: 'Amount',
+      command: () => this.form().get('trailingType')?.setValue(ExitTrailingType.AMOUNT)
+    }
+  ];
+
+  readonly trailingActivationMenuItems: MenuItem[] = [
+    {
+      label: 'Immediately',
+      command: () => this.form().get('trailingActivation')?.setValue(TrailingActivationType.IMMEDIATE)
+    },
+    {
+      label: 'At Price',
+      command: () => this.form().get('trailingActivation')?.setValue(TrailingActivationType.PRICE)
+    },
+    {
+      label: 'At % Gain',
+      command: () => this.form().get('trailingActivation')?.setValue(TrailingActivationType.PERCENTAGE)
+    }
+  ];
+
   private readonly destroyRef = inject(DestroyRef);
+
+  activeStrategyCount(): number {
+    const f = this.form();
+    let count = 0;
+    if (f.get('enableStopLoss')?.value) count++;
+    if (f.get('enableTakeProfit')?.value) count++;
+    if (f.get('enableTrailingStop')?.value) count++;
+    return count;
+  }
 
   showOcoToggle(): boolean {
     const f = this.form();
@@ -50,17 +134,25 @@ export class ExitConfigComponent implements OnInit {
     return this.form().get('trailingActivation')?.value === TrailingActivationType.IMMEDIATE;
   }
 
-  stopLossValueSuffix(): string {
-    return this.form().get('stopLossType')?.value === StopLossType.PERCENTAGE
-      ? '%'
-      : this.selectedPair()?.quoteAsset?.symbol?.toUpperCase() || '';
+  stopLossButtonLabel(): string {
+    return this.form().get('stopLossType')?.value === StopLossType.PERCENTAGE ? '%' : this.quoteSymbol() || '$';
   }
 
-  takeProfitValueSuffix(): string {
+  takeProfitButtonLabel(): string {
     const type = this.form().get('takeProfitType')?.value;
     if (type === TakeProfitType.PERCENTAGE) return '%';
-    if (type === TakeProfitType.RISK_REWARD) return ':1';
-    return this.selectedPair()?.quoteAsset?.symbol?.toUpperCase() || '';
+    if (type === TakeProfitType.RISK_REWARD) return 'R:R';
+    return this.quoteSymbol() || '$';
+  }
+
+  trailingValueButtonLabel(): string {
+    return this.form().get('trailingType')?.value === ExitTrailingType.PERCENTAGE ? '%' : this.quoteSymbol() || '$';
+  }
+
+  trailingActivationButtonLabel(): string {
+    return this.form().get('trailingActivation')?.value === TrailingActivationType.PERCENTAGE
+      ? '%'
+      : this.quoteSymbol() || '$';
   }
 
   stopLossHelperText(): string {
@@ -69,10 +161,14 @@ export class ExitConfigComponent implements OnInit {
     if (!value) return '';
     if (type === StopLossType.PERCENTAGE) {
       return this.side() === 'BUY'
-        ? `Sells if price drops ${value}% below your entry`
+        ? `Automatically sells if price falls ${value}% from your buy price`
         : `Buys back if price rises ${value}% above your entry`;
     }
-    return this.side() === 'BUY' ? `Sells if price drops to ${value}` : `Buys back if price rises to ${value}`;
+    const symbol = this.quoteSymbol();
+    const suffix = symbol ? ` ${symbol}` : '';
+    return this.side() === 'BUY'
+      ? `Sells if price drops to ${value}${suffix}`
+      : `Buys back if price rises to ${value}${suffix}`;
   }
 
   takeProfitHelperText(): string {
@@ -85,17 +181,13 @@ export class ExitConfigComponent implements OnInit {
         : `Buys back when price drops ${value}% below your entry`;
     }
     if (type === TakeProfitType.RISK_REWARD) {
-      return `Targets ${value}:1 reward relative to your stop loss distance`;
+      return `Aims for ${value}x the gain compared to your stop loss risk`;
     }
-    return this.side() === 'BUY' ? `Sells when price reaches ${value}` : `Buys back when price drops to ${value}`;
-  }
-
-  getTakeProfitTypeOptions() {
-    const slEnabled = !!this.form().get('enableStopLoss')?.value;
-    return TAKE_PROFIT_TYPE_OPTIONS.map((opt) => ({
-      ...opt,
-      disabled: opt.value === TakeProfitType.RISK_REWARD && !slEnabled
-    }));
+    const symbol = this.quoteSymbol();
+    const suffix = symbol ? ` ${symbol}` : '';
+    return this.side() === 'BUY'
+      ? `Sells when price reaches ${value}${suffix}`
+      : `Buys back when price drops to ${value}${suffix}`;
   }
 
   toggleExpanded(): void {
@@ -111,6 +203,10 @@ export class ExitConfigComponent implements OnInit {
     ]);
     this.watchTrailingActivation();
     this.watchTakeProfitRiskReward();
+  }
+
+  private quoteSymbol(): string {
+    return (this.selectedPair()?.quoteAsset?.symbol?.toUpperCase() || '').slice(0, 6);
   }
 
   private watchToggle(toggleField: string, valueFields: { name: string; max: number }[]): void {
@@ -154,16 +250,14 @@ export class ExitConfigComponent implements OnInit {
       .get('enableStopLoss')
       ?.valueChanges.pipe(startWith(this.form().get('enableStopLoss')?.value), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        // When SL is disabled and TP type is RISK_REWARD, switch to PERCENTAGE
         const slEnabled = this.form().get('enableStopLoss')?.value;
+        // Update Risk:Reward disabled state in the stable menu items array
+        const rrItem = this.takeProfitMenuItems.find((i) => i.label === 'Risk:Reward');
+        if (rrItem) rrItem.disabled = !slEnabled;
         const tpType = this.form().get('takeProfitType')?.value;
         if (!slEnabled && tpType === TakeProfitType.RISK_REWARD) {
           this.form().get('takeProfitType')?.setValue(TakeProfitType.PERCENTAGE);
         }
       });
-  }
-
-  isRiskRewardDisabled(): boolean {
-    return !this.form().get('enableStopLoss')?.value;
   }
 }

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.html
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.html
@@ -59,10 +59,10 @@
       </label>
     </p-floatlabel>
     @if (isFieldInvalid('quantity')) {
-      <small class="p-error" role="alert">{{ getFieldError('quantity') }}</small>
+      <small class="p-error" aria-live="polite">{{ getFieldError('quantity') }}</small>
     }
     @if (marketLimits()?.minQuantity || marketLimits()?.minCost) {
-      <div class="mt-1 text-xs text-surface-400">
+      <div class="mt-1 text-xs text-surface-500 dark:text-surface-400">
         @if (marketLimits()?.minQuantity) {
           Min: {{ marketLimits()?.minQuantity }} {{ selectedPair()?.baseAsset?.symbol | uppercase }}
         }
@@ -114,7 +114,7 @@
         </label>
       </p-floatlabel>
       @if (isFieldInvalid('price')) {
-        <small class="p-error" role="alert">{{ getFieldError('price') }}</small>
+        <small class="p-error" aria-live="polite">{{ getFieldError('price') }}</small>
       }
     </div>
   }
@@ -128,7 +128,8 @@
           formControlName="stopPrice"
           mode="decimal"
           [minFractionDigits]="2"
-          [maxFractionDigits]="8"
+          [maxFractionDigits]="marketLimits()?.priceStep ? countDecimals(marketLimits()!.priceStep) : 8"
+          [step]="marketLimits()?.priceStep && marketLimits()!.priceStep > 0 ? marketLimits()!.priceStep : 1"
           class="w-full"
           [class.ng-invalid]="isFieldInvalid('stopPrice')"
           [class.ng-dirty]="isFieldInvalid('stopPrice')"
@@ -141,7 +142,7 @@
         </label>
       </p-floatlabel>
       @if (isFieldInvalid('stopPrice')) {
-        <small class="p-error" role="alert">{{ getFieldError('stopPrice') }}</small>
+        <small class="p-error" aria-live="polite">{{ getFieldError('stopPrice') }}</small>
       }
       <p-message severity="warn" size="small">
         Order executes when price
@@ -169,7 +170,7 @@
             <label [for]="side() + 'TrailingAmount'">Trailing Amount</label>
           </p-floatlabel>
           @if (isFieldInvalid('trailingAmount')) {
-            <small class="p-error" role="alert">{{ getFieldError('trailingAmount') }}</small>
+            <small class="p-error" aria-live="polite">{{ getFieldError('trailingAmount') }}</small>
           }
         </div>
         <p-floatlabel variant="on">
@@ -205,7 +206,7 @@
       </p>
       <!-- Mini price diagram -->
       <div
-        class="flex flex-col items-center gap-0.5 rounded-md border border-dashed border-primary-300 bg-white/60 px-3 py-2 text-xs dark:border-primary-700 dark:bg-surface-800/60"
+        class="flex flex-col items-center gap-0.5 rounded-md border border-dashed border-primary-300 bg-surface-0/60 px-3 py-2 text-xs dark:border-primary-700 dark:bg-surface-800/60"
       >
         <div class="flex items-center gap-1.5 font-medium text-green-600 dark:text-green-400">
           <i class="pi pi-arrow-up text-[10px]" aria-hidden="true"></i>
@@ -230,7 +231,8 @@
             formControlName="takeProfitPrice"
             mode="decimal"
             [minFractionDigits]="2"
-            [maxFractionDigits]="8"
+            [maxFractionDigits]="marketLimits()?.priceStep ? countDecimals(marketLimits()!.priceStep) : 8"
+            [step]="marketLimits()?.priceStep && marketLimits()!.priceStep > 0 ? marketLimits()!.priceStep : 1"
             class="w-full"
             [class.ng-invalid]="isFieldInvalid('takeProfitPrice')"
             [class.ng-dirty]="isFieldInvalid('takeProfitPrice')"
@@ -243,7 +245,7 @@
           </label>
         </p-floatlabel>
         @if (isFieldInvalid('takeProfitPrice')) {
-          <small class="p-error" role="alert">{{ getFieldError('takeProfitPrice') }}</small>
+          <small class="p-error" aria-live="polite">{{ getFieldError('takeProfitPrice') }}</small>
         }
       </div>
       <!-- Stop Loss input -->
@@ -254,7 +256,8 @@
             formControlName="stopLossPrice"
             mode="decimal"
             [minFractionDigits]="2"
-            [maxFractionDigits]="8"
+            [maxFractionDigits]="marketLimits()?.priceStep ? countDecimals(marketLimits()!.priceStep) : 8"
+            [step]="marketLimits()?.priceStep && marketLimits()!.priceStep > 0 ? marketLimits()!.priceStep : 1"
             class="w-full"
             [class.ng-invalid]="isFieldInvalid('stopLossPrice')"
             [class.ng-dirty]="isFieldInvalid('stopLossPrice')"
@@ -267,7 +270,7 @@
           </label>
         </p-floatlabel>
         @if (isFieldInvalid('stopLossPrice')) {
-          <small class="p-error" role="alert">{{ getFieldError('stopLossPrice') }}</small>
+          <small class="p-error" aria-live="polite">{{ getFieldError('stopLossPrice') }}</small>
         }
       </div>
     </div>
@@ -282,7 +285,8 @@
           formControlName="takeProfitPrice"
           mode="decimal"
           [minFractionDigits]="2"
-          [maxFractionDigits]="8"
+          [maxFractionDigits]="marketLimits()?.priceStep ? countDecimals(marketLimits()!.priceStep) : 8"
+          [step]="marketLimits()?.priceStep && marketLimits()!.priceStep > 0 ? marketLimits()!.priceStep : 1"
           class="w-full"
           [class.ng-invalid]="isFieldInvalid('takeProfitPrice')"
           [class.ng-dirty]="isFieldInvalid('takeProfitPrice')"
@@ -295,7 +299,7 @@
         </label>
       </p-floatlabel>
       @if (isFieldInvalid('takeProfitPrice')) {
-        <small class="p-error" role="alert">{{ getFieldError('takeProfitPrice') }}</small>
+        <small class="p-error" aria-live="polite">{{ getFieldError('takeProfitPrice') }}</small>
       }
     </div>
   }
@@ -350,14 +354,16 @@
           <span
             class="tabular-nums"
             [class.text-green-600]="orderPreview()?.hasSufficientBalance"
+            [class.dark:text-green-400]="orderPreview()?.hasSufficientBalance"
             [class.text-red-600]="!orderPreview()?.hasSufficientBalance"
+            [class.dark:text-red-400]="!orderPreview()?.hasSufficientBalance"
           >
             {{ orderPreview()?.availableBalance | number: '1.2-6' }}
             {{ orderPreview()?.balanceCurrency?.toUpperCase() }}
           </span>
         </div>
         @if (!orderPreview()?.hasSufficientBalance) {
-          <div role="alert" class="mt-1 flex items-center gap-1 text-xs text-red-600">
+          <div role="alert" class="mt-1 flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
             <i class="pi pi-exclamation-triangle" aria-hidden="true"></i>
             <span>Insufficient balance</span>
           </div>
@@ -392,19 +398,21 @@
     </p-message>
   }
 
-  <p-button
-    type="submit"
-    [label]="buttonLabel()"
-    [icon]="buttonIcon()"
-    [severity]="buttonSeverity()"
-    styleClass="w-full"
-    [disabled]="
-      form().invalid ||
-      isSubmitting() ||
-      !selectedPair() ||
-      (orderPreview() && !hasSufficientBalance()) ||
-      isBelowMinCost()
-    "
-    [loading]="isSubmitting()"
-  />
+  <span [pTooltip]="buttonDisabledReason()" tooltipPosition="top" class="inline-block w-full">
+    <p-button
+      type="submit"
+      [label]="buttonLabel()"
+      [icon]="buttonIcon()"
+      [severity]="buttonSeverity()"
+      styleClass="w-full"
+      [disabled]="
+        form().invalid ||
+        isSubmitting() ||
+        !selectedPair() ||
+        (orderPreview() && !hasSufficientBalance()) ||
+        isBelowMinCost()
+      "
+      [loading]="isSubmitting()"
+    />
+  </span>
 </form>

--- a/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.ts
+++ b/apps/chansey/src/app/shared/components/crypto-trading/order-form/order-form.component.ts
@@ -8,6 +8,7 @@ import { InputNumberModule } from 'primeng/inputnumber';
 import { MessageModule } from 'primeng/message';
 import { SelectModule } from 'primeng/select';
 import { SelectButtonModule } from 'primeng/selectbutton';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { MarketLimits, OrderPreview, OrderType, TickerPair, TrailingType } from '@chansey/api-interfaces';
 
@@ -26,6 +27,7 @@ import { ExitConfigComponent } from './exit-config/exit-config.component';
     MessageModule,
     SelectModule,
     SelectButtonModule,
+    TooltipModule,
     ExitConfigComponent
   ],
   templateUrl: './order-form.component.html',
@@ -98,6 +100,14 @@ export class OrderFormComponent {
   summaryTotalLabel = computed(() => (this.isBuy() ? 'Total' : 'Net'));
   summaryHeaderLabel = computed(() => (this.isBuy() ? 'Buy Order Summary' : 'Sell Order Summary'));
   summaryIcon = computed(() => (this.isBuy() ? 'pi pi-arrow-up' : 'pi pi-arrow-down'));
+
+  buttonDisabledReason = computed(() => {
+    if (!this.selectedPair()) return 'Select a trading pair first';
+    if (this.form().invalid) return 'Please fill in all required fields';
+    if (this.isBelowMinCost()) return 'Order value is below the minimum';
+    if (this.orderPreview() && !this.hasSufficientBalance()) return 'Insufficient balance';
+    return '';
+  });
 
   shouldShowExitConfig = computed(() => {
     const type = this.form().get('type')?.value;

--- a/apps/chansey/src/app/validators/step-size.validator.spec.ts
+++ b/apps/chansey/src/app/validators/step-size.validator.spec.ts
@@ -7,7 +7,8 @@ describe('stepSizeValidator', () => {
     [0.01, 0.02, 'decimal multiple'],
     [0.1, 0.3, 'float-precision edge case (0.3 / 0.1)'],
     [1, 5, 'whole number multiple'],
-    [1e-8, 0.00000002, 'scientific notation step']
+    [1e-8, 0.00000002, 'scientific notation step'],
+    [0.01, 60000.05, 'large value with small step']
   ])('should accept valid value (step=%s, value=%s, %s)', (step, value) => {
     const validator = stepSizeValidator(step);
     expect(validator(new FormControl(value))).toBeNull();
@@ -54,8 +55,8 @@ describe('snapToStep', () => {
     expect(snapToStep(1.234, 0)).toBe(1.234);
   });
 
-  it('should handle negative values', () => {
-    expect(snapToStep(-0.123, 0.01)).toBe(-0.13);
+  it('should return negative value unchanged', () => {
+    expect(snapToStep(-0.123, 0.01)).toBe(-0.123);
   });
 });
 

--- a/apps/chansey/src/app/validators/step-size.validator.ts
+++ b/apps/chansey/src/app/validators/step-size.validator.ts
@@ -13,7 +13,7 @@ export function stepSizeValidator(stepSize: number): ValidatorFn {
     const multiplier = Math.pow(10, precision);
     const remainder = Math.abs((value * multiplier) % (stepSize * multiplier));
 
-    if (remainder > Number.EPSILON) {
+    if (remainder > 1e-9 && remainder < stepSize * multiplier - 1e-9) {
       return { stepSize: { requiredStep: stepSize, actualValue: value } };
     }
 
@@ -25,7 +25,7 @@ export function stepSizeValidator(stepSize: number): ValidatorFn {
  * Rounds a value down to the nearest valid step (mirrors backend's `calculateMaxQuantity`).
  */
 export function snapToStep(value: number, stepSize: number): number {
-  if (stepSize <= 0) return value;
+  if (stepSize <= 0 || value < 0) return value;
   const precision = getPrecisionFromStep(stepSize);
   const multiplier = Math.pow(10, precision);
   const scaledValue = value * multiplier;


### PR DESCRIPTION
## Summary
- Add step-size validation, quantity snapping, and precise balance calculations for exchange tick size enforcement
- Polish trading UI with order book depth bars, spread indicator, order type badges, and compact exit config menus
- Improve accessibility with aria labels, disabled-button tooltips, and dark mode color refinements

## Changes

### Validation & Precision
- Add `stepSizeValidator` and `snapToStep` utility for exchange tick size enforcement
- Use Decimal.js for precise quantity/spread calculations (avoid floating-point drift)
- Fix buy balance calculation (divide by 1+fee instead of multiply by 1-fee)
- Add order-type-aware fee rate lookup (taker vs maker)
- Handle scientific notation (e.g., 1e-8) in step precision

### Order Book
- Add depth visualization bars with bid/ask color coding
- Show spread indicator between best bid and ask
- Add refresh button

### Active Orders
- Show order type badges and formatted status labels
- Add colored left-border indicators for buy/sell order cards
- Add refresh button

### Exit Config
- Replace select dropdowns with compact popup menus
- Add slide animations and active strategy count badge
- Look up Risk:Reward menu item by label instead of hardcoded index

### Order Form
- Prefill price fields with market price when switching order types
- Reset unsupported order types on exchange change
- Apply price step constraints on stop/take-profit inputs
- Add disabled-button tooltip explaining submission blockers
- Remove OCO auto-prefill of stop-loss/take-profit prices

### Tests
- Add comprehensive tests for safety margin, limit price, fee rate, and step-size snapping
- Add unit tests for `stepSizeValidator`, `snapToStep`, and `getPrecisionFromStep`

### Cleanup
- Remove unused MCP server configs from `.mcp.json`
- Extract duplicated price-step validator logic into `applyPriceStepValidator()`

## Test Plan
- [ ] Verify order book shows depth bars and spread indicator
- [ ] Verify quantity snaps to step size when using percentage buttons
- [ ] Verify price fields prefill with market price on order type change
- [ ] Verify exit config popup menus work correctly
- [ ] Verify disabled submit button shows tooltip with reason
- [ ] Run `nx test chansey` — all unit tests pass