### PR TITLE
docs: split CLAUDE.md into per-module rule files and add subdirectory READMEs

### DIFF
--- a/.claude/rules/admin-api-module.md
+++ b/.claude/rules/admin-api-module.md
@@ -1,0 +1,35 @@
+---
+description: Admin API — trading kill switch, backtest monitoring, live trade analytics
+globs:
+  - "apps/api/src/admin/**"
+---
+
+# Admin API Module
+
+## Sub-Modules
+
+### `trading-state/`
+- Global kill switch — singleton entity (one row in DB)
+- `isTradingEnabled()` is **synchronous** (in-memory cache) — hot path for every trade
+- `haltTrading()` supports `pauseDeployments` + `cancelOpenOrders` flags
+- All actions audit-logged as `MANUAL_INTERVENTION`
+
+### `backtest-monitoring/`
+- Read-only analytics over backtest/optimization/paper-trading data
+
+### `live-trade-monitoring/`
+- Live trade analytics, alerts, slippage analysis
+- Alert thresholds: `sharpeRatioWarning=25`, `maxDrawdownWarning=25`
+
+## Constants
+
+- `MAX_EXPORT_LIMIT = 10000` — caps CSV/JSON exports
+
+## Dependencies
+
+- Uses `forwardRef()` for `OrderModule`, `StrategyModule`, `TasksModule`
+
+## Notes
+
+- Frontend admin pages have their own rule file (`admin-pages.md`)
+- The trading state in-memory cache means changes take effect immediately without DB round-trip on read

--- a/.claude/rules/admin-pages.md
+++ b/.claude/rules/admin-pages.md
@@ -1,0 +1,46 @@
+---
+description: Admin pages — algorithm monitoring, backtest dashboards, CRUD management
+globs:
+  - "apps/chansey/src/app/pages/admin/**"
+---
+
+# Admin Pages
+
+## Overview
+68 files. Admin-only pages for monitoring algorithms, backtests, live trades, and managing platform entities.
+
+## Directory Layout
+```
+admin/
+├── algorithms/            # Algorithm detail + 7 sub-components
+├── backtest-monitoring/   # Backtest dashboard + 10 sub-components
+├── live-trade-monitoring/ # Live trade dashboard + 7 sub-components + types
+├── categories/            # Simple CRUD
+├── coins/                 # Simple CRUD
+├── exchanges/             # Simple CRUD
+├── risks/                 # Simple CRUD
+├── bull-board/            # BullMQ dashboard embed
+└── trading-state/         # Trading state management
+```
+
+## Key Patterns
+- **Component conventions**: Standalone, `OnPush` change detection, Angular Signals, inline templates for sub-components
+- **Data fetching**: TanStack Query via `useAuthQuery()` / `useAuthMutation()`, query keys from `@chansey/shared`
+- **Lazy tab pattern**: `computed(() => this.activeTab() === 'X')` gates expensive queries — only fetches data when tab is active
+- **Query organization**: `algorithm-detail.queries.ts` uses an injectable query config factory pattern — follow this for complex pages with many queries
+
+## Available PrimeNG Components (commonly used)
+`Table`, `Drawer`, `Tag`, `Chart`, `SelectButton`, `Dialog`, `TabView`
+
+## How to Add a New Admin Page
+1. Create standalone component in a new subdirectory
+2. Use `OnPush` + Signals pattern
+3. Fetch data via `useAuthQuery()` with query keys from `@chansey/shared`
+4. Add route in admin routing configuration
+5. Add navigation link in admin layout/menu
+
+## Gotchas
+- All admin pages require authentication — `useAuthQuery`/`useAuthMutation` handle token injection
+- Sub-components use inline templates — keep them small and focused
+- The lazy tab pattern is important for performance — don't fetch all tab data upfront
+- Query keys must be defined in `@chansey/shared` for cache invalidation consistency

--- a/.claude/rules/algorithm-module.md
+++ b/.claude/rules/algorithm-module.md
@@ -1,0 +1,43 @@
+---
+description: Trading algorithms — 13 strategies, indicator service, registry pattern
+globs:
+  - "apps/api/src/algorithm/**"
+---
+
+# Algorithm Module
+
+## Overview
+79 files containing 13 trading strategies extending `BaseAlgorithmStrategy`. Uses a registry pattern to map strategy IDs to instances at runtime.
+
+## Directory Layout
+```
+algorithm/
+├── strategies/           # 13 concrete strategy implementations
+├── indicators/           # IndicatorService + 8 calculators
+├── algorithm.registry.ts # Maps strategyId → strategy instance
+├── entities/             # Algorithm entity + related
+├── scripts/              # LEGACY seeding — not runtime code
+└── algorithm.module.ts
+```
+
+## Key Patterns
+- **Inheritance chain**: `AlgorithmStrategy` (interface) → `BaseAlgorithmStrategy` (abstract) → concrete strategies
+- **Registry**: `AlgorithmRegistry` maps `strategyId` → strategy instance. Registration happens in module factory provider `ALGORITHM_STRATEGIES_INIT`
+- **Strategy IDs**: kebab-case with numeric suffix (e.g., `'rsi-momentum-001'`, `'confluence-001'`)
+- **Indicator caching**: `IndicatorService` has L1 (in-memory) / L2 (Redis) caching. 8 calculators: RSI, EMA, SMA, MACD, Bollinger, ATR, StdDev, plus composite
+- **Backtest fast-path**: `getPrecomputedSlice()` avoids Redis during simulation — use this instead of live indicator calls in backtest context
+
+## How to Add a New Strategy
+1. Create class in `strategies/` extending `BaseAlgorithmStrategy`
+2. Add to module `providers` array
+3. Add to `ALGORITHM_STRATEGIES_INIT` factory so it registers in `AlgorithmRegistry`
+4. Insert corresponding DB row in `algorithm` table with matching `strategyId`
+
+## Available Calculators
+`RSI`, `EMA`, `SMA`, `MACD`, `BollingerBands`, `ATR`, `StdDev` — all accessible via `IndicatorService`
+
+## Gotchas
+- `scripts/` directory is legacy seeding — not used at runtime, don't add new scripts there
+- Suppress chart data emission in simulation mode (unnecessary overhead)
+- Strategy `evaluate()` must return a signal object, not execute trades directly
+- The registry is populated at module init — adding a strategy without registering it will silently fail

--- a/.claude/rules/api-config.md
+++ b/.claude/rules/api-config.md
@@ -1,0 +1,36 @@
+---
+description: API configuration — database, Redis, env validation, logging
+globs:
+  - "apps/api/src/config/**"
+---
+
+# API Config Module
+
+## Configuration Files
+
+### `database.config.ts`
+- TypeORM PostgreSQL connection
+- `synchronize: true` in non-prod, `migrationsRun: true` in prod only
+- Uses `pgcrypto` extension (not `uuid-ossp`)
+- Pool size: `PG_POOL_MAX` env var (default 20)
+
+### `redis.config.ts`
+- Registered as `'redis'` namespace
+- Exposes: host, port, username, password, tls, url
+
+### `env.validation.ts`
+- Zod schema validation
+- **Fully skipped** in test env (`NODE_ENV=test` or `JEST_WORKER_ID` set)
+- Calls `process.exit(1)` on validation failure
+
+### `logger.config.ts`
+- Pino via `nestjs-pino`
+- Dev: `pino-pretty` | Prod: JSON + optional Loki
+- **Redacts**: authorization, cookies, apiKey, apiSecret, token, privateKey
+- **Ignores**: `/api/health`, `/api/metrics`, `/bull-board`
+- Request ID resolution: `x-request-id` → `x-correlation-id` → W3C `traceparent` → random UUID
+- Dynamic log levels: 5xx=error, 4xx=warn, 2xx=info
+
+## Key Environment Variable
+
+`DISABLE_BACKGROUND_TASKS=true` — skips all background job scheduling (used in dev/testing).

--- a/.claude/rules/api-interfaces.md
+++ b/.claude/rules/api-interfaces.md
@@ -1,0 +1,46 @@
+---
+description: Shared TypeScript interfaces and contracts between API and frontend
+globs:
+  - "libs/api-interfaces/**"
+---
+
+# API Interfaces
+
+## Overview
+
+20+ folders in `libs/api-interfaces/src/lib/`. Shared TypeScript contracts between API and frontend.
+
+## Import Path
+
+Consumed via `@chansey/api-interfaces` path alias.
+
+## Naming Conventions
+
+- Files: `<domain>.<type>.ts` (e.g., `coin.interface.ts`, `order-side.enum.ts`)
+- Interfaces: `I` prefix for user models (`IUser`); plain names for DTOs (`Order`, `Coin`)
+- Enums: PascalCase, standalone `.enum.ts` or inline
+- Constants: `SCREAMING_SNAKE_CASE`
+
+## Barrel Exports
+
+**WITH** barrel `index.ts`: auth, balance, category, coin-selection, notification, order, paper-trading, pipeline, risk, user.
+
+**WITHOUT** (import by path): admin, algorithm, audit, backtesting, coin, constants, exchange, market, strategy.
+
+## Key Interfaces
+
+| Interface | Notes |
+|-----------|-------|
+| `IUser` | OIDC + trading config |
+| `PipelineDetail` | Most complex — 5-stage |
+| `Risk` | Helper functions + constants |
+| `NotificationPreferences` | Channels, events, quiet hours |
+| `CoinDetailResponseDto` | Hybrid public/private |
+
+## Logic Files
+
+Some folders contain pure logic + spec tests (e.g., `pipeline/allocation-limits.ts`).
+
+## Root Export
+
+`api-interfaces.ts` only exports `Message` + `backtesting` — most consumption via folder imports.

--- a/.claude/rules/api-utils.md
+++ b/.claude/rules/api-utils.md
@@ -1,0 +1,43 @@
+---
+description: API utilities — decorators, interceptors, transformers, validators, sanitizers
+globs:
+  - "apps/api/src/utils/**"
+---
+
+# API Utils
+
+## Decorators
+
+| Decorator | Purpose |
+|-----------|---------|
+| `@UseCacheKey(factory)` | Dynamic cache key via `SetMetadata`. Pair with `CustomCacheInterceptor` |
+| `@AuthThrottle()` | 3/s, 5/min, 20/hr |
+| `@ApiThrottle()` | 5/s, 50/min, 500/hr |
+| `@UploadThrottle()` | 1/s, 5/min, 10/hr |
+| `@Match(property)` | class-validator field equality (e.g., password confirm) |
+| `@MinStringNumber(min)` | Validates string coerces to number ≥ min |
+
+## Interceptors
+
+- `CustomCacheInterceptor` — extends NestJS default. Supports `@UseCacheKey` factories. Adds `X-Cache: HIT/MISS` header
+
+## Transformers
+
+- `ColumnNumericTransformer` — TypeORM transformer, PostgreSQL numeric string → `number` via `parseFloat`
+
+## Validators
+
+- `sanitizeNumericValue(value, opts)` — returns `null` for NaN/Infinity/overflow
+- `sanitizeNumericValues<T>()` — applies sanitization to all numeric fields in an object
+
+## Pure Utils
+
+| Utility | Purpose |
+|---------|---------|
+| `sanitizeObject()` | Deep JSONB sanitization. Blocks prototype pollution, enforces depth (10), key count (100), string length (10000), array length (1000) |
+| `escapeLikeWildcards()` | Escapes `%` and `_` for LIKE queries |
+| `escapeHtml()` | HTML entity encoding |
+| `stripNullProps()` | Removes null/undefined keys from objects |
+| `strip-html.util.ts` | HTML tag removal |
+| `file-validation.util.ts` | File upload validation |
+| `isRecord()` | Type guard for `Record<string, unknown>` |

--- a/.claude/rules/auth-pages.md
+++ b/.claude/rules/auth-pages.md
@@ -1,0 +1,42 @@
+---
+description: Frontend auth pages — login, register, OTP, password reset flows
+globs:
+  - "apps/chansey/src/app/pages/auth/**"
+---
+
+# Auth Pages
+
+## Overview
+
+6 auth flows, each with 3 files: `component.ts`, `component.html`, `service.ts` + barrel `index.ts`.
+
+## Pattern
+
+- Standalone component + `providedIn: 'root'` service with `useAuthMutation()`
+- No state stored in services — all transient
+
+## Feedback System
+
+`signal<AuthMessage[]>([])` with `{ content, severity, icon }`. Displayed via shared `AuthMessagesComponent`.
+
+## Shared UI Components
+
+- `AuthPageShellComponent` — two-panel layout
+- `PasswordRequirementsComponent`, `PasswordMatchValidator`, `PasswordStrengthValidator`
+
+## Error Handling
+
+Use `isApiError(error)` + `error.hasCode(ErrorCodes.X)` from `@chansey/shared` (never string matching).
+
+## Flow-Specific Notes
+
+| Flow | Detail |
+|------|--------|
+| **Login** | Handles OTP redirect via `sessionStorage` (`otpEmail`, `otpRemember`) |
+| **OTP** | Auto-submits when 6-digit code complete. Email censored: `replace(/(.{2})(.*)(@.*)/, '$1****$3')` |
+| **New Password** | Reads `?token=` from query params. `AUTH_REDIRECT_DELAY = 3000ms` + `timer()` redirect |
+| **Register** | Uses `getRawValue()` (not `.value`) to bypass disabled controls |
+
+## API Interfaces
+
+Import from `@chansey/api-interfaces` (e.g., `ILogin`, `ILoginResponse`, `IRegister`).

--- a/.claude/rules/authentication-module.md
+++ b/.claude/rules/authentication-module.md
@@ -1,0 +1,53 @@
+---
+description: JWT auth with Passport strategies, OTP, security audit logging
+globs:
+  - "apps/api/src/authentication/**"
+---
+
+# Authentication Module
+
+## Overview
+
+39 files. JWT auth with Passport strategies, OTP, and security audit logging.
+
+## Strategies
+
+| Strategy | Details |
+|----------|---------|
+| `JwtStrategy` | HS512, Bearer header or `chansey_access` cookie |
+| `LocalStrategy` | Email/password |
+| `ApiKeyStrategy` | `Api-Key` header |
+
+## Guards
+
+- `JwtAuthenticationGuard` — standard JWT
+- `LocalAuthenticationGuard` — login form
+- `OptionalJwtAuthenticationGuard` — returns null if unauthenticated
+- `RolesGuard` — reads `@Roles()` metadata
+- `WsJwtAuthenticationGuard` — Socket.IO: `handshake.auth.token` → header → cookie → query
+
+## Decorators
+
+- `@GetUser()` — extracts user from request
+- `@Roles(...roles)` — sets required roles
+
+## Tokens
+
+- Access: HS512, 15min. Refresh: HS512, 7d/30d
+- HttpOnly cookies: `chansey_access`/`chansey_refresh`, `SameSite=Strict`
+
+## OTP
+
+6-digit, bcrypt 6 rounds, emailed, verified via `POST /authentication/verify-otp`.
+
+## Security
+
+- Lockout: 5 failed attempts → 15-min lockout
+- Anti-enumeration on forgot/resend endpoints
+- `SecurityAuditLog`: 15 event types, indexed `[userId, createdAt]`. Failures never throw
+- `PasswordService`: standalone injectable (bcrypt + crypto)
+- `@AuthThrottle()` on all routes
+
+## Gotcha
+
+`JwtModule.register({})` is empty — signing config is per-call in `RefreshTokenService`.

