### PR TITLE
feat(api): add volume-aware fill simulation with square-root impact model

### DIFF
--- a/apps/api/src/order/backtest/backtest-engine.service.spec.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.spec.ts
@@ -289,7 +289,7 @@ describe('BacktestEngine.executeTrade', () => {
         createMarketData('BTC', 100),
         0,
         { next: () => 0.5 },
-        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5, volumeImpactFactor: 100 },
+        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
         1000000000 // High volume
       );
 
@@ -299,7 +299,7 @@ describe('BacktestEngine.executeTrade', () => {
         createMarketData('BTC', 100),
         0,
         { next: () => 0.5 },
-        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5, volumeImpactFactor: 100 },
+        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
         1000 // Low volume
       );
 
@@ -308,8 +308,8 @@ describe('BacktestEngine.executeTrade', () => {
     });
   });
 
-  describe('Bug Fix: SELL slippage estimation uses position quantity', () => {
-    it('uses existing position quantity for SELL slippage estimation (percentage)', async () => {
+  describe('SELL slippage uses actual position quantity', () => {
+    it('uses actual position quantity for SELL slippage calculation (percentage)', async () => {
       const engine = createEngine();
       // Large portfolio ($100,000) with small position (10 BTC @ $100 = $1,000)
       // Selling 50% should estimate slippage for 5 BTC, not $10,000 worth
@@ -345,16 +345,15 @@ describe('BacktestEngine.executeTrade', () => {
         createMarketData('BTC', 100),
         0,
         { next: () => 0.5 },
-        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5, volumeImpactFactor: 100 },
+        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
         10000 // $1M daily volume
       );
 
       expect(result).toBeTruthy();
       // Should sell 5 BTC (50% of 10)
       expect(result.trade.quantity).toBeCloseTo(5);
-      // Slippage should be reasonable given 5 BTC * $100 = $500 vs $10k volume
-      // Not inflated due to $10,000 (10% of $100k portfolio) estimate
-      expect(result.trade.metadata?.slippageBps).toBeLessThanOrEqual(15);
+      // Slippage uses square-root model on actual quantity: 5 + 0.1 * sqrt(500/10000) * 10000 ≈ 228.6 bps
+      expect(result.trade.metadata?.slippageBps).toBeLessThanOrEqual(250);
     });
 
     it('calculates volume-based slippage correctly for SELL trades with no explicit quantity', async () => {
@@ -389,7 +388,7 @@ describe('BacktestEngine.executeTrade', () => {
         createMarketData('BTC', 100),
         0,
         { next: () => 0.5 },
-        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5, volumeImpactFactor: 100 },
+        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
         1000 // Low volume
       );
 
@@ -399,7 +398,7 @@ describe('BacktestEngine.executeTrade', () => {
         createMarketData('BTC', 100),
         0,
         { next: () => 0.5 },
-        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5, volumeImpactFactor: 100 },
+        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
         10000000 // High volume
       );
 
@@ -459,7 +458,7 @@ describe('BacktestEngine.executeTrade', () => {
         createMarketData('BTC', 100),
         0,
         { next: () => 0.5 },
-        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5, volumeImpactFactor: 100 },
+        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
         10000
       );
 

--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -120,6 +120,13 @@ export interface TradingSignal {
   exitConfig?: Partial<ExitConfig>;
 }
 
+interface ExecuteTradeResult {
+  trade: Partial<BacktestTrade>;
+  slippageBps: number;
+  fillStatus: SimulatedOrderStatus;
+  requestedQuantity?: number;
+}
+
 interface ExecuteOptions {
   dataset: MarketDataSet;
   deterministicSeed: string;
@@ -730,12 +737,21 @@ export class BacktestEngine {
 
     // Build slippage config from backtest configSnapshot using shared service
     const slippageSnapshot = backtest.configSnapshot?.slippage;
+    const slippageModel = slippageSnapshot
+      ? this.mapSlippageModelType(slippageSnapshot.model as string)
+      : SlippageModelType.FIXED;
+    const riskDefaults =
+      slippageModel === SlippageModelType.VOLUME_BASED
+        ? this.getParticipationDefaults(backtest.configSnapshot?.regime?.riskLevel ?? 3)
+        : undefined;
     const slippageConfig: SlippageConfig = slippageSnapshot
       ? this.slippageService.buildConfig({
-          type: this.mapSlippageModelType(slippageSnapshot.model as string),
+          type: slippageModel,
           fixedBps: slippageSnapshot.fixedBps ?? 5,
-          baseSlippageBps: slippageSnapshot.baseBps ?? 5,
-          volumeImpactFactor: slippageSnapshot.volumeImpactFactor ?? 100
+          baseSlippageBps: slippageSnapshot.baseSlippageBps ?? 5,
+          participationRateLimit: slippageSnapshot.participationRateLimit ?? riskDefaults?.participationRateLimit,
+          rejectParticipationRate: slippageSnapshot.rejectParticipationRate ?? riskDefaults?.rejectParticipationRate,
+          volatilityFactor: slippageSnapshot.volatilityFactor
         })
       : DEFAULT_SLIPPAGE_CONFIG;
 
@@ -1080,41 +1096,57 @@ export class BacktestEngine {
         }
 
         if (tradeResult) {
-          const { trade, slippageBps } = tradeResult;
+          const { trade, slippageBps, fillStatus } = tradeResult;
 
-          const baseCoin = coinMap.get(strategySignal.coinId);
-          if (!baseCoin) {
-            throw new Error(
-              `baseCoin not found for coinId ${strategySignal.coinId}. Ensure all coins referenced by the algorithm are included in the backtest.`
-            );
-          }
-
-          trades.push({ ...trade, executedAt: timestamp, backtest, baseCoin, quoteCoin });
-          simulatedFills.push({
-            orderType: SimulatedOrderType.MARKET,
-            status: SimulatedOrderStatus.FILLED,
-            filledQuantity: trade.quantity,
-            averagePrice: trade.price,
-            fees: trade.fee,
-            slippageBps,
-            executionTimestamp: timestamp,
-            instrument: strategySignal.coinId,
-            metadata: trade.metadata,
-            backtest
-          });
-
-          // Update exit tracker: register new BUY positions, reduce on SELL
-          if (exitTracker && trade.price != null && trade.quantity != null) {
-            if (strategySignal.action === 'BUY') {
-              exitTracker.onBuy(
-                strategySignal.coinId,
-                trade.price,
-                trade.quantity,
-                undefined,
-                strategySignal.exitConfig
+          if (fillStatus === SimulatedOrderStatus.CANCELLED) {
+            simulatedFills.push({
+              orderType: SimulatedOrderType.MARKET,
+              status: SimulatedOrderStatus.CANCELLED,
+              filledQuantity: 0,
+              averagePrice: trade.price,
+              fees: 0,
+              slippageBps,
+              executionTimestamp: timestamp,
+              instrument: strategySignal.coinId,
+              metadata: { ...trade.metadata, requestedQuantity: tradeResult.requestedQuantity },
+              backtest
+            });
+            if (strategySignal.action === 'BUY') metricsAcc.skippedBuyCount++;
+          } else {
+            const baseCoin = coinMap.get(strategySignal.coinId);
+            if (!baseCoin) {
+              throw new Error(
+                `baseCoin not found for coinId ${strategySignal.coinId}. Ensure all coins referenced by the algorithm are included in the backtest.`
               );
-            } else if (strategySignal.action === 'SELL') {
-              exitTracker.onSell(strategySignal.coinId, trade.quantity);
+            }
+
+            trades.push({ ...trade, executedAt: timestamp, backtest, baseCoin, quoteCoin });
+            simulatedFills.push({
+              orderType: SimulatedOrderType.MARKET,
+              status: fillStatus,
+              filledQuantity: trade.quantity,
+              averagePrice: trade.price,
+              fees: trade.fee,
+              slippageBps,
+              executionTimestamp: timestamp,
+              instrument: strategySignal.coinId,
+              metadata: trade.metadata,
+              backtest
+            });
+
+            // Update exit tracker: register new BUY positions, reduce on SELL
+            if (exitTracker && trade.price != null && trade.quantity != null) {
+              if (strategySignal.action === 'BUY') {
+                exitTracker.onBuy(
+                  strategySignal.coinId,
+                  trade.price,
+                  trade.quantity,
+                  undefined,
+                  strategySignal.exitConfig
+                );
+              } else if (strategySignal.action === 'SELL') {
+                exitTracker.onSell(strategySignal.coinId, trade.quantity);
+              }
             }
           }
         } else if (strategySignal.action === 'BUY') {
@@ -1512,13 +1544,22 @@ export class BacktestEngine {
 
     // Build slippage config from backtest configSnapshot
     const slippageSnapshot = backtest.configSnapshot?.slippage;
+    const lrSlippageModel = slippageSnapshot
+      ? this.mapSlippageModelType(slippageSnapshot.model as string)
+      : SlippageModelType.FIXED;
+    const lrRiskDefaults =
+      lrSlippageModel === SlippageModelType.VOLUME_BASED
+        ? this.getParticipationDefaults(backtest.configSnapshot?.regime?.riskLevel ?? 3)
+        : undefined;
     const slippageConfig: SlippageConfig = slippageSnapshot
-      ? {
-          type: this.mapSlippageModelType(slippageSnapshot.model as string),
+      ? this.slippageService.buildConfig({
+          type: lrSlippageModel,
           fixedBps: slippageSnapshot.fixedBps ?? 5,
-          baseSlippageBps: slippageSnapshot.baseBps ?? 5,
-          volumeImpactFactor: slippageSnapshot.volumeImpactFactor ?? 100
-        }
+          baseSlippageBps: slippageSnapshot.baseSlippageBps ?? 5,
+          participationRateLimit: slippageSnapshot.participationRateLimit ?? lrRiskDefaults?.participationRateLimit,
+          rejectParticipationRate: slippageSnapshot.rejectParticipationRate ?? lrRiskDefaults?.rejectParticipationRate,
+          volatilityFactor: slippageSnapshot.volatilityFactor
+        })
       : DEFAULT_SLIPPAGE_CONFIG;
 
     // Minimum hold period: configurable via options, default 24h
@@ -1943,41 +1984,57 @@ export class BacktestEngine {
           barMinAllocation
         );
         if (tradeResult) {
-          const { trade, slippageBps } = tradeResult;
+          const { trade, slippageBps, fillStatus } = tradeResult;
 
-          const baseCoin = coinMap.get(strategySignal.coinId);
-          if (!baseCoin) {
-            throw new Error(
-              `baseCoin not found for coinId ${strategySignal.coinId}. Ensure all coins referenced by the algorithm are included in the backtest.`
-            );
-          }
-
-          trades.push({ ...trade, executedAt: timestamp, backtest, baseCoin, quoteCoin });
-          simulatedFills.push({
-            orderType: SimulatedOrderType.MARKET,
-            status: SimulatedOrderStatus.FILLED,
-            filledQuantity: trade.quantity,
-            averagePrice: trade.price,
-            fees: trade.fee,
-            slippageBps,
-            executionTimestamp: timestamp,
-            instrument: strategySignal.coinId,
-            metadata: trade.metadata,
-            backtest
-          });
-
-          // Update exit tracker: register new BUY positions, reduce on SELL
-          if (exitTracker && trade.price != null && trade.quantity != null) {
-            if (strategySignal.action === 'BUY') {
-              exitTracker.onBuy(
-                strategySignal.coinId,
-                trade.price,
-                trade.quantity,
-                undefined,
-                strategySignal.exitConfig
+          if (fillStatus === SimulatedOrderStatus.CANCELLED) {
+            simulatedFills.push({
+              orderType: SimulatedOrderType.MARKET,
+              status: SimulatedOrderStatus.CANCELLED,
+              filledQuantity: 0,
+              averagePrice: trade.price,
+              fees: 0,
+              slippageBps,
+              executionTimestamp: timestamp,
+              instrument: strategySignal.coinId,
+              metadata: { ...trade.metadata, requestedQuantity: tradeResult.requestedQuantity },
+              backtest
+            });
+            if (strategySignal.action === 'BUY') metricsAcc.skippedBuyCount++;
+          } else {
+            const baseCoin = coinMap.get(strategySignal.coinId);
+            if (!baseCoin) {
+              throw new Error(
+                `baseCoin not found for coinId ${strategySignal.coinId}. Ensure all coins referenced by the algorithm are included in the backtest.`
               );
-            } else if (strategySignal.action === 'SELL') {
-              exitTracker.onSell(strategySignal.coinId, trade.quantity);
+            }
+
+            trades.push({ ...trade, executedAt: timestamp, backtest, baseCoin, quoteCoin });
+            simulatedFills.push({
+              orderType: SimulatedOrderType.MARKET,
+              status: fillStatus,
+              filledQuantity: trade.quantity,
+              averagePrice: trade.price,
+              fees: trade.fee,
+              slippageBps,
+              executionTimestamp: timestamp,
+              instrument: strategySignal.coinId,
+              metadata: trade.metadata,
+              backtest
+            });
+
+            // Update exit tracker: register new BUY positions, reduce on SELL
+            if (exitTracker && trade.price != null && trade.quantity != null) {
+              if (strategySignal.action === 'BUY') {
+                exitTracker.onBuy(
+                  strategySignal.coinId,
+                  trade.price,
+                  trade.quantity,
+                  undefined,
+                  strategySignal.exitConfig
+                );
+              } else if (strategySignal.action === 'SELL') {
+                exitTracker.onSell(strategySignal.coinId, trade.quantity);
+              }
             }
           }
         } else if (strategySignal.action === 'BUY') {
@@ -2395,7 +2452,11 @@ export class BacktestEngine {
    * Extract daily volume from OHLC candles for a specific coin
    */
   private extractDailyVolume(currentPrices: OHLCCandle[], coinId: string): number | undefined {
-    return currentPrices.find((c) => c.coinId === coinId)?.volume;
+    const candle = currentPrices.find((c) => c.coinId === coinId);
+    if (!candle) return undefined;
+    // Convert base-currency volume to quote-currency (USD) for participation rate math.
+    // quoteVolume is preferred but typically NULL (CCXT fetchOHLCV doesn't provide it).
+    return candle.quoteVolume ?? (candle.volume ? candle.volume * candle.close : undefined);
   }
 
   private groupPricesByTimestamp(candles: OHLCCandle[]): Record<string, OHLCCandle[]> {
@@ -2412,6 +2473,20 @@ export class BacktestEngine {
     );
   }
 
+  private getParticipationDefaults(riskLevel: number): {
+    participationRateLimit: number;
+    rejectParticipationRate: number;
+  } {
+    const defaults = [
+      { participationRateLimit: 0.02, rejectParticipationRate: 0.25 }, // risk 1
+      { participationRateLimit: 0.03, rejectParticipationRate: 0.3 }, // risk 2
+      { participationRateLimit: 0.05, rejectParticipationRate: 0.5 }, // risk 3
+      { participationRateLimit: 0.08, rejectParticipationRate: 0.6 }, // risk 4
+      { participationRateLimit: 0.1, rejectParticipationRate: 0.75 } // risk 5
+    ];
+    return defaults[Math.max(0, Math.min(4, (riskLevel ?? 3) - 1))];
+  }
+
   private async executeTrade(
     signal: TradingSignal,
     portfolio: Portfolio,
@@ -2424,7 +2499,7 @@ export class BacktestEngine {
     maxAllocation: number = getAllocationLimits().maxAllocation,
     minAllocation: number = getAllocationLimits().minAllocation,
     defaultLeverage = 1
-  ): Promise<{ trade: Partial<BacktestTrade>; slippageBps: number } | null> {
+  ): Promise<ExecuteTradeResult | null> {
     const marketPrice = marketData.prices.get(signal.coinId);
     if (!marketPrice) {
       this.logger.warn(`No price data available for coin ${signal.coinId}`);
@@ -2458,54 +2533,61 @@ export class BacktestEngine {
         ? signal.metadata.stopExecutionPrice
         : marketPrice;
 
-    const isBuy = signal.action === 'BUY';
     let quantity = 0;
     let totalValue = 0;
+    let slippageBps = 0;
+    let price = basePrice;
+    let fillStatus = SimulatedOrderStatus.FILLED;
+    let requestedQuantity: number | undefined;
 
-    // Calculate slippage based on estimated order size and market volume
-    let estimatedQuantity: number;
-    if (signal.quantity) {
-      estimatedQuantity = signal.quantity;
-    } else if (isBuy) {
-      // For BUY: estimate based on typical portfolio allocation (10%)
-      estimatedQuantity = (portfolio.totalValue * 0.1) / basePrice;
-    } else {
-      // For SELL: estimate based on existing position (50% as reasonable middle-ground)
-      const existingPosition = portfolio.positions.get(signal.coinId);
-      estimatedQuantity = (existingPosition?.quantity ?? 0) * 0.5;
-    }
-
-    // Use shared SlippageService for consistent slippage calculation
-    const slippageResult = this.slippageService.calculateSlippage(
-      {
-        price: basePrice,
-        quantity: estimatedQuantity,
-        isBuy,
-        dailyVolume
-      },
-      slippageConfig
-    );
-    const slippageBps = slippageResult.slippageBps;
-    const price = slippageResult.executionPrice;
-
-    if (isBuy) {
+    if (signal.action === 'BUY') {
       // Position sizing priority: quantity > percentage > confidence > random
+      // Size on basePrice (market price) — slippage applied after sizing
       if (signal.quantity) {
-        // Use explicit quantity if provided
         quantity = signal.quantity;
       } else if (signal.percentage) {
-        // Use percentage (from signal.strength) if provided
         const investmentAmount = portfolio.totalValue * signal.percentage;
-        quantity = investmentAmount / price;
+        quantity = investmentAmount / basePrice;
       } else if (signal.confidence !== undefined) {
-        // Use confidence-based sizing: higher confidence = larger position (scaled between min and max allocation)
         const confidenceBasedAllocation = minAllocation + signal.confidence * (maxAllocation - minAllocation);
         const investmentAmount = portfolio.totalValue * confidenceBasedAllocation;
-        quantity = investmentAmount / price;
+        quantity = investmentAmount / basePrice;
       } else {
-        // Fallback to random allocation (within min–max range of portfolio)
         const investmentAmount = portfolio.totalValue * Math.min(maxAllocation, Math.max(minAllocation, rng.next()));
-        quantity = investmentAmount / price;
+        quantity = investmentAmount / basePrice;
+      }
+
+      // Calculate slippage on actual quantity
+      const slippageResult = this.slippageService.calculateSlippage(
+        { price: basePrice, quantity, isBuy: true, dailyVolume },
+        slippageConfig
+      );
+      slippageBps = slippageResult.slippageBps;
+      price = slippageResult.executionPrice;
+
+      // Volume-aware fill assessment on actual quantity
+      const buyFillAssessment = this.slippageService.assessFillability(
+        quantity * price,
+        price,
+        dailyVolume,
+        slippageConfig
+      );
+      if (buyFillAssessment.fillStatus === 'CANCELLED') {
+        return {
+          trade: {
+            quantity: 0,
+            price,
+            metadata: { volumeRejection: true, reason: buyFillAssessment.reason }
+          } as Partial<BacktestTrade>,
+          slippageBps,
+          fillStatus: SimulatedOrderStatus.CANCELLED,
+          requestedQuantity: quantity
+        };
+      }
+      if (buyFillAssessment.fillStatus === 'PARTIAL') {
+        requestedQuantity = quantity;
+        quantity = buyFillAssessment.fillableQuantity;
+        fillStatus = SimulatedOrderStatus.PARTIAL;
       }
 
       totalValue = quantity * price;
@@ -2575,20 +2657,50 @@ export class BacktestEngine {
 
       // Position sizing priority: quantity > percentage > confidence > random
       if (signal.quantity) {
-        // Use explicit quantity if provided
         quantity = signal.quantity;
       } else if (signal.percentage) {
-        // Use percentage (from signal.strength) to determine portion to sell
         quantity = existingPosition.quantity * Math.min(1, signal.percentage);
       } else if (signal.confidence !== undefined) {
-        // Use confidence-based sizing: higher confidence = sell more (25% to 100% of position)
         const confidenceBasedPercent = 0.25 + signal.confidence * 0.75;
         quantity = existingPosition.quantity * confidenceBasedPercent;
       } else {
-        // Fallback to random exit size (25-100% of position)
         quantity = existingPosition.quantity * Math.min(1, Math.max(0.25, rng.next()));
       }
       quantity = Math.min(quantity, existingPosition.quantity);
+
+      // Calculate slippage on actual quantity
+      const slippageResult = this.slippageService.calculateSlippage(
+        { price: basePrice, quantity, isBuy: false, dailyVolume },
+        slippageConfig
+      );
+      slippageBps = slippageResult.slippageBps;
+      price = slippageResult.executionPrice;
+
+      // Volume-aware fill assessment on actual quantity
+      const sellFillAssessment = this.slippageService.assessFillability(
+        quantity * price,
+        price,
+        dailyVolume,
+        slippageConfig
+      );
+      if (sellFillAssessment.fillStatus === 'CANCELLED') {
+        return {
+          trade: {
+            quantity: 0,
+            price,
+            metadata: { volumeRejection: true, reason: sellFillAssessment.reason }
+          } as Partial<BacktestTrade>,
+          slippageBps,
+          fillStatus: SimulatedOrderStatus.CANCELLED,
+          requestedQuantity: quantity
+        };
+      }
+      if (sellFillAssessment.fillStatus === 'PARTIAL') {
+        requestedQuantity = quantity;
+        quantity = Math.min(sellFillAssessment.fillableQuantity, existingPosition.quantity);
+        fillStatus = SimulatedOrderStatus.PARTIAL;
+      }
+
       totalValue = quantity * price;
 
       // Calculate realized P&L: (sell price - cost basis) * quantity
@@ -2620,18 +2732,52 @@ export class BacktestEngine {
       );
 
       // Position sizing priority: quantity > percentage > confidence > random
+      // Size on basePrice (market price) — slippage applied after sizing
       if (signal.quantity) {
         quantity = signal.quantity;
       } else if (signal.percentage) {
         const investmentAmount = portfolio.totalValue * signal.percentage;
-        quantity = investmentAmount / price;
+        quantity = investmentAmount / basePrice;
       } else if (signal.confidence !== undefined) {
         const confidenceBasedAllocation = minAllocation + signal.confidence * (maxAllocation - minAllocation);
         const investmentAmount = portfolio.totalValue * confidenceBasedAllocation;
-        quantity = investmentAmount / price;
+        quantity = investmentAmount / basePrice;
       } else {
         const investmentAmount = portfolio.totalValue * Math.min(maxAllocation, Math.max(minAllocation, rng.next()));
-        quantity = investmentAmount / price;
+        quantity = investmentAmount / basePrice;
+      }
+
+      // Calculate slippage on actual quantity (opening short = selling)
+      const slippageResult = this.slippageService.calculateSlippage(
+        { price: basePrice, quantity, isBuy: false, dailyVolume },
+        slippageConfig
+      );
+      slippageBps = slippageResult.slippageBps;
+      price = slippageResult.executionPrice;
+
+      // Volume-aware fill assessment on actual quantity
+      const shortFillAssessment = this.slippageService.assessFillability(
+        quantity * price,
+        price,
+        dailyVolume,
+        slippageConfig
+      );
+      if (shortFillAssessment.fillStatus === 'CANCELLED') {
+        return {
+          trade: {
+            quantity: 0,
+            price,
+            metadata: { volumeRejection: true, reason: shortFillAssessment.reason }
+          } as Partial<BacktestTrade>,
+          slippageBps,
+          fillStatus: SimulatedOrderStatus.CANCELLED,
+          requestedQuantity: quantity
+        };
+      }
+      if (shortFillAssessment.fillStatus === 'PARTIAL') {
+        requestedQuantity = quantity;
+        quantity = shortFillAssessment.fillableQuantity;
+        fillStatus = SimulatedOrderStatus.PARTIAL;
       }
 
       const marginAmount = (quantity * price) / shortLeverage;
@@ -2694,6 +2840,39 @@ export class BacktestEngine {
         quantity = existingPosition.quantity * Math.min(1, Math.max(0.25, rng.next()));
       }
       quantity = Math.min(quantity, existingPosition.quantity);
+
+      // Calculate slippage on actual quantity (closing short = buying)
+      const slippageResult = this.slippageService.calculateSlippage(
+        { price: basePrice, quantity, isBuy: true, dailyVolume },
+        slippageConfig
+      );
+      slippageBps = slippageResult.slippageBps;
+      price = slippageResult.executionPrice;
+
+      // Volume-aware fill assessment on actual quantity
+      const closeShortFillAssessment = this.slippageService.assessFillability(
+        quantity * price,
+        price,
+        dailyVolume,
+        slippageConfig
+      );
+      if (closeShortFillAssessment.fillStatus === 'CANCELLED') {
+        return {
+          trade: {
+            quantity: 0,
+            price,
+            metadata: { volumeRejection: true, reason: closeShortFillAssessment.reason }
+          } as Partial<BacktestTrade>,
+          slippageBps,
+          fillStatus: SimulatedOrderStatus.CANCELLED,
+          requestedQuantity: quantity
+        };
+      }
+      if (closeShortFillAssessment.fillStatus === 'PARTIAL') {
+        requestedQuantity = quantity;
+        quantity = Math.min(closeShortFillAssessment.fillableQuantity, existingPosition.quantity);
+        fillStatus = SimulatedOrderStatus.PARTIAL;
+      }
 
       // Calculate realized P&L: (entryPrice - exitPrice) * quantity (inverted from long)
       realizedPnL = (costBasis - price) * quantity;
@@ -2768,10 +2947,13 @@ export class BacktestEngine {
           confidence: signal.confidence ?? 0,
           basePrice, // Original price before slippage
           slippageBps, // Simulated slippage applied
-          ...(holdTimeMs !== undefined && { holdTimeMs })
+          ...(holdTimeMs !== undefined && { holdTimeMs }),
+          ...(fillStatus === SimulatedOrderStatus.PARTIAL && { fillStatus: 'PARTIAL', requestedQuantity })
         }
       } as Partial<BacktestTrade>,
-      slippageBps
+      slippageBps,
+      fillStatus,
+      requestedQuantity
     };
   }
 
@@ -2925,8 +3107,27 @@ export class BacktestEngine {
       );
 
       if (tradeResult) {
-        const { trade, slippageBps } = tradeResult;
-        if (fullFidelity) {
+        const { trade, slippageBps, fillStatus } = tradeResult;
+        if (fillStatus === SimulatedOrderStatus.CANCELLED) {
+          if (fullFidelity) {
+            opts.simulatedFills!.push({
+              orderType: SimulatedOrderType.MARKET,
+              status: SimulatedOrderStatus.CANCELLED,
+              filledQuantity: 0,
+              averagePrice: trade.price,
+              fees: 0,
+              slippageBps,
+              executionTimestamp: timestamp,
+              instrument: exitSig.coinId,
+              metadata: {
+                ...(trade.metadata ?? {}),
+                exitType: exitSig.exitType,
+                requestedQuantity: tradeResult.requestedQuantity
+              },
+              backtest: opts.backtest
+            });
+          }
+        } else if (fullFidelity) {
           const baseCoin = opts.coinMap?.get(exitSig.coinId);
           trades.push({
             ...trade,
@@ -2937,7 +3138,7 @@ export class BacktestEngine {
           });
           opts.simulatedFills!.push({
             orderType: SimulatedOrderType.MARKET,
-            status: SimulatedOrderStatus.FILLED,
+            status: fillStatus,
             filledQuantity: trade.quantity,
             averagePrice: trade.price,
             fees: trade.fee,
@@ -3168,26 +3369,45 @@ export class BacktestEngine {
         0
       );
       if (sellResult) {
-        const { trade, slippageBps } = sellResult;
-        const baseCoin = coinMap.get(candidate.coinId);
+        const { trade, slippageBps, fillStatus } = sellResult;
+        if (fillStatus === SimulatedOrderStatus.CANCELLED) {
+          simulatedFills.push({
+            orderType: SimulatedOrderType.MARKET,
+            status: SimulatedOrderStatus.CANCELLED,
+            filledQuantity: 0,
+            averagePrice: trade.price,
+            fees: 0,
+            slippageBps,
+            executionTimestamp: timestamp,
+            instrument: candidate.coinId,
+            metadata: {
+              ...(trade.metadata ?? {}),
+              opportunitySell: true,
+              requestedQuantity: sellResult.requestedQuantity
+            },
+            backtest
+          });
+        } else {
+          const baseCoin = coinMap.get(candidate.coinId);
 
-        trades.push({ ...trade, executedAt: timestamp, backtest, baseCoin: baseCoin || undefined, quoteCoin });
-        simulatedFills.push({
-          orderType: SimulatedOrderType.MARKET,
-          status: SimulatedOrderStatus.FILLED,
-          filledQuantity: trade.quantity,
-          averagePrice: trade.price,
-          fees: trade.fee,
-          slippageBps,
-          executionTimestamp: timestamp,
-          instrument: candidate.coinId,
-          metadata: { ...(trade.metadata ?? {}), opportunitySell: true },
-          backtest
-        });
+          trades.push({ ...trade, executedAt: timestamp, backtest, baseCoin: baseCoin || undefined, quoteCoin });
+          simulatedFills.push({
+            orderType: SimulatedOrderType.MARKET,
+            status: fillStatus,
+            filledQuantity: trade.quantity,
+            averagePrice: trade.price,
+            fees: trade.fee,
+            slippageBps,
+            executionTimestamp: timestamp,
+            instrument: candidate.coinId,
+            metadata: { ...(trade.metadata ?? {}), opportunitySell: true },
+            backtest
+          });
 
-        totalSellValue += (trade.quantity ?? 0) * (trade.price ?? 0);
-        remainingShortfall -= (trade.quantity ?? 0) * (trade.price ?? 0);
-        sellExecuted = true;
+          totalSellValue += (trade.quantity ?? 0) * (trade.price ?? 0);
+          remainingShortfall -= (trade.quantity ?? 0) * (trade.price ?? 0);
+          sellExecuted = true;
+        }
       }
     }
 
@@ -3598,7 +3818,8 @@ export class BacktestEngine {
     for (const tsKey of timestamps) {
       for (const candle of pricesByTimestamp[tsKey]) {
         if (candle.volume != null) {
-          volumeMap.set(`${tsKey}:${candle.coinId}`, candle.volume);
+          const quoteVol = candle.quoteVolume ?? candle.volume * candle.close;
+          volumeMap.set(`${tsKey}:${candle.coinId}`, quoteVol);
         }
       }
     }
@@ -3817,7 +4038,7 @@ export class BacktestEngine {
           optMaxAllocation,
           optMinAllocation
         );
-        if (tradeResult) {
+        if (tradeResult && tradeResult.fillStatus !== SimulatedOrderStatus.CANCELLED) {
           trades.push({ ...tradeResult.trade, executedAt: timestamp });
           if (optExitTracker && tradeResult.trade.price != null && tradeResult.trade.quantity != null) {
             if (strategySignal.action === 'BUY') {
@@ -4136,7 +4357,8 @@ export class BacktestEngine {
     for (const tsKey of timestamps) {
       for (const candle of pricesByTimestamp[tsKey]) {
         if (candle.volume != null) {
-          volumeMap.set(`${tsKey}:${candle.coinId}`, candle.volume);
+          const quoteVol = candle.quoteVolume ?? candle.volume * candle.close;
+          volumeMap.set(`${tsKey}:${candle.coinId}`, quoteVol);
         }
       }
     }
@@ -4281,7 +4503,7 @@ export class BacktestEngine {
           optMaxAllocation,
           optMinAllocation
         );
-        if (tradeResult) {
+        if (tradeResult && tradeResult.fillStatus !== SimulatedOrderStatus.CANCELLED) {
           trades.push({ ...tradeResult.trade, executedAt: timestamp });
           if (coreExitTracker && tradeResult.trade.price != null && tradeResult.trade.quantity != null) {
             if (strategySignal.action === 'BUY') {

--- a/apps/api/src/order/backtest/backtest.service.ts
+++ b/apps/api/src/order/backtest/backtest.service.ts
@@ -193,8 +193,10 @@ export class BacktestService implements OnModuleInit, OnModuleDestroy {
         slippage: {
           model: createBacktestDto.slippageModel || 'fixed',
           fixedBps: createBacktestDto.slippageFixedBps ?? 5,
-          baseBps: createBacktestDto.slippageBaseBps ?? 5,
-          volumeImpactFactor: createBacktestDto.slippageVolumeImpactFactor ?? 100
+          baseSlippageBps: createBacktestDto.slippageBaseBps ?? 5,
+          participationRateLimit: createBacktestDto.slippageParticipationRate,
+          rejectParticipationRate: createBacktestDto.slippageRejectThreshold,
+          volatilityFactor: createBacktestDto.slippageVolatilityFactor
         },
         regime: {
           enableRegimeGate: createBacktestDto.enableRegimeGate,

--- a/apps/api/src/order/backtest/dto/backtest.dto.ts
+++ b/apps/api/src/order/backtest/dto/backtest.dto.ts
@@ -228,7 +228,7 @@ export class CreateBacktestDto {
 
   @IsNumber()
   @Min(0)
-  @Max(100)
+  @Max(500)
   @IsOptional()
   @ApiProperty({
     description: 'Base slippage for volume-based model in basis points',
@@ -241,18 +241,44 @@ export class CreateBacktestDto {
   slippageBaseBps?: number = 5;
 
   @IsNumber()
-  @Min(0)
-  @Max(1000)
+  @Min(0.01)
+  @Max(0.5)
   @IsOptional()
   @ApiProperty({
-    description: 'Volume impact factor for volume-based slippage model',
-    example: 100,
-    default: 100,
-    minimum: 0,
-    maximum: 1000,
+    description: 'Max fraction of daily volume for a single order (e.g., 0.05 = 5%)',
+    example: 0.05,
+    minimum: 0.01,
+    maximum: 0.5,
     required: false
   })
-  slippageVolumeImpactFactor?: number = 100;
+  slippageParticipationRate?: number;
+
+  @IsNumber()
+  @Min(0.1)
+  @Max(1.0)
+  @IsOptional()
+  @ApiProperty({
+    description: 'If order exceeds this fraction of daily volume, reject entirely (e.g., 0.50 = 50%)',
+    example: 0.5,
+    minimum: 0.1,
+    maximum: 1.0,
+    required: false
+  })
+  slippageRejectThreshold?: number;
+
+  @IsNumber()
+  @Min(0.01)
+  @Max(1.0)
+  @IsOptional()
+  @ApiProperty({
+    description: 'Volatility factor (sigma) for square-root impact model',
+    example: 0.1,
+    default: 0.1,
+    minimum: 0.01,
+    maximum: 1.0,
+    required: false
+  })
+  slippageVolatilityFactor?: number;
 
   @IsDateString()
   @IsNotEmpty()

--- a/apps/api/src/order/backtest/shared/slippage/slippage.interface.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage.interface.ts
@@ -29,10 +29,14 @@ export interface SlippageConfig {
   fixedBps?: number;
   /** Base slippage in basis points (for VOLUME_BASED model) */
   baseSlippageBps?: number;
-  /** Multiplier for volume impact (for VOLUME_BASED model) */
-  volumeImpactFactor?: number;
   /** Maximum slippage in basis points (default: 500 = 5%) */
   maxSlippageBps?: number;
+  /** Max fraction of daily volume for a single order (e.g., 0.05 = 5%). Undefined = no limit. */
+  participationRateLimit?: number;
+  /** If raw order exceeds this fraction, reject entirely (e.g., 0.50 = 50%). Undefined = no rejection. */
+  rejectParticipationRate?: number;
+  /** Volatility factor (sigma) for square-root impact model (default: 0.1) */
+  volatilityFactor?: number;
 }
 
 /**
@@ -64,13 +68,25 @@ export interface SlippageInput {
 }
 
 /**
+ * Fill assessment result from volume participation analysis
+ */
+export interface FillAssessment {
+  fillable: boolean;
+  fillableQuantity: number;
+  fillStatus: 'FILLED' | 'PARTIAL' | 'CANCELLED';
+  participationRate: number;
+  reason?: string;
+}
+
+/**
  * Default slippage configuration
  * Uses fixed 5 bps (0.05%) slippage as a conservative default
  */
 export const DEFAULT_SLIPPAGE_CONFIG: SlippageConfig = {
   type: SlippageModelType.FIXED,
   fixedBps: 5,
-  maxSlippageBps: 500
+  maxSlippageBps: 500,
+  volatilityFactor: 0.1
 };
 
 /**
@@ -110,4 +126,19 @@ export interface ISlippageService {
    * @returns Complete SlippageConfig with defaults applied
    */
   buildConfig(config?: Partial<SlippageConfig>): SlippageConfig;
+
+  /**
+   * Assess whether an order can be filled given daily volume constraints
+   * @param orderValue Total order value in quote currency
+   * @param price Current price per unit
+   * @param dailyVolume Daily trading volume in quote currency
+   * @param config Slippage configuration with participation limits
+   * @returns FillAssessment with fillable quantity and status
+   */
+  assessFillability(
+    orderValue: number,
+    price: number,
+    dailyVolume: number | undefined,
+    config?: SlippageConfig
+  ): FillAssessment;
 }

--- a/apps/api/src/order/backtest/shared/slippage/slippage.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage.service.spec.ts
@@ -35,105 +35,80 @@ describe('SlippageService', () => {
         const config: SlippageConfig = { type: SlippageModelType.FIXED };
         expect(service.calculateSlippageBps(100, 50000, config)).toBe(5);
       });
-
-      it('should ignore quantity and price for fixed model', () => {
-        const config: SlippageConfig = {
-          type: SlippageModelType.FIXED,
-          fixedBps: 15
-        };
-        expect(service.calculateSlippageBps(1, 1, config)).toBe(15);
-        expect(service.calculateSlippageBps(1000000, 100000, config)).toBe(15);
-      });
     });
 
     describe('VOLUME_BASED model', () => {
       it('should increase slippage with larger order size relative to volume', () => {
         const config: SlippageConfig = {
           type: SlippageModelType.VOLUME_BASED,
-          baseSlippageBps: 5,
-          volumeImpactFactor: 100
+          baseSlippageBps: 5
         };
 
-        // Small order (1% of daily volume)
         const smallOrder = service.calculateSlippageBps(100, 50000, config, 500000000);
-        // Medium order (10% of daily volume)
         const mediumOrder = service.calculateSlippageBps(1000, 50000, config, 500000000);
-        // Large order (50% of daily volume)
         const largeOrder = service.calculateSlippageBps(5000, 50000, config, 500000000);
 
         expect(smallOrder).toBeLessThan(mediumOrder);
         expect(mediumOrder).toBeLessThan(largeOrder);
       });
 
-      it('should calculate slippage from order value and volume', () => {
+      it('should calculate slippage using square-root impact model', () => {
         const config: SlippageConfig = {
           type: SlippageModelType.VOLUME_BASED,
           baseSlippageBps: 5,
-          volumeImpactFactor: 100
+          volatilityFactor: 0.1
         };
 
-        // orderValue = 10 * 100 = 1000; volumeRatio = 0.01
+        // orderValue = 10 * 100 = 1000; participationRate = 0.01
+        // impact = 0.1 * sqrt(0.01) = 0.1 * 0.1 = 0.01 => 100 bps
+        // total = 5 + 100 = 105
         const result = service.calculateSlippageBps(10, 100, config, 100000);
-        expect(result).toBe(6);
-      });
-
-      it('should use default values when not specified', () => {
-        const config: SlippageConfig = { type: SlippageModelType.VOLUME_BASED };
-        const result = service.calculateSlippageBps(100, 50000, config, 500000000);
-        // Should be base 5 + volume impact
-        expect(result).toBeGreaterThanOrEqual(5);
+        expect(result).toBeCloseTo(105, 5);
       });
 
       it('should cap slippage at maxSlippageBps', () => {
         const config: SlippageConfig = {
           type: SlippageModelType.VOLUME_BASED,
           baseSlippageBps: 5,
-          volumeImpactFactor: 1000,
+          volatilityFactor: 0.5,
           maxSlippageBps: 500
         };
-        // Very large order relative to volume
         const result = service.calculateSlippageBps(1000000, 50000, config, 1000000);
         expect(result).toBeLessThanOrEqual(500);
       });
 
-      it('should handle missing volume with small default ratio', () => {
+      it.each([
+        ['missing', undefined],
+        ['zero', 0],
+        ['negative', -1000]
+      ])('should return baseSlippageBps when volume is %s', (_label, volume) => {
         const config: SlippageConfig = {
           type: SlippageModelType.VOLUME_BASED,
-          baseSlippageBps: 5,
-          volumeImpactFactor: 100
+          baseSlippageBps: 5
         };
-        const result = service.calculateSlippageBps(100, 50000, config);
-        // Should use default 0.001 volume ratio
-        expect(result).toBeGreaterThanOrEqual(5);
+        const result = service.calculateSlippageBps(100, 50000, config, volume);
+        expect(result).toBe(5);
       });
 
-      it('should handle zero volume gracefully', () => {
+      it('should show convexity: doubling order increases impact by ~sqrt(2)x, not 2x', () => {
         const config: SlippageConfig = {
           type: SlippageModelType.VOLUME_BASED,
-          baseSlippageBps: 5,
-          volumeImpactFactor: 100
+          baseSlippageBps: 0,
+          volatilityFactor: 0.1,
+          maxSlippageBps: 10000
         };
-        const result = service.calculateSlippageBps(100, 50000, config, 0);
-        expect(result).toBeGreaterThanOrEqual(5);
-      });
-
-      it('should fall back to default ratio when volume is negative', () => {
-        const config: SlippageConfig = {
-          type: SlippageModelType.VOLUME_BASED,
-          baseSlippageBps: 5,
-          volumeImpactFactor: 100
-        };
-        const result = service.calculateSlippageBps(10, 100, config, -1000);
-        expect(result).toBeCloseTo(5.1, 5);
+        const dailyVolume = 1000000;
+        const small = service.calculateSlippageBps(100, 100, config, dailyVolume);
+        const double = service.calculateSlippageBps(200, 100, config, dailyVolume);
+        expect(double / small).toBeCloseTo(Math.sqrt(2), 2);
       });
 
       it('should cap slippage using default max when maxSlippageBps not provided', () => {
         const config: SlippageConfig = {
           type: SlippageModelType.VOLUME_BASED,
           baseSlippageBps: 5,
-          volumeImpactFactor: 1000
+          volatilityFactor: 0.5
         };
-        // Very large order; should be capped at default 500 bps
         const result = service.calculateSlippageBps(1000000, 50000, config, 1000000);
         expect(result).toBe(500);
       });
@@ -174,62 +149,31 @@ describe('SlippageService', () => {
   describe('applySlippage', () => {
     const basePrice = 50000;
 
-    describe('BUY orders', () => {
-      it('should increase price for buy orders', () => {
-        const result = service.applySlippage(basePrice, 10, true);
-        // 10 bps = 0.1% increase = 50000 * 0.001 = 50
-        expect(result).toBeCloseTo(50050, 2);
-      });
-
-      it('should handle zero slippage', () => {
-        const result = service.applySlippage(basePrice, 0, true);
-        expect(result).toBe(basePrice);
-      });
-
-      it('should handle large slippage correctly', () => {
-        const result = service.applySlippage(basePrice, 100, true);
-        // 100 bps = 1% increase = 50000 * 0.01 = 500
-        expect(result).toBeCloseTo(50500, 2);
-      });
+    it('should increase price for buy orders', () => {
+      const result = service.applySlippage(basePrice, 10, true);
+      expect(result).toBeCloseTo(50050, 2);
     });
 
-    describe('SELL orders', () => {
-      it('should decrease price for sell orders', () => {
-        const result = service.applySlippage(basePrice, 10, false);
-        // 10 bps = 0.1% decrease = 50000 * 0.001 = 50
-        expect(result).toBeCloseTo(49950, 2);
-      });
+    it('should decrease price for sell orders', () => {
+      const result = service.applySlippage(basePrice, 10, false);
+      expect(result).toBeCloseTo(49950, 2);
+    });
 
-      it('should handle zero slippage', () => {
-        const result = service.applySlippage(basePrice, 0, false);
-        expect(result).toBe(basePrice);
-      });
-
-      it('should handle large slippage correctly', () => {
-        const result = service.applySlippage(basePrice, 100, false);
-        // 100 bps = 1% decrease = 50000 * 0.01 = 500
-        expect(result).toBeCloseTo(49500, 2);
-      });
+    it('should return original price for zero slippage', () => {
+      expect(service.applySlippage(basePrice, 0, true)).toBe(basePrice);
+      expect(service.applySlippage(basePrice, 0, false)).toBe(basePrice);
     });
 
     it('should be symmetric for buy and sell', () => {
       const slippageBps = 50;
       const buyPrice = service.applySlippage(basePrice, slippageBps, true);
       const sellPrice = service.applySlippage(basePrice, slippageBps, false);
-
-      // Buy adds, sell subtracts the same amount (within floating point tolerance)
       expect(buyPrice - basePrice).toBeCloseTo(basePrice - sellPrice, 2);
     });
 
     it('should handle fractional bps with precision', () => {
       const result = service.applySlippage(basePrice, 12.5, true);
       expect(result).toBeCloseTo(50062.5, 5);
-    });
-
-    it('should increase price impact with higher bps', () => {
-      const low = service.applySlippage(basePrice, 5, true);
-      const high = service.applySlippage(basePrice, 50, true);
-      expect(high - basePrice).toBeGreaterThan(low - basePrice);
     });
   });
 
@@ -242,15 +186,13 @@ describe('SlippageService', () => {
         dailyVolume: 1000000
       });
 
-      expect(result).toHaveProperty('slippageBps');
-      expect(result).toHaveProperty('executionPrice');
-      expect(result).toHaveProperty('priceImpact');
-      expect(result).toHaveProperty('originalPrice');
       expect(result.originalPrice).toBe(50000);
       expect(result.executionPrice).toBeGreaterThan(50000);
+      expect(result.slippageBps).toBeGreaterThan(0);
+      expect(result.priceImpact).toBeGreaterThan(0);
     });
 
-    it('should return complete SlippageResult for sell order', () => {
+    it('should return lower execution price for sell order', () => {
       const result = service.calculateSlippage({
         price: 50000,
         quantity: 1,
@@ -272,26 +214,19 @@ describe('SlippageService', () => {
         { type: SlippageModelType.FIXED, fixedBps: 10 }
       );
 
-      // 10 bps = 0.1% = 0.001
       expect(result.priceImpact).toBeCloseTo(0.001, 5);
     });
 
     it('should use custom config when provided', () => {
-      const customConfig: SlippageConfig = {
-        type: SlippageModelType.FIXED,
-        fixedBps: 20
-      };
-
       const result = service.calculateSlippage(
         {
           price: 10000,
           quantity: 1,
           isBuy: true
         },
-        customConfig
+        { type: SlippageModelType.FIXED, fixedBps: 20 }
       );
 
-      // 20 bps = 0.2% = 0.002 price impact
       expect(result.slippageBps).toBe(20);
       expect(result.priceImpact).toBeCloseTo(0.002, 5);
     });
@@ -303,7 +238,6 @@ describe('SlippageService', () => {
         isBuy: true
       });
 
-      // Default is FIXED with 5 bps
       expect(result.slippageBps).toBe(5);
     });
 
@@ -323,40 +257,15 @@ describe('SlippageService', () => {
     });
 
     describe('input validation', () => {
-      it('should throw error for zero price', () => {
+      it.each([
+        ['zero', 0],
+        ['negative', -100],
+        ['NaN', NaN],
+        ['Infinity', Infinity]
+      ])('should throw error for %s price', (_label, price) => {
         expect(() =>
           service.calculateSlippage({
-            price: 0,
-            quantity: 1,
-            isBuy: true
-          })
-        ).toThrow('Price must be a positive finite number');
-      });
-
-      it('should throw error for negative price', () => {
-        expect(() =>
-          service.calculateSlippage({
-            price: -100,
-            quantity: 1,
-            isBuy: true
-          })
-        ).toThrow('Price must be a positive finite number');
-      });
-
-      it('should throw error for NaN price', () => {
-        expect(() =>
-          service.calculateSlippage({
-            price: NaN,
-            quantity: 1,
-            isBuy: true
-          })
-        ).toThrow('Price must be a positive finite number');
-      });
-
-      it('should throw error for Infinity price', () => {
-        expect(() =>
-          service.calculateSlippage({
-            price: Infinity,
+            price,
             quantity: 1,
             isBuy: true
           })
@@ -371,15 +280,19 @@ describe('SlippageService', () => {
         type: SlippageModelType.VOLUME_BASED,
         fixedBps: 10,
         baseSlippageBps: 7,
-        volumeImpactFactor: 150,
-        maxSlippageBps: 300
+        maxSlippageBps: 300,
+        participationRateLimit: 0.05,
+        rejectParticipationRate: 0.5,
+        volatilityFactor: 0.2
       });
 
       expect(config.type).toBe(SlippageModelType.VOLUME_BASED);
       expect(config.fixedBps).toBe(10);
       expect(config.baseSlippageBps).toBe(7);
-      expect(config.volumeImpactFactor).toBe(150);
       expect(config.maxSlippageBps).toBe(300);
+      expect(config.participationRateLimit).toBe(0.05);
+      expect(config.rejectParticipationRate).toBe(0.5);
+      expect(config.volatilityFactor).toBe(0.2);
     });
 
     it('should use defaults when parameters not provided', () => {
@@ -388,41 +301,88 @@ describe('SlippageService', () => {
       expect(config.type).toBe(SlippageModelType.FIXED);
       expect(config.fixedBps).toBe(5);
       expect(config.baseSlippageBps).toBe(5);
-      expect(config.volumeImpactFactor).toBe(100);
       expect(config.maxSlippageBps).toBe(500);
+      expect(config.volatilityFactor).toBe(0.1);
+      expect(config.participationRateLimit).toBeUndefined();
+      expect(config.rejectParticipationRate).toBeUndefined();
+    });
+  });
+
+  describe('assessFillability', () => {
+    const volumeConfig: SlippageConfig = {
+      type: SlippageModelType.VOLUME_BASED,
+      participationRateLimit: 0.05,
+      rejectParticipationRate: 0.5
+    };
+
+    it('should return FILLED when order is within participation limit', () => {
+      const result = service.assessFillability(1000, 100, 100000, volumeConfig);
+      expect(result.fillStatus).toBe('FILLED');
+      expect(result.fillable).toBe(true);
+      expect(result.fillableQuantity).toBe(10);
+      expect(result.participationRate).toBeCloseTo(0.01);
     });
 
-    it('should handle partial parameters', () => {
-      const config = service.buildConfig({
-        type: SlippageModelType.FIXED,
-        fixedBps: 20
-      });
-
-      expect(config.type).toBe(SlippageModelType.FIXED);
-      expect(config.fixedBps).toBe(20);
-      expect(config.baseSlippageBps).toBe(5);
-      expect(config.volumeImpactFactor).toBe(100);
-      expect(config.maxSlippageBps).toBe(500);
+    it('should return PARTIAL when order exceeds participation limit', () => {
+      const result = service.assessFillability(10000, 100, 100000, volumeConfig);
+      expect(result.fillStatus).toBe('PARTIAL');
+      expect(result.fillable).toBe(true);
+      expect(result.fillableQuantity).toBe(50);
+      expect(result.participationRate).toBeCloseTo(0.1);
+      expect(result.reason).toContain('5.0%');
     });
 
-    it('should default model when only other values are provided', () => {
-      const config = service.buildConfig({
-        fixedBps: 12,
-        volumeImpactFactor: 200
-      });
+    it('should return CANCELLED when order exceeds reject threshold', () => {
+      const result = service.assessFillability(60000, 100, 100000, volumeConfig);
+      expect(result.fillStatus).toBe('CANCELLED');
+      expect(result.fillable).toBe(false);
+      expect(result.fillableQuantity).toBe(0);
+      expect(result.participationRate).toBeCloseTo(0.6);
+      expect(result.reason).toContain('rejection threshold');
+    });
 
-      expect(config.type).toBe(SlippageModelType.FIXED);
-      expect(config.fixedBps).toBe(12);
-      expect(config.baseSlippageBps).toBe(5);
-      expect(config.volumeImpactFactor).toBe(200);
+    it.each([
+      ['undefined', undefined],
+      ['zero', 0]
+    ])('should return FILLED when volume is %s (graceful degradation)', (_label, volume) => {
+      const result = service.assessFillability(10000, 100, volume, volumeConfig);
+      expect(result.fillStatus).toBe('FILLED');
+      expect(result.fillable).toBe(true);
+      expect(result.participationRate).toBe(0);
+    });
+
+    it.each([
+      ['NONE', SlippageModelType.NONE],
+      ['FIXED', SlippageModelType.FIXED]
+    ])('should always return FILLED for %s model', (_label, type) => {
+      const config: SlippageConfig = { type, participationRateLimit: 0.01 };
+      const result = service.assessFillability(100000, 100, 1000, config);
+      expect(result.fillStatus).toBe('FILLED');
+      expect(result.fillable).toBe(true);
+    });
+
+    it('should return FILLED when no participation limits are set', () => {
+      const config: SlippageConfig = { type: SlippageModelType.VOLUME_BASED };
+      const result = service.assessFillability(50000, 100, 100000, config);
+      expect(result.fillStatus).toBe('FILLED');
+      expect(result.fillable).toBe(true);
+      expect(result.participationRate).toBeCloseTo(0.5);
+    });
+
+    it('should return fillableQuantity 0 when price is 0', () => {
+      const config: SlippageConfig = { type: SlippageModelType.VOLUME_BASED };
+      const result = service.assessFillability(10000, 0, 100000, config);
+      expect(result.fillStatus).toBe('FILLED');
+      expect(result.fillableQuantity).toBe(0);
     });
   });
 
   describe('DEFAULT_SLIPPAGE_CONFIG', () => {
-    it('should have FIXED model with 5 bps and 500 max', () => {
+    it('should have FIXED model with 5 bps, 500 max, and volatilityFactor 0.1', () => {
       expect(DEFAULT_SLIPPAGE_CONFIG.type).toBe(SlippageModelType.FIXED);
       expect(DEFAULT_SLIPPAGE_CONFIG.fixedBps).toBe(5);
       expect(DEFAULT_SLIPPAGE_CONFIG.maxSlippageBps).toBe(500);
+      expect(DEFAULT_SLIPPAGE_CONFIG.volatilityFactor).toBe(0.1);
     });
   });
 });

--- a/apps/api/src/order/backtest/shared/slippage/slippage.service.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import {
   DEFAULT_SLIPPAGE_CONFIG,
+  FillAssessment,
   ISlippageService,
   SlippageConfig,
   SlippageInput,
@@ -75,12 +76,17 @@ export class SlippageService implements ISlippageService {
         break;
 
       case SlippageModelType.VOLUME_BASED: {
-        // Slippage increases with order size relative to daily volume
         const orderValue = quantity * price;
-        const volumeRatio = dailyVolume && dailyVolume > 0 ? orderValue / dailyVolume : 0.001;
         const baseSlippage = effectiveConfig.baseSlippageBps ?? 5;
-        const volumeImpact = effectiveConfig.volumeImpactFactor ?? 100;
-        slippageBps = baseSlippage + volumeRatio * volumeImpact;
+        if (!dailyVolume || dailyVolume <= 0) {
+          slippageBps = baseSlippage;
+          break;
+        }
+        const participationRate = orderValue / dailyVolume;
+        const sigma = effectiveConfig.volatilityFactor ?? 0.1;
+        // Almgren-Chriss square-root temporary impact: impact ∝ σ * √(Q/V)
+        const impactDecimal = sigma * Math.sqrt(participationRate);
+        slippageBps = baseSlippage + impactDecimal * 10000;
         break;
       }
 
@@ -109,6 +115,63 @@ export class SlippageService implements ISlippageService {
   }
 
   /**
+   * Assess whether an order can be filled given daily volume constraints.
+   * Only applies participation limits for VOLUME_BASED model with defined volume.
+   */
+  assessFillability(
+    orderValue: number,
+    price: number,
+    dailyVolume: number | undefined,
+    config: SlippageConfig = DEFAULT_SLIPPAGE_CONFIG
+  ): FillAssessment {
+    const effectiveConfig = this.buildConfig(config);
+    const orderQuantity = price > 0 ? orderValue / price : 0;
+
+    // Non-VOLUME_BASED models or missing volume: always full fill
+    if (effectiveConfig.type !== SlippageModelType.VOLUME_BASED || !dailyVolume || dailyVolume <= 0) {
+      return { fillable: true, fillableQuantity: orderQuantity, fillStatus: 'FILLED', participationRate: 0 };
+    }
+
+    const rawParticipationRate = orderValue / dailyVolume;
+
+    // Check rejection threshold first
+    if (
+      effectiveConfig.rejectParticipationRate != null &&
+      rawParticipationRate >= effectiveConfig.rejectParticipationRate
+    ) {
+      return {
+        fillable: false,
+        fillableQuantity: 0,
+        fillStatus: 'CANCELLED',
+        participationRate: rawParticipationRate,
+        reason: `Order participation rate ${(rawParticipationRate * 100).toFixed(1)}% exceeds rejection threshold ${(effectiveConfig.rejectParticipationRate * 100).toFixed(1)}%`
+      };
+    }
+
+    // Check participation rate limit for partial fill
+    if (
+      effectiveConfig.participationRateLimit != null &&
+      rawParticipationRate > effectiveConfig.participationRateLimit
+    ) {
+      const fillableQuantity = (effectiveConfig.participationRateLimit * dailyVolume) / price;
+      return {
+        fillable: true,
+        fillableQuantity,
+        fillStatus: 'PARTIAL',
+        participationRate: rawParticipationRate,
+        reason: `Order capped to ${(effectiveConfig.participationRateLimit * 100).toFixed(1)}% participation rate`
+      };
+    }
+
+    return {
+      fillable: true,
+      fillableQuantity: orderQuantity,
+      fillStatus: 'FILLED',
+      participationRate: rawParticipationRate
+    };
+  }
+
+  /**
    * Build complete configuration from partial inputs with defaults
    */
   buildConfig(config?: Partial<SlippageConfig>): SlippageConfig {
@@ -116,8 +179,10 @@ export class SlippageService implements ISlippageService {
       type: config?.type ?? SlippageModelType.FIXED,
       fixedBps: config?.fixedBps ?? 5,
       baseSlippageBps: config?.baseSlippageBps ?? 5,
-      volumeImpactFactor: config?.volumeImpactFactor ?? 100,
-      maxSlippageBps: config?.maxSlippageBps ?? 500
+      maxSlippageBps: config?.maxSlippageBps ?? 500,
+      participationRateLimit: config?.participationRateLimit,
+      rejectParticipationRate: config?.rejectParticipationRate,
+      volatilityFactor: config?.volatilityFactor ?? 0.1
     };
   }
 }


### PR DESCRIPTION
## Summary

- Replace linear slippage model with Almgren-Chriss square-root temporary impact model (`σ√(Q/V)`) for realistic volume-aware fill simulation
- Add participation rate limits with partial fill and rejection thresholds based on risk level
- Introduce pre-trade volume feasibility checks (`assessFillability()`) and handle CANCELLED/PARTIAL fill statuses across all trade execution paths

## Changes

- **Backtest Engine** (`backtest-engine.service.ts`) — Move slippage calculation after position sizing; add volume-aware fill assessment to all trade types (BUY, SELL, SHORT, CLOSE_SHORT); handle partial fills and cancellations
- **Slippage Service** (`slippage.service.ts`) — Implement square-root impact model; add `assessFillability()` with participation rate checks; add `getParticipationDefaults()` with risk-level-based limits
- **Slippage Interface** (`slippage.interface.ts`) — Replace `volumeImpactFactor` with `volatilityFactor`; add `FillAssessment` and `FillStatus` types
- **Backtest DTO** (`backtest.dto.ts`) — Expose new fields: `slippageParticipationRate`, `slippageRejectThreshold`, `slippageVolatilityFactor`
- **Tests** — Add comprehensive tests for fill assessment and square-root impact convexity; remove redundant low-value tests

## Test Plan

- [ ] `npx nx test api -- --testPathPattern='slippage.service.spec'` passes
- [ ] `npx nx test api -- --testPathPattern='backtest-engine.service.spec'` passes
- [ ] Backtest runs with default parameters produce realistic fill rates
- [ ] High participation rate trades correctly result in partial fills or rejections