### PR TITLE
feat(api): add live trading signal outcome recording system

### DIFF
--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -18,6 +18,7 @@ import { OrderModule } from '../order/order.module';
 import { PaperTradingOrder } from '../order/paper-trading/entities/paper-trading-order.entity';
 import { PaperTradingSession } from '../order/paper-trading/entities/paper-trading-session.entity';
 import { PaperTradingSignal } from '../order/paper-trading/entities/paper-trading-signal.entity';
+import { LiveTradingSignal } from '../strategy/entities/live-trading-signal.entity';
 import { StrategyModule } from '../strategy/strategy.module';
 import { TasksModule } from '../tasks/tasks.module';
 
@@ -45,7 +46,8 @@ import { TasksModule } from '../tasks/tasks.module';
       OptimizationResult,
       PaperTradingSession,
       PaperTradingOrder,
-      PaperTradingSignal
+      PaperTradingSignal,
+      LiveTradingSignal
     ]),
     AuditModule,
     LiveTradeMonitoringModule,

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.spec.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.spec.ts
@@ -1,7 +1,10 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
+
+import { SignalSource } from '@chansey/api-interfaces';
 
 import { BacktestMonitoringService } from './backtest-monitoring.service';
 import { ExportFormat } from './dto/backtest-listing.dto';
@@ -25,6 +28,7 @@ import {
 import { PaperTradingOrder } from '../../order/paper-trading/entities/paper-trading-order.entity';
 import { PaperTradingSession } from '../../order/paper-trading/entities/paper-trading-session.entity';
 import { PaperTradingSignal } from '../../order/paper-trading/entities/paper-trading-signal.entity';
+import { LiveTradingSignal } from '../../strategy/entities/live-trading-signal.entity';
 
 type MockRepo<T extends ObjectLiteral> = Partial<jest.Mocked<Repository<T>>>;
 
@@ -206,6 +210,10 @@ describe('BacktestMonitoringService', () => {
           useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) }
         },
         {
+          provide: getRepositoryToken(LiveTradingSignal),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) }
+        },
+        {
           provide: getRepositoryToken(Coin),
           useValue: { find: jest.fn().mockResolvedValue([]) }
         }
@@ -305,7 +313,14 @@ describe('BacktestMonitoringService', () => {
 
       await service.getOverview(filters);
 
-      expect(mockQueryBuilder.where).toHaveBeenCalled();
+      // Verify date range was applied to query builders
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        'b.createdAt BETWEEN :start AND :end',
+        expect.objectContaining({
+          start: expect.any(Date),
+          end: expect.any(Date)
+        })
+      );
     });
   });
 
@@ -538,16 +553,19 @@ describe('BacktestMonitoringService', () => {
       expect(result.toString()).toContain('id,');
     });
 
-    it('returns empty data when no backtests exist', async () => {
-      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
-
-      const jsonResult = await service.exportBacktests({}, ExportFormat.JSON);
-      expect(jsonResult).toEqual([]);
-
-      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+    it('returns CSV with headers matching JSON export fields', async () => {
+      const backtests = [createBacktest()];
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce(backtests);
 
       const csvResult = await service.exportBacktests({}, ExportFormat.CSV);
-      expect(csvResult.toString()).toBe('');
+      const csvString = csvResult.toString();
+      const headers = csvString.split('\n')[0];
+
+      // Verify CSV headers match the export field mapping
+      expect(headers).toContain('id');
+      expect(headers).toContain('sharpeRatio');
+      expect(headers).toContain('totalReturn');
+      expect(headers).toContain('algorithmName');
     });
   });
 
@@ -586,38 +604,48 @@ describe('BacktestMonitoringService', () => {
 
   describe('getSignalActivityFeed', () => {
     it('returns combined feed with health summary when no signals exist', async () => {
-      // Mock backtest signals query (getMany returns empty)
+      // Mock 3 signal sources (backtest, paper, live)
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
-      // Mock paper signals query (getMany returns empty)
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
-      // Mock backtest stats (getRawOne for consolidated query)
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      // Mock health stats for all 3 sources
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
         maxTs: null,
         hourCount: '0',
         dayCount: '0'
       });
-      // Mock paper stats (getRawOne for consolidated query)
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
         maxTs: null,
         hourCount: '0',
         dayCount: '0'
       });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: '0',
+        dayCount: '0'
+      });
+      // Mock active source counts
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(0);
 
       const result = await service.getSignalActivityFeed(100);
 
       expect(result).toMatchObject({
         signals: [],
-        health: expect.objectContaining({
+        health: {
           signalsLastHour: 0,
           signalsLast24h: 0,
-          totalActiveSources: 0
-        })
+          totalActiveSources: 0,
+          activeBacktestSources: 0,
+          activePaperTradingSources: 0
+        }
       });
-      expect(result).not.toHaveProperty('totalCount');
+      expect(result.health.lastSignalTime).toBeUndefined();
+      expect(result.health.lastSignalAgoMs).toBeUndefined();
     });
 
-    it('merges and sorts signals by timestamp DESC', async () => {
+    it('merges and sorts signals from all sources by timestamp DESC', async () => {
       const now = new Date();
+      const twoMinAgo = new Date(now.getTime() - 2 * 60 * 1000);
       const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
       const tenMinAgo = new Date(now.getTime() - 10 * 60 * 1000);
 
@@ -657,7 +685,28 @@ describe('BacktestMonitoringService', () => {
         }
       ]);
 
-      // Mock health queries
+      // Mock live signals
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 'ls-1',
+          createdAt: twoMinAgo,
+          action: 'buy',
+          symbol: 'SOL/USDT',
+          quantity: 10,
+          price: 150,
+          confidence: 0.9,
+          status: 'PLACED',
+          reasonCode: null,
+          reason: 'Strong momentum',
+          strategyConfigId: 'sc-1',
+          algorithmActivationId: null,
+          user: { email: 'user3@test.com' },
+          strategyConfig: { id: 'sc-1', name: 'Momentum', algorithm: { name: 'Algo3' } },
+          algorithmActivation: null
+        }
+      ]);
+
+      // Mock health queries (3 sources + 2 counts)
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
         maxTs: tenMinAgo.toISOString(),
         hourCount: '1',
@@ -668,15 +717,25 @@ describe('BacktestMonitoringService', () => {
         hourCount: '1',
         dayCount: '1'
       });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: twoMinAgo.toISOString(),
+        hourCount: '1',
+        dayCount: '1'
+      });
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(1);
 
       const result = await service.getSignalActivityFeed(10);
 
-      expect(result.signals).toHaveLength(2);
-      // Paper signal (5min ago) should come first (more recent)
-      expect(result.signals[0].id).toBe('ps-1');
-      expect(result.signals[0].source).toBe('PAPER_TRADING');
-      expect(result.signals[1].id).toBe('bs-1');
-      expect(result.signals[1].source).toBe('BACKTEST');
+      expect(result.signals).toHaveLength(3);
+      // Live signal (2min ago) → Paper (5min ago) → Backtest (10min ago)
+      expect(result.signals[0].id).toBe('ls-1');
+      expect(result.signals[0].source).toBe('LIVE_TRADING');
+      expect(result.signals[0].signalType).toBe(SignalType.ENTRY);
+      expect(result.signals[0].direction).toBe(SignalDirection.LONG);
+      expect(result.signals[1].id).toBe('ps-1');
+      expect(result.signals[1].source).toBe('PAPER_TRADING');
+      expect(result.signals[2].id).toBe('bs-1');
+      expect(result.signals[2].source).toBe('BACKTEST');
     });
 
     it('respects limit parameter', async () => {
@@ -695,49 +754,70 @@ describe('BacktestMonitoringService', () => {
 
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce(signals);
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
 
-      // Health queries
+      // Health queries (3 sources + count)
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(0);
 
       const result = await service.getSignalActivityFeed(3);
 
-      expect(result.signals.length).toBeLessThanOrEqual(3);
+      expect(result.signals).toHaveLength(3);
     });
   });
 
   describe('getSignalHealth (via getSignalActivityFeed)', () => {
-    it('returns combined counts from both signal tables', async () => {
+    it('returns combined counts from all three signal tables', async () => {
+      // 3 signal sources return empty
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
 
       const recentTime = new Date(Date.now() - 60000).toISOString();
 
+      // Health: backtest stats
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
         maxTs: recentTime,
         hourCount: '5',
         dayCount: '20'
       });
+      // Health: paper stats
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
         maxTs: null,
         hourCount: '3',
         dayCount: '10'
       });
+      // Health: live stats
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: '2',
+        dayCount: '5'
+      });
+      // Active source counts
       (backtestRepo.count as jest.Mock).mockResolvedValueOnce(2);
 
       const result = await service.getSignalActivityFeed(100);
 
-      expect(result.health.signalsLastHour).toBe(8);
-      expect(result.health.signalsLast24h).toBe(30);
+      expect(result.health.signalsLastHour).toBe(10); // 5+3+2
+      expect(result.health.signalsLast24h).toBe(35); // 20+10+5
       expect(result.health.lastSignalTime).toBe(recentTime);