--- a/.claude/rules/balance-module.md
+++ b/.claude/rules/balance-module.md
@@ -1,0 +1,38 @@
+---
+description: Balance module — current balances, historical tracking, chart downsampling
+globs:
+  - "apps/api/src/balance/**"
+---
+
+# Balance Module
+
+## Current Balances
+
+- `getCurrentBalances()` — Redis cached 60s (`balance:user:{id}:current`)
+- Exchange fetches run in parallel via `Promise.allSettled` with 15s timeout per exchange
+
+## Background Sync
+
+- `BalanceSyncTask` — BullMQ `balance-queue`, runs hourly
+- Skipped in dev env or when `DISABLE_BACKGROUND_TASKS=true`
+- Users processed in chunks of 5
+
+## Chart Downsampling
+
+| Period | Granularity |
+|--------|-------------|
+| ≤2 days | Hourly |
+| ≤14 days | Daily |
+| ≤90 days | Weekly |
+| 91+ days | Monthly |
+
+Basic interval sampling (not LTTB).
+
+## Holdings
+
+- `getHoldingsForCoin()` computes from live balance (not order history)
+- Average buy price is always `0` (not calculated)
+
+## Historical Data
+
+Uses closest-match algorithm per exchange per period.

--- a/.claude/rules/coin-module.md
+++ b/.claude/rules/coin-module.md
@@ -1,0 +1,46 @@
+---
+description: Cryptocurrency data — CoinGecko integration, ticker pairs, risk-based selection
+globs:
+  - "apps/api/src/coin/**"
+---
+
+# Coin Module
+
+## Overview
+
+21 files. Cryptocurrency data from CoinGecko + exchange ticker pairs.
+
+## Entities
+
+- `Coin`: market data (prices, ATH/ATL, scores, links JSONB, supply). Relations: Order, CoinSelection, TickerPairs
+- `TickerPairs`: unique `(symbol, exchange)`, auto-generated symbol via hooks. Status: `TRADING/BREAK/DELISTED`
+
+## CoinGecko Caching
+
+- `fetchCoinDetail()`: 5min TTL + circuit breaker (3 failures, 60s reset)
+- `fetchMarketChart()`: dual cache (primary + stale 24h fallback) + `Promise.race` 30s timeout
+
+## Risk-Based Selection
+
+| Level | Strategy |
+|-------|----------|
+| 1 | Highest volume |
+| 5 | Lowest gecko rank |
+| 2-4 | Logarithmic composite |
+
+## Virtual USD
+
+`createVirtualUsdCoin()` returns synthetic Coin with id `USD-virtual`.
+
+## Sync Tasks
+
+- `coin-sync`: weekly (CoinGecko list + ticker pairs)
+- `coin-detail`: daily 11PM (batches of 3, 2.5s delay)
+
+## Filtering
+
+`getCoinsByIdsFiltered()`: `minMarketCap` 100M + `minDailyVolume` 1M for backtest quality.
+
+## Helpers
+
+`stripNullProps()`, `sanitizeNumericValue()`. Disabled in dev/`DISABLE_BACKGROUND_TASKS`.

--- a/.claude/rules/coin-selection-module.md
+++ b/.claude/rules/coin-selection-module.md
@@ -1,0 +1,30 @@
+---
+description: Coin selection — manual/automatic/watched selections, OHLC pre-fetching
+globs:
+  - "apps/api/src/coin-selection/**"
+---
+
+# Coin Selection Module
+
+## Selection Types
+
+`CoinSelectionType` enum: `MANUAL`, `AUTOMATIC`, `WATCHED`
+
+## Dual Query Pattern
+
+- **User-scoped**: `getCoinSelectionsByUser` — for user-facing APIs
+- **Global system**: `getCoinSelections`, `getCoinSelectionCoins` — for background algorithm execution
+
+## Sorting
+
+`getCoinSelectionsByUser` orders by:
+- `coin.name ASC` when coin relation is loaded
+- `createdAt ASC` otherwise
+
+## Background Task
+
+`coin-selection-historical-price.task.ts` — pre-fetches OHLC data for selected coins.
+
+## Dependencies
+
+- Circular dependency with OHLC: `forwardRef(() => OHLCService)`

--- a/.claude/rules/coins-pages.md
+++ b/.claude/rules/coins-pages.md
@@ -1,0 +1,34 @@
+---
+description: Coin detail page — price chart, market stats, holdings, external links
+globs:
+  - "apps/chansey/src/app/coins/**"
+---
+
+# Coins Pages
+
+## Overview
+
+12 files. Coin detail page at `/app/coins/:slug` with smart/presentational split.
+
+## Smart Component
+
+`CoinDetailComponent`: receives `slug` via `withComponentInputBinding()`, injects `CoinDetailQueries`, passes data down.
+
+## CoinDetailQueries
+
+`@Injectable()` at component level (NOT `providedIn: 'root'`). Returns TanStack query configs.
+
+4 queries:
+- detail (STANDARD_POLICY)
+- price (REALTIME ~45s)
+- history (STABLE, 15min gcTime)
+- holdings (FREQUENT, auth-gated)
+
+## Presentational Sub-Components
+
+| Component | Purpose |
+|-----------|---------|
+| `PriceChartComponent` | Chart.js, custom `hoverLine` plugin, LTTB decimation (150 samples), green/red coloring |
+| `MarketStatsComponent` | 3-column grid, `[appCounter]` directive, supply progress bar |
+| `HoldingsCardComponent` | Amount, value, avg buy price, P&L, per-exchange breakdown |
+| `ExternalLinksComponent` | Website, explorer, Reddit, GitHub, forum links from `CoinLinksDto` |

--- a/.claude/rules/common-module.md
+++ b/.claude/rules/common-module.md
@@ -1,0 +1,52 @@
+---
+description: Common foundation — exception hierarchy, CLS context, global filters, metrics, crypto
+globs:
+  - "apps/api/src/common/**"
+---
+
+# Common Module
+
+## Overview
+37 files. Foundation shared across all API modules — exception hierarchy, CLS context, global filters, metrics calculators, and crypto utilities.
+
+## Directory Layout
+```
+common/
+├── exceptions/
+│   ├── base/              # AppException (abstract) → 9 base exception types
+│   ├── auth/              # Auth leaf exceptions
+│   ├── backtest/          # Backtest leaf exceptions
+│   ├── external/          # External service leaf exceptions
+│   ├── order/             # Order leaf exceptions
+│   ├── resource/          # Resource leaf exceptions
+│   └── error-codes.enum.ts # ErrorCode enum — 58 codes in DOMAIN.SPECIFIC_ERROR format
+├── filters/               # GlobalExceptionFilter
+├── cls/                   # ClsContextModule, ClsContextInterceptor, RequestContext
+├── metrics/               # Pure function calculators + 3 injectable services
+├── crypto.service.ts      # CryptoService (AES-256-CBC, hashing)
+└── index.ts
+```
+
+## Key Patterns
+- **Exception hierarchy**: `AppException` (abstract) → 9 base types → leaf exceptions. Leaf pattern: extend base type, provide `ErrorCode` and `context`
+- **ErrorCode enum**: 58 codes in `DOMAIN.SPECIFIC_ERROR` format (e.g., `AUTH.INVALID_TOKEN`, `ORDER.INSUFFICIENT_BALANCE`)
+- **CLS context**: `ClsContextModule` (@Global) seeds `requestId`, `ipAddress`, `userAgent` per request. `ClsContextInterceptor` adds `userId` after JWT guard. Access via `RequestContext` service
+- **GlobalExceptionFilter**: 5xx → error log, 4xx → warn log, attaches `requestId`/`userId`
+- **Metrics**: Pure functions in `metric-calculator.ts` + 3 injectable services (Sharpe, Correlation, Drawdown). Not registered in common module — imported directly by domain modules
+
+## How to Add a New Exception
+1. Choose the appropriate base type from `exceptions/base/`
+2. Create leaf class in `exceptions/<category>/`
+3. Add a new `ErrorCode` entry to the enum
+4. Pass `ErrorCode` and contextual data to the base constructor
+
+## Available Utilities
+- **CryptoService**: `encrypt()`, `decrypt()` (AES-256-CBC), `hash()` (SHA-256), audit chain hashing
+- **RequestContext**: `getRequestId()`, `getUserId()`, `getIpAddress()`, `getUserAgent()`
+- **Metric calculators**: Sharpe ratio, max drawdown, correlation — pure functions and injectable services
+
+## Gotchas
+- Metrics calculators are not centrally registered — import them directly in your domain module
+- `ClsContextInterceptor` runs after the JWT guard — `userId` is only available in authenticated routes
+- Always use `ErrorCode` enum values, not raw strings, when creating exceptions
+- `GlobalExceptionFilter` is applied globally — don't add per-controller exception filters unless you need to override behavior

--- a/.claude/rules/exchange-module.md
+++ b/.claude/rules/exchange-module.md
@@ -1,0 +1,53 @@
+---
+description: Multi-exchange support — adapter pattern, CCXT integration, encrypted API keys
+globs:
+  - "apps/api/src/exchange/**"
+---
+
+# Exchange Module
+
+## Overview
+49 files. Multi-exchange support via an adapter pattern with `BaseExchangeService` and a facade `ExchangeManagerService` for routing.
+
+## Directory Layout
+```
+exchange/
+├── services/
+│   ├── base-exchange.service.ts    # Abstract base — extend for new exchanges
+│   ├── binance.service.ts          # Binance adapter
+│   ├── coinbase.service.ts         # Coinbase adapter
+│   ├── exchange-manager.service.ts # Facade with slug-based routing
+│   └── exchange-selection.service.ts # Smart routing for automated trading
+├── entities/
+│   ├── exchange.entity.ts          # Exchange configuration
+│   └── exchange-key.entity.ts      # Encrypted user API keys
+├── constants/                      # Quote currencies, defaults
+└── exchange.module.ts
+```
+
+## Key Patterns
+- **Adapter pattern**: `BaseExchangeService` (abstract) defines 5 required properties: `exchangeSlug`, `exchangeId`, `apiKeyConfigName`, `apiSecretConfigName`, `quoteAsset`
+- **Facade routing**: `ExchangeManagerService` routes by slug via switch statement
+- **CCXT client caching**: `Map<string, ccxt.Exchange>` with 30min TTL, IPv4 forced
+- **DI tokens**: `EXCHANGE_SERVICE`, `EXCHANGE_MANAGER_SERVICE` — symbol-based injection to break circular deps
+- **Key encryption**: `ExchangeKey` entity uses AES-256-CBC via TypeORM hooks (`@BeforeInsert`/`@BeforeUpdate`)
+- **Smart selection**: `ExchangeSelectionService.selectForBuy()` / `selectForSell()` with 3-step fallback
+
+## How to Add a New Exchange
+1. Create service extending `BaseExchangeService` in `services/`
+2. Implement the 5 required abstract properties
+3. Add to module providers
+4. Add case to `ExchangeManagerService` switch routing
+5. Add quote currency constant to `constants/`
+6. Override any exchange-specific methods (order format, fee calc, etc.)
+
+## Available Constants
+- `EXCHANGE_QUOTE_CURRENCY` — per-exchange quote currency map
+- `DEFAULT_QUOTE_CURRENCY = 'USDT'`
+- `USD_QUOTE_CURRENCIES` — set of USD-equivalent currencies
+
+## Gotchas
+- CCXT clients are cached per user+exchange — don't create new instances per request
+- IPv4 is forced on CCXT connections (some exchanges reject IPv6)
+- `ExchangeKey` encryption happens in TypeORM hooks — don't encrypt manually before save
+- The manager switch statement must be updated when adding exchanges — no auto-discovery

--- a/.claude/rules/failed-jobs-module.md
+++ b/.claude/rules/failed-jobs-module.md
@@ -1,0 +1,44 @@
+---
+description: Failed jobs — BullMQ failure tracking, severity classification, alerting
+globs:
+  - "apps/api/src/failed-jobs/**"
+---
+
+# Failed Jobs Module
+
+## Severity Classification
+
+| Severity | Queues |
+|----------|--------|
+| CRITICAL | `trade-execution`, `order-queue`, `live-trading-cron` |
+| HIGH | `position-monitor`, `liquidation-monitor` |
+| MEDIUM | `backtest*`, `pipeline*`, `optimization*` |
+| LOW | Everything else |
+
+## Non-Retryable Queues
+
+`NON_RETRYABLE_QUEUES = {'live-trading-cron'}` — cron-driven queues can't be manually retried.
+
+## Key Behaviors
+
+- `recordFailure()` is **fail-safe** (never throws)
+- Strips sensitive keys (`apiKey`, `apiSecret`, `token`) → `[REDACTED]`
+- `retryJob()` resolves queue dynamically via `ModuleRef.get(getQueueToken(queueName))`
+
+## Alert Service
+
+- In-memory rolling window: 5 min / 5 CRITICAL failures → spike detection
+- Spikes logged as `FAILED_JOB_SPIKE_DETECTED` in audit log
+
+## Status Flow
+
+`pending → reviewed | retried | dismissed`
+
+- `bulkDismiss()` only updates jobs with `pending` status
+
+## Database Indexes
+
+- `(queueName, createdAt)`
+- `(status, createdAt)`
+- `(severity, createdAt)`
+- `(userId, createdAt)`

