### PR TITLE
feat: add exchange health alerts to dashboard

### DIFF
--- a/apps/api/src/exchange/exchange-key/dto/exchange-key-health.dto.ts
+++ b/apps/api/src/exchange/exchange-key/dto/exchange-key-health.dto.ts
@@ -3,6 +3,8 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
 
+import type { ExchangeKeyErrorCategory, ExchangeKeyHealthStatus } from '@chansey/api-interfaces';
+
 export class HealthHistoryQueryDto {
   @IsOptional()
   @Type(() => Number)
@@ -29,7 +31,7 @@ export class ExchangeKeyHealthSummaryDto {
   exchange: { id: string; name: string; slug: string };
 
   @ApiProperty({ description: 'Current health status', example: 'healthy' })
-  healthStatus: string;
+  healthStatus: ExchangeKeyHealthStatus;
 
   @ApiPropertyOptional({ description: 'Last health check timestamp' })
   lastHealthCheckAt: Date | null;
@@ -38,7 +40,7 @@ export class ExchangeKeyHealthSummaryDto {
   consecutiveFailures: number;
 
   @ApiPropertyOptional({ description: 'Last error category', example: 'authentication' })
-  lastErrorCategory: string | null;
+  lastErrorCategory: ExchangeKeyErrorCategory | null;
 
   @ApiPropertyOptional({ description: 'Last error message' })
   lastErrorMessage: string | null;
@@ -55,10 +57,10 @@ export class ExchangeKeyHealthLogDto {
   id: string;
 
   @ApiProperty({ description: 'Health check status', example: 'healthy' })
-  status: string;
+  status: ExchangeKeyHealthStatus;
 
   @ApiPropertyOptional({ description: 'Error category' })
-  errorCategory: string | null;
+  errorCategory: ExchangeKeyErrorCategory | null;
 
   @ApiPropertyOptional({ description: 'Error message' })
   errorMessage: string | null;

--- a/apps/api/src/exchange/exchange-key/dto/exchange-key-response.dto.ts
+++ b/apps/api/src/exchange/exchange-key/dto/exchange-key-response.dto.ts
@@ -2,6 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { Exclude } from 'class-transformer';
 
+import type { ExchangeKeyErrorCategory, ExchangeKeyHealthStatus } from '@chansey/api-interfaces';
+
 export class ExchangeKeyResponseDto {
   @ApiProperty({
     description: 'Unique identifier for the exchange key',
@@ -69,7 +71,7 @@ export class ExchangeKeyResponseDto {
     description: 'Current health status of the exchange key',
     example: 'healthy'
   })
-  healthStatus: string;
+  healthStatus: ExchangeKeyHealthStatus;
 
   @ApiProperty({
     description: 'When the last health check was performed',
@@ -89,7 +91,7 @@ export class ExchangeKeyResponseDto {
     example: 'authentication',
     nullable: true
   })
-  lastErrorCategory: string | null;
+  lastErrorCategory: ExchangeKeyErrorCategory | null;
 
   @ApiProperty({
     description: 'Message of the last error',

--- a/apps/api/src/exchange/exchange-key/exchange-key-health-log.entity.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key-health-log.entity.ts
@@ -1,5 +1,7 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Relation } from 'typeorm';
 
+import type { ExchangeKeyErrorCategory, ExchangeKeyHealthStatus } from '@chansey/api-interfaces';
+
 import { ExchangeKey } from './exchange-key.entity';
 
 @Entity()
@@ -15,10 +17,10 @@ export class ExchangeKeyHealthLog {
   exchangeKeyId: string;
 
   @Column({ type: 'varchar', length: 20 })
-  status: string;
+  status: ExchangeKeyHealthStatus;
 
   @Column({ type: 'varchar', length: 30, nullable: true })
-  errorCategory: string | null;
+  errorCategory: ExchangeKeyErrorCategory | null;
 
   @Column({ type: 'text', nullable: true })
   errorMessage: string | null;

--- a/apps/api/src/exchange/exchange-key/exchange-key-health.service.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key-health.service.ts
@@ -5,6 +5,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import * as ccxt from 'ccxt';
 import { LessThan, Repository } from 'typeorm';
 
+import type { ExchangeKeyErrorCategory } from '@chansey/api-interfaces';
+
 import {
   ExchangeKeyHealthHistoryResponseDto,
   ExchangeKeyHealthLogDto,
@@ -19,9 +21,7 @@ import { User } from '../../users/users.entity';
 import { UsersService } from '../../users/users.service';
 import { ExchangeManagerService } from '../exchange-manager.service';
 
-type ErrorCategory = 'authentication' | 'permission' | 'nonce' | 'exchange_down' | 'network' | 'rate_limit' | 'unknown';
-
-const DEACTIVATION_ELIGIBLE_CATEGORIES = new Set<ErrorCategory>(['authentication', 'permission']);
+const DEACTIVATION_ELIGIBLE_CATEGORIES = new Set<ExchangeKeyErrorCategory>(['authentication', 'permission']);
 const WARNING_THRESHOLD = 3;
 const DEACTIVATION_THRESHOLD = 5;
 
@@ -46,7 +46,7 @@ export class ExchangeKeyHealthService implements OnModuleInit {
     this.usersService = this.moduleRef.get(UsersService, { strict: false });
   }
 
-  classifyError(error: unknown): ErrorCategory {
+  classifyError(error: unknown): ExchangeKeyErrorCategory {
     // PermissionDenied extends AuthenticationError in CCXT, so check it first
     if (error instanceof ccxt.PermissionDenied) return 'permission';
     if (error instanceof ccxt.AuthenticationError) return 'authentication';
@@ -60,7 +60,7 @@ export class ExchangeKeyHealthService implements OnModuleInit {
   async checkKeyHealth(exchangeKey: ExchangeKey): Promise<void> {
     const startTime = Date.now();
     let user: User | null = null;
-    let errorCategory: ErrorCategory | null = null;
+    let errorCategory: ExchangeKeyErrorCategory | null = null;
     let errorMessage: string | null = null;
 
     try {
@@ -87,7 +87,6 @@ export class ExchangeKeyHealthService implements OnModuleInit {
       const err = toErrorInfo(error);
       errorCategory = this.classifyError(error);
       errorMessage = err.message;
-
 
       exchangeKey.lastErrorCategory = errorCategory;
       exchangeKey.lastErrorMessage = errorMessage;
@@ -199,26 +198,46 @@ export class ExchangeKeyHealthService implements OnModuleInit {
     return { total: keys.length, healthy, unhealthy, deactivated };
   }
 
+  async recheckKey(exchangeKeyId: string, userId: string): Promise<ExchangeKeyHealthSummaryDto> {
+    const key = await this.exchangeKeyRepo.findOne({
+      where: { id: exchangeKeyId, userId },
+      relations: ['exchange']
+    });
+
+    if (!key) {
+      throw new NotFoundException('Exchange key not found');
+    }
+
+    // Reactivate if it was deactivated by health check
+    if (key.deactivatedByHealthCheck) {
+      key.isActive = true;
+      key.deactivatedByHealthCheck = false;
+      key.consecutiveFailures = 0;
+      await this.exchangeKeyRepo.save(key);
+    }
+
+    await this.checkKeyHealth(key);
+
+    // Reload to get updated state after health check
+    const updated = await this.exchangeKeyRepo.findOne({
+      where: { id: exchangeKeyId, userId },
+      relations: ['exchange']
+    });
+
+    if (!updated) {
+      throw new NotFoundException('Exchange key not found');
+    }
+
+    return this.toHealthSummaryDto(updated);
+  }
+
   async getHealthSummary(userId: string): Promise<ExchangeKeyHealthSummaryDto[]> {
     const keys = await this.exchangeKeyRepo.find({
       where: { userId },
       relations: ['exchange']
     });
 
-    return keys.map((key) => ({
-      id: key.id,
-      exchangeId: key.exchangeId,
-      exchange: key.exchange
-        ? { id: key.exchange.id, name: key.exchange.name, slug: key.exchange.slug }
-        : { id: key.exchangeId, name: '', slug: '' },
-      healthStatus: key.healthStatus,
-      lastHealthCheckAt: key.lastHealthCheckAt,
-      consecutiveFailures: key.consecutiveFailures,
-      lastErrorCategory: key.lastErrorCategory,
-      lastErrorMessage: key.lastErrorMessage,
-      deactivatedByHealthCheck: key.deactivatedByHealthCheck,
-      isActive: key.isActive
-    }));
+    return keys.map((key) => this.toHealthSummaryDto(key));
   }
 
   async getHealthHistory(
@@ -266,6 +285,23 @@ export class ExchangeKeyHealthService implements OnModuleInit {
     const deleted = result.affected ?? 0;
     this.logger.log(`Cleaned up ${deleted} health log entries older than ${retentionDays} days`);
     return deleted;
+  }
+
+  private toHealthSummaryDto(key: ExchangeKey): ExchangeKeyHealthSummaryDto {
+    return {
+      id: key.id,
+      exchangeId: key.exchangeId,
+      exchange: key.exchange
+        ? { id: key.exchange.id, name: key.exchange.name, slug: key.exchange.slug }
+        : { id: key.exchangeId, name: '', slug: '' },
+      healthStatus: key.healthStatus,
+      lastHealthCheckAt: key.lastHealthCheckAt,
+      consecutiveFailures: key.consecutiveFailures,
+      lastErrorCategory: key.lastErrorCategory,
+      lastErrorMessage: key.lastErrorMessage,
+      deactivatedByHealthCheck: key.deactivatedByHealthCheck,
+      isActive: key.isActive
+    };
   }
 
   private async notifyWarning(exchangeKey: ExchangeKey, user: User): Promise<void> {

--- a/apps/api/src/exchange/exchange-key/exchange-key.controller.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key.controller.ts
@@ -14,6 +14,7 @@ import {
   UseInterceptors
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 import {
   CreateExchangeKeyDto,
@@ -70,6 +71,25 @@ export class ExchangeKeyController {
   async findAll(@GetUser() user: User): Promise<ExchangeKeyResponseDto[]> {
     const keys = await this.exchangeKeyService.findAll(user.id);
     return keys.map((key) => this.transformToResponse(key));
+  }
+
+  @Throttle({ default: { limit: 2, ttl: 60000 } })
+  @Post(':id/recheck')
+  @ApiOperation({ summary: 'Recheck health of an exchange key (reactivates if deactivated by health check)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns updated health status after recheck',
+    type: ExchangeKeyHealthSummaryDto
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Exchange key not found'
+  })
+  async recheckKey(
+    @GetUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string
+  ): Promise<ExchangeKeyHealthSummaryDto> {
+    return this.exchangeKeyHealthService.recheckKey(id, user.id);
   }
 
   @Get('health')

--- a/apps/api/src/exchange/exchange-key/exchange-key.entity.ts
+++ b/apps/api/src/exchange/exchange-key/exchange-key.entity.ts
@@ -17,6 +17,8 @@ import {
 import { createCipheriv, createDecipheriv, randomBytes, scrypt } from 'crypto';
 import { promisify } from 'util';
 
+import type { ExchangeKeyErrorCategory, ExchangeKeyHealthStatus } from '@chansey/api-interfaces';
+
 import type { User } from '../../users/users.entity';
 import type { Exchange } from '../exchange.entity';
 
@@ -65,7 +67,7 @@ export class ExchangeKey {
   isActive: boolean;
 
   @Column({ type: 'varchar', length: 20, default: 'unknown' })
-  healthStatus: string;
+  healthStatus: ExchangeKeyHealthStatus;
 
   @Column({ type: 'timestamptz', nullable: true })
   lastHealthCheckAt: Date | null;
@@ -74,7 +76,7 @@ export class ExchangeKey {
   consecutiveFailures: number;
 
   @Column({ type: 'varchar', length: 30, nullable: true })
-  lastErrorCategory: string | null;
+  lastErrorCategory: ExchangeKeyErrorCategory | null;
 
   @Column({ type: 'text', nullable: true })
   lastErrorMessage: string | null;

--- a/apps/chansey/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/chansey/src/app/pages/dashboard/dashboard.component.html
@@ -11,6 +11,9 @@
     } @else {
       <div class="grid grid-cols-12 gap-x-6 gap-y-4">
         <div class="col-span-12">
+          <app-exchange-status-alert />
+        </div>
+        <div class="col-span-12">
           <app-exchange-balance />
         </div>
         <div class="col-span-12 md:col-span-6">

--- a/apps/chansey/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/chansey/src/app/pages/dashboard/dashboard.component.ts
@@ -3,6 +3,7 @@ import { Component, computed, DestroyRef, effect, inject, signal } from '@angula
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 
 import { ExchangeBalanceComponent } from '../../shared/components/exchange-balance/exchange-balance.component';
+import { ExchangeStatusAlertComponent } from '../../shared/components/exchange-status-alert/exchange-status-alert.component';
 import { GettingStartedComponent } from '../../shared/components/getting-started/getting-started.component';
 import { RecentTransactionsComponent } from '../../shared/components/recent-transactions/recent-transactions.component';
 import { UserAssetsComponent } from '../../shared/components/user-assets/user-assets.component';
@@ -14,6 +15,7 @@ import { LayoutService } from '../../shared/services/layout.service';
   imports: [
     ProgressSpinnerModule,
     ExchangeBalanceComponent,
+    ExchangeStatusAlertComponent,
     GettingStartedComponent,
     UserAssetsComponent,
     RecentTransactionsComponent

--- a/apps/chansey/src/app/shared/components/exchange-status-alert/exchange-status-alert.component.ts
+++ b/apps/chansey/src/app/shared/components/exchange-status-alert/exchange-status-alert.component.ts
@@ -1,0 +1,119 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { ButtonModule } from 'primeng/button';
+import { MessageModule } from 'primeng/message';
+
+import { ExchangeKeyErrorCategory, ExchangeKeyHealthSummary } from '@chansey/api-interfaces';
+
+import { ExchangeService } from '../../services/exchange.service';
+
+const CRITICAL_CATEGORIES = new Set<ExchangeKeyErrorCategory>(['authentication', 'permission']);
+
+@Component({
+  selector: 'app-exchange-status-alert',
+  imports: [ButtonModule, MessageModule, RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @for (key of unhealthyExchanges(); track key.id) {
+      <p-message severity="error" class="mb-3 block">
+        <ng-template #container>
+          <div class="flex w-full flex-wrap items-center justify-between gap-3 p-3">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-exclamation-circle" aria-hidden="true"></i>
+              <span>
+                <strong>{{ key.exchange.name }} Disconnected</strong> —
+                @if (key.deactivatedByHealthCheck) {
+                  Your API key was deactivated after repeated failures. Please recheck or update your API keys.
+                } @else {
+                  {{
+                    key.lastErrorCategory === 'authentication'
+                      ? 'Invalid API credentials.'
+                      : 'Insufficient API key permissions.'
+                  }}
+                  Trading is paused for this exchange.
+                }
+              </span>
+            </div>
+            <div class="flex shrink-0 items-center gap-2">
+              <p-button
+                label="Recheck"
+                icon="pi pi-refresh"
+                severity="danger"
+                [outlined]="true"
+                size="small"
+                [loading]="recheckMutation.isPending() && recheckingKeyId() === key.id"
+                (onClick)="recheck(key.id)"
+              />
+              <p-button
+                label="Update API Keys"
+                icon="pi pi-arrow-right"
+                iconPos="right"
+                routerLink="/app/settings"
+                severity="danger"
+                [outlined]="true"
+                size="small"
+              />
+            </div>
+          </div>
+        </ng-template>
+      </p-message>
+    }
+
+    @for (key of degradedExchanges(); track key.id) {
+      <p-message severity="warn" class="mb-3 block">
+        <ng-template #container>
+          <div class="flex w-full flex-wrap items-center justify-between gap-3 p-3">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-exclamation-triangle" aria-hidden="true"></i>
+              <span>
+                <strong>{{ key.exchange.name }} Degraded</strong> — experiencing connectivity issues. Trading may be
+                temporarily affected.
+              </span>
+            </div>
+            <div class="flex shrink-0 items-center gap-2">
+              <p-button
+                label="Recheck"
+                icon="pi pi-refresh"
+                severity="warn"
+                [outlined]="true"
+                size="small"
+                [loading]="recheckMutation.isPending() && recheckingKeyId() === key.id"
+                (onClick)="recheck(key.id)"
+              />
+            </div>
+          </div>
+        </ng-template>
+      </p-message>
+    }
+  `
+})
+export class ExchangeStatusAlertComponent {
+  private readonly exchangeService = inject(ExchangeService);
+  private readonly healthQuery = this.exchangeService.useExchangeHealth();
+  readonly recheckMutation = this.exchangeService.useRecheckKeyMutation();
+  private readonly recheckingId = signal<string | null>(null);
+  readonly recheckingKeyId = computed(() => (this.recheckMutation.isPending() ? this.recheckingId() : null));
+
+  readonly unhealthyExchanges = computed<ExchangeKeyHealthSummary[]>(() => {
+    const data = this.healthQuery.data();
+    if (!data) return [];
+    return data.filter(
+      (k) =>
+        k.healthStatus === 'deactivated' ||
+        (k.healthStatus !== 'healthy' && k.lastErrorCategory !== null && CRITICAL_CATEGORIES.has(k.lastErrorCategory))
+    );
+  });
+
+  readonly degradedExchanges = computed<ExchangeKeyHealthSummary[]>(() => {
+    const data = this.healthQuery.data();
+    if (!data) return [];
+    const unhealthyIds = new Set(this.unhealthyExchanges().map((k) => k.id));
+    return data.filter((k) => k.healthStatus !== 'healthy' && k.healthStatus !== 'unknown' && !unhealthyIds.has(k.id));
+  });
+
+  recheck(keyId: string): void {
+    this.recheckingId.set(keyId);
+    this.recheckMutation.mutate(keyId);
+  }
+}

--- a/apps/chansey/src/app/shared/services/exchange.service.ts
+++ b/apps/chansey/src/app/shared/services/exchange.service.ts
@@ -3,8 +3,8 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { MessageService } from 'primeng/api';
 
-import { Exchange, ExchangeKey } from '@chansey/api-interfaces';
-import { queryKeys, useAuthMutation, useAuthQuery, STATIC_POLICY } from '@chansey/shared';
+import { Exchange, ExchangeKey, ExchangeKeyHealthSummary } from '@chansey/api-interfaces';
+import { queryKeys, useAuthMutation, useAuthQuery, FREQUENT_POLICY, STATIC_POLICY } from '@chansey/shared';
 
 import { ExchangeFormState } from '../types/exchange-form.types';
 
@@ -28,6 +28,22 @@ export class ExchangeService {
     return useAuthQuery<Exchange[]>(queryKeys.exchanges.supported(), '/api/exchange?supported=true', {
       cachePolicy: STATIC_POLICY
     });
+  }
+
+  useExchangeHealth() {
+    return useAuthQuery<ExchangeKeyHealthSummary[]>(queryKeys.exchanges.health(), '/api/exchange-keys/health', {
+      cachePolicy: FREQUENT_POLICY
+    });
+  }
+
+  useRecheckKeyMutation() {
+    return useAuthMutation<ExchangeKeyHealthSummary, string>(
+      (id: string) => `/api/exchange-keys/${id}/recheck`,
+      'POST',
+      {
+        invalidateQueries: [queryKeys.exchanges.health(), queryKeys.auth.user(), queryKeys.profile.exchangeKeys()]
+      }
+    );
   }
 
   useSaveExchangeKeysMutation() {

--- a/libs/api-interfaces/src/lib/exchange/exchange.interface.ts
+++ b/libs/api-interfaces/src/lib/exchange/exchange.interface.ts
@@ -71,3 +71,26 @@ export interface ExchangeKey {
   supportsFutures?: boolean;
   createdAt?: Date;
 }
+
+export type ExchangeKeyHealthStatus = 'healthy' | 'unhealthy' | 'warning' | 'deactivated' | 'unknown';
+export type ExchangeKeyErrorCategory =
+  | 'authentication'
+  | 'permission'
+  | 'nonce'
+  | 'exchange_down'
+  | 'rate_limit'
+  | 'network'
+  | 'unknown';
+
+export interface ExchangeKeyHealthSummary {
+  id: string;
+  exchangeId: string;
+  exchange: { id: string; name: string; slug: string };
+  healthStatus: ExchangeKeyHealthStatus;
+  lastHealthCheckAt: Date | null;
+  consecutiveFailures: number;
+  lastErrorCategory: ExchangeKeyErrorCategory | null;
+  lastErrorMessage: string | null;
+  deactivatedByHealthCheck: boolean;
+  isActive: boolean;
+}

--- a/libs/shared/src/lib/query/query-keys.ts
+++ b/libs/shared/src/lib/query/query-keys.ts
@@ -75,7 +75,8 @@ export const queryKeys = {
     lists: () => [...queryKeys.exchanges.all, 'list'] as const,
     supported: () => [...queryKeys.exchanges.lists(), 'supported'] as const,
     detail: (id: string) => [...queryKeys.exchanges.all, 'detail', id] as const,
-    sync: () => [...queryKeys.exchanges.all, 'sync'] as const
+    sync: () => [...queryKeys.exchanges.all, 'sync'] as const,
+    health: () => [...queryKeys.exchanges.all, 'health'] as const
   },
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add scheduled exchange key health monitoring with BullMQ (every 4 hours) — classifies errors by category, auto-deactivates keys after auth failures, and sends email notifications
- Add recheck endpoint to reactivate and re-verify deactivated exchange keys
- Create `ExchangeStatusAlert` dashboard component showing error/warning banners for unhealthy keys
- Add shared `ExchangeKeyHealthStatus` and `ExchangeKeyErrorCategory` types across API and frontend

## Changes

### API
- `exchange-key-health.service.ts` — Parallelized health checks with staggered execution, atomic failure counters, `toHealthSummaryDto()` helper
- `exchange-key.controller.ts` — Add recheck endpoint with `ParseUUIDPipe` validation
- `exchange-key-health-log.entity.ts` / `exchange-key.entity.ts` — Use shared enum types instead of strings
- `exchange-key-health.dto.ts` / `exchange-key-response.dto.ts` — Updated DTOs with shared types and `HealthHistoryQueryDto` validation

### Frontend
- `exchange-status-alert.component.ts` — New standalone component displaying health warnings/errors with recheck action
- `exchange.service.ts` — Add health summary query and recheck mutation via TanStack Query
- `dashboard.component.*` — Wire up the alert component

### Shared
- `exchange.interface.ts` — Add `ExchangeKeyHealthSummary`, `ExchangeKeyHealthStatus`, `ExchangeKeyErrorCategory`
- `query-keys.ts` — Add health query key

## Test Plan

- [ ] `nx test api` passes (includes exchange-key-health unit tests)
- [ ] Dashboard shows alert banner when exchange key has health issues
- [ ] Recheck button reactivates a deactivated key and re-verifies it
- [ ] No alerts shown when all keys are healthy

## Related Issues

Closes #295