-      expect(result.health.lastSignalAgoMs).toBeDefined();
+      expect(result.health.lastSignalAgoMs).toBeGreaterThan(0);
+      expect(result.health.lastSignalAgoMs).toBeLessThan(120000);
+      expect(result.health.activeBacktestSources).toBe(2);
     });
 
     it('handles no signals gracefully', async () => {
+      // 3 signal sources return empty
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
       (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      // 3 health stats return zeros
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
       (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(0);
 
       const result = await service.getSignalActivityFeed(100);
 
@@ -745,6 +825,223 @@ describe('BacktestMonitoringService', () => {
       expect(result.health.lastSignalAgoMs).toBeUndefined();
       expect(result.health.signalsLastHour).toBe(0);
       expect(result.health.signalsLast24h).toBe(0);
+      expect(result.health.totalActiveSources).toBe(0);
+    });
+
+    it('preserves partial NaN values instead of zeroing entire sum', async () => {
+      // 3 signal sources return empty
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      // backtest returns valid count, paper returns null/NaN, live returns valid count
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: '7',
+        dayCount: '20'
+      });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: null,
+        dayCount: null
+      });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: null,
+        hourCount: '3',
+        dayCount: '5'
+      });
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(0);
+
+      const result = await service.getSignalActivityFeed(100);
+
+      // With fixed parseInt precedence, null entries default to 0 individually
+      // so 7+0+3=10 (not 0 due to || 0 applying only to last parseInt)
+      expect(result.health.signalsLastHour).toBe(10);
+      expect(result.health.signalsLast24h).toBe(25);
+    });
+  });
+
+  describe('exportSignals — error path', () => {
+    it('throws NotFoundException when backtest does not exist', async () => {
+      (backtestRepo.existsBy as jest.Mock).mockResolvedValueOnce(false);
+
+      await expect(service.exportSignals('nonexistent-id', ExportFormat.JSON)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('exportTrades — error path', () => {
+    it('throws NotFoundException when backtest does not exist', async () => {
+      (backtestRepo.existsBy as jest.Mock).mockResolvedValueOnce(false);
+
+      await expect(service.exportTrades('nonexistent-id', ExportFormat.JSON)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getSignalActivityFeed — live signal mapping', () => {
+    it('maps buy action to ENTRY/LONG and sell action to EXIT/LONG', async () => {
+      const now = new Date();
+      const oneMinAgo = new Date(now.getTime() - 60000);
+      const twoMinAgo = new Date(now.getTime() - 120000);
+
+      // Backtest + paper empty
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      // Live signals with different actions
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 'ls-buy',
+          createdAt: oneMinAgo,
+          action: 'buy',
+          symbol: 'BTC/USDT',
+          quantity: 1,
+          price: 60000,
+          confidence: 0.85,
+          status: 'PLACED',
+          reasonCode: null,
+          reason: 'Bullish signal',
+          strategyConfigId: 'sc-1',
+          algorithmActivationId: null,
+          user: { email: 'u@t.com' },
+          strategyConfig: { id: 'sc-1', name: 'Strat', algorithm: { name: 'Algo' } },
+          algorithmActivation: null
+        },
+        {
+          id: 'ls-sell',
+          createdAt: twoMinAgo,
+          action: 'sell',
+          symbol: 'BTC/USDT',
+          quantity: 1,
+          price: 61000,
+          confidence: 0.7,
+          status: 'PLACED',
+          reasonCode: null,
+          reason: 'Take profit',
+          strategyConfigId: 'sc-1',
+          algorithmActivationId: null,
+          user: { email: 'u@t.com' },
+          strategyConfig: { id: 'sc-1', name: 'Strat', algorithm: { name: 'Algo' } },
+          algorithmActivation: null
+        }
+      ]);
+      // Health queries
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: oneMinAgo.toISOString(),
+        hourCount: '2',
+        dayCount: '2'
+      });
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(0);
+
+      const result = await service.getSignalActivityFeed(10);
+
+      const buySignal = result.signals.find((s) => s.id === 'ls-buy');
+      const sellSignal = result.signals.find((s) => s.id === 'ls-sell');
+
+      expect(buySignal).toBeDefined();
+      expect(buySignal!.signalType).toBe(SignalType.ENTRY);
+      expect(buySignal!.direction).toBe(SignalDirection.LONG);
+      expect(buySignal!.source).toBe(SignalSource.LIVE_TRADING);
+      expect(buySignal!.instrument).toBe('BTC/USDT');
+
+      expect(sellSignal).toBeDefined();
+      expect(sellSignal!.signalType).toBe(SignalType.EXIT);
+      expect(sellSignal!.direction).toBe(SignalDirection.LONG);
+    });
+
+    it('maps short_entry to ENTRY/SHORT and short_exit to EXIT/SHORT', async () => {
+      const now = new Date();
+
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 'ls-short-entry',
+          createdAt: now,
+          action: 'short_entry',
+          symbol: 'ETH/USDT',
+          quantity: 5,
+          price: 3000,
+          confidence: 0.6,
+          status: 'PLACED',
+          reasonCode: null,
+          reason: 'Bearish',
+          strategyConfigId: null,
+          algorithmActivationId: 'aa-1',
+          user: { email: 'u@t.com' },
+          strategyConfig: null,
+          algorithmActivation: { id: 'aa-1', algorithm: { name: 'ShortAlgo' } }
+        }
+      ]);
+      // Health queries
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({ maxTs: null, hourCount: '0', dayCount: '0' });
+      (mockQueryBuilder.getRawOne as jest.Mock).mockResolvedValueOnce({
+        maxTs: now.toISOString(),
+        hourCount: '1',
+        dayCount: '1'
+      });
+      (backtestRepo.count as jest.Mock).mockResolvedValueOnce(0);
+
+      const result = await service.getSignalActivityFeed(10);
+
+      expect(result.signals[0].signalType).toBe(SignalType.ENTRY);
+      expect(result.signals[0].direction).toBe(SignalDirection.SHORT);
+      expect(result.signals[0].algorithmName).toBe('ShortAlgo');
+    });
+  });
+
+  describe('getPipelineStageCounts', () => {
+    it('returns status breakdowns for all pipeline stages', async () => {
+      // Mock optimization runs
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([
+        { status: 'COMPLETED', count: '5' },
+        { status: 'RUNNING', count: '2' }
+      ]);
+      // Mock historical backtests
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([
+        { status: 'COMPLETED', count: '10' },
+        { status: 'FAILED', count: '1' }
+      ]);
+      // Mock live replay backtests
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([{ status: 'RUNNING', count: '3' }]);
+      // Mock paper trading sessions
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([
+        { status: 'ACTIVE', count: '4' },
+        { status: 'COMPLETED', count: '6' }
+      ]);
+
+      const result = await service.getPipelineStageCounts();
+
+      expect(result.optimizationRuns).toEqual({
+        total: 7,
+        statusBreakdown: { COMPLETED: 5, RUNNING: 2 }
+      });
+      expect(result.historicalBacktests).toEqual({
+        total: 11,
+        statusBreakdown: { COMPLETED: 10, FAILED: 1 }
+      });
+      expect(result.liveReplayBacktests).toEqual({
+        total: 3,
+        statusBreakdown: { RUNNING: 3 }
+      });
+      expect(result.paperTradingSessions).toEqual({
+        total: 10,
+        statusBreakdown: { ACTIVE: 4, COMPLETED: 6 }
+      });
+    });
+
+    it('returns zeros for empty pipeline stages', async () => {
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([]);
+      (mockQueryBuilder.getRawMany as jest.Mock).mockResolvedValueOnce([]);
+
+      const result = await service.getPipelineStageCounts();
+
+      expect(result.optimizationRuns.total).toBe(0);
+      expect(result.historicalBacktests.total).toBe(0);
+      expect(result.liveReplayBacktests.total).toBe(0);
+      expect(result.paperTradingSessions.total).toBe(0);
     });
   });
 });