--- a/.claude/rules/frontend-shared.md
+++ b/.claude/rules/frontend-shared.md
@@ -1,0 +1,66 @@
+---
+description: Frontend shared — reusable components, services, pipes, directives, trading utilities
+globs:
+  - "apps/chansey/src/app/shared/**"
+---
+
+# Frontend Shared
+
+## Overview
+80 files. Reusable components, services, pipes, directives, and utilities shared across the Angular frontend.
+
+## Directory Layout
+```
+shared/
+├── components/           # Reusable UI components
+├── services/             # Singleton services (providedIn: 'root')
+├── pipes/                # Transform pipes
+├── directives/           # Attribute directives
+├── utils/                # Pure utility functions
+└── trading/              # Trading-specific query/mutation/state/utils
+```
+
+## Available Components (check before creating new ones)
+- **Auth**: `auth-page-shell`, `auth-messages`, `auth-illustrations` (login/register/forgot)
+- **Trading**: `crypto-trading` (full widget: order-form, order-book, active-orders, exit-config), `crypto-table` (feature-rich coin table)
+- **Data**: `exchange-balance` (chart + history), `recent-transactions`, `user-assets`
+- **Forms**: `risk-profile-form`, `image-crop`, `password-requirements`
+- **Shell**: `empty-state`, `getting-started` (3-step onboarding), `lazy-image`, `pwa-toast`, `timeout-warning`
+
+## Available Services
+- `auth.service.ts`: `useUser()`, `useLogoutMutation()`, `refreshToken()`
+- `coin-data.service.ts`: `useCoins()`, `usePrices()`, `useWatchedCoins()`, watchlist/trading coin mutations, `useCoinPreview()`
+- `exchange.service.ts`: `useSupportedExchanges()`, `useSaveExchangeKeysMutation()`, `buildExchangeForms()`
+- `layout.service.ts`: Theme config, `isDarkTheme()`, localStorage persistence
+- `trading/`: Query, mutation, state, utils services for order flow
+- `pwa.service.ts`, `session-activity.service.ts`, `title.service.ts`
+
+## Available Pipes
+- `formatLargeNumber`: Formats to T/B/M/K suffixes
+- `timeAgo`: Relative time display
+
+## Available Directives
+- `appCounter`: Animated number counting with easing
+
+## Available Utilities
+- `createExternalChartTooltip()`: Custom chart tooltip factory
+- `filterCoinSuggestions()`: Autocomplete filter helper
+- Order format/severity helpers
+
+## Conventions
+- All services use `providedIn: 'root'` — no need to add to module providers
+- Use `decimal.js` for all financial math — never native JS floats
+- PrimeNG only — no Material or Bootstrap components
+- Standalone components with `OnPush` change detection
+
+## How to Add a New Shared Component
+1. Create standalone component in `components/`
+2. Use `OnPush` change detection + Angular Signals
+3. Follow existing naming: `<purpose>.component.ts`
+4. Export from component's directory (no barrel files needed — standalone)
+
+## Gotchas
+- Check the component/service inventory above before creating anything new — it may already exist
+- `decimal.js` is required for financial calculations — PRs using `Number` for money will be rejected
+- Services are tree-shaken via `providedIn: 'root'` — don't manually register them in modules
+- The `trading/` subdirectory has its own service organization (query, mutation, state, utils) — follow that pattern for trading features

--- a/.claude/rules/layout.md
+++ b/.claude/rules/layout.md
@@ -1,0 +1,42 @@
+---
+description: App layout shell — sidebar, topbar, breadcrumbs, search, theme configuration
+globs:
+  - "apps/chansey/src/app/layout/**"
+---
+
+# Layout
+
+## Overview
+
+16 files. Two layout variants: `AppLayout` (authenticated shell) and `AuthLayout` (bare auth pages).
+
+## AppLayout
+
+Sidebar + topbar + breadcrumb + footer. `containerClass()` maps 7 menu modes to CSS classes.
+
+## Components
+
+| Component | Details |
+|-----------|---------|
+| `AppTopBar` | Hamburger, search, notifications (All/Unread/Critical tabs + badge), profile dropdown (DiceBear `funEmoji` fallback) |
+| `AppSidebar` | Hover-expand/collapse (300ms debounce), anchor to pin |
+| `AppMenu` | "Trading" (5 routes) + "Admin" (9 routes, role-gated) |
+| `AppMenuitem` | `[chansey-menuitem]` attribute selector, recursive, animations, hover-open for compact/slim modes |
+| `AppBreadcrumb` | Auto from `route.data['breadcrumb']`, `?from=` parent crumb injection |
+| `AppSearch` | Coin autocomplete dialog (max 10), navigates to `/app/coins/:slug` |
+| `AppRightMenu` | Right drawer for trading, `?trading=open` query param, lazy `CryptoTradingComponent` |
+| `AppConfigurator` | PrimeNG `$t()` live theme switch, updates `meta[name="theme-color"]` |
+
+## Services
+
+- `NotificationFeedService`: `providedIn: 'root'`, feed/unread queries, mark-read mutations
+- `LayoutService`: `layoutConfig` + `layoutState` signals, mutations via `.update()`
+
+## Theme Utils
+
+- `preset-utils.ts`: semantic token config, special `'noir'` handling
+- `surface-palettes.ts`: 8 palettes (slate, gray, zinc, neutral, stone, soho, viva, ocean)
+
+## Gotcha
+
+`surface-palettes.ts` duplicates `settings.constants.ts` — must stay in sync.

--- a/.claude/rules/market-regime-module.md
+++ b/.claude/rules/market-regime-module.md
@@ -1,0 +1,44 @@
+---
+description: Market regime detection — volatility analysis, BTC trend, regime gating
+globs:
+  - "apps/api/src/market-regime/**"
+---
+
+# Market Regime Module
+
+## Overview
+
+Detects market regime from volatility + BTC trend. Produces `CompositeRegimeType`: `BULL`, `BEAR`, `NEUTRAL`, `EXTREME`.
+
+## Regime Persistence
+
+- Current regime = DB row where `effectiveUntil IS NULL`
+- On change: old row gets `effectiveUntil = now()`, new row inserted
+- Self-referential `previousRegimeId` for history tracking
+
+## Key Services
+
+### `VolatilityCalculator`
+Three methods: standard, exponential (EWMA λ=0.94), Parkinson.
+
+### `CompositeRegimeService`
+- Combines volatility regime + BTC 200-day SMA trend filter
+- Restores override state from Redis on boot (24h TTL safety expiry)
+- **Falls back to `NEUTRAL`** if BTC data unavailable
+
+### `RegimeGateService`
+Signal filter for backtest paths:
+
+| Regime | BUY | SELL/SL/TP |
+|--------|-----|------------|
+| BULL / NEUTRAL | Pass | Pass |
+| BEAR / EXTREME | **Blocked** | Pass |
+
+## Shared Types
+
+`VolatilityConfig` and `DEFAULT_VOLATILITY_CONFIG` come from `@chansey/api-interfaces`.
+
+## Gotchas
+
+- Override state is Redis-backed with 24h TTL — if Redis flushes, override resets
+- BTC data failure silently degrades to NEUTRAL (no error thrown)

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -1,0 +1,89 @@
+---
+description: Database migrations — naming conventions, timestamp rules, UUID generation
+globs:
+  - 'apps/api/src/migrations/**'
+---
+
+# Migrations
+
+## Naming Convention
+
+`{13-digit-unix-epoch-ms}-{kebab-case-description}.ts`
+
+Example: `1748500000000-create-failed-job-logs.ts`
+
+## Timestamp Rules
+
+- Use `Date.now()` to generate timestamps
+- Always verify with `ls apps/api/src/migrations/` to find the latest timestamp before naming your file
+
+## UUID Generation
+
+**Always use `gen_random_uuid()`** — never `uuid_generate_v4()`.
+
+The `uuid-ossp` extension is not available. `gen_random_uuid()` is built into PostgreSQL 13+ natively.
+
+## Database Config
+
+- Uses `pgcrypto` extension
+- `migrationsRun: true` in production only
+- `synchronize: true` in non-prod (migrations not auto-run in dev)
+
+## Current State
+
+53 migration files as of last count.
+
+## Table Name Reference
+
+Table naming is **inconsistent** — some are singular, some plural. Always check this list before writing migrations.
+
+### Singular tables (18) — DO NOT pluralize these
+
+Implicit (`@Entity()` — class name → snake_case):
+
+| Entity Class           | Table Name                |
+| ---------------------- | ------------------------- |
+| `User`                 | `user`                    |
+| `Coin`                 | `coin`                    |
+| `Risk`                 | `risk`                    |
+| `Exchange`             | `exchange`                |
+| `ExchangeKey`          | `exchange_key`            |
+| `ExchangeKeyHealthLog` | `exchange_key_health_log` |
+| `Order`                | `order`                   |
+| `Notification`         | `notification`            |
+| `Category`             | `category`                |
+| `HistoricalBalance`    | `historical_balance`      |
+| `TickerPairs`          | `ticker_pairs`            |
+| `Algorithm`            | `algorithm`               |
+
+Explicit `@Entity('name')` but still singular:
+
+| Table Name             | Entity Class         |
+| ---------------------- | -------------------- |
+| `coin_selection`       | `CoinSelection`      |
+| `push_subscription`    | `PushSubscription`   |
+| `exchange_symbol_map`  | `ExchangeSymbolMap`  |
+| `trading_state`        | `TradingState`       |
+| `security_audit_log`   | `SecurityAuditLog`   |
+| `order_status_history` | `OrderStatusHistory` |
+
+### Plural tables (33)
+
+`algorithm_activations`, `algorithm_performances`, `audit_logs`, `backtests`, `backtest_performance_snapshots`,
+`backtest_runs`, `backtest_signals`, `backtest_trades`, `comparison_reports`, `comparison_report_runs`, `deployments`,
+`drift_alerts`, `failed_job_logs`, `live_trading_signals`, `market_data_sets`, `market_regimes`, `ohlc_candles`,
+`optimization_results`, `optimization_runs`, `paper_trading_accounts`, `paper_trading_orders`, `paper_trading_sessions`,
+`paper_trading_signals`, `paper_trading_snapshots`, `performance_metrics`, `pipelines`, `position_exits`,
+`opportunity_sell_evaluations`, `simulated_order_fills`, `strategy_configs`, `strategy_scores`,
+`user_strategy_positions`, `walk_forward_windows`
+
+### Common mistakes
+
+- `users` → **wrong**. Actual: `user`
+- `orders` → **wrong**. Actual: `order`
+- `coins` → **wrong**. Actual: `coin`
+- `exchanges` → **wrong**. Actual: `exchange`
+- `algorithms` → **wrong**. Actual: `algorithm`
+- `categories` → **wrong**. Actual: `category`
+- `notifications` → **wrong**. Actual: `notification`
+- `coin_selections` → **wrong**. Actual: `coin_selection`

--- a/.claude/rules/monitoring-module.md
+++ b/.claude/rules/monitoring-module.md
@@ -1,0 +1,53 @@
+---
+description: Post-deployment drift detection and alerting for live strategies
+globs:
+  - "apps/api/src/monitoring/**"
+---
+
+# Monitoring Module
+
+## Overview
+
+12 files. Post-deployment drift detection and alerting for live strategies.
+
+## Drift Detectors
+
+All implement `detect(deployment, latestMetric): Promise<DriftAlert | null>`:
+
+| Detector | Warning/High/Critical Thresholds |
+|----------|----------------------------------|
+| Sharpe | 30% / 50% / 70% |
+| Return | 40% / 60% / 80% (negative always critical) |
+| Drawdown | threshold-based |
+| WinRate | threshold-based |
+| Volatility | threshold-based |
+
+## Orchestration
+
+`DriftDetectorService`: runs all 5 sequentially → persists `DriftAlert` → updates Deployment fields → audit log.
+
+## DriftAlert Entity
+
+- Indexed `[deploymentId, createdAt]`
+- Resolution: `manual / auto-demotion / ignored`
+- Computed properties: `isActive`, `isCritical`, `daysOpen`
+
+## MonitoringService
+
+- `getLatestMetric()` — most recent performance snapshot
+- `compareToBacktest()` — live vs historical comparison
+- `getRollingStatistics(windowDays)` — windowed aggregation
+- `getPerformanceTrend()` — 7d vs 30d comparison
+
+## Alert Escalation
+
+- Emits `NOTIFICATION_EVENTS.DRIFT_ALERT`
+- Unresolved high/critical >24h → emits `RISK_BREACH`
+
+## Templates
+
+`DriftAlertTemplate`: static class for email HTML, Slack attachments, SMS with severity coloring.
+
+## Pattern
+
+Detectors return unpersisted alert or null → orchestrator persists → alert service notifies.

--- a/.claude/rules/notification-module.md
+++ b/.claude/rules/notification-module.md
@@ -1,0 +1,50 @@
+---
+description: Multi-channel notification system — email, push, SMS, rate limiting, quiet hours
+globs:
+  - "apps/api/src/notification/**"
+---
+
+# Notification Module
+
+## Overview
+
+16 files. Multi-channel notification system (email, push, SMS stub).
+
+## Channel Adapters
+
+All implement `send(job: NotificationJobData): Promise<boolean>`:
+
+| Channel | Details |
+|---------|---------|
+| Email | Severity-prefixed subjects (`[URGENT]` critical, `[Alert]` high) |
+| Push | `web-push` with VAPID, auto-removes expired (410 Gone) |
+| SMS | Stub/no-op |
+
+## NotificationService Flow
+
+1. Check user preferences
+2. Rate-limit (Redis SET NX EX 300, 5-min per user+event)
+3. Quiet hours check (UTC, midnight-wrap)
+4. Enqueue BullMQ job
+
+## Event Listener
+
+`NotificationListener`: `@OnEvent()` for 9 domain events mapped to severity levels.
+
+## Processor
+
+`NotificationProcessor`: persists `Notification` entity first, then dispatches channels independently.
+
+## Entities
+
+- `Notification`: userId, eventType, read/readAt
+- `PushSubscription`: endpoint unique
+
+## Infrastructure
+
+- Dedicated Redis on DB 5
+- BullMQ queue: `notification` (attempts 3, exponential backoff 5s)
+
+## Quiet Hours
+
+Skip email/SMS except critical; push always allowed.

--- a/.claude/rules/ohlc-module.md
+++ b/.claude/rules/ohlc-module.md
@@ -1,0 +1,49 @@
+---
+description: 1-hour OHLC candle pipeline — fetch, cache, store, serve, backfill
+globs:
+  - "apps/api/src/ohlc/**"
+---
+
+# OHLC Module
+
+## Overview
+
+20 files. 1-hour OHLC candle pipeline: fetch → cache → store → serve.
+
+## Entities
+
+- `OHLCCandle`: unique on `coinId+timestamp+exchangeId`, prices `decimal(25,8)`
+- `ExchangeSymbolMap`: coin-to-exchange mapping with priority + health tracking
+
+## Data Flow
+
+CCXT → `ExchangeOHLCService.fetchOHLCWithFallback()` (priority: binance_us → gdax → kraken, 500ms fallback delay) → `OHLCSyncTask` (hourly) → `upsertCandles()` → PostgreSQL.
+
+## Backfill
+
+`OHLCBackfillService`: batches of 500 candles, 100ms delay, Redis progress tracking (`ohlc:backfill:{coinId}`), 1-year default lookback.
+
+## Realtime
+
+`RealtimeTickerService`: 45s Redis cache (`ticker:price:{coinId}`), returns 24h stats.
+
+## Symbol Map Seeding
+
+Top 50 coins on first boot, weekly refresh (Sunday 4AM), prefers `/USD` over `/USDT`.
+
+## Health & Pruning
+
+- Auto-deactivation after 24 consecutive failures
+- `OHLCPruneTask`: daily 3AM, 365-day retention
+
+## Key Types
+
+`PriceSummary extends CandleData` — compatibility interface for algorithm strategies.
+
+## BullMQ
+
+Queues: `ohlc-sync-queue`, `ohlc-prune-queue`. Tasks live here (not in `tasks/`).
+
+## Price Ranges
+
+`PriceRange` enum: `30m | 1h | 6h | 12h | 1d | 7d | 14d | 30d | 90d | 180d | 1y | 5y | all`

--- a/.claude/rules/optimization-module.md
+++ b/.claude/rules/optimization-module.md
@@ -1,0 +1,52 @@
+---
+description: Grid search parameter optimization with walk-forward validation
+globs:
+  - "apps/api/src/optimization/**"
+---
+
+# Optimization Module
+
+## Overview
+
+26 files. Grid search parameter optimization with walk-forward validation.
+
+## Entities
+
+- `OptimizationRun`: campaign + progress tracking
+- `OptimizationResult`: per-combination with rank
+
+## Config Presets
+
+| Preset | Iterations | Max Combos | Notes |
+|--------|-----------|------------|-------|
+| DEFAULT | 100 | 75 | Standard |
+| FAST | — | 20 | Quick validation |
+| THOROUGH | — | 5000 | Composite objective |
+
+## GridSearchService
+
+Cartesian product → constraint filtering → random-sample if exceeding `maxCombinations` → baseline always index 0.
+
+## ParameterSpaceBuilder
+
+Auto-derives from algorithm's `getConfigSchema()`. Excludes: `enabled, riskLevel, cooldownMs, maxTradesPerDay, minSellPercent`.
+
+## Recovery
+
+`OptimizationRecoveryService` (`OnApplicationBootstrap`): auto-resumes RUNNING/PENDING at boot (max 3 retries, 6-hour stale threshold).
+
+## Processor
+
+`OptimizationProcessor`: lock duration 4h, extends lock every 30min, calls `global.gc()` on completion.
+
+## Events
+
+Emits `PIPELINE_EVENTS.OPTIMIZATION_COMPLETED/FAILED` via `EventEmitter2`.
+
+## BullMQ
+
+Queue: `optimization` (concurrency via `OPTIMIZATION_CONCURRENCY` env, default 5).
+
+## Key Constants
+
+- `ZERO_TRADE_PENALTY = -10` for combinations producing no trades

--- a/.claude/rules/order-module.md
+++ b/.claude/rules/order-module.md
@@ -1,0 +1,52 @@
+---
+description: Order execution — live trades, backtests, paper trading, simulated fills
+globs:
+  - "apps/api/src/order/**"
+---
+
+# Order Module
+
+## Overview
+172 files handling all trade execution across 4 modes: Live (`Order`), Backtest (`BacktestTrade`), Paper (`PaperTradingOrder`), and Testnet (legacy — do not extend). The `BacktestSharedModule` is the cross-cutting layer used by Historical, Live Replay, and Paper Trading stages.
+
+## Directory Layout
+```
+order/
+├── backtest/
+│   ├── shared/           # BacktestSharedModule — 7 shared services
+│   ├── dto/              # Backtest DTOs
+│   └── *.ts              # Processors + services at root (incl. live-replay.processor.ts)
+├── paper-trading/        # Separate from backtest (sibling, not nested)
+│   ├── dto/
+│   └── entities/
+├── config/
+├── dto/
+├── entities/
+├── interfaces/
+├── services/
+├── tasks/                # BullMQ consumers and scheduled tasks
+├── testnet/              # LEGACY — do not extend
+├── utils/
+└── order.module.ts
+```
+
+## Key Patterns
+- **BacktestSharedModule**: 7 services reused across all simulation modes — slippage, fees, positions, metrics, portfolio state, signal throttle, signal filter chain
+- **Exit system**: `ExitConfig` interface defines exit rules. Live uses `PositionManagementService`; simulated modes use `BacktestExitTracker`
+- **Entity hierarchy**: `Backtest` → `BacktestTrade`/`BacktestSnapshot`/`BacktestSignal` → `SimulatedOrderFill`
+
+## BullMQ Queues
+7 queues: `order-queue`, `backtest-historical`, `backtest-live-replay`, `paper-trading`, `trade-execution`, `position-monitor`, `liquidation-monitor`
+
+## How to Add a New Execution Mode
+1. Create a new subdirectory under `backtest/` or `order/`
+2. Implement a processor extending the shared backtest services
+3. Register a new BullMQ queue in the module
+4. Add the consumer to module providers
+5. Wire up the pipeline stage in the strategy module if needed
+
+## Gotchas
+- `testnet/` is legacy code — do not add new features there
+- Circular dependency with `AlgorithmModule` resolved via `forwardRef()` — maintain this pattern
+- `BacktestTrade` and `Order` are separate entities with different schemas — don't assume field parity
+- Simulated fills go through `SimulatedOrderFill`, not the real `Order` entity

--- a/.claude/rules/pipeline-module.md
+++ b/.claude/rules/pipeline-module.md
@@ -1,0 +1,78 @@
+---
+description: 5-stage validation pipeline — optimize, historical, live replay, paper trade, completed
+globs:
+  - 'apps/api/src/pipeline/**'
+---
+
+# Pipeline Module
+
+## Overview
+
+19 files. Orchestrates the 5-stage validation pipeline: `OPTIMIZE → HISTORICAL → LIVE_REPLAY → PAPER_TRADE → COMPLETED`.
+
+## Event-Driven Architecture
+
+Uses `EventEmitter2` + `PIPELINE_EVENTS` constants — no direct cross-module method calls for completion.
+
+`PipelineEventListener` handles: `optimization.completed/failed`, `backtest.completed`, `paper-trading.completed`.
+
+## Stage Promotion Logic
+
+| Transition                | Gate                                                                       |
+| ------------------------- | -------------------------------------------------------------------------- |
+| OPTIMIZE → HISTORICAL     | `improvement >= 3%`                                                        |
+| HISTORICAL → LIVE_REPLAY  | Auto-advances unconditionally                                              |
+| LIVE_REPLAY → PAPER_TRADE | Score-gated via `ScoringService.calculatePipelineScore()` (min score 30)   |
+| PAPER_TRADE → COMPLETED   | `StageProgressionThresholds`: minSharpe 0.3, maxDrawdown 0.45, minReturn 0 |
+
+## Entity
+
+Pipeline has nullable FK per stage. `PipelineStageConfig` stored as JSONB.
+
+## BullMQ
+
+Queue: `pipeline` (concurrency 3, 1-hour timeout).
+
+## API
+
+Controller: admin-only at `/admin/pipelines`.
+
+## Dependencies
+
+Heavy `forwardRef()` zone — circular deps with Algorithm, Auth, Optimization, Order, PaperTrading, Scoring,
+MarketRegime, CoinSelection modules.
+
+## User Isolation Model
+
+Pipelines and backtests are **strictly user-specific**. Each has a mandatory `user` FK with cascade delete. Users cannot
+see each other's results — all queries filter by `user.id`.
+
+### What Makes Each Run Unique
+
+| Factor             | Description                                           |
+| ------------------ | ----------------------------------------------------- |
+| User               | Each run belongs to one user                          |
+| Algorithm          | Which trading strategy to use                         |
+| Strategy Params    | User-specific parameter overrides                     |
+| Market Data Set    | Which historical data to backtest against             |
+| Date Range         | Start/end dates for the backtest period               |
+| Initial Capital    | Starting portfolio value                              |
+| Trading Fee        | Commission percentage                                 |
+| Slippage Model     | How to simulate execution slippage                    |
+| Risk Level (1-5)   | User's risk profile drives all pipeline stage configs |
+| Exchange Key       | User's specific exchange credentials                  |
+| Deterministic Seed | For reproducibility                                   |
+
+### Shared vs User-Specific Resources
+
+| Shared (Global)  | User-Specific                      |
+| ---------------- | ---------------------------------- |
+| Algorithms       | Strategy Configs (param overrides) |
+| Market Data Sets | Exchange Keys                      |
+|                  | Backtests & Pipelines              |
+|                  | Risk Profile                       |
+
+## Key Constants
+
+- `PIPELINE_EVENTS` — all event names
+- `StageProgressionThresholds` — configurable per risk level

--- a/.claude/rules/portfolio-module.md
+++ b/.claude/rules/portfolio-module.md
@@ -1,0 +1,53 @@
+---
+description: Portfolio aggregation across algo trading strategies — positions, P&L, allocation
+globs:
+  - 'apps/api/src/portfolio/**'
+---
+
+# Portfolio Module
+
+## Overview
+
+3 files. Algo trading portfolio aggregation across strategies. Asset allocation, P&L, and performance metrics.
+
+## API Routes
+
+All JWT-guarded at `/portfolio`:
+
+| Route                          | Purpose                                    |
+| ------------------------------ | ------------------------------------------ |
+| `GET /summary`                 | Aggregated portfolio across all strategies |
+| `GET /performance`             | Overall P&L, returns, win rate             |
+| `GET /positions`               | All positions grouped by strategy          |
+| `GET /performance/by-strategy` | Per-strategy P&L breakdown                 |
+| `GET /allocation`              | Allocation percentages by symbol           |
+
+## PortfolioAggregationService
+
+- `getAggregatedPortfolio(userId)` — single DB call, in-memory grouping by symbol, fetches current prices
+- `getPositionsByStrategy(userId)` — groups by `strategyConfigId`, per-strategy P&L
+- `getAllocationBreakdown(userId)` — allocation % per symbol
+
+### Price Fetching Fallback Chain
+
+`RealtimeTickerService.price` → `Coin.currentPrice` → `avgEntryPrice`
+
+Graceful degradation — returns empty map on failure, never throws.
+
+## Dependencies
+
+- `PositionTrackingService` — position data
+- `UserPerformanceService` — performance metrics
+- `CoinService`, `RealtimeTickerService` — pricing
+- Circular deps with `CoinModule`, `OHLCModule`, `StrategyModule` via `forwardRef()`
+
+## Patterns
+
+- `Decimal.js` for all P&L calculations — converts to numbers only for final output
+- Single DB query per aggregation with in-memory Map grouping
+- Weighted average price: `weightedCost / quantity`
+- Unrealized P&L: `(marketPrice - avgPrice) × quantity`
+
+## Portfolio Capacity Gate
+
+`PortfolioCapacityGate` in `strategy/gates/` — max 35 active strategies, critical severity (blocks promotions).

--- a/.claude/rules/risk-module.md
+++ b/.claude/rules/risk-module.md
@@ -1,0 +1,41 @@
+---
+description: Risk module — risk levels, custom risk, coin count configuration
+globs:
+  - "apps/api/src/risk/**"
+---
+
+# Risk Module
+
+## Overview
+
+Standard CRUD module (controller, service, entity, DTOs). No subdirectories.
+
+## Risk Entity
+
+- `level` (1-6), `name`, `description`, `coinCount` (default 10), `selectionUpdateCron` (nullable)
+
+## Key Constants
+
+From `@chansey/api-interfaces` (not local):
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `CUSTOM_RISK_LEVEL` | 6 | Manual coin selection (no auto-pick) |
+| `DEFAULT_RISK_LEVEL` | 1 | Default for new users |
+| `MIN_TRADING_COINS` | — | Minimum coins required to trade |
+
+## Important Behaviors
+
+- `findByLevel()` returns `null` (does not throw) — callers must handle missing
+- Level 6 means the user manually manages their coin selections
+- Levels 1-5 drive auto-selection behavior and pipeline stage configs
+
+## Risk-Based Configuration
+
+Determines pipeline stage behavior:
+
+| Risk Level | Paper Trading | Training Period | Max Drawdown |
+|------------|---------------|-----------------|--------------|
+| 1 (Conservative) | 14 days | 180 days | 15% |
+| 3 (Moderate) | 7 days | 90 days | 25% |
+| 5 (Aggressive) | 3 days | 30 days | 40% |

--- a/.claude/rules/scoring-module.md
+++ b/.claude/rules/scoring-module.md
@@ -1,0 +1,60 @@
+---
+description: Strategy scoring with walk-forward analysis and promotion criteria
+globs:
+  - "apps/api/src/scoring/**"
+---
+
+# Scoring Module
+
+## Overview
+
+11 files. Strategy scoring with walk-forward analysis (WFA).
+
+## Default Weights (must sum to 1.0)
+
+| Component | Weight | Notes |
+|-----------|--------|-------|
+| sharpe | 0.25 | |
+| wfaDegradation | 0.20 | Heaviest — anti-overfitting |
+| calmar | 0.15 | |
+| winRate | 0.10 | |
+| profitFactor | 0.10 | |
+| stability | 0.10 | |
+| correlation | 0.10 | |
+
+Also available: `CONSERVATIVE_WEIGHTS`, `AGGRESSIVE_WEIGHTS`.
+
+## ScoringService
+
+- `calculateScore()`: components → weighted score → SQL percentile → grade → promotion eligibility → warnings
+- `calculateScoreFromMetrics()`: in-memory only, used in backtest pipeline. `marketRegime` modifier (+15 extreme, -5 low vol)
+
+## Promotion Criteria
+
+Score ≥ 70, trades ≥ 30, maxDrawdown ≤ 40%, wfaDegradation ≤ 30%, totalReturn > 0.
+
+## Calculators
+
+4 local: Calmar, WinRate, ProfitFactor, Stability. Also imports 3 from `common/metrics/`.
+
+## Walk-Forward Analysis
+
+`WalkForwardService` (rolling or anchored). 3 presets:
+
+| Preset | Train/Test/Step (days) |
+|--------|------------------------|
+| DEFAULT | 180 / 90 / 30 |
+| AGGRESSIVE | 365 / 90 / 30 |
+| FAST | 90 / 30 / 15 |
+
+## WindowProcessor
+
+Degradation = Sharpe(0.5) + return(0.3) + profitFactor(0.2). Overfitting flags at >30% degradation.
+
+## DegradationCalculator
+
+6 metrics weighted: Sharpe 0.30, return 0.25, winRate 0.15, profitFactor 0.15, drawdown 0.10, vol 0.05.
+
+## Gotcha
+
+Correlation defaults to 100 — updated lazily when comparing with other strategies.