--- a/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/backtest-monitoring.service.ts
@@ -4,6 +4,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Decimal } from 'decimal.js';
 import { Between, In, ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
 
+import { SignalSource, SignalStatus } from '@chansey/api-interfaces';
+
 import {
   BacktestListItemDto,
   BacktestListQueryDto,
@@ -35,12 +37,7 @@ import {
   PipelineStageCountsDto,
   StageCountWithStatusDto
 } from './dto/paper-trading-analytics.dto';
-import {
-  SignalActivityFeedDto,
-  SignalFeedItemDto,
-  SignalHealthSummaryDto,
-  SignalSource
-} from './dto/signal-activity-feed.dto';
+import { SignalActivityFeedDto, SignalFeedItemDto, SignalHealthSummaryDto } from './dto/signal-activity-feed.dto';
 import {
   ConfidenceBucketDto,
   SignalAnalyticsDto,
@@ -85,6 +82,7 @@ import {
   PaperTradingSignalDirection,
   PaperTradingSignalType
 } from '../../order/paper-trading/entities/paper-trading-signal.entity';
+import { LiveTradingSignal } from '../../strategy/entities/live-trading-signal.entity';
 
 /** Maximum number of records to export to prevent DoS */
 const MAX_EXPORT_LIMIT = 10000;
@@ -131,7 +129,9 @@ export class BacktestMonitoringService {
     @InjectRepository(PaperTradingOrder)
     private readonly paperOrderRepo: Repository<PaperTradingOrder>,
     @InjectRepository(PaperTradingSignal)
-    private readonly paperSignalRepo: Repository<PaperTradingSignal>
+    private readonly paperSignalRepo: Repository<PaperTradingSignal>,
+    @InjectRepository(LiveTradingSignal)
+    private readonly liveSignalRepo: Repository<LiveTradingSignal>
   ) {}
 
   /**
@@ -683,7 +683,7 @@ export class BacktestMonitoringService {
   }
 
   private async getRecentSignals(limit: number): Promise<SignalFeedItemDto[]> {
-    const [backtestSignals, paperSignals] = await Promise.all([
+    const [backtestSignals, paperSignals, liveSignals] = await Promise.all([
       this.signalRepo
         .createQueryBuilder('s')
         .innerJoinAndSelect('s.backtest', 'b')
@@ -730,6 +730,36 @@ export class BacktestMonitoringService {
         ])
         .orderBy('ps.createdAt', 'DESC')
         .take(limit)
+        .getMany(),
+      this.liveSignalRepo
+        .createQueryBuilder('ls')
+        .leftJoinAndSelect('ls.user', 'u')
+        .leftJoinAndSelect('ls.strategyConfig', 'sc')
+        .leftJoinAndSelect('sc.algorithm', 'sca')
+        .leftJoinAndSelect('ls.algorithmActivation', 'aa')
+        .leftJoinAndSelect('aa.algorithm', 'aaa')
+        .select([
+          'ls.id',
+          'ls.createdAt',
+          'ls.action',
+          'ls.symbol',
+          'ls.quantity',
+          'ls.price',
+          'ls.confidence',
+          'ls.status',
+          'ls.reasonCode',
+          'ls.reason',
+          'ls.strategyConfigId',
+          'ls.algorithmActivationId',
+          'u.email',
+          'sc.id',
+          'sc.name',
+          'sca.name',
+          'aa.id',
+          'aaa.name'
+        ])
+        .orderBy('ls.createdAt', 'DESC')
+        .take(limit)
         .getMany()
     ]);
 
@@ -745,6 +775,8 @@ export class BacktestMonitoringService {
         quantity: s.quantity,
         price: s.price ?? undefined,
         confidence: s.confidence ?? undefined,
+        status: SignalStatus.RECORDED,
+        reasonCode: undefined,
         reason: s.reason ?? undefined,
         source: SignalSource.BACKTEST,
         sourceId: s.backtest.id,
@@ -764,6 +796,8 @@ export class BacktestMonitoringService {
         quantity: ps.quantity,
         price: ps.price ?? undefined,
         confidence: ps.confidence ?? undefined,
+        status: ps.processed ? SignalStatus.PROCESSED : SignalStatus.PENDING,
+        reasonCode: undefined,
         reason: ps.reason ?? undefined,
         source: SignalSource.PAPER_TRADING,
         sourceId: ps.session.id,
@@ -771,6 +805,27 @@ export class BacktestMonitoringService {
         algorithmName: ps.session.algorithm?.name || 'Unknown',
         userEmail: ps.session.user?.email,
         processed: ps.processed
+      });
+    }
+
+    for (const ls of liveSignals) {
+      mapped.push({
+        id: ls.id,
+        timestamp: ls.createdAt.toISOString(),
+        signalType: this.mapLiveSignalType(ls.action),
+        direction: this.mapLiveSignalDirection(ls.action),
+        instrument: ls.symbol?.toUpperCase() ?? ls.symbol,
+        quantity: ls.quantity,
+        price: ls.price ?? undefined,
+        confidence: ls.confidence ?? undefined,
+        status: ls.status,
+        reasonCode: ls.reasonCode ?? undefined,
+        reason: ls.reason ?? undefined,
+        source: SignalSource.LIVE_TRADING,
+        sourceId: ls.strategyConfigId ?? ls.algorithmActivationId ?? ls.id,
+        sourceName: ls.strategyConfig?.name ?? ls.algorithmActivation?.id ?? 'Live trading',
+        algorithmName: ls.strategyConfig?.algorithm?.name ?? ls.algorithmActivation?.algorithm?.name ?? 'Unknown',
+        userEmail: ls.user?.email
       });
     }
 
@@ -793,7 +848,7 @@ export class BacktestMonitoringService {
     const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
     const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
 
-    const [backtestStats, paperStats, activeBacktests, activePaperSessions] = await Promise.all([
+    const [backtestStats, paperStats, liveStats, activeBacktests, activePaperSessions] = await Promise.all([
       this.signalRepo
         .createQueryBuilder('s')
         .select('MAX(s.timestamp)', 'maxTs')
@@ -810,18 +865,28 @@ export class BacktestMonitoringService {
         .setParameter('oneHourAgo', oneHourAgo)
         .setParameter('oneDayAgo', oneDayAgo)
         .getRawOne(),
+      this.liveSignalRepo
+        .createQueryBuilder('ls')
+        .select('MAX(ls.createdAt)', 'maxTs')
+        .addSelect(`COUNT(*) FILTER (WHERE ls.createdAt >= :oneHourAgo)`, 'hourCount')
+        .addSelect(`COUNT(*) FILTER (WHERE ls.createdAt >= :oneDayAgo)`, 'dayCount')
+        .setParameter('oneHourAgo', oneHourAgo)
+        .setParameter('oneDayAgo', oneDayAgo)
+        .getRawOne(),
       this.backtestRepo.count({ where: { status: BacktestStatus.RUNNING } }),
       this.paperSessionRepo.count({ where: { status: PaperTradingStatus.ACTIVE } })
     ]);
 
     const backtestMax = backtestStats?.maxTs ? new Date(backtestStats.maxTs) : null;
     const paperMax = paperStats?.maxTs ? new Date(paperStats.maxTs) : null;
+    const liveMax = liveStats?.maxTs ? new Date(liveStats.maxTs) : null;
 
     let lastSignalTime: string | undefined;
     let lastSignalAgoMs: number | undefined;
 
-    const latest =
-      backtestMax && paperMax ? (backtestMax > paperMax ? backtestMax : paperMax) : (backtestMax ?? paperMax);
+    const latest = [backtestMax, paperMax, liveMax]
+      .filter((value): value is Date => value != null)
+      .sort((left, right) => right.getTime() - left.getTime())[0];
 
     if (latest) {
       lastSignalTime = latest.toISOString();
@@ -833,12 +898,26 @@ export class BacktestMonitoringService {
     return {
       lastSignalTime,
       lastSignalAgoMs,
-      signalsLastHour: parseInt(backtestStats?.hourCount, 10) + parseInt(paperStats?.hourCount, 10) || 0,
-      signalsLast24h: parseInt(backtestStats?.dayCount, 10) + parseInt(paperStats?.dayCount, 10) || 0,
+      signalsLastHour:
+        (parseInt(backtestStats?.hourCount, 10) || 0) +
+        (parseInt(paperStats?.hourCount, 10) || 0) +
+        (parseInt(liveStats?.hourCount, 10) || 0),
+      signalsLast24h:
+        (parseInt(backtestStats?.dayCount, 10) || 0) +
+        (parseInt(paperStats?.dayCount, 10) || 0) +
+        (parseInt(liveStats?.dayCount, 10) || 0),
       activeBacktestSources: activeBacktests,
       activePaperTradingSources: activePaperSessions,
       totalActiveSources
     };
+  }
+
+  private mapLiveSignalType(action: string): SignalType {
+    return action === 'buy' || action === 'short_entry' ? SignalType.ENTRY : SignalType.EXIT;
+  }
+
+  private mapLiveSignalDirection(action: string): SignalDirection {
+    return action === 'short_entry' || action === 'short_exit' ? SignalDirection.SHORT : SignalDirection.LONG;
   }
 
   // ===========================================================================

--- a/apps/api/src/admin/backtest-monitoring/dto/signal-activity-feed.dto.ts
+++ b/apps/api/src/admin/backtest-monitoring/dto/signal-activity-feed.dto.ts
@@ -3,12 +3,9 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
 
-import { SignalDirection, SignalType } from '../../../order/backtest/backtest.entity';
+import { SignalReasonCode, SignalSource, SignalStatus } from '@chansey/api-interfaces';
 
-export enum SignalSource {
-  BACKTEST = 'BACKTEST',
-  PAPER_TRADING = 'PAPER_TRADING'
-}
+import { SignalDirection, SignalType } from '../../../order/backtest/backtest.entity';
 
 /**
  * A single signal in the activity feed
@@ -37,6 +34,12 @@ export class SignalFeedItemDto {
 
   @ApiPropertyOptional({ description: 'Confidence score 0-1' })
   confidence?: number;
+
+  @ApiProperty({ description: 'Signal status', enum: SignalStatus })
+  status: SignalStatus;
+
+  @ApiPropertyOptional({ description: 'Machine-readable signal reason code', enum: SignalReasonCode })
+  reasonCode?: SignalReasonCode;
 
   @ApiPropertyOptional({ description: 'Human-readable reason' })
   reason?: string;

--- a/apps/api/src/migrations/1774830000000-create-live-trading-signals.ts
+++ b/apps/api/src/migrations/1774830000000-create-live-trading-signals.ts
@@ -1,0 +1,108 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateLiveTradingSignals1774830000000 implements MigrationInterface {
+  name = 'CreateLiveTradingSignals1774830000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "signal_source_enum" AS ENUM (
+        'BACKTEST',
+        'PAPER_TRADING',
+        'LIVE_TRADING'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "signal_status_enum" AS ENUM (
+        'RECORDED',
+        'PENDING',
+        'PROCESSED',
+        'PLACED',
+        'BLOCKED',
+        'FAILED'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "signal_reason_code_enum" AS ENUM (
+        'SIGNAL_VALIDATION_FAILED',
+        'DAILY_LOSS_LIMIT',
+        'REGIME_GATE',
+        'DRAWDOWN_GATE',
+        'CONCENTRATION_LIMIT',
+        'CONCENTRATION_REDUCED',
+        'OPPORTUNITY_SELLING_REJECTED',
+        'INSUFFICIENT_FUNDS',
+        'EXCHANGE_SELECTION_FAILED',
+        'TRADE_COOLDOWN',
+        'ORDER_EXECUTION_FAILED',
+        'SIGNAL_THROTTLED',
+        'SYMBOL_RESOLUTION_FAILED'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "live_trading_signal_action_enum" AS ENUM (
+        'buy',
+        'sell',
+        'short_entry',
+        'short_exit'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "live_trading_signals" (
+        "id" UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        "userId" UUID NOT NULL,
+        "strategyConfigId" UUID,
+        "algorithmActivationId" UUID,
+        "source" "signal_source_enum" NOT NULL DEFAULT 'LIVE_TRADING',
+        "action" "live_trading_signal_action_enum" NOT NULL,
+        "symbol" VARCHAR(50) NOT NULL,
+        "quantity" DECIMAL(25, 8) NOT NULL,
+        "price" DECIMAL(25, 8),
+        "confidence" DECIMAL(5, 4),
+        "status" "signal_status_enum" NOT NULL,
+        "reasonCode" "signal_reason_code_enum",
+        "reason" TEXT,
+        "metadata" JSONB,
+        "orderId" UUID,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "fk_live_trading_signals_user" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE,
+        CONSTRAINT "fk_live_trading_signals_strategy" FOREIGN KEY ("strategyConfigId") REFERENCES "strategy_configs"("id") ON DELETE SET NULL,
+        CONSTRAINT "fk_live_trading_signals_activation" FOREIGN KEY ("algorithmActivationId") REFERENCES "algorithm_activations"("id") ON DELETE SET NULL,
+        CONSTRAINT "fk_live_trading_signals_order" FOREIGN KEY ("orderId") REFERENCES "order"("id") ON DELETE SET NULL,
+        CONSTRAINT "CHK_live_signal_confidence" CHECK ("confidence" IS NULL OR ("confidence" >= 0 AND "confidence" <= 1))
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_live_trading_signals_created_at" ON "live_trading_signals" ("createdAt")`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_live_trading_signals_status_created_at" ON "live_trading_signals" ("status", "createdAt")`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_live_trading_signals_user_created_at" ON "live_trading_signals" ("userId", "createdAt")`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_live_trading_signals_strategy_created_at" ON "live_trading_signals" ("strategyConfigId", "createdAt")`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_live_trading_signals_activation_created_at" ON "live_trading_signals" ("algorithmActivationId", "createdAt")`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_live_trading_signals_activation_created_at"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_live_trading_signals_strategy_created_at"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_live_trading_signals_user_created_at"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_live_trading_signals_status_created_at"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_live_trading_signals_created_at"`);
+    await queryRunner.query(`DROP TABLE "live_trading_signals"`);
+    await queryRunner.query(`DROP TYPE "live_trading_signal_action_enum"`);
+    await queryRunner.query(`DROP TYPE "signal_reason_code_enum"`);
+    await queryRunner.query(`DROP TYPE "signal_status_enum"`);
+    await queryRunner.query(`DROP TYPE "signal_source_enum"`);
+  }
+}

--- a/apps/api/src/order/services/trade-execution.service.ts
+++ b/apps/api/src/order/services/trade-execution.service.ts
@@ -59,6 +59,8 @@ export interface TradeSignal {
  * Extended trade signal with exit configuration
  */
 export interface TradeSignalWithExit extends TradeSignal {
+  /** Original algorithm confidence score (0-1) */
+  confidence?: number;
   /** Exit configuration for automatic SL/TP/trailing stop placement */
   exitConfig?: Partial<ExitConfig>;
   /** Historical price data for ATR-based exit calculations */

--- a/apps/api/src/order/tasks/trade-execution.task.spec.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.spec.ts
@@ -3,7 +3,7 @@ import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { MarketType } from '@chansey/api-interfaces';
+import { MarketType, SignalReasonCode, SignalStatus } from '@chansey/api-interfaces';
 
 import { TradeExecutionTask } from './trade-execution.task';
 
@@ -21,6 +21,7 @@ import { TradeCooldownService } from '../../shared/trade-cooldown.service';
 import { ConcentrationGateService } from '../../strategy/concentration-gate.service';
 import { DailyLossLimitGateService } from '../../strategy/daily-loss-limit-gate.service';
 import { StrategyConfig } from '../../strategy/entities/strategy-config.entity';
+import { LiveSignalService } from '../../strategy/live-signal.service';
 import { User } from '../../users/users.entity';
 import { UsersService } from '../../users/users.service';
 import { SignalThrottleService } from '../backtest/shared/throttle';
@@ -44,6 +45,7 @@ describe('TradeExecutionTask', () => {
   let mockDailyLossLimitGate: any;
   let mockMetricsService: any;
   let mockExchangeSelectionService: any;
+  let mockLiveSignalService: any;
 
   const mockJob = {
     id: 'job-1',
@@ -183,6 +185,10 @@ describe('TradeExecutionTask', () => {
       selectForSell: jest.fn().mockResolvedValue({ id: 'key-1', exchange: { slug: 'binance_us' } })
     };
 
+    mockLiveSignalService = {
+      recordOutcome: jest.fn().mockResolvedValue({ id: 'live-signal-1' })
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TradeExecutionTask,
@@ -209,6 +215,7 @@ describe('TradeExecutionTask', () => {
         },
         { provide: MetricsService, useValue: mockMetricsService },
         { provide: ExchangeSelectionService, useValue: mockExchangeSelectionService },
+        { provide: LiveSignalService, useValue: mockLiveSignalService },
         { provide: FailedJobService, useValue: { recordFailure: jest.fn() } }
       ]
     }).compile();
@@ -361,7 +368,7 @@ describe('TradeExecutionTask', () => {
       expect(signalArg.positionSide).toBeUndefined();
     });
 
-    it('should skip when coin symbol resolution fails', async () => {
+    it('should block when coin symbol resolution fails', async () => {
       const activation = buildActivation();
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
       configureActionableSignal('unknown-coin');
@@ -369,8 +376,26 @@ describe('TradeExecutionTask', () => {
 
       const result: any = await task.process(mockJob);
 
-      expect(result.skippedCount).toBe(1);
+      expect(result.blockedCount).toBe(1);
       expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+    });
+
+    it('should record SYMBOL_RESOLUTION_FAILED outcome when coin resolution fails', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal('unknown-coin');
+      mockCoinService.getCoinById.mockRejectedValue(new Error('Coin not found'));
+
+      await task.process(mockJob);
+
+      expect(mockLiveSignalService.recordOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          algorithmActivationId: 'activation-1',
+          status: SignalStatus.BLOCKED,
+          reasonCode: SignalReasonCode.SYMBOL_RESOLUTION_FAILED
+        })
+      );
     });
 
     it('should use legacy service field when strategyId is missing', async () => {
@@ -416,7 +441,7 @@ describe('TradeExecutionTask', () => {
       expect(mockTradeExecutionService.executeTradeSignal.mock.calls[0][0].symbol).toBe(expectedSymbol);
     });
 
-    it('should skip when exchange selection fails', async () => {
+    it('should block when exchange selection fails', async () => {
       const activation = buildActivation();
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
       mockExchangeSelectionService.selectForBuy.mockRejectedValue(new Error('No active exchange keys'));
@@ -424,8 +449,26 @@ describe('TradeExecutionTask', () => {
 
       const result: any = await task.process(mockJob);
 
-      expect(result.skippedCount).toBe(1);
+      expect(result.blockedCount).toBe(1);
       expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+    });
+
+    it('should record EXCHANGE_SELECTION_FAILED outcome when exchange selection fails', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      mockExchangeSelectionService.selectForBuy.mockRejectedValue(new Error('No active exchange keys'));
+      configureActionableSignal();
+
+      await task.process(mockJob);
+
+      expect(mockLiveSignalService.recordOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          algorithmActivationId: 'activation-1',
+          status: SignalStatus.BLOCKED,
+          reasonCode: SignalReasonCode.EXCHANGE_SELECTION_FAILED
+        })
+      );
     });
   });
 
@@ -620,7 +663,7 @@ describe('TradeExecutionTask', () => {
       );
     });
 
-    it('should skip activation when all signals are throttled', async () => {
+    it('should block activation when all signals are throttled', async () => {
       const activation = buildActivation();
       mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
       configureActionableSignal();
@@ -628,8 +671,26 @@ describe('TradeExecutionTask', () => {
 
       const result: any = await task.process(mockJob);
 
-      expect(result.skippedCount).toBe(1);
+      expect(result.blockedCount).toBe(1);
       expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+    });
+
+    it('should record SIGNAL_THROTTLED outcome when all signals are throttled', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+      mockSignalThrottle.filterSignals.mockReturnValue([]);
+
+      await task.process(mockJob);
+
+      expect(mockLiveSignalService.recordOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          algorithmActivationId: 'activation-1',
+          status: SignalStatus.BLOCKED,
+          reasonCode: SignalReasonCode.SIGNAL_THROTTLED
+        })
+      );
     });
 
     it('should resolve throttle config from activation.config', async () => {
@@ -779,6 +840,18 @@ describe('TradeExecutionTask', () => {
       // Fail-closed: portfolio=0 skips activation before daily loss gate even checked
       expect(result.skippedCount).toBe(1);
       expect(mockTradeExecutionService.executeTradeSignal).not.toHaveBeenCalled();
+    });
+
+    it('does not crash when recordOutcome rejects — successCount still 1', async () => {
+      const activation = buildActivation();
+      mockActivationService.findAllActiveAlgorithms.mockResolvedValue([activation]);
+      configureActionableSignal();
+      mockLiveSignalService.recordOutcome.mockRejectedValue(new Error('DB write failed'));
+
+      const result: any = await task.process(mockJob);
+
+      expect(result.successCount).toBe(1);
+      expect(mockTradeExecutionService.executeTradeSignal).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/order/tasks/trade-execution.task.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.ts
@@ -6,7 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Job, Queue } from 'bullmq';
 import { In, Repository } from 'typeorm';
 
-import { MarketType } from '@chansey/api-interfaces';
+import { MarketType, SignalReasonCode, SignalSource, SignalStatus } from '@chansey/api-interfaces';
 
 import { TradingStateService } from '../../admin/trading-state/trading-state.service';
 import { AlgorithmActivation } from '../../algorithm/algorithm-activation.entity';
@@ -24,12 +24,24 @@ import { toErrorInfo } from '../../shared/error.util';
 import { TradeCooldownService } from '../../shared/trade-cooldown.service';
 import { ConcentrationGateService } from '../../strategy/concentration-gate.service';
 import { DailyLossLimitGateService } from '../../strategy/daily-loss-limit-gate.service';
+import { LiveTradingSignalAction } from '../../strategy/entities/live-trading-signal.entity';
 import { StrategyConfig } from '../../strategy/entities/strategy-config.entity';
+import { LiveSignalService } from '../../strategy/live-signal.service';
 import { AssetAllocation } from '../../strategy/risk/concentration-check.service';
 import { User } from '../../users/users.entity';
 import { UsersService } from '../../users/users.service';
 import { SignalThrottleService, ThrottleState } from '../backtest/shared/throttle';
 import { TradeExecutionService, TradeSignalWithExit } from '../services/trade-execution.service';
+
+interface GenerateSignalResult {
+  signal: TradeSignalWithExit | null;
+  skipReason?: {
+    reasonCode: SignalReasonCode;
+    reason: string;
+    metadata?: Record<string, unknown>;
+    partialSignal?: { action?: 'BUY' | 'SELL'; symbol?: string; confidence?: number; positionSide?: 'long' | 'short' };
+  };
+}
 
 const MIN_CONFIDENCE_THRESHOLD = 0.6;
 const ACTIONABLE_SIGNAL_TYPES = new Set([
@@ -74,7 +86,8 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     private readonly concentrationGate: ConcentrationGateService,
     private readonly metricsService: MetricsService,
     private readonly exchangeSelectionService: ExchangeSelectionService,
-    private readonly failedJobService: FailedJobService
+    private readonly failedJobService: FailedJobService,
+    private readonly liveSignalService: LiveSignalService
   ) {
     super();
   }
@@ -360,7 +373,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       return 'skipped';
     }
 
-    const signal = await this.generateTradeSignal(activation, portfolioValue);
+    const { signal, skipReason } = await this.generateTradeSignal(activation, portfolioValue);
 
     if (signal) {
       // Daily loss limit gate: block entry signals when user's rolling 24h losses exceed threshold
@@ -372,6 +385,11 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
         this.logger.warn(
           `Daily loss limit blocked activation ${activation.id}: ${signal.action} ${signal.symbol} (entry) for user ${activation.userId}`
         );
+        await this.recordActivationSignalOutcome(activation, signal, SignalStatus.BLOCKED, {
+          reasonCode: SignalReasonCode.DAILY_LOSS_LIMIT,
+          reason: `Daily loss limit blocked ${signal.action} ${signal.symbol}`,
+          metadata: { portfolioValue }
+        });
         return 'blocked';
       }
 
@@ -393,6 +411,11 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
           this.logger.warn(
             `Concentration gate blocked activation ${activation.id}: ${signal.action} ${signal.symbol} for user ${activation.userId}: ${concCheck.reason}`
           );
+          await this.recordActivationSignalOutcome(activation, signal, SignalStatus.BLOCKED, {
+            reasonCode: SignalReasonCode.CONCENTRATION_LIMIT,
+            reason: concCheck.reason,
+            metadata: { estimatedTradeUsd }
+          });
           return 'blocked';
         }
       }
@@ -410,11 +433,22 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
           `Trade cooldown blocked activation ${activation.id}: ${signal.action} ${signal.symbol} ` +
             `already claimed by ${cooldownCheck.existingClaim?.pipeline}`
         );
+        await this.recordActivationSignalOutcome(activation, signal, SignalStatus.BLOCKED, {
+          reasonCode: SignalReasonCode.TRADE_COOLDOWN,
+          reason:
+            `Trade cooldown blocked activation ${activation.id}: ${signal.action} ${signal.symbol} ` +
+            `already claimed by ${cooldownCheck.existingClaim?.pipeline}`,
+          metadata: { existingClaim: cooldownCheck.existingClaim?.pipeline }
+        });
         return 'blocked';
       }
 
       try {
-        await this.tradeExecutionService.executeTradeSignal(signal);
+        const order = await this.tradeExecutionService.executeTradeSignal(signal);
+        await this.recordActivationSignalOutcome(activation, signal, SignalStatus.PLACED, {
+          orderId: order.id,
+          quantity: Number(order.executedQuantity ?? order.quantity ?? signal.quantity)
+        });
         this.logger.log(
           `Executed trade for activation ${activation.id} (${activation.algorithm.name}): ${signal.action} ${signal.symbol}`
         );
@@ -422,8 +456,18 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       } catch (error: unknown) {
         // Clear cooldown on failure so next cycle can retry
         await this.tradeCooldownService.clearCooldown(signal.userId, signal.symbol, signal.action);
+        const err = toErrorInfo(error);
+        await this.recordActivationSignalOutcome(activation, signal, SignalStatus.FAILED, {
+          reasonCode: SignalReasonCode.ORDER_EXECUTION_FAILED,
+          reason: err.message
+        });
         throw error;
       }
+    }
+
+    if (skipReason) {
+      await this.recordSkippedSignalOutcome(activation, skipReason);
+      return 'blocked';
     }
 
     this.logger.debug(`No actionable signal for activation ${activation.id} (${activation.algorithm.name})`);
@@ -437,13 +481,13 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
   private async generateTradeSignal(
     activation: AlgorithmActivation,
     portfolioValue: number
-  ): Promise<TradeSignalWithExit | null> {
+  ): Promise<GenerateSignalResult> {
     const algorithm = activation.algorithm;
 
     // Skip algorithms without a strategy
     if (!algorithm.strategyId && !algorithm.service) {
       this.logger.debug(`Algorithm ${algorithm.name} has no strategy configured, skipping`);
-      return null;
+      return { signal: null };
     }
 
     // Build execution context
@@ -451,14 +495,14 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
 
     if (!this.contextBuilder.validateContext(context)) {
       this.logger.debug(`Context validation failed for algorithm ${algorithm.name}, skipping`);
-      return null;
+      return { signal: null };
     }
 
     // Execute the algorithm strategy
     const result = await this.algorithmRegistry.executeAlgorithm(activation.algorithmId, context);
 
     if (!result.success || !result.signals || result.signals.length === 0) {
-      return null;
+      return { signal: null };
     }
 
     // Filter to actionable signals with sufficient confidence
@@ -467,7 +511,7 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     );
 
     if (actionableSignals.length === 0) {
-      return null;
+      return { signal: null };
     }
 
     // Apply signal throttle: cooldowns, daily cap, min sell %
@@ -477,7 +521,23 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     const throttleOutput = this.signalThrottle.filterSignals(throttleInput, throttleState, throttleConfig, Date.now());
 
     if (throttleOutput.length === 0) {
-      return null;
+      const bestThrottled = actionableSignals.reduce((best, cur) =>
+        cur.strength * cur.confidence > best.strength * best.confidence ? cur : best
+      );
+      return {
+        signal: null,
+        skipReason: {
+          reasonCode: SignalReasonCode.SIGNAL_THROTTLED,
+          reason: `All ${actionableSignals.length} actionable signal(s) filtered by throttle`,
+          metadata: { filteredCount: actionableSignals.length },
+          partialSignal: {
+            action: this.mapSignalToAction(bestThrottled.type, 'spot')?.action,
+            symbol: bestThrottled.coinId,
+            confidence: bestThrottled.confidence,
+            positionSide: this.mapSignalToAction(bestThrottled.type, 'spot')?.positionSide
+          }
+        }
+      };
     }
 
     // Map accepted throttle signals back to original algorithm signals
@@ -499,14 +559,30 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     const symbol = await this.resolveTradingSymbol(bestSignal.coinId);
     if (!symbol) {
       this.logger.warn(`Could not resolve trading symbol for coin ${bestSignal.coinId}, skipping`);
-      return null;
+      return {
+        signal: null,
+        skipReason: {
+          reasonCode: SignalReasonCode.SYMBOL_RESOLUTION_FAILED,
+          reason: `Could not resolve trading symbol for coin ${bestSignal.coinId}`,
+          metadata: { coinId: bestSignal.coinId },
+          partialSignal: { confidence: bestSignal.confidence }
+        }
+      };
     }
 
     const marketContext = await this.resolveMarketContext(activation);
     const mapped = this.mapSignalToAction(bestSignal.type, marketContext.marketType);
     if (!mapped) {
       this.logger.warn(`Unknown signal type ${bestSignal.type} for activation ${activation.id}, skipping`);
-      return null;
+      return {
+        signal: null,
+        skipReason: {
+          reasonCode: SignalReasonCode.SIGNAL_VALIDATION_FAILED,
+          reason: `Unknown signal type ${bestSignal.type} for activation ${activation.id}`,
+          metadata: { signalType: bestSignal.type },
+          partialSignal: { symbol, confidence: bestSignal.confidence }
+        }
+      };
     }
     const { action, positionSide } = mapped;
 
@@ -520,7 +596,15 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
     } catch (error) {
       const err = toErrorInfo(error);
       this.logger.warn(`Exchange selection failed for activation ${activation.id}: ${err.message}`);
-      return null;
+      return {
+        signal: null,
+        skipReason: {
+          reasonCode: SignalReasonCode.EXCHANGE_SELECTION_FAILED,
+          reason: `Exchange selection failed: ${err.message}`,
+          metadata: { errorMessage: err.message },
+          partialSignal: { action, symbol, confidence: bestSignal.confidence, positionSide }
+        }
+      };
     }
 
     // Re-resolve symbol with correct exchange-specific quote currency if needed
@@ -530,19 +614,22 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       : symbol;
 
     return {
-      algorithmActivationId: activation.id,
-      userId: activation.userId,
-      exchangeKeyId: exchangeKey.id,
-      action,
-      symbol: finalSymbol,
-      quantity: 0,
-      autoSize: true,
-      portfolioValue,
-      allocationPercentage: activation.allocationPercentage || 5.0,
-      marketType: marketContext.marketType,
-      leverage: marketContext.leverage,
-      positionSide,
-      exitConfig
+      signal: {
+        algorithmActivationId: activation.id,
+        userId: activation.userId,
+        exchangeKeyId: exchangeKey.id,
+        action,
+        symbol: finalSymbol,
+        quantity: 0,
+        confidence: bestSignal.confidence,
+        autoSize: true,
+        portfolioValue,
+        allocationPercentage: activation.allocationPercentage || 5.0,
+        marketType: marketContext.marketType,
+        leverage: marketContext.leverage,
+        positionSide,
+        exitConfig
+      }
     };
   }
 
@@ -616,21 +703,6 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
   }
 
   /**
-   * Fetch total portfolio USD value for a user
-   * Returns 0 on error for graceful degradation
-   */
-  private async fetchPortfolioValue(user: User): Promise<number> {
-    try {
-      const balances = await this.balanceService.getUserBalances(user);
-      return balances.totalUsdValue || 0;
-    } catch (error) {
-      const err = toErrorInfo(error);
-      this.logger.warn(`Failed to fetch portfolio value for user ${user.id}: ${err.message}`);
-      return 0;
-    }
-  }
-
-  /**
    * Filter out activations belonging to robo-advisor users (algoTradingEnabled=true).
    * Those users are handled exclusively by Pipeline 1 (LiveTradingService).
    */
@@ -688,5 +760,76 @@ export class TradeExecutionTask extends WorkerHost implements OnModuleInit {
       this.throttleStates.set(activationId, state);
     }
     return state;
+  }
+
+  private async recordActivationSignalOutcome(
+    activation: AlgorithmActivation,
+    signal: TradeSignalWithExit,
+    status: SignalStatus,
+    details: {
+      reasonCode?: SignalReasonCode;
+      reason?: string;
+      metadata?: Record<string, unknown>;
+      orderId?: string;
+      quantity?: number;
+    }
+  ): Promise<void> {
+    try {
+      await this.liveSignalService.recordOutcome({
+        userId: activation.userId,
+        algorithmActivationId: activation.id,
+        action: this.toLiveSignalAction(signal.action, signal.positionSide),
+        symbol: signal.symbol,
+        quantity: details.quantity ?? signal.quantity,
+        confidence: signal.confidence,
+        status,
+        reasonCode: details.reasonCode,
+        reason: details.reason,
+        metadata: details.metadata,
+        orderId: details.orderId,
+        source: SignalSource.LIVE_TRADING
+      });
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Failed to record signal outcome for activation ${activation.id}: ${err.message}`, err.stack);
+    }
+  }
+
+  private async recordSkippedSignalOutcome(
+    activation: AlgorithmActivation,
+    skipReason: NonNullable<GenerateSignalResult['skipReason']>
+  ): Promise<void> {
+    try {
+      const partial = skipReason.partialSignal ?? {};
+      const action = partial.action ?? 'BUY';
+      const symbol = partial.symbol ?? 'UNKNOWN';
+      await this.liveSignalService.recordOutcome({
+        userId: activation.userId,
+        algorithmActivationId: activation.id,
+        action: this.toLiveSignalAction(action, partial.positionSide),
+        symbol,
+        quantity: 0,
+        confidence: partial.confidence,
+        status: SignalStatus.BLOCKED,
+        reasonCode: skipReason.reasonCode,
+        reason: skipReason.reason,
+        metadata: skipReason.metadata,
+        source: SignalSource.LIVE_TRADING
+      });
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to record skipped signal outcome for activation ${activation.id}: ${err.message}`,
+        err.stack
+      );
+    }
+  }
+
+  private toLiveSignalAction(action: 'BUY' | 'SELL', positionSide?: 'long' | 'short'): LiveTradingSignalAction {
+    if (positionSide === 'short') {
+      return action === 'BUY' ? LiveTradingSignalAction.SHORT_EXIT : LiveTradingSignalAction.SHORT_ENTRY;
+    }
+
+    return action === 'BUY' ? LiveTradingSignalAction.BUY : LiveTradingSignalAction.SELL;
   }
 }

--- a/apps/api/src/strategy/entities/live-trading-signal.entity.ts
+++ b/apps/api/src/strategy/entities/live-trading-signal.entity.ts
@@ -1,0 +1,118 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation
+} from 'typeorm';
+
+import { LiveTradingSignalAction, SignalReasonCode, SignalSource, SignalStatus } from '@chansey/api-interfaces';
+
+import { StrategyConfig } from './strategy-config.entity';
+
+import { AlgorithmActivation } from '../../algorithm/algorithm-activation.entity';
+import { Order } from '../../order/order.entity';
+import { User } from '../../users/users.entity';
+import { ColumnNumericTransformer } from '../../utils/transformers';
+
+export { LiveTradingSignalAction } from '@chansey/api-interfaces';
+
+@Entity('live_trading_signals')
+@Index(['createdAt'])
+@Index(['status', 'createdAt'])
+@Index(['userId', 'createdAt'])
+@Index(['strategyConfigId', 'createdAt'])
+@Index(['algorithmActivationId', 'createdAt'])
+export class LiveTradingSignal {
+  @PrimaryGeneratedColumn('uuid')
+  @ApiProperty({ description: 'Unique identifier for the live signal outcome' })
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @ApiProperty({ description: 'User ID associated with the signal outcome' })
+  userId: string;
+
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: Relation<User>;
+
+  @Column({ type: 'uuid', nullable: true })
+  @ApiPropertyOptional({ description: 'Strategy config ID for robo-advisor live trading signals' })
+  strategyConfigId?: string | null;
+
+  @ManyToOne(() => StrategyConfig, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'strategyConfigId' })
+  strategyConfig?: Relation<StrategyConfig> | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  @ApiPropertyOptional({ description: 'Algorithm activation ID for trade-execution signals' })
+  algorithmActivationId?: string | null;
+
+  @ManyToOne(() => AlgorithmActivation, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'algorithmActivationId' })
+  algorithmActivation?: Relation<AlgorithmActivation> | null;
+
+  @Column({ type: 'enum', enum: SignalSource, default: SignalSource.LIVE_TRADING })
+  @ApiProperty({ description: 'Signal source', enum: SignalSource, default: SignalSource.LIVE_TRADING })
+  source: SignalSource;
+
+  @Column({ type: 'enum', enum: LiveTradingSignalAction })
+  @ApiProperty({ description: 'Signal action', enum: LiveTradingSignalAction })
+  action: LiveTradingSignalAction;
+
+  @Column({ type: 'varchar', length: 50 })
+  @ApiProperty({ description: 'Target instrument/symbol for the signal' })
+  symbol: string;
+
+  @Column({ type: 'decimal', precision: 25, scale: 8, transformer: new ColumnNumericTransformer() })
+  @ApiProperty({ description: 'Requested trade quantity' })
+  quantity: number;
+
+  @Column({ type: 'decimal', precision: 25, scale: 8, nullable: true, transformer: new ColumnNumericTransformer() })
+  @ApiPropertyOptional({ description: 'Reference price used for the trade decision' })
+  price?: number | null;
+
+  @Column({ type: 'decimal', precision: 5, scale: 4, nullable: true, transformer: new ColumnNumericTransformer() })
+  @ApiPropertyOptional({ description: 'Signal confidence score (0-1)' })
+  confidence?: number | null;
+
+  @Column({ type: 'enum', enum: SignalStatus })
+  @ApiProperty({ description: 'Final signal outcome status', enum: SignalStatus })
+  status: SignalStatus;
+
+  @Column({ type: 'enum', enum: SignalReasonCode, nullable: true })
+  @ApiPropertyOptional({
+    description: 'Machine-readable reason code for blocks/failures/adjustments',
+    enum: SignalReasonCode
+  })
+  reasonCode?: SignalReasonCode | null;
+
+  @Column({ type: 'text', nullable: true })
+  @ApiPropertyOptional({ description: 'Human-readable explanation for the signal outcome' })
+  reason?: string | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  @ApiPropertyOptional({ description: 'Additional context about the signal outcome' })
+  metadata?: Record<string, unknown> | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  @ApiPropertyOptional({ description: 'Order ID created from the signal when applicable' })
+  orderId?: string | null;
+
+  @ManyToOne(() => Order, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'orderId' })
+  order?: Relation<Order> | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  @ApiProperty({ description: 'When the signal outcome was recorded' })
+  createdAt: Date;
+
+  constructor(partial: Partial<LiveTradingSignal>) {
+    Object.assign(this, partial);
+  }
+}