--- a/.claude/rules/shared-lib.md
+++ b/.claude/rules/shared-lib.md
@@ -1,0 +1,53 @@
+---
+description: Shared library (@chansey/shared) — TanStack Query infrastructure, API error handling, cache policies
+globs:
+  - "libs/shared/**"
+---
+
+# Shared Library (`@chansey/shared`)
+
+## API Error Handling (`api-error.ts`)
+
+- `ApiError` class with `hasCode(code)` and `hasCodePrefix(prefix)`
+- `ErrorCodes` const — all backend error codes
+- `isApiError()` type guard
+- `extractErrorInfo()` — normalizes unknown errors
+
+## Cache Policies (`cache-policies.ts`)
+
+| Policy | Stale | Refetch |
+|--------|-------|---------|
+| `REALTIME_POLICY` | 0 | 30s/45s |
+| `FREQUENT_POLICY` | 30s | 5m |
+| `STANDARD_POLICY` | 1m | 10m (default) |
+| `STABLE_POLICY` | 5m | 30m |
+| `STATIC_POLICY` | 10m | 1h |
+| `INFINITE_POLICY` | Infinity | 24h |
+
+`TIME` constants provide named durations.
+
+## Query Keys (`query-keys.ts`)
+
+Single `queryKeys` object — source of truth for all cache keys.
+
+Pattern: `domain.all` → `domain.lists()` → `domain.list(filters?)` → `domain.detail(id)`. All `as const`.
+
+## Query Utils (`query-utils.ts`)
+
+### `authenticatedFetch<T>()`
+- HttpOnly cookie credentials
+- Transparent 401 → token refresh → single retry
+- Coalesces concurrent refresh calls
+- Dispatches `auth:session-expired` event on terminal failure
+
+### `useAuthQuery<T>()`
+Two overloads: static `(queryKey, url)` and reactive `(factory)`. Default: `STANDARD_POLICY`.
+
+### `useAuthMutation<TData, TVariables>()`
+- `url` can be a function
+- **Auto-strips `id` from body** for PATCH/DELETE
+- Handles FormData
+- Runs `invalidateQueries` before `onSuccess`
+
+### Other Utilities
+`useInvalidateQueries()`, `usePrefetchQuery()`, `useSetQueryData()`, `useGetQueryData()`, `createDomainInvalidator()`, `batchInvalidate()`

--- a/.claude/rules/shared-resilience.md
+++ b/.claude/rules/shared-resilience.md
@@ -1,0 +1,51 @@
+---
+description: Shared resilience utilities — circuit breakers, distributed locks, retry helpers, CCXT error mapping
+globs:
+  - "apps/api/src/shared/**"
+---
+
+# Shared Resilience Module
+
+## Module Structure
+
+Two global modules:
+
+- **`SharedResilienceModule`** — exports `CircuitBreakerService`
+- **`SharedLockModule`** — exports `DistributedLockService`, `TradeCooldownService`, `LOCK_REDIS` token
+
+Lock Redis runs on DB `1` (separate from BullMQ/cache DB), closed in `onModuleDestroy`.
+
+## Utility Inventory (no DI — import from `'../shared'`)
+
+| Utility | Purpose |
+|---------|---------|
+| `withRetry` / `withRetryThrow` | Exponential backoff + jitter. `isTransientError()` covers network/rate-limit/50x/CCXT errors |
+| `withRateLimitRetry` | Preset for exchange API calls, respects `Retry-After` headers |
+| `mapCcxtError()` | Maps CCXT exceptions → `AppException` subclasses |
+| `precisionToStepSize()` | Handles 3 CCXT precision modes (TICK_SIZE, DECIMAL_PLACES, SIGNIFICANT_DIGITS) |
+| `forceRemoveJob()` | Orphaned BullMQ job recovery after deployment |
+| `toErrorInfo()` | Safe message/stack extraction from unknown errors |
+
+### Gotcha
+
+Binance `DDoSProtection` with "permission" in message → reclassified as `ExchangePermissionDeniedException` by `mapCcxtError()`.
+
+## CircuitBreakerService
+
+In-memory, keyed by string. States: CLOSED → OPEN → HALF_OPEN → CLOSED.
+
+- **5 failures / 60s** opens the circuit
+- **30s** reset timeout
+- **2 successes** in HALF_OPEN to close
+
+## TradeCooldownService
+
+Redis-based, 11min TTL, atomic Lua check-and-claim.
+
+**Fail-open design**: Redis down = trading allowed (never blocks trades due to infrastructure failure).
+
+## When Adding New Utilities
+
+- Pure functions go in utility files (no DI needed)
+- Stateful services go in the appropriate global module
+- Keep `isTransientError()` up to date when adding new error types

--- a/.claude/rules/strategy-module.md
+++ b/.claude/rules/strategy-module.md
@@ -1,0 +1,48 @@
+---
+description: Strategy lifecycle — shadow status, promotion gates, runtime risk checks, deployments
+globs:
+  - "apps/api/src/strategy/**"
+---
+
+# Strategy Module
+
+## Overview
+57 files. Central entity: `StrategyConfig` with a `shadowStatus` lifecycle (`testing → shadow → live → retired`). Contains two distinct validation systems: promotion gates and runtime risk checks.
+
+## Directory Layout
+```
+strategy/
+├── gates/                # 8 promotion gates (IPromotionGate)
+├── risk/                 # 6 runtime risk checks (IRiskCheck)
+├── entities/             # StrategyConfig, Deployment, BacktestRun, WalkForwardWindow, PerformanceMetric
+├── services/             # Promotion, deployment, pre-trade risk
+└── strategy.module.ts
+```
+
+## Key Patterns
+- **Gates vs Risk Checks** — two separate systems:
+  - **Gates** (`gates/`): Pre-promotion quality barriers. Implement `IPromotionGate.evaluate()`. 8 gates sorted by priority. A critical gate failure blocks promotion entirely.
+  - **Risk Checks** (`risk/`): Post-live hourly monitoring. Implement `IRiskCheck.evaluate()`. 6 checks. The `autoDemote` flag triggers automatic demotion on critical severity.
+- **PreTradeRiskGateService**: Real-time per-trade drawdown gate — distinct from the hourly risk checks
+- **Shadow status lifecycle**: `testing → shadow → live → retired` — transitions are gate-controlled
+
+## Entity Relationships
+- `StrategyConfig` → `BacktestRun` → `WalkForwardWindow`
+- `StrategyConfig` → `Deployment` → `PerformanceMetric`
+- `Deployment` has computed getters: `isActive`, `winRate`, `totalPnl` + embedded risk limits
+
+## How to Add a New Gate
+1. Create class in `gates/` implementing `IPromotionGate`
+2. Set `priority` (lower = runs first) and `critical` flag
+3. Register in module providers
+4. The promotion service auto-discovers gates via DI
+
+## How to Add a New Risk Check
+1. Create class in `risk/` implementing `IRiskCheck`
+2. Set `autoDemote` flag if the check should trigger automatic demotion
+3. Register in module providers
+
+## Gotchas
+- Gates block promotion; risk checks monitor post-promotion — don't confuse the two
+- `PreTradeRiskGateService` runs per-trade in real-time, not on the hourly schedule
+- `Deployment` computed getters (`winRate`, etc.) derive from `PerformanceMetric` — don't duplicate the calculation

--- a/.claude/rules/tasks-module.md
+++ b/.claude/rules/tasks-module.md
@@ -1,0 +1,45 @@
+---
+description: Scheduled background tasks — performance calc, pipelines, backtests, risk monitoring
+globs:
+  - "apps/api/src/tasks/**"
+---
+
+# Tasks Module
+
+## Overview
+
+23 files. Top-level scheduled tasks orchestrating cross-module background work.
+
+## Task Schedule (all UTC)
+
+| Task | Schedule | Purpose |
+|------|----------|---------|
+| `PerformanceCalcTask` | 1AM daily | P&L, Sharpe, drawdown for deployments |
+| `PipelineOrchestrationTask` | 2AM daily | Validation pipelines for eligible users |
+| `PromotionTask` | 2AM daily | Evaluate validated strategies for live deployment |
+| `BacktestOrchestrationTask` | 3AM daily | Auto backtests + watchdog for stuck runs |
+| `RedisMaintenanceTask` | 4AM daily | Trim BullMQ job sets, event streams (ioredis to DB 3) |
+| `MarketRegimeTask` | Hourly | BTC/ETH/SOL/POL regime detection |
+| `RiskMonitoringTask` | Hourly | Deployment risk threshold checks |
+| `StrategyEvaluationTask` | Every 6h | Evaluate `TESTING` status strategies |
+| `DriftDetectionTask` | Every 6h | Multi-dimensional drift detection |
+
+## Pattern
+
+Tasks schedule BullMQ jobs; processing happens in separate `*Processor` classes.
+
+## Staggering
+
+Per-user jobs delayed by `STAGGER_INTERVAL_MS` (1 min) to avoid thundering herd.
+
+## Eligibility
+
+`getEligibleUsers()` requires `algoTradingEnabled = true` + active `ExchangeKey`.
+
+## Watchdog
+
+`BacktestOrchestrationTask` detects stale runs (90min/120min/6h thresholds) and emits `PIPELINE_EVENTS`.
+
+## Risk Config
+
+`buildStageConfigFromRisk()` generates pipeline config per risk level (1-5).

--- a/.claude/rules/user-pages.md
+++ b/.claude/rules/user-pages.md
@@ -1,0 +1,44 @@
+---
+description: User settings page — account, trading, security, notifications, appearance tabs
+globs:
+  - "apps/chansey/src/app/pages/user/**"
+---
+
+# User Pages
+
+## Overview
+
+28 files. Settings page with 5 tabs synced to `?tab=` query param.
+
+## Tab Shell
+
+`SettingsComponent` with fragment scroll on init.
+
+## Sub-Components (10)
+
+| Component | Purpose |
+|-----------|---------|
+| `AccountSettingsComponent` | Profile, avatar (ImageCropComponent), email-change confirmation + auto-logout |
+| `TradingSettingsComponent` | Risk profile, opportunity selling, futures toggle, exchange keys. `createAutoSave()` for toggles |
+| `SecuritySettingsComponent` | OTP enable/disable, embeds `ChangePasswordComponent` |
+| `NotificationSettingsComponent` | Channel/event toggles, quiet hours, browser Notification API for push |
+| `AppearanceSettingsComponent` | PrimeNG `$t()` theme switching — preset, colors, dark mode, menu mode |
+| `ExchangeIntegrationsComponent` | Tabbed exchange list |
+| `ExchangeKeyFormComponent` | Masked key fields |
+| `ChangePasswordComponent` | Password change form |
+| `ProfileInfoComponent` | Profile display/edit |
+| `SaveStatusIndicatorComponent` | Auto-save status feedback |
+
+## Utilities
+
+- `createAutoSave(saveFn, 500ms)` — signal-based status with auto-reset
+- `createPanelState()` — localStorage collapsed state
+
+## Services
+
+`SettingsService` (TanStack queries), `NotificationSettingsService`.
+
+## Patterns
+
+- Forms via `effect()` with `{ emitEvent: false }`
+- Masked keys (`'••••'`) in disabled fields

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,34 +48,11 @@ This is an Nx monorepo with Angular frontend and NestJS API backend:
 - **External APIs**: CCXT (cryptocurrency exchanges), CoinGecko
 - **Infrastructure**: Railway deployment, Minio (file storage)
 
-### Core Business Logic
+### Core Domain
 
-#### Exchange Integration
-
-- Supports multiple cryptocurrency exchanges (Binance, Coinbase)
-- Uses CCXT library for standardized exchange API interactions
-- Exchange keys stored securely with user authentication
-- Automated order synchronization via scheduled tasks
-
-#### Key Entities
-
-- **Users**: Authentication with JWT, role-based access
-- **Exchanges**: Cryptocurrency exchange configurations
-- **Exchange Keys**: User's encrypted API keys for exchanges
-- **Orders**: Trading orders synced from exchanges
-- **Coin Selections**: Which coins a user trades (auto-picked by risk level or manual watchlist)
-- **Coins**: Cryptocurrency information with price tracking
-- **Categories**: Asset categorization system
-- **Algorithms**: Trading algorithm configurations
-
-#### Background Processing
-
-- Uses BullMQ for job queues with Redis backend
-- Scheduled tasks for data synchronization:
-  - Order sync (hourly)
-  - Price updates
-  - Balance calculations
-  - Coin selection historical data
+- Cryptocurrency exchange integration (Binance, Coinbase) via CCXT with encrypted API keys
+- BullMQ background jobs for order sync, price updates, balance tracking, and algo trading pipeline
+- Module-specific details are in `.claude/rules/` files (loaded automatically by path)
 
 ### Frontend Architecture
 
@@ -84,16 +61,6 @@ This is an Nx monorepo with Angular frontend and NestJS API backend:
 - PrimeNG component library with custom theming
 - Responsive design with mobile-first approach
 - PWA capabilities with service worker
-
-### Authentication & Security
-
-- JWT-based authentication with refresh token implementation
-- Role-based access control (admin/user)
-- API key encryption for exchange credentials
-- CSRF protection and security headers
-- Rate limiting on all endpoints with stricter limits for auth/upload
-- Secure HttpOnly cookies for token storage
-- File upload validation and restrictions
 
 ## Development Workflow
 
@@ -135,97 +102,6 @@ This is an Nx monorepo with Angular frontend and NestJS API backend:
 
 - Swagger/OpenAPI documentation available when running API
 - Bruno collection provides comprehensive API testing examples