--- a/apps/api/src/strategy/live-signal.service.ts
+++ b/apps/api/src/strategy/live-signal.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { SignalReasonCode, SignalSource, SignalStatus } from '@chansey/api-interfaces';
+
+import { LiveTradingSignal, LiveTradingSignalAction } from './entities/live-trading-signal.entity';
+
+export interface RecordLiveSignalOutcomeInput {
+  userId: string;
+  strategyConfigId?: string;
+  algorithmActivationId?: string;
+  action: LiveTradingSignalAction;
+  symbol: string;
+  quantity: number;
+  price?: number | null;
+  confidence?: number;
+  status: SignalStatus;
+  reasonCode?: SignalReasonCode;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+  orderId?: string;
+  source?: SignalSource;
+}
+
+@Injectable()
+export class LiveSignalService {
+  constructor(
+    @InjectRepository(LiveTradingSignal)
+    private readonly liveSignalRepo: Repository<LiveTradingSignal>
+  ) {}
+
+  async recordOutcome(input: RecordLiveSignalOutcomeInput): Promise<LiveTradingSignal> {
+    const entity = this.liveSignalRepo.create({
+      userId: input.userId,
+      strategyConfigId: input.strategyConfigId,
+      algorithmActivationId: input.algorithmActivationId,
+      action: input.action,
+      symbol: input.symbol,
+      quantity: input.quantity,
+      price: input.price,
+      confidence: input.confidence,
+      status: input.status,
+      reasonCode: input.reasonCode,
+      reason: input.reason,
+      metadata: input.metadata,
+      orderId: input.orderId,
+      ...(input.source != null && { source: input.source })
+    });
+
+    return this.liveSignalRepo.save(entity);
+  }
+}

--- a/apps/api/src/strategy/live-trading.service.spec.ts
+++ b/apps/api/src/strategy/live-trading.service.spec.ts
@@ -3,9 +3,12 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { ObjectLiteral, Repository } from 'typeorm';
 
+import { SignalReasonCode, SignalSource, SignalStatus } from '@chansey/api-interfaces';
+
 import { CapitalAllocationService } from './capital-allocation.service';
 import { ConcentrationGateService } from './concentration-gate.service';
 import { DailyLossLimitGateService } from './daily-loss-limit-gate.service';
+import { LiveSignalService } from './live-signal.service';
 import { LiveTradingService } from './live-trading.service';
 import { PositionTrackingService } from './position-tracking.service';
 import { PreTradeRiskGateService } from './pre-trade-risk-gate.service';
@@ -77,6 +80,7 @@ describe('LiveTradingService', () => {
   let tradeExecutionService: jest.Mocked<TradeExecutionService>;
   let tradeCooldownService: jest.Mocked<TradeCooldownService>;
   let opportunitySellService: jest.Mocked<OpportunitySellService>;
+  let liveSignalService: jest.Mocked<LiveSignalService>;
 
   beforeEach(async () => {
     userRepo = {
@@ -158,6 +162,10 @@ describe('LiveTradingService', () => {
       })
     } as unknown as jest.Mocked<OpportunitySellService>;
 
+    liveSignalService = {
+      recordOutcome: jest.fn().mockResolvedValue({ id: 'live-signal-1' })
+    } as unknown as jest.Mocked<LiveSignalService>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LiveTradingService,
@@ -200,6 +208,7 @@ describe('LiveTradingService', () => {
           }
         },
         { provide: OpportunitySellService, useValue: opportunitySellService },
+        { provide: LiveSignalService, useValue: liveSignalService },
         {
           provide: MetricsService,
           useValue: {
@@ -1264,6 +1273,66 @@ describe('LiveTradingService', () => {
         expect.objectContaining({ action: 'sell', symbol: 'ETH/USDT' }),
         'ek-1'
       );
+    });
+  });
+
+  describe('recordOutcome assertions', () => {
+    it('records PLACED outcome with orderId on successful order', async () => {
+      setupSignalPath({
+        user: {
+          exchanges: [{ id: 'ex-2', name: 'Binance US', slug: 'binance_us', isActive: true }] as any
+        }
+      });
+
+      const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+      strategyExecutor.executeStrategy.mockResolvedValue(signal);
+      strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+      orderService.placeAlgorithmicOrder.mockResolvedValue({ id: 'order-1' } as any);
+
+      await service.executeLiveTrading();
+
+      expect(liveSignalService.recordOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: SignalStatus.PLACED,
+          orderId: 'order-1',
+          source: SignalSource.LIVE_TRADING
+        })
+      );
+    });
+
+    it('records BLOCKED outcome when signal validation fails', async () => {
+      setupSignalPath();
+
+      const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+      strategyExecutor.executeStrategy.mockResolvedValue(signal);
+      strategyExecutor.validateSignal.mockReturnValue({ valid: false, reason: 'low confidence' });
+
+      await service.executeLiveTrading();
+
+      expect(liveSignalService.recordOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: SignalStatus.BLOCKED,
+          reasonCode: SignalReasonCode.SIGNAL_VALIDATION_FAILED,
+          source: SignalSource.LIVE_TRADING
+        })
+      );
+    });
+
+    it('does not propagate recordOutcome rejection — order still placed', async () => {
+      setupSignalPath({
+        user: {
+          exchanges: [{ id: 'ex-2', name: 'Binance US', slug: 'binance_us', isActive: true }] as any
+        }
+      });
+
+      const signal: TradingSignal = { action: 'buy', symbol: 'BTC/USDT', quantity: 0.01, price: 30000 } as any;
+      strategyExecutor.executeStrategy.mockResolvedValue(signal);
+      strategyExecutor.validateSignal.mockReturnValue({ valid: true });
+      orderService.placeAlgorithmicOrder.mockResolvedValue({ id: 'order-1' } as any);
+      liveSignalService.recordOutcome.mockRejectedValue(new Error('DB write failed'));
+
+      await expect(service.executeLiveTrading()).resolves.not.toThrow();
+      expect(orderService.placeAlgorithmicOrder).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/strategy/live-trading.service.ts
+++ b/apps/api/src/strategy/live-trading.service.ts
@@ -4,13 +4,15 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import { MarketType, PositionSide } from '@chansey/api-interfaces';
+import { MarketType, PositionSide, SignalReasonCode, SignalSource, SignalStatus } from '@chansey/api-interfaces';
 
 import { CapitalAllocationService } from './capital-allocation.service';
 import { ConcentrationGateService } from './concentration-gate.service';
 import { DailyLossLimitGateService } from './daily-loss-limit-gate.service';
+import { LiveTradingSignalAction } from './entities/live-trading-signal.entity';
 import { StrategyConfig } from './entities/strategy-config.entity';
 import { UserStrategyPosition } from './entities/user-strategy-position.entity';
+import { LiveSignalService } from './live-signal.service';
 import { PositionTrackingService } from './position-tracking.service';
 import { PreTradeRiskGateService } from './pre-trade-risk-gate.service';
 import { RiskPoolMappingService } from './risk-pool-mapping.service';
@@ -38,6 +40,20 @@ import { User } from '../users/users.entity';
 
 /** Maximum consecutive errors before disabling algo trading for a user */
 const MAX_ERROR_STRIKES = 3;
+
+type PlaceOrderResult =
+  | { status: 'placed'; orderId: string; metadata?: Record<string, unknown> }
+  | {
+      status: 'blocked' | 'failed';
+      reasonCode: SignalReasonCode;
+      reason: string;
+      metadata?: Record<string, unknown>;
+    };
+
+interface OpportunitySellingResult {
+  freed: boolean;
+  reason?: string;
+}
 
 /**
  * Orchestrates live trading for all enrolled robo-advisor users.
@@ -72,7 +88,8 @@ export class LiveTradingService implements OnApplicationShutdown {
     private readonly metricsService: MetricsService,
     private readonly exchangeSelectionService: ExchangeSelectionService,
     private readonly opportunitySellService: OpportunitySellService,
-    private readonly failedJobService: FailedJobService
+    private readonly failedJobService: FailedJobService,
+    private readonly liveSignalService: LiveSignalService
   ) {}
 
   @Cron('*/2 * * * *')
@@ -220,10 +237,17 @@ export class LiveTradingService implements OnApplicationShutdown {
 
         if (signal && signal.action !== 'hold') {
           const action: Exclude<typeof signal.action, 'hold'> = signal.action as Exclude<typeof signal.action, 'hold'>;
+          let placedReasonCode: SignalReasonCode | undefined;
+          let placedReason: string | undefined;
 
           const validation = this.strategyExecutor.validateSignal(signal, allocatedCapital);
           if (!validation.valid) {
             this.logger.warn(`Invalid signal for user ${user.id}, strategy ${strategy.id}: ${validation.reason}`);
+            await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.BLOCKED, {
+              reasonCode: SignalReasonCode.SIGNAL_VALIDATION_FAILED,
+              reason: validation.reason,
+              metadata: { allocatedCapital }
+            });
             continue;
           }
 
@@ -231,6 +255,11 @@ export class LiveTradingService implements OnApplicationShutdown {
           if (dailyLossBlocked && (action === 'buy' || action === 'short_entry')) {
             this.metricsService.recordDailyLossGateBlock();
             dailyLossBlockedCount++;
+            await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.BLOCKED, {
+              reasonCode: SignalReasonCode.DAILY_LOSS_LIMIT,
+              reason: dailyLossCheck.reason,
+              metadata: { allocatedCapital }
+            });
             continue;
           }
 
@@ -250,6 +279,11 @@ export class LiveTradingService implements OnApplicationShutdown {
           if (gateResult.signals.length === 0) {
             this.metricsService.recordRegimeGateBlock(compositeRegime);
             gateBlockedCount++;
+            await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.BLOCKED, {
+              reasonCode: SignalReasonCode.REGIME_GATE,
+              reason: `Composite regime ${compositeRegime} blocked ${action.toUpperCase()} signal`,
+              metadata: { compositeRegime, overrideActive }
+            });
             continue;
           }
 
@@ -258,6 +292,11 @@ export class LiveTradingService implements OnApplicationShutdown {
           if (!drawdownCheck.allowed) {
             this.metricsService.recordDrawdownGateBlock();
             drawdownBlockedCount++;
+            await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.BLOCKED, {
+              reasonCode: SignalReasonCode.DRAWDOWN_GATE,
+              reason: drawdownCheck.reason,
+              metadata: { allocatedCapital }
+            });
             continue;
           }
 
@@ -274,11 +313,18 @@ export class LiveTradingService implements OnApplicationShutdown {
             if (!concCheck.allowed) {
               this.metricsService.recordConcentrationGateBlock();
               concentrationBlockedCount++;
+              await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.BLOCKED, {
+                reasonCode: SignalReasonCode.CONCENTRATION_LIMIT,
+                reason: concCheck.reason,
+                metadata: { tradeUsdValue }
+              });
               continue;
             }
             if (concCheck.adjustedQuantity != null && concCheck.adjustedQuantity < 1) {
               signal.quantity *= concCheck.adjustedQuantity;
               concentrationReducedCount++;
+              placedReasonCode = SignalReasonCode.CONCENTRATION_REDUCED;
+              placedReason = concCheck.reason;
             }
           }
 
@@ -288,7 +334,7 @@ export class LiveTradingService implements OnApplicationShutdown {
             const availableCash = this.calculateFreeUsdValue(balances.current);
 
             if (buyAmount > availableCash) {
-              const freed = await this.attemptOpportunitySelling(
+              const opportunitySellingResult = await this.attemptOpportunitySelling(
                 user,
                 signal,
                 strategy.id,
@@ -298,16 +344,28 @@ export class LiveTradingService implements OnApplicationShutdown {
                 buyAmount,
                 availableCash
               );
-              if (!freed) continue;
+              if (!opportunitySellingResult.freed) {
+                await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.BLOCKED, {
+                  reasonCode: SignalReasonCode.OPPORTUNITY_SELLING_REJECTED,
+                  reason: opportunitySellingResult.reason ?? 'Opportunity selling did not free enough capital',
+                  metadata: { availableCash, requiredBuyAmount: buyAmount }
+                });
+                continue;
+              }
 
               // Re-verify available cash after opportunity sells (Fix #2)
               const updatedBalances = await this.balanceService.getUserBalances(user, false);
               const newAvailableCash = this.calculateFreeUsdValue(updatedBalances.current);
               if (newAvailableCash < buyAmount * 0.95) {
-                this.logger.warn(
+                const insufficientFundsReason =
                   `Insufficient funds after opportunity sells: needed $${buyAmount.toFixed(2)}, ` +
-                    `available $${newAvailableCash.toFixed(2)} — skipping buy`
-                );
+                  `available $${newAvailableCash.toFixed(2)} — skipping buy`;
+                this.logger.warn(insufficientFundsReason);
+                await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.BLOCKED, {
+                  reasonCode: SignalReasonCode.INSUFFICIENT_FUNDS,
+                  reason: insufficientFundsReason,
+                  metadata: { availableCash: newAvailableCash, requiredBuyAmount: buyAmount }
+                });
                 continue;
               }
 
@@ -317,7 +375,27 @@ export class LiveTradingService implements OnApplicationShutdown {
             }
           }
 
-          await this.placeOrder(user, strategy.id, signal, strategy);
+          const orderResult = await this.placeOrder(user, strategy.id, signal, strategy);
+          if (orderResult.status === 'placed') {
+            await this.recordLiveSignalOutcome(user.id, strategy.id, signal, SignalStatus.PLACED, {
+              reasonCode: placedReasonCode,
+              reason: placedReason,
+              metadata: orderResult.metadata,
+              orderId: orderResult.orderId
+            });
+          } else {
+            await this.recordLiveSignalOutcome(
+              user.id,
+              strategy.id,
+              signal,
+              orderResult.status === 'blocked' ? SignalStatus.BLOCKED : SignalStatus.FAILED,
+              {
+                reasonCode: orderResult.reasonCode,
+                reason: orderResult.reason,
+                metadata: orderResult.metadata
+              }
+            );
+          }
         }
       } catch (error: unknown) {
         const err = toErrorInfo(error);
@@ -368,7 +446,7 @@ export class LiveTradingService implements OnApplicationShutdown {
     strategyConfigId: string,
     signal: TradingSignal,
     strategy: StrategyConfig
-  ): Promise<void> {
+  ): Promise<PlaceOrderResult> {
     try {
       // Dynamically select exchange key based on signal action
       const isBuyAction = signal.action === 'buy' || signal.action === 'short_exit';
@@ -377,9 +455,15 @@ export class LiveTradingService implements OnApplicationShutdown {
         exchangeKey = isBuyAction
           ? await this.exchangeSelectionService.selectForBuy(user.id, signal.symbol)
           : await this.exchangeSelectionService.selectForSell(user.id, signal.symbol, strategyConfigId);
-      } catch {
-        this.logger.error(`No suitable exchange key found for user ${user.id} and symbol ${signal.symbol}`);
-        return;
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        const reason = `No suitable exchange key found for user ${user.id} and symbol ${signal.symbol}: ${err.message}`;
+        this.logger.error(reason);
+        return {
+          status: 'blocked',
+          reasonCode: SignalReasonCode.EXCHANGE_SELECTION_FAILED,
+          reason
+        };
       }
 
       // Trade cooldown: prevent double-trading if Pipeline 2 already placed this trade
@@ -393,16 +477,23 @@ export class LiveTradingService implements OnApplicationShutdown {
 
       if (!cooldownCheck.allowed) {
         this.metricsService.recordTradeCooldownBlock(direction, signal.symbol);
-        this.logger.warn(
+        const reason =
           `Trade cooldown blocked strategy ${strategyConfigId} for user ${user.id}: ` +
-            `${direction} ${signal.symbol} already claimed by ${cooldownCheck.existingClaim?.pipeline}`
-        );
-        return;
+          `${direction} ${signal.symbol} already claimed by ${cooldownCheck.existingClaim?.pipeline}`;
+        this.logger.warn(reason);
+        return {
+          status: 'blocked',
+          reasonCode: SignalReasonCode.TRADE_COOLDOWN,
+          reason,
+          metadata: { direction, existingClaim: cooldownCheck.existingClaim?.pipeline }
+        };
       }
 
       this.metricsService.recordTradeCooldownClaim(direction, signal.symbol);
 
       try {
+        let placedOrderId = '';
+        let orderMetadata: Record<string, unknown> | undefined;
         const isFutures =
           signal.action === 'short_entry' ||
           signal.action === 'short_exit' ||
@@ -418,14 +509,23 @@ export class LiveTradingService implements OnApplicationShutdown {
             action,
             symbol: signal.symbol,
             quantity: signal.quantity,
+            confidence: signal.confidence,
             marketType: 'futures',
             positionSide,
             leverage: Number(strategy.defaultLeverage) || 1,
             exitConfig: signal.exitConfig
           };
 
-          await this.tradeExecutionService.executeTradeSignal(tradeSignal);
+          const order = await this.tradeExecutionService.executeTradeSignal(tradeSignal);
           this.metricsService.recordLiveOrderPlaced('futures', action);
+          placedOrderId = order.id;
+          orderMetadata = {
+            exchangeKeyId: exchangeKey.id,
+            exchangeName: exchangeKey.name,
+            marketType: 'futures',
+            leverage: tradeSignal.leverage,
+            positionSide
+          };
 
           this.logger.log(
             `Futures order placed for user ${user.id}: ${action} ${signal.quantity} ${signal.symbol} ` +
@@ -447,6 +547,12 @@ export class LiveTradingService implements OnApplicationShutdown {
             exchangeKey.id
           );
           this.metricsService.recordLiveOrderPlaced('spot', signal.action);
+          placedOrderId = order.id;
+          orderMetadata = {
+            exchangeKeyId: exchangeKey.id,
+            exchangeName: exchangeKey.name,
+            marketType: 'spot'
+          };
 
           this.logger.log(
             `Order placed for user ${user.id}: ${signal.action} ${signal.quantity} ${signal.symbol} ` +
@@ -467,16 +573,80 @@ export class LiveTradingService implements OnApplicationShutdown {
           trackingPositionSide,
           isBuyAction ? exchangeKey.id : undefined
         );
+        return {
+          status: 'placed',
+          orderId: placedOrderId,
+          metadata: orderMetadata
+        };
       } catch (error: unknown) {
         // Clear cooldown on failure so next cycle can retry
         await this.tradeCooldownService.clearCooldown(user.id, signal.symbol, direction);
         this.metricsService.recordTradeCooldownCleared('order_failure');
-        throw error;
+        const err = toErrorInfo(error);
+        return {
+          status: 'failed',
+          reasonCode: SignalReasonCode.ORDER_EXECUTION_FAILED,
+          reason: err.message,
+          metadata: { direction }
+        };
       }
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Failed to place order for user ${user.id}: ${err.message}`);
-      throw error;
+      return {
+        status: 'failed',
+        reasonCode: SignalReasonCode.ORDER_EXECUTION_FAILED,
+        reason: err.message
+      };
+    }
+  }
+
+  private async recordLiveSignalOutcome(
+    userId: string,
+    strategyConfigId: string,
+    signal: TradingSignal,
+    status: SignalStatus,
+    details: {
+      reasonCode?: SignalReasonCode;
+      reason?: string;
+      metadata?: Record<string, unknown>;
+      orderId?: string;
+    }
+  ): Promise<void> {
+    try {
+      await this.liveSignalService.recordOutcome({
+        userId,
+        strategyConfigId,
+        action: this.toLiveSignalAction(signal.action as Exclude<TradingSignal['action'], 'hold'>),
+        symbol: signal.symbol,
+        quantity: signal.quantity,
+        price: signal.price,
+        confidence: signal.confidence,
+        status,
+        reasonCode: details.reasonCode,
+        reason: details.reason,
+        metadata: details.metadata,
+        orderId: details.orderId,
+        source: SignalSource.LIVE_TRADING
+      });
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Failed to record live signal outcome for user ${userId}: ${err.message}`, err.stack);
+    }
+  }
+
+  private toLiveSignalAction(action: Exclude<TradingSignal['action'], 'hold'>): LiveTradingSignalAction {
+    switch (action) {
+      case 'buy':
+        return LiveTradingSignalAction.BUY;
+      case 'sell':
+        return LiveTradingSignalAction.SELL;
+      case 'short_entry':
+        return LiveTradingSignalAction.SHORT_ENTRY;
+      case 'short_exit':
+        return LiveTradingSignalAction.SHORT_EXIT;
+      default:
+        throw new Error(`Unknown live signal action: ${action}`);
     }
   }
 
@@ -559,14 +729,17 @@ export class LiveTradingService implements OnApplicationShutdown {
     marketData: MarketData[],
     requiredBuyAmount: number,
     availableCash: number
-  ): Promise<boolean> {
+  ): Promise<OpportunitySellingResult> {
     // Regime guard — selling in extreme/bear conditions is counterproductive
     const regime = compositeRegime.toLowerCase();
     if (regime === 'extreme' || regime === 'bear') {
       this.logger.log(
         `Skipping opportunity selling for user ${user.id}: regime=${compositeRegime} is too risky for liquidation`
       );
-      return false;
+      return {
+        freed: false,
+        reason: `Skipping opportunity selling: regime=${compositeRegime} is too risky for liquidation`
+      };
     }
 
     // Re-fetch market data for fresh prices (Fix #3)
@@ -648,7 +821,10 @@ export class LiveTradingService implements OnApplicationShutdown {
 
     if (plan.decision !== OpportunitySellDecision.APPROVED || plan.sellOrders.length === 0) {
       this.logger.log(`Opportunity selling rejected for user ${user.id}, coin=${buySignalCoinId}: ${plan.reason}`);
-      return false;
+      return {
+        freed: false,
+        reason: plan.reason || 'Opportunity selling was rejected'
+      };
     }
 
     // Execute sell orders sequentially
@@ -665,7 +841,10 @@ export class LiveTradingService implements OnApplicationShutdown {
         if (!sellSymbol) {
           this.logger.error(`No market symbol found for coinId ${sellOrder.coinId}, aborting opportunity sells`);
           await this.cleanupOrphanedSells(user.id, executedSells);
-          return false;
+          return {
+            freed: false,
+            reason: `No market symbol found for coinId ${sellOrder.coinId}`
+          };
         }
 
         // Look up source positions for this coin to use correct strategyConfigIds
@@ -678,7 +857,10 @@ export class LiveTradingService implements OnApplicationShutdown {
         } catch {
           this.logger.error(`No exchange key for opportunity sell: user=${user.id}, symbol=${sellSymbol}`);
           await this.cleanupOrphanedSells(user.id, executedSells);
-          return false;
+          return {
+            freed: false,
+            reason: `No exchange key available for opportunity sell on ${sellSymbol}`
+          };
         }
 
         // Trade cooldown check
@@ -691,7 +873,10 @@ export class LiveTradingService implements OnApplicationShutdown {
         if (!cooldownCheck.allowed) {
           this.logger.warn(`Opportunity sell cooldown blocked for ${sellSymbol}, aborting remaining sells`);
           await this.cleanupOrphanedSells(user.id, executedSells);
-          return false;
+          return {
+            freed: false,
+            reason: `Opportunity sell cooldown blocked for ${sellSymbol}`
+          };
         }
 
         try {
@@ -756,13 +941,19 @@ export class LiveTradingService implements OnApplicationShutdown {
           await this.tradeCooldownService.clearCooldown(user.id, sellSymbol, 'SELL');
           this.logger.error(`Opportunity sell failed for ${sellSymbol}, aborting: ${err.message}`);
           await this.cleanupOrphanedSells(user.id, executedSells);
-          return false;
+          return {
+            freed: false,
+            reason: `Opportunity sell failed for ${sellSymbol}: ${err.message}`
+          };
         }
       } catch (error: unknown) {
         const err = toErrorInfo(error);
         this.logger.error(`Unexpected error during opportunity sell for coinId ${sellOrder.coinId}: ${err.message}`);
         await this.cleanupOrphanedSells(user.id, executedSells);
-        return false;
+        return {
+          freed: false,
+          reason: `Unexpected opportunity sell error for coinId ${sellOrder.coinId}: ${err.message}`
+        };
       }
     }
 
@@ -770,7 +961,7 @@ export class LiveTradingService implements OnApplicationShutdown {
       `All opportunity sells completed for user ${user.id}: ` +
         `freed $${plan.projectedProceeds.toFixed(2)} to fund ${buySignalCoinId} buy`
     );
-    return true;
+    return { freed: true };
   }
 
   /**
@@ -828,12 +1019,13 @@ export class LiveTradingService implements OnApplicationShutdown {
    * Fetch current market data for common trading pairs.
    * Uses the exchange manager to get real-time prices from connected exchanges.
    */
-  private async fetchMarketData(): Promise<MarketData[]> {
+  private async fetchMarketData(coinSymbols?: string[]): Promise<MarketData[]> {
     const marketData: MarketData[] = [];
     // Use Binance US as the default price source for consistency
     const exchangeSlug = 'binance_us';
     const quote = EXCHANGE_QUOTE_CURRENCY[exchangeSlug] ?? DEFAULT_QUOTE_CURRENCY;
-    const tradingPairs = ['BTC', 'ETH', 'SOL', 'XRP', 'ADA'].map((base) => `${base}/${quote}`);
+    const bases = coinSymbols?.length ? [...new Set(coinSymbols)] : ['BTC', 'ETH', 'SOL', 'XRP', 'ADA'];
+    const tradingPairs = bases.map((base) => `${base}/${quote}`);
 
     try {
       for (const symbol of tradingPairs) {

--- a/apps/api/src/strategy/strategy.module.ts
+++ b/apps/api/src/strategy/strategy.module.ts
@@ -9,6 +9,7 @@ import { DeploymentController } from './deployment.controller';
 import { DeploymentService } from './deployment.service';
 import { BacktestRun } from './entities/backtest-run.entity';
 import { Deployment } from './entities/deployment.entity';
+import { LiveTradingSignal } from './entities/live-trading-signal.entity';
 import { PerformanceMetric } from './entities/performance-metric.entity';
 import { StrategyConfig } from './entities/strategy-config.entity';
 import { StrategyScore } from './entities/strategy-score.entity';
@@ -23,12 +24,11 @@ import { PositiveReturnsGate } from './gates/positive-returns.gate';
 import { PromotionGateService } from './gates/promotion-gate.service';
 import { VolatilityCapGate } from './gates/volatility-cap.gate';
 import { WFAConsistencyGate } from './gates/wfa-consistency.gate';
+import { LiveSignalService } from './live-signal.service';
 import { LiveTradingService } from './live-trading.service';
 import { PoolStatisticsService } from './pool-statistics.service';
 import { PositionTrackingService } from './position-tracking.service';
 import { PreTradeRiskGateService } from './pre-trade-risk-gate.service';
-// eslint-disable-next-line import/order
-import { RiskPoolMappingService } from './risk-pool-mapping.service';
 import { ConcentrationCheckService } from './risk/concentration-check.service';
 import { ConcentrationRiskCheck } from './risk/concentration-risk.check';
 import { ConsecutiveLossesCheck } from './risk/consecutive-losses.check';
@@ -37,9 +37,11 @@ import { DrawdownBreachCheck } from './risk/drawdown-breach.check';
 import { RiskManagementService } from './risk/risk-management.service';
 import { SharpeDegradationCheck } from './risk/sharpe-degradation.check';
 import { VolatilitySpikeCheck } from './risk/volatility-spike.check';
+import { RiskPoolMappingService } from './risk-pool-mapping.service';
 import { StrategyExecutorService } from './strategy-executor.service';
 import { StrategyController } from './strategy.controller';
 import { StrategyService } from './strategy.service';
+import { LiveSignalCleanupTask } from './tasks/live-signal-cleanup.task';
 import { UserPerformanceService } from './user-performance.service';
 
 import { AdminModule } from '../admin/admin.module';
@@ -62,6 +64,7 @@ import { User } from '../users/users.entity';
   imports: [
     TypeOrmModule.forFeature([
       StrategyConfig,
+      LiveTradingSignal,
       BacktestRun,
       WalkForwardWindow,
       StrategyScore,
@@ -93,6 +96,7 @@ import { User } from '../users/users.entity';
     StrategyExecutorService,
     SignalThrottleService,
     LiveTradingService,
+    LiveSignalService,
     PreTradeRiskGateService,
     DailyLossLimitGateService,
     ConcentrationCheckService,
@@ -114,7 +118,8 @@ import { User } from '../users/users.entity';
     DailyLossLimitCheck,
     ConsecutiveLossesCheck,
     VolatilitySpikeCheck,
-    SharpeDegradationCheck
+    SharpeDegradationCheck,
+    LiveSignalCleanupTask
   ],
   controllers: [StrategyController, DeploymentController, AdminPoolController],
   exports: [
@@ -126,6 +131,7 @@ import { User } from '../users/users.entity';
     PositionTrackingService,
     CapitalAllocationService,
     StrategyExecutorService,
+    LiveSignalService,
     UserPerformanceService,
     DailyLossLimitGateService,
     ConcentrationGateService

--- a/apps/api/src/strategy/tasks/live-signal-cleanup.task.ts
+++ b/apps/api/src/strategy/tasks/live-signal-cleanup.task.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { LessThan, Repository } from 'typeorm';
+
+import { toErrorInfo } from '../../shared/error.util';
+import { LiveTradingSignal } from '../entities/live-trading-signal.entity';
+
+const RETENTION_DAYS = 90;
+
+@Injectable()
+export class LiveSignalCleanupTask {
+  private readonly logger = new Logger(LiveSignalCleanupTask.name);
+
+  constructor(
+    @InjectRepository(LiveTradingSignal)
+    private readonly repo: Repository<LiveTradingSignal>
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async cleanupOldRecords(): Promise<void> {
+    try {
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - RETENTION_DAYS);
+
+      const result = await this.repo.delete({
+        createdAt: LessThan(cutoff)
+      });
+
+      if (result.affected && result.affected > 0) {
+        this.logger.log(`Cleaned up ${result.affected} live signal record(s) older than ${RETENTION_DAYS} days`);
+      }
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Live signal cleanup error (fail-safe): ${err.message}`, err.stack);
+    }
+  }
+}

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/components/signal-activity-feed/signal-activity-feed.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/components/signal-activity-feed/signal-activity-feed.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 import { CardModule } from 'primeng/card';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
 
-import { SignalActivityFeedDto } from '@chansey/api-interfaces';
+import { SignalActivityFeedDto, SignalReasonCode } from '@chansey/api-interfaces';
 
 import { TimeAgoPipe } from '../../../../../shared/pipes';
 
@@ -21,11 +21,11 @@ import { TimeAgoPipe } from '../../../../../shared/pipes';
       <p-card>
         <div class="text-center">
           <div class="text-sm text-gray-500">Last Signal</div>
-          @if (feed?.health?.lastSignalTime) {
+          @if (feed()?.health?.lastSignalTime) {
             <div class="text-xl font-bold" [class]="lastSignalColorClass">
-              {{ feed?.health?.lastSignalTime | timeAgo }}
+              {{ feed()?.health?.lastSignalTime | timeAgo }}
             </div>
-            <div class="mt-1 text-xs text-gray-400">{{ feed?.health?.lastSignalTime | date: 'short' }}</div>
+            <div class="mt-1 text-xs text-gray-400">{{ feed()?.health?.lastSignalTime | date: 'short' }}</div>
           } @else {
             <div class="text-xl font-bold text-gray-400">No signals</div>
           }
@@ -35,24 +35,24 @@ import { TimeAgoPipe } from '../../../../../shared/pipes';
       <p-card>
         <div class="text-center">
           <div class="text-sm text-gray-500">Signals / Hour</div>
-          <div class="text-2xl font-bold">{{ feed?.health?.signalsLastHour ?? 0 }}</div>
+          <div class="text-2xl font-bold">{{ feed()?.health?.signalsLastHour ?? 0 }}</div>
         </div>
       </p-card>
 
       <p-card>
         <div class="text-center">
           <div class="text-sm text-gray-500">Signals / 24h</div>
-          <div class="text-2xl font-bold">{{ feed?.health?.signalsLast24h ?? 0 }}</div>
+          <div class="text-2xl font-bold">{{ feed()?.health?.signalsLast24h ?? 0 }}</div>
         </div>
       </p-card>
 
       <p-card>
         <div class="text-center">
           <div class="text-sm text-gray-500">Active Sources</div>
-          <div class="text-2xl font-bold">{{ feed?.health?.totalActiveSources ?? 0 }}</div>
+          <div class="text-2xl font-bold">{{ feed()?.health?.totalActiveSources ?? 0 }}</div>
           <div class="mt-1 text-xs text-gray-400">
-            {{ feed?.health?.activeBacktestSources ?? 0 }} backtest ·
-            {{ feed?.health?.activePaperTradingSources ?? 0 }} paper
+            {{ feed()?.health?.activeBacktestSources ?? 0 }} backtest ·
+            {{ feed()?.health?.activePaperTradingSources ?? 0 }} paper
           </div>
         </div>
       </p-card>
@@ -61,9 +61,9 @@ import { TimeAgoPipe } from '../../../../../shared/pipes';
     <!-- Signal Feed Table -->
     <p-card header="Recent Signals">
       <p-table
-        [value]="feed?.signals ?? []"
+        [value]="feed()?.signals ?? []"
         [rows]="20"
-        [paginator]="(feed?.signals?.length ?? 0) > 20"
+        [paginator]="(feed()?.signals?.length ?? 0) > 20"
         [rowsPerPageOptions]="[20, 50, 100]"
         [scrollable]="true"
         scrollHeight="500px"
@@ -80,6 +80,8 @@ import { TimeAgoPipe } from '../../../../../shared/pipes';
             <th style="width: 100px">Source</th>
             <th>Algorithm</th>
             <th>User</th>
+            <th style="width: 90px">Status</th>
+            <th style="width: 140px">Reason Code</th>
             <th>Reason</th>
           </tr>
         </ng-template>
@@ -108,25 +110,36 @@ import { TimeAgoPipe } from '../../../../../shared/pipes';
               }
             </td>
             <td>
-              <p-tag
-                [value]="signal.source === 'BACKTEST' ? 'Backtest' : 'Paper'"
-                [severity]="signal.source === 'BACKTEST' ? 'info' : 'warn'"
-              />
+              <p-tag [value]="getSourceLabel(signal.source)" [severity]="getSourceSeverity(signal.source)" />
             </td>
-            <td class="max-w-[120px] truncate" [pTooltip]="signal.algorithmName">
+            <td class="max-w-30 truncate" [pTooltip]="signal.algorithmName">
               {{ signal.algorithmName }}
             </td>
-            <td class="max-w-[120px] truncate" [pTooltip]="signal.userEmail || ''">
+            <td class="max-w-30 truncate" [pTooltip]="signal.userEmail || ''">
               {{ signal.userEmail || '-' }}
             </td>
-            <td class="max-w-[200px] truncate" [pTooltip]="signal.reason || ''">
+            <td>
+              <p-tag [value]="signal.status" [severity]="getStatusSeverity(signal.status)" />
+            </td>
+            <td>
+              @if (signal.reasonCode) {
+                <p-tag
+                  [value]="getReasonCodeLabel(signal.reasonCode)"
+                  [severity]="getReasonCodeSeverity(signal.reasonCode)"
+                  [pTooltip]="signal.reasonCode"
+                />
+              } @else {
+                <span class="text-gray-400">-</span>
+              }
+            </td>
+            <td class="max-w-50 truncate" [pTooltip]="signal.reason || ''">
               {{ signal.reason || '-' }}
             </td>
           </tr>
         </ng-template>
         <ng-template #emptymessage>
           <tr>
-            <td colspan="10" class="py-8 text-center text-gray-500">No signals found</td>
+            <td colspan="12" class="py-8 text-center text-gray-500">No signals found</td>
           </tr>
         </ng-template>
       </p-table>
@@ -134,10 +147,10 @@ import { TimeAgoPipe } from '../../../../../shared/pipes';
   `
 })
 export class SignalActivityFeedComponent {
-  @Input() feed?: SignalActivityFeedDto;
+  feed = input<SignalActivityFeedDto>();
 
   get lastSignalColorClass(): string {
-    const lastSignalTime = this.feed?.health?.lastSignalTime;
+    const lastSignalTime = this.feed()?.health?.lastSignalTime;
     if (lastSignalTime == null) return 'text-gray-400';
     const ms = Date.now() - new Date(lastSignalTime).getTime();
     if (ms < 5 * 60 * 1000) return 'text-green-500'; // < 5 min
@@ -165,6 +178,88 @@ export class SignalActivityFeedComponent {
       case 'LONG':
         return 'success';
       case 'SHORT':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+
+  getSourceLabel(source: string): string {
+    switch (source) {
+      case 'BACKTEST':
+        return 'Backtest';
+      case 'PAPER_TRADING':
+        return 'Paper';
+      case 'LIVE_TRADING':
+        return 'Live';
+      default:
+        return source;
+    }
+  }
+
+  getSourceSeverity(source: string): 'success' | 'info' | 'warn' | 'danger' | 'secondary' {
+    switch (source) {
+      case 'BACKTEST':
+        return 'info';
+      case 'PAPER_TRADING':
+        return 'warn';
+      case 'LIVE_TRADING':
+        return 'success';
+      default:
+        return 'secondary';
+    }
+  }
+
+  getReasonCodeLabel(code: string): string {
+    const labels: Record<string, string> = {
+      [SignalReasonCode.SIGNAL_VALIDATION_FAILED]: 'Validation Failed',
+      [SignalReasonCode.DAILY_LOSS_LIMIT]: 'Daily Loss',
+      [SignalReasonCode.REGIME_GATE]: 'Regime Gate',
+      [SignalReasonCode.DRAWDOWN_GATE]: 'Drawdown Gate',
+      [SignalReasonCode.CONCENTRATION_LIMIT]: 'Concentration',
+      [SignalReasonCode.CONCENTRATION_REDUCED]: 'Conc. Reduced',
+      [SignalReasonCode.OPPORTUNITY_SELLING_REJECTED]: 'Opp. Rejected',
+      [SignalReasonCode.INSUFFICIENT_FUNDS]: 'Insufficient Funds',
+      [SignalReasonCode.EXCHANGE_SELECTION_FAILED]: 'Exchange Failed',
+      [SignalReasonCode.TRADE_COOLDOWN]: 'Cooldown',
+      [SignalReasonCode.ORDER_EXECUTION_FAILED]: 'Execution Failed',
+      [SignalReasonCode.SIGNAL_THROTTLED]: 'Throttled',
+      [SignalReasonCode.SYMBOL_RESOLUTION_FAILED]: 'Symbol Failed'
+    };
+    return labels[code] ?? code;
+  }
+
+  getReasonCodeSeverity(code: string): 'success' | 'info' | 'warn' | 'danger' | 'secondary' {
+    switch (code) {
+      case SignalReasonCode.ORDER_EXECUTION_FAILED:
+      case SignalReasonCode.INSUFFICIENT_FUNDS:
+      case SignalReasonCode.SIGNAL_VALIDATION_FAILED:
+      case SignalReasonCode.SYMBOL_RESOLUTION_FAILED:
+        return 'danger';
+      case SignalReasonCode.DAILY_LOSS_LIMIT:
+      case SignalReasonCode.DRAWDOWN_GATE:
+      case SignalReasonCode.CONCENTRATION_LIMIT:
+      case SignalReasonCode.CONCENTRATION_REDUCED:
+        return 'warn';
+      case SignalReasonCode.SIGNAL_THROTTLED:
+      case SignalReasonCode.TRADE_COOLDOWN:
+        return 'info';
+      default:
+        return 'secondary';
+    }
+  }
+
+  getStatusSeverity(status: string): 'success' | 'info' | 'warn' | 'danger' | 'secondary' {
+    switch (status) {
+      case 'PLACED':
+      case 'PROCESSED':
+        return 'success';
+      case 'PENDING':
+      case 'RECORDED':
+        return 'info';
+      case 'BLOCKED':
+        return 'warn';
+      case 'FAILED':
         return 'danger';
       default:
         return 'secondary';

--- a/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
+++ b/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
@@ -452,7 +452,40 @@ export interface PipelineStageCountsDto {
 
 export enum SignalSource {
   BACKTEST = 'BACKTEST',
-  PAPER_TRADING = 'PAPER_TRADING'
+  PAPER_TRADING = 'PAPER_TRADING',
+  LIVE_TRADING = 'LIVE_TRADING'
+}
+
+export enum SignalStatus {
+  RECORDED = 'RECORDED',
+  PENDING = 'PENDING',
+  PROCESSED = 'PROCESSED',
+  PLACED = 'PLACED',
+  BLOCKED = 'BLOCKED',
+  FAILED = 'FAILED'
+}
+
+export enum SignalReasonCode {
+  SIGNAL_VALIDATION_FAILED = 'SIGNAL_VALIDATION_FAILED',
+  DAILY_LOSS_LIMIT = 'DAILY_LOSS_LIMIT',
+  REGIME_GATE = 'REGIME_GATE',
+  DRAWDOWN_GATE = 'DRAWDOWN_GATE',
+  CONCENTRATION_LIMIT = 'CONCENTRATION_LIMIT',
+  CONCENTRATION_REDUCED = 'CONCENTRATION_REDUCED',
+  OPPORTUNITY_SELLING_REJECTED = 'OPPORTUNITY_SELLING_REJECTED',
+  INSUFFICIENT_FUNDS = 'INSUFFICIENT_FUNDS',
+  EXCHANGE_SELECTION_FAILED = 'EXCHANGE_SELECTION_FAILED',
+  TRADE_COOLDOWN = 'TRADE_COOLDOWN',
+  ORDER_EXECUTION_FAILED = 'ORDER_EXECUTION_FAILED',
+  SIGNAL_THROTTLED = 'SIGNAL_THROTTLED',
+  SYMBOL_RESOLUTION_FAILED = 'SYMBOL_RESOLUTION_FAILED'
+}
+
+export enum LiveTradingSignalAction {
+  BUY = 'buy',
+  SELL = 'sell',
+  SHORT_ENTRY = 'short_entry',
+  SHORT_EXIT = 'short_exit'
 }
 
 export interface SignalFeedItemDto {
@@ -464,6 +497,8 @@ export interface SignalFeedItemDto {
   quantity: number;
   price?: number;
   confidence?: number;
+  status: SignalStatus;
+  reasonCode?: SignalReasonCode;
   reason?: string;
   source: SignalSource;
   sourceId: string;


### PR DESCRIPTION
## Summary

- Add a `LiveTradingSignal` entity and recording system to persist the outcome of every live trading signal (placed, blocked, or failed) with detailed reason codes
- Integrate signal outcomes into the admin signal activity feed, extending it from two sources (backtest/paper) to three (backtest/paper/live)
- Add a 90-day retention cleanup cron for live signal records

## Changes

### New Files
- **`live-trading-signal.entity.ts`** — Entity with status, reason code, confidence, price, and source tracking
- **`live-signal.service.ts`** — Service for persisting signal outcomes with graceful degradation on DB failures
- **`live-signal-cleanup.task.ts`** — Cron task with 90-day retention policy
- **`1774830000000-create-live-trading-signals.ts`** — Migration with CHECK constraints and indexes

### Modified Files
- **`trade-execution.task.ts`** — Record signal outcomes (placed/blocked/failed) during live trade execution
- **`live-trading.service.ts`** — Add `recordOutcome` calls with explicit `SignalSource` at all decision points
- **`backtest-monitoring.service.ts`** — Query live signals alongside backtest/paper for unified activity feed
- **`signal-activity-feed.dto.ts`** — Add status/reason fields to DTO
- **`signal-activity-feed.component.ts`** — Convert to signal-based inputs, add status/reason columns

### Shared Interfaces
- **`backtest-monitoring.interface.ts`** — Add `SignalStatus`, `SignalReasonCode`, `SignalSource`, and `LiveTradingSignalAction` enums

### Bug Fixes
- Fix `parseInt` operator precedence bug in signal health stat aggregation
- Make price column nullable and widen decimal precision to `(25,8)`

## Test Plan

- [x] Unit tests updated for three-source signal feed (`backtest-monitoring.service.spec.ts`)
- [x] Trade execution task tests cover signal recording paths (`trade-execution.task.spec.ts`)
- [x] Live trading service tests verify outcome recording (`live-trading.service.spec.ts`)
- [ ] Verify migration runs cleanly on fresh and existing databases
- [ ] Confirm admin signal activity feed displays live signal entries with status/reason columns