-
-## Important Implementation Notes
-
-### Order Synchronization
-
-The order sync system (`apps/api/src/order/tasks/order-sync.task.ts`) runs hourly and:
-
-1. Fetches orders from connected exchanges using CCXT
-2. Processes multiple exchanges in parallel
-3. Identifies new/changed orders and saves to database
-4. Handles exchange-specific data mapping and fee calculations
-
-### Coin Selection & Portfolio
-
-Two separate modules handle coin-related tracking:
-
-- **Coin Selection** (`apps/api/src/coin-selection/`) — Which coins a user trades. Auto-selected by risk level (1-5) or
-  manually managed (level 6). Routes: `/coin-selections`
-- **Portfolio** (`apps/api/src/portfolio/`) — Algo trading portfolio aggregation across strategies. Asset allocation,
-  P&L, and performance metrics. Routes: `/portfolio`
-
-### Price Data & Coin Detail Pages
-
-- Real-time price feeds from CoinGecko API
-- Historical price storage for charting
-- Redis caching layer to minimize API calls (5-minute TTL)
-- Dedicated coin detail pages at `/app/coins/:slug` with:
-  - Comprehensive market statistics and price charts
-  - Auto-refreshing price data (45-second intervals)
-  - User holdings display (authenticated users only)
-  - Multiple chart time periods (24h, 7d, 30d, 1y)
-  - External resource links (website, blockchain explorers, GitHub, Reddit)
-
-**Coin Detail API Endpoints:**
-
-- `GET /coins/:slug` - Comprehensive coin detail (optional auth for holdings)
-- `GET /coins/:slug/chart?period={24h|7d|30d|1y}` - Market chart data
-- `GET /coins/:slug/holdings` - User holdings (requires auth)
-
-**Key Implementation Details:**
-
-- Uses TanStack Query for client-side state management and caching
-- Frontend components in `apps/chansey/src/app/coins/`
-- Backend services in `apps/api/src/coin/coin.service.ts` (see T015-T022 methods)
-- Redis caching in `fetchCoinDetail()` and `fetchMarketChart()` methods
-- Hybrid data model: Public CoinGecko data + private user holdings from exchange orders
-
-When working with this codebase, prioritize understanding the exchange integration patterns and background job
-processing, as these are core to the application's functionality.
-
-### Pipeline & Backtest Architecture
-
-**User Isolation Model**: Pipelines and backtests are **strictly user-specific**. Each has a mandatory `user` FK with
-cascade delete. Users cannot see each other's results - all queries filter by `user.id`.
-
-**What Makes Each Run Unique**:
-
-| Factor             | Description                                           |
-| ------------------ | ----------------------------------------------------- |
-| User               | Each run belongs to one user                          |
-| Algorithm          | Which trading algorithm to use                        |
-| Strategy Params    | User-specific parameter overrides (e.g., MA periods)  |
-| Market Data Set    | Which historical data to backtest against             |
-| Date Range         | Start/end dates for the backtest period               |
-| Initial Capital    | Starting portfolio value                              |
-| Trading Fee        | Commission percentage                                 |
-| Slippage Model     | How to simulate execution slippage                    |
-| Risk Level (1-5)   | User's risk profile drives all pipeline stage configs |
-| Exchange Key       | User's specific exchange credentials                  |
-| Deterministic Seed | For reproducibility                                   |
-
-**Shared vs User-Specific Resources**:
-
-| Shared (Global)  | User-Specific                      |
-| ---------------- | ---------------------------------- |
-| Algorithms       | Strategy Configs (param overrides) |
-| Market Data Sets | Exchange Keys                      |
-|                  | Backtests & Pipelines              |
-|                  | Risk Profile                       |
-
-**Risk-Based Configuration** (determines pipeline stage behavior):
-
-| Risk Level        | Min Trades | Time Cap | Training Period | Max Drawdown | Target Return |
-| ----------------- | ---------- | -------- | --------------- | ------------ | ------------- |
-| 1 (Conservative)  | 50         | 30 days  | 180 days        | 15%          | 25%           |
-| 2 (Low-Moderate)  | 45         | 30 days  | 120 days        | 20%          | 40%           |
-| 3 (Moderate)      | 40         | 30 days  | 90 days         | 25%          | 50%           |
-| 4 (Moderate-High) | 35         | 30 days  | 60 days         | 35%          | 75%           |
-| 5 (Aggressive)    | 30         | 30 days  | 30 days         | 40%          | 100%          |
-
-**Pipeline Stage Flow**: `OPTIMIZE → HISTORICAL → LIVE_REPLAY → PAPER_TRADING → COMPLETED`
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/apps/api/src/algorithm/indicators/calculators/README.md
+++ b/apps/api/src/algorithm/indicators/calculators/README.md
@@ -1,0 +1,46 @@
+# Calculators
+
+## Overview
+
+Indicator calculator implementations that wrap the `technicalindicators` npm package. Each calculator extends `BaseIndicatorCalculator` to provide a consistent interface for computing technical analysis indicators from raw price data. Calculators are stateless and instantiated once in the `IndicatorService` calculator map.
+
+## Calculators
+
+| ID               | Class                        | Options Type                      | Result Type                |
+| ---------------- | ---------------------------- | --------------------------------- | -------------------------- |
+| `sma`            | `SMACalculator`              | `CalculatorPeriodOptions`         | `number[]`                 |
+| `ema`            | `EMACalculator`              | `CalculatorPeriodOptions`         | `number[]`                 |
+| `rsi`            | `RSICalculator`              | `CalculatorPeriodOptions`         | `number[]`                 |
+| `sd`             | `StandardDeviationCalculator`| `CalculatorPeriodOptions`         | `number[]`                 |
+| `macd`           | `MACDCalculator`             | `CalculatorMACDOptions`           | `MACDDataPoint[]`          |
+| `bollingerBands` | `BollingerBandsCalculator`   | `CalculatorBollingerBandsOptions` | `BollingerBandsDataPoint[]`|
+| `atr`            | `ATRCalculator`              | `CalculatorATROptions`            | `number[]`                 |
+
+## Contract
+
+`BaseIndicatorCalculator<TOptions, TResult>` implements `IIndicatorCalculator` and requires three abstract methods:
+
+- **`calculate(options: TOptions): TResult`** -- compute indicator values from input data
+- **`getWarmupPeriod(options: Partial<TOptions>): number`** -- minimum data points before valid output
+- **`validateOptions(options: TOptions): void`** -- throw if options are malformed
+
+Inherited helper methods:
+
+- `padResults(results, originalLength)` -- left-pad with `NaN` to align output with input array length
+- `countValidValues(values)` -- count non-`NaN` entries
+- `validatePeriod(period, name)` -- assert positive integer
+- `validateDataLength(values, minLength)` -- assert sufficient input data
+- `validateNumericValues(values)` -- assert all entries are valid numbers
+
+## How to Add a New Calculator
+
+1. Create a class in this directory extending `BaseIndicatorCalculator<TOptions, TResult>`. Set `id` and `name` readonly properties and implement `calculate()`, `getWarmupPeriod()`, and `validateOptions()`. Define option/result types in `indicator.interface.ts` and add the entry to `IndicatorCalculatorMap`.
+2. Export the class from `index.ts`.
+3. Register an instance in the `calculators` map inside `IndicatorService` and add a corresponding public method to expose it.
+
+## Gotchas
+
+- **Warmup period does not equal minimum data length.** RSI with `period=14` needs 15 input values (14 price changes). ATR similarly needs `period + 1` values because the first True Range requires a previous close.
+- **All results are padded to input length with leading `NaN`.** The `IndicatorService` calls `padResults()` so output arrays align index-for-index with the input price array.
+- **All calculators wrap the `technicalindicators` npm package.** They do not implement indicator math directly. If the upstream library changes behavior, calculator output changes too.
+- **ATR requires three parallel arrays** (`high`, `low`, `close`) of equal length, unlike the other calculators which take a single `values` array.

--- a/apps/api/src/algorithm/strategies/README.md
+++ b/apps/api/src/algorithm/strategies/README.md
@@ -1,0 +1,55 @@
+# Strategies
+
+## Overview
+
+Trading strategy implementations that extend `BaseAlgorithmStrategy` and are registered at module init via the `AlgorithmRegistry`. Each strategy evaluates price data through one or more technical indicators and returns buy/sell signals with confidence scores. All strategies implement the `IIndicatorProvider` interface and use the centralized `IndicatorService` for cached indicator calculations.
+
+## Strategies
+
+| ID | File | Signal Logic |
+|----|------|-------------|
+| `atr-trailing-stop-001` | `atr-trailing-stop.strategy.ts` | Dynamic stop-loss using ATR-based trailing stop; generates STOP_LOSS/TAKE_PROFIT when price breaches stop level |
+| `bb-squeeze-001` | `bollinger-band-squeeze.strategy.ts` | Detects low-volatility squeeze (bandwidth below threshold) then trades the breakout direction |
+| `bb-breakout-001` | `bollinger-bands-breakout.strategy.ts` | Momentum breakout: buy when price closes above upper band, sell when below lower band |
+| `confluence-001` | `confluence.strategy.ts` | Multi-indicator vote (EMA crossover, RSI, MACD, ATR, Bollinger %B); signal when >= minConfluence agree |
+| `ema-rsi-filter-001` | `ema-rsi-filter.strategy.ts` | EMA crossover filtered by RSI to avoid buying overbought / selling oversold |
+| `ema-crossover-001` | `exponential-moving-average.strategy.ts` | EMA crossover with price momentum confirmation |
+| `macd-crossover-001` | `macd.strategy.ts` | Buy on bullish MACD/signal crossover, sell on bearish crossover |
+| `mean-reversion-001` | `mean-reversion.strategy.ts` | Z-score deviation from SMA; buy when oversold below lower band, sell when overbought above upper band |
+| `rsi-divergence-001` | `rsi-divergence.strategy.ts` | Bullish divergence (price lower low + RSI higher low) and bearish divergence (price higher high + RSI lower high) |
+| `rsi-macd-combo-001` | `rsi-macd-combo.strategy.ts` | Dual confirmation: RSI oversold/overbought AND MACD crossover within a configurable window |
+| `rsi-momentum-001` | `rsi.strategy.ts` | Classic RSI: buy when RSI < 30 (oversold), sell when RSI > 70 (overbought) |
+| `sma-crossover-001` | `simple-moving-average-crossover.strategy.ts` | SMA fast/slow crossover signals |
+| `triple-ema-001` | `triple-ema.strategy.ts` | Three EMAs (fast/medium/slow); signal on alignment change (all bullish or all bearish) |
+
+## Contract
+
+`BaseAlgorithmStrategy` (in `algorithm/base/`) defines the interface every strategy must satisfy.
+
+**Required overrides:**
+- `execute(context: AlgorithmContext): Promise<AlgorithmResult>` -- core signal generation logic
+- `getConfigSchema(): Record<string, unknown>` -- parameter definitions with types, defaults, and ranges
+- `getMinDataPoints(config): number` -- minimum price history length needed for signal generation
+- `getIndicatorRequirements(config): IndicatorRequirement[]` -- declares indicators for precomputation during optimization
+- `getParameterConstraints(): ParameterConstraint[]` -- cross-parameter constraints (e.g., `fastPeriod < slowPeriod`)
+
+**Protected helpers:**
+- `getPrecomputedSlice(context, coinId, key, windowLength)` -- retrieves precomputed indicator data for the backtest fast-path, bypassing per-timestamp Redis lookups
+- `createSuccessResult(signals, chartData?, metadata?, exitConfig?)` -- builds a well-formed success result
+- `createErrorResult(error, executionTime?)` -- builds a well-formed error result
+- `safeExecute(context)` -- wraps `execute()` with error handling, timing metrics, and confidence aggregation
+
+## How to Add a New Strategy
+
+1. Create a new file in `strategies/` with a class extending `BaseAlgorithmStrategy` and implementing `IIndicatorProvider`. Set a unique `readonly id` in kebab-case with numeric suffix (e.g., `'my-strategy-001'`).
+2. Add the class to the `providers` array in `algorithm.module.ts`.
+3. Add the class to the `ALGORITHM_STRATEGIES_INIT` factory provider so it registers in `AlgorithmRegistry` at startup.
+4. Insert a row in the `algorithm` database table with a matching `strategyId` value.
+
+## Gotchas
+
+- Strategy IDs are kebab-case with a numeric suffix (e.g., `rsi-momentum-001`). The ID must exactly match the `strategyId` column in the `algorithm` DB table.
+- Suppress chart data when `context.metadata?.backtestId` or `context.metadata?.optimizationId` exists. Every strategy already does this to avoid massive allocations during simulation.
+- The registry is populated at module init. A strategy that is not added to the `ALGORITHM_STRATEGIES_INIT` factory will silently fail to register and never receive execution requests.
+- All strategies use `IndicatorService` for cached indicator calculations. Do not call indicator calculators directly.
+- The `scripts/` directory in the parent `algorithm/` folder is legacy seeding code and is not used at runtime.

--- a/apps/api/src/common/exceptions/README.md
+++ b/apps/api/src/common/exceptions/README.md
@@ -1,0 +1,75 @@
+# Exceptions
+
+## Overview
+
+Structured exception hierarchy for the API. All application errors extend the abstract `AppException` base class, which provides a consistent response shape with machine-readable `ErrorCode`, human-readable message, optional context, and timestamp. The `GlobalExceptionFilter` handles serialization to HTTP responses automatically.
+
+## Hierarchy
+
+`AppException` (abstract) -> 9 base types -> 37 leaf exceptions across 5 domain categories.
+
+## Base Types
+
+| Base Type                 | HTTP Status | When to Use                                  |
+| ------------------------- | ----------- | -------------------------------------------- |
+| `AuthenticationException` | 401         | Invalid credentials, expired/invalid tokens  |
+| `ValidationException`     | 400         | Malformed input, missing fields, bad format  |
+| `NotFoundException`       | 404         | Requested resource does not exist            |
+| `BusinessRuleException`   | 422         | Domain logic violation (e.g., low balance)   |
+| `ConflictException`       | 409         | Duplicate resource, unique constraint clash  |
+| `ExternalServiceException`| 503         | Third-party API failure or unavailability    |
+| `ForbiddenException`      | 403         | Insufficient permissions or role mismatch    |
+| `InternalException`       | 500         | Unexpected server-side errors                |
+| `TooManyRequestsException`| 429         | Rate limit exceeded                          |
+
+## Domain Categories
+
+| Category     | Leaf Count | Examples                                                            |
+| ------------ | ---------- | ------------------------------------------------------------------- |
+| `auth/`      | 10         | `InvalidCredentialsException`, `TokenExpiredException`, `AccountLockedException` |
+| `backtest/`  | 3          | `AlgorithmNotRegisteredException`, `QuoteCurrencyNotFoundException` |
+| `external/`  | 5          | `ExchangeUnavailableException`, `ExchangeRateLimitedException`     |
+| `order/`     | 7          | `InsufficientBalanceException`, `SlippageExceededException`        |
+| `resource/`  | 12         | `CoinNotFoundException`, `ExchangeKeyNotFoundException`            |
+
+## ErrorCode Enum
+
+58 codes in `error-codes.enum.ts`, following the `DOMAIN.SPECIFIC_ERROR` naming convention:
+
+- `AUTH.*` (11 codes) -- `AUTH.TOKEN_EXPIRED`, `AUTH.INVALID_OTP`
+- `FORBIDDEN.*` (3) -- `FORBIDDEN.ADMIN_REQUIRED`
+- `VALIDATION.*` (5) -- `VALIDATION.INVALID_INPUT`, `VALIDATION.OUT_OF_RANGE`
+- `NOT_FOUND.*` (12) -- `NOT_FOUND.COIN`, `NOT_FOUND.EXCHANGE_KEY`
+- `CONFLICT.*` (4) -- `CONFLICT.DUPLICATE_RESOURCE`
+- `BUSINESS.*` (13) -- `BUSINESS.INSUFFICIENT_BALANCE`, `BUSINESS.TRADING_SUSPENDED`
+- `EXTERNAL.*` (7) -- `EXTERNAL.EXCHANGE_UNAVAILABLE`, `EXTERNAL.COINGECKO_ERROR`
+- `INTERNAL.*` (3) -- `INTERNAL.SERVER_ERROR`, `INTERNAL.DATABASE_ERROR`
+
+## Leaf Pattern
+
+Each leaf exception extends the appropriate base type and wires up the `ErrorCode` plus contextual data in its constructor. Constructors accept domain-specific arguments rather than raw strings.
+
+```typescript
+export class InsufficientBalanceException extends BusinessRuleException {
+  constructor(currency: string, available: number | string, required: number | string) {
+    super(`Insufficient ${currency} balance: ${available} < ${required}`,
+      ErrorCode.BUSINESS_INSUFFICIENT_BALANCE,
+      { currency, available, required });
+  }
+}
+```
+
+## How to Add a New Exception
+
+1. Pick the base type from `base/` that matches the HTTP semantics.
+2. Create a leaf class in the correct domain directory (`auth/`, `order/`, etc.).
+3. Add a new entry to the `ErrorCode` enum in `error-codes.enum.ts`.
+4. Pass the `ErrorCode` and any contextual data up through `super()`.
+5. Re-export from the directory's `index.ts`.
+
+## Gotchas
+
+- Always use `ErrorCode` enum values, never raw strings.
+- `NotFoundException.forResource()` is a factory method for quick "X not found" errors with consistent messaging -- prefer it for simple cases or use it as a fallback with `NOT_FOUND_RESOURCE`.
+- Context objects propagate to the HTTP response and are available to the frontend for debugging; include identifiers but never sensitive data.
+- `GlobalExceptionFilter` serializes all `AppException` subclasses automatically -- do not add per-controller exception filters unless you need to override behavior.

--- a/apps/api/src/common/metrics/README.md
+++ b/apps/api/src/common/metrics/README.md
@@ -1,0 +1,46 @@
+# Metrics
+
+## Overview
+
+Financial metrics calculation utilities for evaluating trading strategy performance. Provides statistical functions for risk-adjusted returns, drawdown analysis, and portfolio correlation. Used by backtest, optimization, and live trading modules.
+
+## Dual API Pattern
+
+The metrics module exposes two complementary APIs: 13 **pure functions** (import directly, no DI required) and 3 **injectable services** (register in your domain module's `providers`). Neither is centrally registered -- import them directly where needed.
+
+## Pure Functions
+
+Exported from `metric-calculator.ts`. No dependencies, no DI -- import and call directly.
+
+| Function | Description |
+|---|---|
+| `calculateMean` | Arithmetic mean (average) |
+| `calculateStandardDeviation` | Population standard deviation |
+| `calculateVariance` | Population variance |
+| `calculateMedian` | Median value (interpolates for even-length arrays) |
+| `calculatePercentile` | Percentile with linear interpolation (0-100) |
+| `calculateCumulativeReturn` | Compound cumulative return from period returns |
+| `annualizeReturn` | Annualize a total return given period count |
+| `annualizeVolatility` | Annualize volatility (stddev * sqrt(periodsPerYear)) |
+| `calculateDownsideDeviation` | Semi-deviation below a minimum acceptable return |
+| `calculateRollingWindow` | Generic rolling window with custom calculator callback |
+| `calculateEMA` | Exponential moving average (first value seeded with SMA) |
+| `calculateZScore` | Standardized z-score of a value within a dataset |
+| `calculateRankPercentile` | Rank percentile of a value within a dataset |
+
+## Injectable Services
+
+NestJS `@Injectable()` services. Add to `providers` in your domain module.
+
+- **`SharpeRatioCalculator`** -- Sharpe ratio, Sortino ratio, and rolling Sharpe. `calculateFromMetrics()` for pre-computed annualized inputs. `interpretSharpe()` returns a human-readable grade (`excellent`, `good`, `acceptable`, `poor`). Clamps output to `MAX_SHARPE = 100` to prevent overflow.
+
+- **`DrawdownCalculator`** -- Max drawdown, all drawdown periods, average drawdown, duration statistics, Calmar ratio, and underwater plot. `calculateFromReturns()` converts period returns to equity curve internally. `interpretDrawdown()` returns a severity level (`low`, `moderate`, `high`, `extreme`).
+
+- **`CorrelationCalculator`** -- Pearson and Spearman correlation, correlation matrix, rolling correlation, Beta, and Alpha. `findHighlyCorrelatedPairs()` extracts pairs above a threshold from a correlation matrix. `interpretCorrelation()` returns strength and direction.
+
+## Gotchas
+
+- **Not centrally registered** -- import calculators directly in domain modules that need them.
+- **`periodsPerYear` defaults to 252** (stock trading days). For 24/7 crypto markets, pass `365` explicitly.
+- **`MIN_STDDEV = 1e-10`** in `SharpeRatioCalculator` -- near-zero volatility returns `0` instead of exploding.
+- Services include `interpret*()` helpers that return human-readable grades/severity for display or alerting.

--- a/apps/api/src/order/backtest/README.md
+++ b/apps/api/src/order/backtest/README.md
@@ -1,0 +1,68 @@
+# Backtest
+
+## Overview
+
+This subfolder implements the backtest execution engine for historical and live-replay simulation modes. It contains 26 root-level source files (plus a `dto/` directory and `shared/` submodule) and lives under the order module. The engine iterates OHLCV candles from a market data set, generates trading signals via pluggable algorithms, executes simulated trades with slippage and fee modeling, and persists results with checkpoint-based resumability.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `backtest-engine.service.ts` | Core simulation loop: iterates candles, runs algorithm, filters signals, executes trades, manages checkpoints |
+| `backtest.processor.ts` | BullMQ processor for `backtest-historical` queue; loads dataset and delegates to engine |
+| `live-replay.processor.ts` | BullMQ processor for `backtest-live-replay` queue; adds pacing delays to simulate real-time execution |
+| `backtest.service.ts` | CRUD operations for backtest entities; queue job creation |
+| `backtest.controller.ts` | REST API endpoints (create, list, detail, compare, signals, fills) |
+| `backtest.entity.ts` | TypeORM entities: `Backtest`, `BacktestTrade`, `BacktestSignal`, `BacktestPerformanceSnapshot`, `SimulatedOrderFill` |
+| `backtest-result.service.ts` | Persists trades, signals, fills, snapshots; computes `BacktestFinalMetrics` |
+| `backtest-stream.service.ts` | Redis Streams-based telemetry: logs, metrics, traces, and status updates during execution |
+| `backtest.gateway.ts` | WebSocket gateway (`/backtests` namespace) for real-time progress subscriptions |
+| `backtest-checkpoint.interface.ts` | `BacktestCheckpointState` interface with SHA256 checksum, portfolio state, RNG state, persisted counts |
+| `backtest-recovery.service.ts` | On-boot recovery: re-queues interrupted backtests with valid checkpoints, fails expired ones |
+| `backtest-pause.service.ts` | Redis-backed pause/resume flags with TTL; checked by processors between candles |
+| `backtest.config.ts` | `registerAs('backtest')` config: queue names, concurrency, telemetry stream settings |
+| `backtest.job-data.ts` | `BacktestJobData` type definition for BullMQ job payloads |
+| `backtest-pacing.interface.ts` | Live-replay pacing: `ReplaySpeed`, delay calculation, checkpoint intervals |
+| `backtest-aborted.error.ts` | Custom error thrown on abort/pause to cleanly exit the engine loop |
+| `market-data-set.entity.ts` | TypeORM entity for stored OHLCV datasets (file path, checksum, date range) |
+| `market-data-reader.service.ts` | Reads and parses OHLCV data from dataset files |
+| `dataset-validator.service.ts` | Validates dataset integrity (checksum, date overlap, storage accessibility) |
+| `coin-resolver.service.ts` | Resolves coin entities from dataset symbols |
+| `quote-currency-resolver.service.ts` | Determines quote currency for a trading pair |
+| `algorithm-watchdog.ts` | Detects stalled algorithms by tracking wall-clock time since last successful execution |
+| `comparison-report.entity.ts` | TypeORM entity for side-by-side backtest comparison reports |
+| `seeded-random.ts` | Deterministic PRNG with save/restore state for checkpoint-safe reproducibility |
+| `incremental-sma.ts` | O(1) incremental Simple Moving Average backed by a circular `Float64Array` |
+| `ring-buffer.ts` | Fixed-capacity circular buffer; O(1) push replacing O(K) splice in price windows |
+| `dto/backtest.dto.ts` | Request/response DTOs with class-validator decorators |
+
+## Architecture
+
+**BacktestEngine** is the core loop shared by both processors. The two BullMQ processors (`BacktestProcessor` for historical, `LiveReplayProcessor` for live-replay) load the dataset, configure the engine, and delegate execution. `BacktestResultService` handles all database persistence (trades, signals, fills, snapshots, final metrics). `BacktestStreamService` publishes real-time telemetry via Redis Streams, consumed by `BacktestGateway` over WebSockets.
+
+**Checkpoint system**: `BacktestCheckpointState` captures the full execution state (candle index, portfolio positions, cash balance, peak value, max drawdown, RNG state, throttle state, exit tracker state, and persisted result counts). Each checkpoint includes a SHA256 checksum (first 16 chars) computed over the state for integrity verification on resume. `SeededRandom` provides deterministic RNG that can be saved and restored. `IncrementalSma` and `RingBuffer` replace O(N) recomputation with O(1) streaming operations, and their state is inherently checkpoint-safe.
+
+**Data flow**: Create backtest via API --> Queue BullMQ job --> Processor loads dataset and validates --> Engine iterates candles --> Algorithm generates signals --> Signals filtered (regime gate, concentration, throttle) --> Trades executed with slippage/fees --> Checkpoints persisted at intervals (default every 500 candles) --> Final metrics computed and saved.
+
+## Shared Services
+
+The `shared/` directory provides `BacktestSharedModule` -- seven services reused across historical, live-replay, and paper-trading stages:
+
+- **SlippageService**: Configurable slippage simulation
+- **FeeCalculatorService**: Flat and maker/taker fee models
+- **PositionManagerService**: Position lifecycle (open, close, partial)
+- **MetricsCalculatorService**: Performance metrics with timeframe awareness
+- **PortfolioStateService**: Portfolio state management and checkpointing
+- **SignalThrottleService**: Cooldown periods, daily caps, minimum sell percentage
+- **SignalFilterChainService**: Composable filter chain (regime gate, concentration limits)
+
+Paper-trading (`../paper-trading/`) imports `BacktestSharedModule` directly, making `shared/` a cross-module dependency.
+
+## Gotchas
+
+- **Checkpoint checksum verified on resume**: If the checksum does not match, the checkpoint is rejected and the backtest restarts from the beginning.
+- **`shared/` is cross-module**: Paper-trading imports `BacktestSharedModule`, so changes there affect three pipeline stages (historical, live-replay, paper-trading).
+- **Recovery on boot**: `BacktestRecoveryService` runs at application startup (`OnApplicationBootstrap`) to re-queue interrupted runs. Checkpoints older than 7 days are expired.
+- **Pause uses Redis TTL**: Pause flags expire after 1 hour by default to prevent permanently stuck backtests.
+- **Optimization is separate**: The optimization processor lives in `src/optimization/`, not here.
+- **Existing pipeline docs**: `PIPELINE-STAGE-HISTORICAL.md` and `PIPELINE-STAGE-LIVE_REPLAY.md` in this directory cover pipeline integration details.

--- a/apps/api/src/order/paper-trading/README.md
+++ b/apps/api/src/order/paper-trading/README.md
@@ -1,0 +1,59 @@
+# Paper Trading
+
+## Overview
+
+Tick-based paper trading execution engine that simulates live trading against real-time exchange prices without risking actual funds. BullMQ repeatable jobs fire every N seconds (default 30s), fetching current prices via CCXT, running the configured algorithm, and executing simulated orders against virtual account balances. Each tick is stateless and independent -- all persistent state lives in the database, making the system resilient to restarts.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `paper-trading.module.ts` | NestJS module registration (queue, entities, providers) |
+| `paper-trading.config.ts` | `registerAs('paperTrading')` config: tick interval, retry limits, allocation bounds, cache TTLs, WebSocket CORS |
+| `paper-trading.controller.ts` | REST API: CRUD sessions, start/pause/resume/stop, query orders/signals/snapshots/positions/performance |
+| `paper-trading.service.ts` | Session lifecycle management, BullMQ job scheduling (`upsertJobScheduler` for ticks, one-shot for retries) |
+| `paper-trading-engine.service.ts` | Core tick logic: fetch prices, build `AlgorithmContext`, run algorithm, execute orders, record snapshots. Reuses `BacktestSharedModule` services (fees, metrics, portfolio state, signal throttle, signal filter chain) |
+| `paper-trading-market-data.service.ts` | Live price fetching via CCXT with short-TTL cache, order book retrieval for realistic slippage, OHLCV candle history for indicator computation |
+| `paper-trading-stream.service.ts` | Redis Streams telemetry publisher (status, tick, metric, log, order, balance scopes) |
+| `paper-trading-recovery.service.ts` | Boot-time recovery of active sessions + 5-min cron watchdog (10 min stale = recover, 20 min stale = mark FAILED) |
+| `paper-trading.gateway.ts` | WebSocket gateway (`socket.io`) for real-time session telemetry to frontend clients |
+| `paper-trading.job-data.ts` | Job type enum and typed payload interfaces for all BullMQ job variants |
+| `entities/` | TypeORM entities: `PaperTradingSession`, `PaperTradingAccount`, `PaperTradingOrder`, `PaperTradingSignal`, `PaperTradingSnapshot` |
+| `dto/` | Request/response DTOs: `CreatePaperTradingSessionDto`, filter DTOs, response DTOs |
+
+## Architecture
+
+- **Tick-based, not loop-based.** `PaperTradingService.scheduleTickJob()` creates a BullMQ repeatable job via `upsertJobScheduler()` that fires every `tickIntervalMs` (default 30s). Each tick is processed independently by `PaperTradingProcessor`.
+- **Session lifecycle:** `PAUSED -> ACTIVE -> PAUSED/STOPPED/COMPLETED/FAILED`. Sessions are created in `PAUSED` status and must be explicitly started. Five job types flow through a single `paper-trading` queue: `START_SESSION`, `TICK`, `RETRY_TICK`, `STOP_SESSION`, `NOTIFY_PIPELINE`.
+- **Account model:** `PaperTradingAccount` tracks `available`, `locked`, and computed `total` balances per currency, with `averageCost` and `entryDate` for hold-period enforcement. This is more realistic than the backtest engine's in-memory `Map<string, number>`.
+- **Pipeline integration:** Sessions can be created and auto-started by the pipeline orchestrator via `startFromPipeline()`. On completion, a `NOTIFY_PIPELINE` job emits an event back to the orchestrator. The `pipelineId` and `riskLevel` fields link sessions to their parent pipeline.
+
+## Error Classification
+
+The processor classifies errors into two categories:
+
+- **RecoverableError** (network timeouts, rate limits, 502/503): Increments `consecutiveErrors`. When the threshold is hit (default 3), tick jobs are removed and a one-shot `RETRY_TICK` is scheduled with exponential backoff (base 60s, capped at 30 min). On successful retry, normal ticks resume.
+- **UnrecoverableError** (auth failures, invalid config, 401/403): Immediately marks the session as `FAILED` and cleans up all jobs and in-memory state.
+
+After exhausting `maxRetryAttempts` (default 5), the session is permanently paused with `retriesExhausted: true`.
+
+## Entity Relationships
+
+```
+PaperTradingSession
+  |-- ManyToOne -> User (CASCADE delete)
+  |-- ManyToOne -> Algorithm (CASCADE delete)
+  |-- ManyToOne -> ExchangeKey (CASCADE delete)
+  |-- OneToMany -> PaperTradingAccount (per currency)
+  |-- OneToMany -> PaperTradingOrder
+  |-- OneToMany -> PaperTradingSignal
+  |-- OneToMany -> PaperTradingSnapshot (portfolio value over time)
+```
+
+## Gotchas
+
+- **Uses live exchange prices via CCXT, not historical data.** The `PaperTradingMarketDataService` fetches real-time tickers and order books from the configured exchange, with a stale-cache fallback (5 min TTL) when all retries are exhausted.
+- **Reuses BacktestSharedModule services.** The engine imports `FeeCalculatorService`, `MetricsCalculatorService`, `PortfolioStateService`, `SignalFilterChainService`, `SignalThrottleService`, and others from `../backtest/shared`.
+- **Throttle state is persisted on the session entity** (`throttleState` JSONB column) and restored into in-memory `SignalThrottleService` at the start of each tick, surviving process restarts.
+- **Recovery service runs on boot and every 5 minutes.** It also cleans up orphaned legacy repeatable jobs created by the old `queue.add({ repeat })` API that cannot be removed by `removeJobScheduler()`.
+- **Stop conditions are checked after every successful tick:** `maxDrawdown` and `targetReturn` thresholds, plus a duration limit parsed from strings like `7d`, `30d`, `3M`.

--- a/apps/api/src/order/tasks/README.md
+++ b/apps/api/src/order/tasks/README.md
@@ -1,0 +1,43 @@
+# Tasks
+
+## Overview
+
+BullMQ background job consumers for order-related processing. Each task extends `WorkerHost`, implements `OnModuleInit` for idempotent job scheduling, and reports failures to `FailedJobService`. All tasks skip scheduling in development or when their respective disable flag is set.
+
+## Tasks
+
+| Task | Queue Name | Schedule | Concurrency | Purpose |
+|------|-----------|----------|-------------|---------|
+| `OrderSyncTask` | `order-queue` | Hourly (prod) / 12h (non-prod) | Sequential per-user | Syncs orders from connected exchanges for all users with active keys. Also schedules a daily midnight cleanup job for stale orders. |
+| `TradeExecutionTask` | `trade-execution` | Every 5 minutes | 5 concurrent user groups | Generates algorithm signals and executes trades. Excludes robo-advisor users (handled by LiveTradingService). |
+| `PositionMonitorTask` | `position-monitor` | Every 60 seconds | Mutex (concurrency=1, 2min lock) | Monitors active positions with trailing stops, ratchets stop prices as market moves in favor. |
+| `LiquidationMonitorTask` | `liquidation-monitor` | Every 60 seconds | Mutex (concurrency=1, 2min lock) | Checks leveraged positions for liquidation risk, classifies as CRITICAL/WARNING/SAFE. |
+
+## BullMQ Pattern
+
+All tasks follow the same structure: `@Processor(queueName)` + `WorkerHost` + `OnModuleInit`. On startup, `onModuleInit()` checks for existing repeatable jobs before adding a new one (idempotent scheduling). Each task uses `@OnWorkerEvent('failed')` to record failures via `FailedJobService.recordFailure()` in a fail-safe wrapper.
+
+## Trade Execution Details
+
+Two-phase processing:
+
+1. **Pre-flight caching** -- For each unique user, fetches portfolio value, balance allocations, risk level, and daily loss limit status. Errors here fail closed (portfolio=0, user blocked).
+2. **Per-activation processing** -- Groups activations by user, processes groups in parallel (up to 5 concurrent groups) with sequential processing within each group.
+
+Gates applied to each entry signal: daily loss limit, concentration gate, and trade cooldown (prevents double-trading with Pipeline 1). Per-activation throttle state (cooldowns, daily cap, min sell percentage) is persisted in-memory across cron cycles and pruned when activations are deactivated. Robo-advisor users (`algoTradingEnabled=true`) are filtered out entirely.
+
+## Position Monitor Details
+
+Trailing stop ratchet: the stop price only moves in the favorable direction (up for longs, down for shorts). Supports three trailing types: percentage, fixed amount, and ATR-based (falls back to 2% if ATR unavailable). Three activation modes: immediate, price threshold, and percentage gain.
+
+Stop order replacement uses a cancel-and-replace pattern. The DB update (mark old order canceled, save new order, update position reference) is atomic via `DataSource.transaction()`. If the replacement order fails after cancellation, the position is marked ERROR (unprotected).
+
+Ticker fetching uses batch `fetchTickers` first, falling back to sequential `fetchTicker` per symbol if the batch call is unavailable or fails.
+
+## Gotchas
+
+- **Fail-closed philosophy**: If balance/portfolio fetch errors during trade execution pre-flight, portfolio is set to 0 and the user is blocked from trading that cycle.
+- **`@OnWorkerEvent('failed')`**: All tasks record failures to `FailedJobService.recordFailure()`, which is itself fail-safe (never throws).
+- **Dev env skips scheduling**: Each task checks `NODE_ENV === 'development'` and its own disable flag.
+- **Disable flags**: `DISABLE_BACKGROUND_TASKS=true` (order sync, liquidation monitor), `DISABLE_TRADE_EXECUTION=true` (trade execution), `DISABLE_POSITION_MONITOR=true` (position monitor).
+- **Trading kill switch**: `TradeExecutionTask` checks `TradingStateService.isTradingEnabled()` synchronously before any processing -- globally halted trading skips the entire job.

--- a/apps/api/src/strategy/gates/README.md
+++ b/apps/api/src/strategy/gates/README.md
@@ -1,0 +1,47 @@
+# Gates
+
+## Overview
+
+Promotion gates are quality checks evaluated before a strategy can advance through the pipeline toward live trading. Each gate inspects a specific criterion (score, drawdown, trade count, etc.) and returns a pass/fail result. `PromotionGateService` orchestrates all gates in priority order -- if any critical gate fails, promotion is blocked entirely. Non-critical failures produce warnings but still allow promotion.
+
+## Gates
+
+| Name | Priority | Critical | Threshold | Description |
+| ---- | -------- | -------- | --------- | ----------- |
+| `minimum-score` | 1 | Yes | >= 70 | Overall strategy score out of 100 |
+| `minimum-trades` | 2 | Yes | >= 30 | Total trades executed during backtest |
+| `maximum-drawdown` | 3 | Yes | < 40% | Maximum drawdown during backtest |
+| `wfa-consistency` | 4 | Yes | < 30% degradation | Walk-forward train/test performance gap |
+| `positive-returns` | 5 | Yes | > 0% | Total backtest return must be positive |
+| `correlation-limit` | 6 | No | < 0.7 | Correlation with existing deployments |
+| `volatility-cap` | 7 | No | < 150% annualized | Annualized strategy volatility |
+| `portfolio-capacity` | 8 | Yes | < 35 strategies | Active deployment count limit |
+
+## Interface
+
+All gates implement `IPromotionGate` from `promotion-gate.interface.ts`:
+
+```typescript
+evaluate(
+  strategyConfig: StrategyConfig,
+  strategyScore: StrategyScore,
+  backtestRun: BacktestRun,
+  context?: PromotionGateContext
+): Promise<PromotionGateResult>
+```
+
+Each result contains: `gateName`, `passed`, `actualValue`, `requiredValue`, `message`, `severity` (`'warning'` | `'critical'`), and optional `metadata`.
+
+## How to Add a New Gate
+
+1. Create a new `@Injectable()` class in `gates/` implementing `IPromotionGate`. Set `priority` (lower = runs first) and `isCritical`.
+2. Register the class in the `providers` array of `strategy.module.ts`.
+3. Inject it into `PromotionGateService` constructor and add it to the gates array. The constructor auto-sorts by priority.
+
+## Gotchas
+
+- A single critical gate failure blocks promotion. Non-critical failures are surfaced as warnings only.
+- `PromotionGateContext` provides `existingDeployments`, `currentMarketRegime`, `totalAllocation`, and user `overrides`. Gates like `correlation-limit` and `portfolio-capacity` depend on this context.
+- If a gate's `evaluate()` throws, the service catches the error and records it as a critical failure.
+- All gate evaluations are audit-logged under `AuditEventType.GATE_EVALUATION`.
+- Gates are distinct from runtime risk checks (`risk/`). Gates run pre-promotion; risk checks monitor post-live.

--- a/apps/api/src/strategy/risk/README.md
+++ b/apps/api/src/strategy/risk/README.md
@@ -1,0 +1,53 @@
+# Risk Checks
+
+## Overview
+
+Runtime risk monitoring checks for deployed (live) strategies. These checks run hourly via a background job orchestrated by `RiskManagementService`, which evaluates all active deployments and logs results to the audit trail. When a check with `autoDemote=true` fails at `severity='critical'`, the deployment is automatically demoted to prevent further losses.
+
+## Checks
+
+| Name | Priority | AutoDemote | Threshold |
+|------|----------|------------|-----------|
+| `drawdown-breach` | 1 | Yes | Current drawdown exceeds 1.5x backtest max drawdown limit |
+| `daily-loss-limit` | 2 | Yes | Daily loss exceeds deployment's configured limit (default 5%) |
+| `consecutive-losses` | 3 | Yes | Warns at 10+ losing days, auto-demotes at 15+ consecutive losing days |
+| `volatility-spike` | 4 | Yes | Warns at 2x expected volatility, auto-demotes at 3x expected |
+| `sharpe-degradation` | 5 | No | Live Sharpe ratio drops 50%+ from backtest Sharpe (warning only) |
+| `concentration-risk` | 6 | No | Single asset exceeds concentration limit for user's risk level (warning only) |
+
+## Interface
+
+```typescript
+IRiskCheck.evaluate(deployment, latestMetric, historicalMetrics?)
+```
+
+Returns a `RiskCheckResult`:
+
+```typescript
+{
+  checkName: string;
+  passed: boolean;
+  actualValue: number | string;
+  threshold: number | string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  message: string;
+  recommendedAction?: string;
+  metadata?: Record<string, any>;
+}
+```
+
+Severity is a four-level enum, not a boolean. The `passed` field indicates whether the check is within acceptable limits, while `severity` conveys how far outside limits a failing check is.
+
+## How to Add a New Check
+
+1. Create a new `@Injectable()` class in `risk/` implementing `IRiskCheck`. Set `name`, `description`, `priority` (lower = runs first), and `autoDemote`.
+2. Register the class in the `providers` array of `strategy.module.ts`.
+3. Inject it into `RiskManagementService` constructor -- it will be added to the sorted `checks` array automatically.
+
+## Gotchas
+
+- `autoDemote=true` alone does not trigger demotion. The check must also return `severity='critical'` on failure. This allows tiered checks (e.g., `consecutive-losses` warns at `high` severity for 10 days but only demotes at `critical` for 15+).
+- These checks run hourly, distinct from the per-trade `PreTradeRiskGateService` which gates individual trades in real time.
+- Most checks need `historicalMetrics` for trend analysis. `RiskManagementService` loads the last 30 days of `PerformanceMetric` records for each evaluation.
+- `concentration-risk` is unique: it fetches live balances and user risk level rather than relying on `PerformanceMetric` data.
+- If a check throws, `RiskManagementService` catches the error and records a failing result with `severity='critical'`.


### PR DESCRIPTION
## Summary

- Extract 32 module-specific rule files into `.claude/rules/` for path-based automatic loading, so Claude Code gets relevant context only when working in specific modules
- Slim down `CLAUDE.md` by removing inline module documentation that is now in dedicated rule files
- Add README files to 9 API subdirectories (algorithm, common, order, strategy) for developer onboarding

## Changes

### New rule files (32 files in `.claude/rules/`)
- API modules: `admin-api-module`, `algorithm-module`, `api-config`, `api-interfaces`, `api-utils`, `authentication-module`, `balance-module`, `coin-module`, `coin-selection-module`, `common-module`, `exchange-module`, `failed-jobs-module`, `market-regime-module`, `monitoring-module`, `notification-module`, `ohlc-module`, `optimization-module`, `order-module`, `pipeline-module`, `risk-module`, `scoring-module`, `shared-resilience`, `strategy-module`, `tasks-module`
- Frontend: `admin-pages`, `auth-pages`, `coins-pages`, `frontend-shared`, `layout`, `user-pages`
- Infrastructure: `migrations`, `shared-lib`

### Subdirectory READMEs (9 files)
- `algorithm/indicators/calculators/`, `algorithm/strategies/`
- `common/exceptions/`, `common/metrics/`
- `order/backtest/`, `order/paper-trading/`, `order/tasks/`
- `strategy/gates/`, `strategy/risk/`

### Updated
- `CLAUDE.md` — removed module-specific sections now covered by rule files

## Test Plan

- [x] All rule files have valid frontmatter with `description` and `globs` fields
- [x] `CLAUDE.md` retains architecture overview, dev commands, and workflow guidance
- [ ] Verify Claude Code loads relevant rules when working in specific module paths