### PR TITLE
refactor(api): split paper trading engine into focused services

### DIFF
--- a/apps/api/src/order/paper-trading/engine/paper-trading-engine.utils.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-engine.utils.spec.ts
@@ -1,0 +1,216 @@
+import {
+  buildPriceDataContext,
+  classifySignalType,
+  extractCoinsFromPrices,
+  extractSymbolsFromConfig,
+  mapStrategySignal,
+  resolveMinHoldMs,
+  resolveOpportunitySellingConfig,
+  toExitType,
+  TradingSignal
+} from './paper-trading-engine.utils';
+
+import { SignalType as AlgoSignalType, TradingSignal as StrategySignal } from '../../../algorithm/interfaces';
+import { PaperTradingExitType, PaperTradingSignalType } from '../entities';
+
+describe('paper-trading-engine.utils', () => {
+  describe('toExitType', () => {
+    it('returns undefined for null/empty', () => {
+      expect(toExitType(null)).toBeUndefined();
+      expect(toExitType(undefined)).toBeUndefined();
+      expect(toExitType('')).toBeUndefined();
+    });
+
+    it('returns undefined for invalid values', () => {
+      expect(toExitType('not-a-real-exit')).toBeUndefined();
+    });
+
+    it('returns the exit type for valid values', () => {
+      const valid = Object.values(PaperTradingExitType)[0];
+      expect(toExitType(valid as string)).toBe(valid);
+    });
+  });
+
+  describe('mapStrategySignal', () => {
+    const base: StrategySignal = {
+      type: AlgoSignalType.BUY,
+      coinId: 'BTC',
+      reason: 'test',
+      confidence: 0.8,
+      strength: 0.5,
+      quantity: 1,
+      metadata: { foo: 'bar' }
+    } as unknown as StrategySignal;
+
+    it('maps BUY to BUY action and builds symbol', () => {
+      const result = mapStrategySignal(base, 'USD');
+      expect(result.action).toBe('BUY');
+      expect(result.symbol).toBe('BTC/USD');
+      expect(result.coinId).toBe('BTC');
+      expect(result.originalType).toBe(AlgoSignalType.BUY);
+    });
+
+    it('maps SELL, STOP_LOSS, TAKE_PROFIT to SELL', () => {
+      for (const t of [AlgoSignalType.SELL, AlgoSignalType.STOP_LOSS, AlgoSignalType.TAKE_PROFIT]) {
+        const r = mapStrategySignal({ ...base, type: t } as StrategySignal, 'USD');
+        expect(r.action).toBe('SELL');
+        expect(r.originalType).toBe(t);
+      }
+    });
+
+    it('maps SHORT_ENTRY and SHORT_EXIT', () => {
+      expect(mapStrategySignal({ ...base, type: AlgoSignalType.SHORT_ENTRY } as StrategySignal, 'USD').action).toBe(
+        'OPEN_SHORT'
+      );
+      expect(mapStrategySignal({ ...base, type: AlgoSignalType.SHORT_EXIT } as StrategySignal, 'USD').action).toBe(
+        'CLOSE_SHORT'
+      );
+    });
+  });
+
+  describe('classifySignalType', () => {
+    const mk = (overrides: Partial<TradingSignal>): TradingSignal =>
+      ({ action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', reason: 'x', ...overrides }) as TradingSignal;
+
+    it('classifies STOP_LOSS/TAKE_PROFIT as RISK_CONTROL', () => {
+      expect(classifySignalType(mk({ originalType: AlgoSignalType.STOP_LOSS }))).toBe(
+        PaperTradingSignalType.RISK_CONTROL
+      );
+      expect(classifySignalType(mk({ originalType: AlgoSignalType.TAKE_PROFIT }))).toBe(
+        PaperTradingSignalType.RISK_CONTROL
+      );
+    });
+
+    it('classifies BUY and OPEN_SHORT as ENTRY', () => {
+      expect(classifySignalType(mk({ action: 'BUY' }))).toBe(PaperTradingSignalType.ENTRY);
+      expect(classifySignalType(mk({ action: 'OPEN_SHORT' }))).toBe(PaperTradingSignalType.ENTRY);
+    });
+
+    it('classifies SELL and CLOSE_SHORT as EXIT', () => {
+      expect(classifySignalType(mk({ action: 'SELL' }))).toBe(PaperTradingSignalType.EXIT);
+      expect(classifySignalType(mk({ action: 'CLOSE_SHORT' }))).toBe(PaperTradingSignalType.EXIT);
+    });
+
+    it('classifies HOLD as ADJUSTMENT', () => {
+      expect(classifySignalType(mk({ action: 'HOLD' }))).toBe(PaperTradingSignalType.ADJUSTMENT);
+    });
+  });
+
+  describe('resolveMinHoldMs', () => {
+    const DEFAULT = 24 * 60 * 60 * 1000;
+    it('returns default when config missing', () => {
+      expect(resolveMinHoldMs()).toBe(DEFAULT);
+      expect(resolveMinHoldMs({})).toBe(DEFAULT);
+    });
+    it('returns default for invalid values', () => {
+      expect(resolveMinHoldMs({ minHoldMs: -1 })).toBe(DEFAULT);
+      expect(resolveMinHoldMs({ minHoldMs: 'x' })).toBe(DEFAULT);
+      expect(resolveMinHoldMs({ minHoldMs: Infinity })).toBe(DEFAULT);
+    });
+    it('returns the configured value', () => {
+      expect(resolveMinHoldMs({ minHoldMs: 5000 })).toBe(5000);
+      expect(resolveMinHoldMs({ minHoldMs: 0 })).toBe(0);
+    });
+  });
+
+  describe('extractSymbolsFromConfig', () => {
+    it('returns empty for undefined config', () => {
+      expect(extractSymbolsFromConfig()).toEqual([]);
+    });
+
+    it('extracts from symbols and tradingPairs', () => {
+      expect(extractSymbolsFromConfig({ symbols: ['BTC/USD'], tradingPairs: ['ETH/USD'] })).toEqual([
+        'BTC/USD',
+        'ETH/USD'
+      ]);
+    });
+
+    it('deduplicates across and within arrays', () => {
+      const result = extractSymbolsFromConfig({
+        symbols: ['BTC/USD', 'ETH/USD', 'BTC/USD'],
+        tradingPairs: ['ETH/USD', 'SOL/USD']
+      });
+      expect(result).toEqual(['BTC/USD', 'ETH/USD', 'SOL/USD']);
+    });
+
+    it('ignores non-string entries', () => {
+      expect(extractSymbolsFromConfig({ symbols: ['BTC/USD', 123, null] as unknown[] })).toEqual(['BTC/USD']);
+    });
+  });
+
+  describe('extractCoinsFromPrices', () => {
+    it('extracts unique base currencies', () => {
+      const result = extractCoinsFromPrices({ 'BTC/USD': 1, 'ETH/USD': 2, 'BTC/USDT': 3 });
+      expect(result).toEqual([
+        { id: 'BTC', symbol: 'BTC' },
+        { id: 'ETH', symbol: 'ETH' }
+      ]);
+    });
+
+    it('returns empty for empty prices', () => {
+      expect(extractCoinsFromPrices({})).toEqual([]);
+    });
+  });
+
+  describe('buildPriceDataContext', () => {
+    it('creates single-candle entry when no history', () => {
+      const ctx = buildPriceDataContext({ 'BTC/USD': 100 });
+      expect(ctx.BTC).toHaveLength(1);
+      expect(ctx.BTC[0].avg).toBe(100);
+    });
+
+    it('appends current price to historical candles', () => {
+      const past = new Date('2024-01-01');
+      const ctx = buildPriceDataContext(
+        { 'BTC/USD': 150 },
+        { 'BTC/USD': [{ avg: 100, high: 110, low: 90, date: past }] }
+      );
+      expect(ctx.BTC).toHaveLength(2);
+      expect(ctx.BTC[1].avg).toBe(150);
+    });
+
+    it('prefers the longer candidate when multiple symbols share a base', () => {
+      const past = new Date('2024-01-01');
+      const ctx = buildPriceDataContext(
+        { 'BTC/USD': 150, 'BTC/USDT': 151 },
+        { 'BTC/USD': [{ avg: 100, high: 110, low: 90, date: past }] }
+      );
+      expect(ctx.BTC.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('resolveOpportunitySellingConfig', () => {
+    it('returns disabled default when config missing', () => {
+      const result = resolveOpportunitySellingConfig();
+      expect(result.enabled).toBe(false);
+      expect(result.config).toBeDefined();
+    });
+
+    it('returns disabled when enableOpportunitySelling is false', () => {
+      const result = resolveOpportunitySellingConfig({ enableOpportunitySelling: false });
+      expect(result.enabled).toBe(false);
+    });
+
+    it('returns enabled with default config when enabled but no user config', () => {
+      const result = resolveOpportunitySellingConfig({ enableOpportunitySelling: true });
+      expect(result.enabled).toBe(true);
+    });
+
+    it('clamps user values into valid ranges', () => {
+      const result = resolveOpportunitySellingConfig({
+        enableOpportunitySelling: true,
+        opportunitySellingConfig: {
+          minOpportunityConfidence: 99,
+          minHoldingPeriodHours: -5,
+          maxLiquidationPercent: 500,
+          protectedCoins: ['BTC']
+        }
+      });
+      expect(result.enabled).toBe(true);
+      expect(result.config.minOpportunityConfidence).toBeLessThanOrEqual(1);
+      expect(result.config.minHoldingPeriodHours).toBeGreaterThanOrEqual(0);
+      expect(result.config.maxLiquidationPercent).toBeLessThanOrEqual(100);
+      expect(result.config.protectedCoins).toEqual(['BTC']);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-engine.utils.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-engine.utils.ts
@@ -1,0 +1,226 @@
+import { SignalType as AlgoSignalType, TradingSignal as StrategySignal } from '../../../algorithm/interfaces';
+import { CandleData } from '../../../ohlc/ohlc-candle.entity';
+import { DEFAULT_OPPORTUNITY_SELLING_CONFIG, OpportunitySellingUserConfig } from '../../backtest/shared';
+import { PaperTradingExitType, PaperTradingOrder, PaperTradingSignalType } from '../entities';
+
+// ─── Public Types ───────────────────────────────────────────────────────────
+
+export interface TradingSignal {
+  action: 'BUY' | 'SELL' | 'HOLD' | 'OPEN_SHORT' | 'CLOSE_SHORT';
+  coinId: string;
+  symbol: string;
+  quantity?: number;
+  percentage?: number;
+  reason: string;
+  confidence?: number;
+  metadata?: Record<string, any>;
+  /** Preserves the original algorithm signal type (e.g. STOP_LOSS, TAKE_PROFIT) */
+  originalType?: AlgoSignalType;
+}
+
+export interface TickResult {
+  processed: boolean;
+  signalsReceived: number;
+  ordersExecuted: number;
+  errors: string[];
+  portfolioValue: number;
+  prices: Record<string, number>;
+}
+
+export type ExecuteOrderStatus = 'success' | 'insufficient_funds' | 'no_price' | 'no_position' | 'hold_period';
+
+export interface ExecuteOrderResult {
+  status: ExecuteOrderStatus;
+  order: PaperTradingOrder | null;
+}
+
+// ─── Exit Type Helpers ──────────────────────────────────────────────────────
+
+export const VALID_EXIT_TYPES = new Set(Object.values(PaperTradingExitType));
+
+/** Safely convert an unknown string to PaperTradingExitType, returning undefined for invalid values */
+export function toExitType(value: string | undefined | null): PaperTradingExitType | undefined {
+  if (!value) return undefined;
+  return VALID_EXIT_TYPES.has(value as PaperTradingExitType) ? (value as PaperTradingExitType) : undefined;
+}
+
+// ─── Signal Mapping ─────────────────────────────────────────────────────────
+
+export const mapStrategySignal = (signal: StrategySignal, quoteCurrency: string): TradingSignal => {
+  let action: TradingSignal['action'];
+  switch (signal.type) {
+    case AlgoSignalType.BUY:
+      action = 'BUY';
+      break;
+    case AlgoSignalType.SELL:
+    case AlgoSignalType.STOP_LOSS:
+    case AlgoSignalType.TAKE_PROFIT:
+      action = 'SELL';
+      break;
+    case AlgoSignalType.SHORT_ENTRY:
+      action = 'OPEN_SHORT';
+      break;
+    case AlgoSignalType.SHORT_EXIT:
+      action = 'CLOSE_SHORT';
+      break;
+    default:
+      action = 'HOLD';
+  }
+
+  const symbol = `${signal.coinId}/${quoteCurrency}`;
+
+  return {
+    action,
+    coinId: signal.coinId,
+    symbol,
+    quantity: signal.quantity,
+    percentage: signal.strength,
+    reason: signal.reason,
+    confidence: signal.confidence,
+    metadata: signal.metadata as Record<string, any>,
+    originalType: signal.type
+  };
+};
+
+export const classifySignalType = (signal: TradingSignal): PaperTradingSignalType => {
+  if (signal.originalType === AlgoSignalType.STOP_LOSS || signal.originalType === AlgoSignalType.TAKE_PROFIT) {
+    return PaperTradingSignalType.RISK_CONTROL;
+  }
+  if (signal.action === 'BUY' || signal.action === 'OPEN_SHORT') return PaperTradingSignalType.ENTRY;
+  if (signal.action === 'SELL' || signal.action === 'CLOSE_SHORT') return PaperTradingSignalType.EXIT;
+  return PaperTradingSignalType.ADJUSTMENT;
+};
+
+// ─── Config Resolvers ───────────────────────────────────────────────────────
+
+export function resolveMinHoldMs(algorithmConfig?: Record<string, any>): number {
+  const DEFAULT_MIN_HOLD_MS = 24 * 60 * 60 * 1000;
+  const val = algorithmConfig?.minHoldMs;
+  if (typeof val !== 'number' || !isFinite(val) || val < 0) return DEFAULT_MIN_HOLD_MS;
+  return val;
+}
+
+/**
+ * Extract symbols from algorithm config. Deduplicates at source.
+ */
+export function extractSymbolsFromConfig(config?: Record<string, any>): string[] {
+  if (!config) return [];
+
+  const seen = new Set<string>();
+  const symbols: string[] = [];
+
+  const addAll = (arr: unknown) => {
+    if (!Array.isArray(arr)) return;
+    for (const s of arr) {
+      if (typeof s === 'string' && !seen.has(s)) {
+        seen.add(s);
+        symbols.push(s);
+      }
+    }
+  };
+
+  addAll(config.symbols);
+  addAll(config.tradingPairs);
+
+  return symbols;
+}
+
+export function extractCoinsFromPrices(prices: Record<string, number>): Array<{ id: string; symbol: string }> {
+  const seen = new Set<string>();
+  const coins: Array<{ id: string; symbol: string }> = [];
+
+  for (const symbol of Object.keys(prices)) {
+    const [baseCurrency] = symbol.split('/');
+    if (!seen.has(baseCurrency)) {
+      seen.add(baseCurrency);
+      coins.push({ id: baseCurrency, symbol: baseCurrency });
+    }
+  }
+
+  return coins;
+}
+
+/**
+ * Build price data context with historical candles for algorithm indicator calculations.
+ */
+export function buildPriceDataContext(
+  prices: Record<string, number>,
+  historicalCandles: Record<string, CandleData[]> = {}
+): Record<string, CandleData[]> {
+  const priceData: Record<string, CandleData[]> = {};
+  const now = new Date();
+
+  for (const [symbol, price] of Object.entries(prices)) {
+    const [baseCurrency] = symbol.split('/');
+    const candles = historicalCandles[symbol] ?? [];
+    const candidate =
+      candles.length > 0
+        ? [...candles, { avg: price, high: price, low: price, date: now }]
+        : [{ avg: price, high: price, low: price, date: now }];
+
+    if (!priceData[baseCurrency] || candidate.length > priceData[baseCurrency].length) {
+      priceData[baseCurrency] = candidate;
+    }
+  }
+
+  return priceData;
+}
+
+function clampNum(val: unknown, fallback: number, min: number, max: number): number {
+  const n = typeof val === 'number' && isFinite(val) ? val : fallback;
+  return Math.max(min, Math.min(max, n));
+}
+
+export function resolveOpportunitySellingConfig(algorithmConfig?: Record<string, any>): {
+  enabled: boolean;
+  config: OpportunitySellingUserConfig;
+} {
+  const params = algorithmConfig ?? {};
+  const enabled = params.enableOpportunitySelling === true;
+  const userConfig = params.opportunitySellingConfig;
+
+  if (!enabled || !userConfig || typeof userConfig !== 'object') {
+    return { enabled, config: { ...DEFAULT_OPPORTUNITY_SELLING_CONFIG } };
+  }
+
+  return {
+    enabled,
+    config: {
+      minOpportunityConfidence: clampNum(
+        userConfig.minOpportunityConfidence,
+        DEFAULT_OPPORTUNITY_SELLING_CONFIG.minOpportunityConfidence,
+        0,
+        1
+      ),
+      minHoldingPeriodHours: clampNum(
+        userConfig.minHoldingPeriodHours,
+        DEFAULT_OPPORTUNITY_SELLING_CONFIG.minHoldingPeriodHours,
+        0,
+        8760
+      ),
+      protectGainsAbovePercent: clampNum(
+        userConfig.protectGainsAbovePercent,
+        DEFAULT_OPPORTUNITY_SELLING_CONFIG.protectGainsAbovePercent,
+        0,
+        1000
+      ),
+      protectedCoins: Array.isArray(userConfig.protectedCoins) ? userConfig.protectedCoins : [],
+      minOpportunityAdvantagePercent: clampNum(
+        userConfig.minOpportunityAdvantagePercent,
+        DEFAULT_OPPORTUNITY_SELLING_CONFIG.minOpportunityAdvantagePercent,
+        0,
+        100
+      ),
+      maxLiquidationPercent: clampNum(
+        userConfig.maxLiquidationPercent,
+        DEFAULT_OPPORTUNITY_SELLING_CONFIG.maxLiquidationPercent,
+        1,
+        100
+      ),
+      useAlgorithmRanking:
+        typeof userConfig.useAlgorithmRanking === 'boolean'
+          ? userConfig.useAlgorithmRanking
+          : DEFAULT_OPPORTUNITY_SELLING_CONFIG.useAlgorithmRanking
+    }
+  };
+}

--- a/apps/api/src/order/paper-trading/engine/paper-trading-exit-executor.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-exit-executor.service.spec.ts
@@ -1,0 +1,278 @@
+import { SignalReasonCode } from '@chansey/api-interfaces';
+
+import { PaperTradingExitExecutorService } from './paper-trading-exit-executor.service';
+
+import { PaperTradingSignalStatus, PaperTradingSession } from '../entities';
+
+describe('PaperTradingExitExecutorService', () => {
+  let service: PaperTradingExitExecutorService;
+  let portfolioService: { refresh: jest.Mock };
+  let signalService: { save: jest.Mock; markProcessed: jest.Mock };
+  let orderExecutor: { execute: jest.Mock };
+
+  beforeEach(() => {
+    portfolioService = {
+      refresh: jest.fn().mockResolvedValue({
+        accounts: [],
+        portfolio: { cashBalance: 0, positions: new Map(), totalValue: 0 }
+      })
+    };
+    signalService = {
+      save: jest.fn(async () => ({ id: 'sig-1' })),
+      markProcessed: jest.fn(async (e) => e)
+    };
+    orderExecutor = { execute: jest.fn() };
+
+    service = new PaperTradingExitExecutorService(portfolioService as any, signalService as any, orderExecutor as any);
+  });
+
+  const makeSession = (overrides: Partial<PaperTradingSession> = {}): PaperTradingSession =>
+    ({
+      id: 'sess-1',
+      riskLevel: 3,
+      exitConfig: { stopLossPercent: 5, takeProfitPercent: 10, atrPeriod: 14 },
+      ...overrides
+    }) as any;
+
+  const installFakeTracker = (sessionId: string, exitSignals: any[] = []) => {
+    const fakeTracker = {
+      size: exitSignals.length || 1,
+      checkExits: jest.fn().mockReturnValue(exitSignals),
+      removePosition: jest.fn(),
+      onBuy: jest.fn(),
+      onSell: jest.fn(),
+      serialize: jest.fn().mockReturnValue({ positions: [] })
+    };
+    (service as any).exitTrackers.set(sessionId, fakeTracker);
+    return fakeTracker;
+  };
+
+  describe('map lifecycle', () => {
+    it('getOrCreate returns null when session has no exitConfig', () => {
+      expect(service.getOrCreate(makeSession({ exitConfig: undefined }))).toBeNull();
+    });
+
+    it('getOrCreate creates a tracker and caches it', () => {
+      const session = makeSession();
+      const first = service.getOrCreate(session);
+      const second = service.getOrCreate(session);
+      expect(first).not.toBeNull();
+      expect(first).toBe(second);
+    });
+
+    it('clear removes the tracker', () => {
+      const session = makeSession();
+      service.getOrCreate(session);
+      service.clear(session.id);
+      expect(service.serialize(session.id)).toBeUndefined();
+    });
+
+    it('serialize returns undefined when no tracker exists', () => {
+      expect(service.serialize('missing')).toBeUndefined();
+    });
+
+    it('serialize delegates to the tracker when one exists', () => {
+      const tracker = installFakeTracker('sess-1');
+      expect(service.serialize('sess-1')).toEqual({ positions: [] });
+      expect(tracker.serialize).toHaveBeenCalledTimes(1);
+    });
+
+    it('sweep removes trackers whose session id is not in the active set', () => {
+      service.getOrCreate(makeSession({ id: 'a' }));
+      service.getOrCreate(makeSession({ id: 'b' }));
+      service.getOrCreate(makeSession({ id: 'c' }));
+
+      expect(service.sweep(new Set(['b']))).toBe(2);
+      expect(service.serialize('a')).toBeUndefined();
+      expect(service.serialize('b')).toBeDefined();
+      expect(service.serialize('c')).toBeUndefined();
+    });
+  });
+
+  describe('onBuyFill', () => {
+    it('is a no-op when no tracker exists for the session', () => {
+      const session = makeSession({ exitConfig: undefined });
+      expect(() =>
+        service.onBuyFill(
+          session,
+          { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', reason: 'x' },
+          { executedPrice: 100, filledQuantity: 1 } as any,
+          {}
+        )
+      ).not.toThrow();
+    });
+
+    it('registers the buy on the tracker when executedPrice is valid', () => {
+      const tracker = installFakeTracker('sess-1');
+      service.onBuyFill(
+        makeSession(),
+        { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', reason: 'x' },
+        { executedPrice: 100, filledQuantity: 2 } as any,
+        {}
+      );
+      expect(tracker.onBuy).toHaveBeenCalledWith('BTC', 100, 2, undefined);
+    });
+
+    it('computes ATR from historical candles and passes it to tracker.onBuy', () => {
+      const tracker = installFakeTracker('sess-1');
+      const candles = Array.from({ length: 15 }, (_, i) => ({
+        high: 110 + i,
+        low: 90 + i,
+        avg: 100 + i,
+        date: new Date()
+      }));
+      service.onBuyFill(
+        makeSession(),
+        { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', reason: 'x' },
+        { executedPrice: 100, filledQuantity: 1 } as any,
+        { 'BTC/USD': candles as any }
+      );
+      const atrArg = tracker.onBuy.mock.calls[0][3];
+      expect(typeof atrArg).toBe('number');
+      expect(atrArg).toBeGreaterThan(0);
+    });
+
+    it('skips tracker registration when executedPrice is invalid', () => {
+      const tracker = installFakeTracker('sess-1');
+      service.onBuyFill(
+        makeSession(),
+        { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', reason: 'x' },
+        { executedPrice: 0, filledQuantity: 1 } as any,
+        {}
+      );
+      expect(tracker.onBuy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onSellFill', () => {
+    it('is a no-op when no tracker exists', () => {
+      expect(() =>
+        service.onSellFill(
+          makeSession({ exitConfig: undefined }),
+          { action: 'SELL', coinId: 'BTC', symbol: 'BTC/USD', reason: 'x' },
+          { filledQuantity: 1 } as any
+        )
+      ).not.toThrow();
+    });
+
+    it('forwards the sell to tracker.onSell', () => {
+      const tracker = installFakeTracker('sess-1');
+      service.onSellFill(makeSession(), { action: 'SELL', coinId: 'BTC', symbol: 'BTC/USD', reason: 'x' }, {
+        filledQuantity: 3
+      } as any);
+      expect(tracker.onSell).toHaveBeenCalledWith('BTC', 3);
+    });
+  });
+
+  describe('checkAndExecute', () => {
+    const exitFixture = {
+      coinId: 'BTC',
+      quantity: 1,
+      reason: 'stop-loss hit',
+      metadata: {},
+      executionPrice: 90,
+      exitType: 'STOP_LOSS' as const
+    };
+
+    it('returns 0 when no tracker exists for the session', async () => {
+      const result = await service.checkAndExecute(
+        makeSession({ exitConfig: undefined }),
+        {},
+        {},
+        'USD',
+        'binance_us',
+        new Date()
+      );
+      expect(result).toBe(0);
+      expect(orderExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 when tracker has no registered positions', async () => {
+      const session = makeSession();
+      service.getOrCreate(session);
+      const result = await service.checkAndExecute(session, { 'BTC/USD': 100 }, {}, 'USD', 'binance_us', new Date());
+      expect(result).toBe(0);
+      expect(orderExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    it('executes an exit order, refreshes portfolio, and removes the position on success', async () => {
+      const session = makeSession();
+      const tracker = installFakeTracker(session.id, [exitFixture]);
+      orderExecutor.execute.mockResolvedValue({
+        status: 'success',
+        order: { executedPrice: 90, filledQuantity: 1 }
+      });
+
+      const result = await service.checkAndExecute(session, { 'BTC/USD': 90 }, {}, 'USD', 'binance_us', new Date());
+
+      expect(result).toBe(1);
+      expect(orderExecutor.execute).toHaveBeenCalledTimes(1);
+      // Refresh called once before the exit loop; not re-called inside the loop.
+      expect(portfolioService.refresh).toHaveBeenCalledTimes(1);
+      expect(tracker.removePosition).toHaveBeenCalledWith('BTC');
+      const processedSignal = signalService.markProcessed.mock.calls[0][0];
+      expect(processedSignal.status).toBe(PaperTradingSignalStatus.SIMULATED);
+    });
+
+    it('uses candle high/low combined with current price when building price bands', async () => {
+      const session = makeSession();
+      const tracker = installFakeTracker(session.id, []);
+      const candles = [{ high: 120, low: 80, avg: 100, date: new Date() }];
+
+      await service.checkAndExecute(
+        session,
+        { 'BTC/USD': 100 },
+        { 'BTC/USD': candles as any },
+        'USD',
+        'binance_us',
+        new Date()
+      );
+
+      const [closeMap, lowMap, highMap] = tracker.checkExits.mock.calls[0];
+      expect(closeMap.get('BTC')).toBe(100);
+      expect(lowMap.get('BTC')).toBe(80);
+      expect(highMap.get('BTC')).toBe(120);
+    });
+
+    it('cleans up the tracker and marks signal SIMULATED on no_position result', async () => {
+      const session = makeSession();
+      const tracker = installFakeTracker(session.id, [exitFixture]);
+      orderExecutor.execute.mockResolvedValue({ status: 'no_position', order: null });
+
+      const result = await service.checkAndExecute(session, { 'BTC/USD': 90 }, {}, 'USD', 'binance_us', new Date());
+
+      expect(result).toBe(0);
+      expect(tracker.removePosition).toHaveBeenCalledWith('BTC');
+      expect(signalService.markProcessed.mock.calls[0][0].status).toBe(PaperTradingSignalStatus.SIMULATED);
+    });
+
+    it.each([
+      ['no_price', SignalReasonCode.SYMBOL_RESOLUTION_FAILED],
+      ['insufficient_funds', SignalReasonCode.INSUFFICIENT_FUNDS],
+      ['hold_period', SignalReasonCode.TRADE_COOLDOWN]
+    ])('marks signal REJECTED with correct code on %s', async (status, expectedCode) => {
+      const session = makeSession();
+      const tracker = installFakeTracker(session.id, [exitFixture]);
+      orderExecutor.execute.mockResolvedValue({ status, order: null });
+
+      const result = await service.checkAndExecute(session, { 'BTC/USD': 90 }, {}, 'USD', 'binance_us', new Date());
+
+      expect(result).toBe(0);
+      expect(tracker.removePosition).not.toHaveBeenCalled();
+      const processed = signalService.markProcessed.mock.calls[0][0];
+      expect(processed.status).toBe(PaperTradingSignalStatus.REJECTED);
+      expect(processed.rejectionCode).toBe(expectedCode);
+    });
+
+    it('marks signal ERROR and continues when order executor throws', async () => {
+      const session = makeSession();
+      installFakeTracker(session.id, [exitFixture]);
+      orderExecutor.execute.mockRejectedValue(new Error('boom'));
+
+      const result = await service.checkAndExecute(session, { 'BTC/USD': 90 }, {}, 'USD', 'binance_us', new Date());
+
+      expect(result).toBe(0);
+      expect(signalService.markProcessed.mock.calls[0][0].status).toBe(PaperTradingSignalStatus.ERROR);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-exit-executor.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-exit-executor.service.ts
@@ -1,0 +1,244 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { getAllocationLimits, PipelineStage, SignalReasonCode } from '@chansey/api-interfaces';
+
+import { toExitType, TradingSignal } from './paper-trading-engine.utils';
+import { PaperTradingOrderExecutorService } from './paper-trading-order-executor.service';
+import { PaperTradingPortfolioService } from './paper-trading-portfolio.service';
+import { PaperTradingSignalService } from './paper-trading-signal.service';
+
+import { SignalType as AlgoSignalType } from '../../../algorithm/interfaces';
+import { CandleData } from '../../../ohlc/ohlc-candle.entity';
+import { DEFAULT_RISK_LEVEL } from '../../../risk/risk.constants';
+import { toErrorInfo } from '../../../shared/error.util';
+import { BacktestExitTracker, computeAtrFromOHLC, SerializableExitTrackerState } from '../../backtest/shared';
+import { resolveExitConfig } from '../../utils/exit-config-merge.util';
+import { PaperTradingOrder, PaperTradingSession, PaperTradingSignal, PaperTradingSignalStatus } from '../entities';
+
+/**
+ * Owns per-session BacktestExitTracker instances and orchestrates SL/TP/trailing
+ * stop checks + exit order execution for the paper-trading engine.
+ */
+@Injectable()
+export class PaperTradingExitExecutorService {
+  private readonly logger = new Logger(PaperTradingExitExecutorService.name);
+
+  /** In-memory exit tracker per session. */
+  private readonly exitTrackers = new Map<string, BacktestExitTracker>();
+
+  constructor(
+    private readonly portfolioService: PaperTradingPortfolioService,
+    private readonly signalService: PaperTradingSignalService,
+    private readonly orderExecutor: PaperTradingOrderExecutorService
+  ) {}
+
+  /**
+   * Get or create an exit tracker for a session. Returns null if the session
+   * has no exitConfig (feature flag — backward compatible).
+   */
+  getOrCreate(session: PaperTradingSession): BacktestExitTracker | null {
+    if (!session.exitConfig) return null;
+
+    let tracker = this.exitTrackers.get(session.id);
+    if (!tracker) {
+      const config = resolveExitConfig(session.exitConfig);
+      if (session.exitTrackerState) {
+        tracker = BacktestExitTracker.deserialize(session.exitTrackerState, config);
+      } else {
+        tracker = new BacktestExitTracker(config);
+      }
+      this.exitTrackers.set(session.id, tracker);
+    }
+    return tracker;
+  }
+
+  /** Clean up exit tracker when a session ends. */
+  clear(sessionId: string): void {
+    this.exitTrackers.delete(sessionId);
+  }
+
+  /** Serialize current tracker state for DB persistence. */
+  serialize(sessionId: string): SerializableExitTrackerState | undefined {
+    const tracker = this.exitTrackers.get(sessionId);
+    if (!tracker) return undefined;
+    return tracker.serialize();
+  }
+
+  /**
+   * Drop in-memory tracker state for sessions that are no longer active.
+   * @returns number of sessions swept
+   */
+  sweep(activeSessionIds: Set<string>): number {
+    let swept = 0;
+    for (const sessionId of this.exitTrackers.keys()) {
+      if (!activeSessionIds.has(sessionId)) {
+        this.exitTrackers.delete(sessionId);
+        swept++;
+      }
+    }
+    return swept;
+  }
+
+  /**
+   * Register an entry in the exit tracker after a successful BUY fill.
+   * Computes ATR from historical candles when available.
+   */
+  onBuyFill(
+    session: PaperTradingSession,
+    signal: TradingSignal,
+    order: PaperTradingOrder,
+    historicalCandles: Record<string, CandleData[]>
+  ): void {
+    const tracker = this.exitTrackers.get(session.id);
+    if (!tracker) return;
+
+    const [baseCurrency] = signal.symbol.split('/');
+    const candles = historicalCandles[signal.symbol];
+    let atr: number | undefined;
+    if (candles && candles.length > 0) {
+      const highs = candles.map((c) => c.high);
+      const lows = candles.map((c) => c.low);
+      const closes = candles.map((c) => c.avg);
+      atr = computeAtrFromOHLC(highs, lows, closes, session.exitConfig?.atrPeriod ?? 14);
+    }
+
+    if (order.executedPrice != null && order.executedPrice > 0) {
+      tracker.onBuy(baseCurrency, order.executedPrice, order.filledQuantity, atr);
+    } else {
+      this.logger.warn(
+        `Skipping exit tracker registration for ${baseCurrency}: executedPrice is ${order.executedPrice}`
+      );
+    }
+  }
+
+  /** Update the tracker after a successful SELL fill. */
+  onSellFill(session: PaperTradingSession, signal: TradingSignal, order: PaperTradingOrder): void {
+    const tracker = this.exitTrackers.get(session.id);
+    if (!tracker) return;
+    const [baseCurrency] = signal.symbol.split('/');
+    tracker.onSell(baseCurrency, order.filledQuantity);
+  }
+
+  /**
+   * Check exit levels and execute exit orders for triggered positions.
+   * Returns the number of exit orders successfully executed.
+   */
+  async checkAndExecute(
+    session: PaperTradingSession,
+    priceMap: Record<string, number>,
+    historicalCandles: Record<string, CandleData[]>,
+    quoteCurrency: string,
+    exchangeSlug: string,
+    timestamp: Date
+  ): Promise<number> {
+    const exitTracker = this.exitTrackers.get(session.id);
+    if (!exitTracker || exitTracker.size === 0) return 0;
+
+    // Build close/low/high price maps from current prices + last candle data.
+    const closePrices = new Map<string, number>();
+    const lowPrices = new Map<string, number>();
+    const highPrices = new Map<string, number>();
+
+    for (const [symbol, price] of Object.entries(priceMap)) {
+      const [baseCurrency] = symbol.split('/');
+      closePrices.set(baseCurrency, price);
+
+      const candles = historicalCandles[symbol];
+      if (candles && candles.length > 0) {
+        const lastCandle = candles[candles.length - 1];
+        lowPrices.set(baseCurrency, Math.min(lastCandle.low, price));
+        highPrices.set(baseCurrency, Math.max(lastCandle.high, price));
+      } else {
+        lowPrices.set(baseCurrency, price);
+        highPrices.set(baseCurrency, price);
+      }
+    }
+
+    const exitSignals = exitTracker.checkExits(closePrices, lowPrices, highPrices);
+    if (exitSignals.length === 0) return 0;
+
+    const { portfolio: currentPortfolio } = await this.portfolioService.refresh(session.id, priceMap, quoteCurrency);
+
+    const { maxAllocation, minAllocation } = getAllocationLimits(
+      PipelineStage.PAPER_TRADE,
+      session.riskLevel ?? DEFAULT_RISK_LEVEL
+    );
+
+    let ordersExecuted = 0;
+    for (const exit of exitSignals) {
+      let signalEntity: PaperTradingSignal | undefined;
+      try {
+        const exitTradingSignal: TradingSignal = {
+          action: 'SELL',
+          coinId: exit.coinId,
+          symbol: `${exit.coinId}/${quoteCurrency}`,
+          quantity: exit.quantity,
+          reason: exit.reason,
+          metadata: exit.metadata as Record<string, any>,
+          originalType:
+            exit.exitType === 'STOP_LOSS'
+              ? AlgoSignalType.STOP_LOSS
+              : exit.exitType === 'TAKE_PROFIT'
+                ? AlgoSignalType.TAKE_PROFIT
+                : AlgoSignalType.STOP_LOSS
+        };
+
+        signalEntity = await this.signalService.save(session, exitTradingSignal);
+
+        const exitPriceMap = { ...priceMap, [`${exit.coinId}/${quoteCurrency}`]: exit.executionPrice };
+
+        const result = await this.orderExecutor.execute({
+          session,
+          signal: exitTradingSignal,
+          signalEntity,
+          portfolio: currentPortfolio,
+          prices: exitPriceMap,
+          exchangeSlug,
+          quoteCurrency,
+          timestamp,
+          allocation: { maxAllocation, minAllocation },
+          exitType: toExitType(exit.exitType)
+        });
+
+        if (result.status === 'success') {
+          ordersExecuted++;
+          exitTracker.removePosition(exit.coinId);
+          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
+          await this.signalService.markProcessed(signalEntity);
+          this.logger.log(
+            `Exit triggered for ${exit.coinId} in session ${session.id}: ${exit.exitType} at ${exit.executionPrice.toFixed(2)}`
+          );
+        } else if (result.status === 'no_position') {
+          exitTracker.removePosition(exit.coinId);
+          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
+          await this.signalService.markProcessed(signalEntity);
+          this.logger.log(
+            `Exit cleanup for ${exit.coinId} in session ${session.id}: position already closed (${result.status})`
+          );
+        } else {
+          signalEntity.status = PaperTradingSignalStatus.REJECTED;
+          if (result.status === 'no_price') {
+            signalEntity.rejectionCode = SignalReasonCode.SYMBOL_RESOLUTION_FAILED;
+          } else if (result.status === 'insufficient_funds') {
+            signalEntity.rejectionCode = SignalReasonCode.INSUFFICIENT_FUNDS;
+          } else if (result.status === 'hold_period') {
+            signalEntity.rejectionCode = SignalReasonCode.TRADE_COOLDOWN;
+          }
+          await this.signalService.markProcessed(signalEntity);
+          this.logger.warn(
+            `Exit deferred for ${exit.coinId} in session ${session.id}: ${result.status} — will retry next tick`
+          );
+        }
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        if (signalEntity) {
+          signalEntity.status = PaperTradingSignalStatus.ERROR;
+          await this.signalService.markProcessed(signalEntity);
+        }
+        this.logger.warn(`Failed to execute exit order for ${exit.coinId}: ${err.message}`);
+      }
+    }
+
+    return ordersExecuted;
+  }
+}

--- a/apps/api/src/order/paper-trading/engine/paper-trading-opportunity-selling.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-opportunity-selling.service.spec.ts
@@ -1,0 +1,323 @@
+import { PaperTradingOpportunitySellingService } from './paper-trading-opportunity-selling.service';
+
+import { PaperTradingSignalStatus } from '../entities';
+
+describe('PaperTradingOpportunitySellingService', () => {
+  let service: PaperTradingOpportunitySellingService;
+  let portfolioService: {
+    loadAccounts: jest.Mock;
+    buildFromAccounts: jest.Mock;
+    updateWithPrices: jest.Mock;
+    refresh: jest.Mock;
+  };
+  let signalService: {
+    save: jest.Mock;
+    markProcessed: jest.Mock;
+  };
+  let feeCalculator: {
+    fromFlatRate: jest.Mock;
+    calculateFee: jest.Mock;
+  };
+  let positionAnalysis: {
+    calculatePositionSellScore: jest.Mock;
+  };
+  let orderExecutor: {
+    execute: jest.Mock;
+  };
+
+  const makePortfolio = (cashBalance: number, positions: Map<string, any> = new Map(), totalValue = 20000) => ({
+    cashBalance,
+    positions,
+    totalValue
+  });
+
+  const makeSession = (overrides: any = {}): any => ({
+    id: 'sess-1',
+    tradingFee: 0.001,
+    riskLevel: 3,
+    algorithmConfig: { enableOpportunitySelling: true },
+    ...overrides
+  });
+
+  beforeEach(() => {
+    portfolioService = {
+      loadAccounts: jest.fn(),
+      buildFromAccounts: jest.fn().mockReturnValue({}),
+      updateWithPrices: jest.fn(),
+      refresh: jest.fn()
+    };
+    signalService = {
+      save: jest.fn(async (_s, sig) => ({ id: 'sig-1', signal: sig })),
+      markProcessed: jest.fn(async (e) => e)
+    };
+    feeCalculator = {
+      fromFlatRate: jest.fn().mockReturnValue({ rate: 0.001 }),
+      calculateFee: jest.fn().mockReturnValue({ fee: 5 })
+    };
+    positionAnalysis = {
+      calculatePositionSellScore: jest.fn()
+    };
+    orderExecutor = {
+      execute: jest.fn()
+    };
+
+    service = new PaperTradingOpportunitySellingService(
+      portfolioService as any,
+      signalService as any,
+      feeCalculator as any,
+      positionAnalysis as any,
+      orderExecutor as any
+    );
+  });
+
+  it('returns 0 when opportunity selling is disabled in config', async () => {
+    const session = makeSession({ algorithmConfig: {} });
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', confidence: 0.9 };
+
+    const result = await service.attempt(session, signal, { 'BTC/USD': 50000 }, 'USD', 'binance', new Date());
+
+    expect(result).toBe(0);
+    expect(portfolioService.loadAccounts).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when buy confidence is below minimum threshold', async () => {
+    const session = makeSession();
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', confidence: 0.3 };
+
+    const result = await service.attempt(session, signal, { 'BTC/USD': 50000 }, 'USD', 'binance', new Date());
+
+    expect(result).toBe(0);
+    expect(portfolioService.loadAccounts).not.toHaveBeenCalled();
+  });
+
+  it('sells a lower-scoring position to free cash and returns the number of sells executed', async () => {
+    const session = makeSession();
+    const signal: any = {
+      action: 'BUY',
+      coinId: 'BTC',
+      symbol: 'BTC/USD',
+      quantity: 0.1,
+      confidence: 0.85
+    };
+
+    const ethAccount = { currency: 'ETH', averageCost: 2800, entryDate: new Date(Date.now() - 72 * 3600000) };
+    portfolioService.loadAccounts.mockResolvedValue([ethAccount]);
+    portfolioService.updateWithPrices.mockReturnValue(
+      makePortfolio(
+        100, // cash — far below required
+        new Map([['ETH', { averagePrice: 2800, quantity: 5 }]]),
+        20000
+      )
+    );
+    portfolioService.refresh.mockResolvedValue({
+      accounts: [],
+      portfolio: makePortfolio(100, new Map(), 20000)
+    });
+
+    positionAnalysis.calculatePositionSellScore.mockReturnValue({
+      eligible: true,
+      totalScore: 10
+    });
+
+    orderExecutor.execute.mockResolvedValue({
+      status: 'executed',
+      order: { totalValue: 3000, fee: 3 }
+    });
+
+    const result = await service.attempt(
+      session,
+      signal,
+      { 'BTC/USD': 50000, 'ETH/USD': 3000 },
+      'USD',
+      'binance',
+      new Date()
+    );
+
+    expect(result).toBe(1);
+    expect(positionAnalysis.calculatePositionSellScore).toHaveBeenCalled();
+    expect(orderExecutor.execute).toHaveBeenCalledTimes(1);
+    const execArg = orderExecutor.execute.mock.calls[0][0];
+    expect(execArg.signal.action).toBe('SELL');
+    expect(execArg.signal.coinId).toBe('ETH');
+    expect(execArg.signal.symbol).toBe('ETH/USD');
+    expect(execArg.signal.metadata).toEqual({ opportunitySell: true, targetBuyCoinId: 'BTC' });
+    expect(execArg.signal.quantity).toBeGreaterThan(0);
+    expect(signalService.markProcessed).toHaveBeenCalledTimes(1);
+    const processedArg = signalService.markProcessed.mock.calls[0][0];
+    expect(processedArg.status).toBe(PaperTradingSignalStatus.SIMULATED);
+  });
+
+  it('returns 0 when buy signal symbol has no price in the price map', async () => {
+    const session = makeSession();
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', quantity: 0.1, confidence: 0.85 };
+
+    portfolioService.loadAccounts.mockResolvedValue([]);
+    portfolioService.updateWithPrices.mockReturnValue(makePortfolio(100, new Map(), 20000));
+
+    const result = await service.attempt(session, signal, {}, 'USD', 'binance', new Date());
+
+    expect(result).toBe(0);
+    expect(orderExecutor.execute).not.toHaveBeenCalled();
+  });
+
+  it('excludes protectedCoins from sell candidates and returns 0 when nothing else is eligible', async () => {
+    const session = makeSession({
+      algorithmConfig: { enableOpportunitySelling: true, opportunitySellingConfig: { protectedCoins: ['ETH'] } }
+    });
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', quantity: 0.1, confidence: 0.85 };
+
+    portfolioService.loadAccounts.mockResolvedValue([{ currency: 'ETH', averageCost: 2800, entryDate: new Date() }]);
+    portfolioService.updateWithPrices.mockReturnValue(
+      makePortfolio(100, new Map([['ETH', { averagePrice: 2800, quantity: 5 }]]), 20000)
+    );
+
+    const result = await service.attempt(
+      session,
+      signal,
+      { 'BTC/USD': 50000, 'ETH/USD': 3000 },
+      'USD',
+      'binance',
+      new Date()
+    );
+
+    expect(result).toBe(0);
+    expect(positionAnalysis.calculatePositionSellScore).not.toHaveBeenCalled();
+    expect(orderExecutor.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when all positions score as ineligible', async () => {
+    const session = makeSession();
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', quantity: 0.1, confidence: 0.85 };
+
+    portfolioService.loadAccounts.mockResolvedValue([{ currency: 'ETH', averageCost: 2800 }]);
+    portfolioService.updateWithPrices.mockReturnValue(
+      makePortfolio(100, new Map([['ETH', { averagePrice: 2800, quantity: 5 }]]), 20000)
+    );
+    positionAnalysis.calculatePositionSellScore.mockReturnValue({ eligible: false, totalScore: 0 });
+
+    const result = await service.attempt(
+      session,
+      signal,
+      { 'BTC/USD': 50000, 'ETH/USD': 3000 },
+      'USD',
+      'binance',
+      new Date()
+    );
+
+    expect(result).toBe(0);
+    expect(orderExecutor.execute).not.toHaveBeenCalled();
+  });
+
+  it('caps total liquidation at maxLiquidationPercent of portfolio value', async () => {
+    // Default cap = 30% of 20000 = 6000. Shortfall is much larger — should still stop after cap.
+    const session = makeSession();
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', quantity: 1, confidence: 0.85 };
+
+    portfolioService.loadAccounts.mockResolvedValue([
+      { currency: 'ETH', averageCost: 2800 },
+      { currency: 'SOL', averageCost: 100 }
+    ]);
+    portfolioService.updateWithPrices.mockReturnValue(
+      makePortfolio(
+        0,
+        new Map([
+          ['ETH', { averagePrice: 2800, quantity: 5 }],
+          ['SOL', { averagePrice: 100, quantity: 50 }]
+        ]),
+        20000
+      )
+    );
+    portfolioService.refresh.mockResolvedValue({ accounts: [], portfolio: makePortfolio(0, new Map(), 20000) });
+    positionAnalysis.calculatePositionSellScore.mockReturnValue({ eligible: true, totalScore: 10 });
+
+    // Each sell returns ~6000 net — second iteration should be skipped because cap is reached.
+    orderExecutor.execute.mockResolvedValue({
+      status: 'executed',
+      order: { totalValue: 6000, fee: 0 }
+    });
+
+    const result = await service.attempt(
+      session,
+      signal,
+      { 'BTC/USD': 50000, 'ETH/USD': 3000, 'SOL/USD': 100 },
+      'USD',
+      'binance',
+      new Date()
+    );
+
+    expect(result).toBe(1);
+    expect(orderExecutor.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks signal REJECTED when the order executor returns no order', async () => {
+    const session = makeSession();
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', quantity: 0.1, confidence: 0.85 };
+
+    portfolioService.loadAccounts.mockResolvedValue([{ currency: 'ETH', averageCost: 2800 }]);
+    portfolioService.updateWithPrices.mockReturnValue(
+      makePortfolio(100, new Map([['ETH', { averagePrice: 2800, quantity: 5 }]]), 20000)
+    );
+    portfolioService.refresh.mockResolvedValue({ accounts: [], portfolio: makePortfolio(100, new Map(), 20000) });
+    positionAnalysis.calculatePositionSellScore.mockReturnValue({ eligible: true, totalScore: 10 });
+    orderExecutor.execute.mockResolvedValue({ status: 'rejected', order: null });
+
+    const result = await service.attempt(
+      session,
+      signal,
+      { 'BTC/USD': 50000, 'ETH/USD': 3000 },
+      'USD',
+      'binance',
+      new Date()
+    );
+
+    expect(result).toBe(0);
+    const processedArg = signalService.markProcessed.mock.calls[0][0];
+    expect(processedArg.status).toBe(PaperTradingSignalStatus.REJECTED);
+    expect(processedArg.rejectionCode).toBeDefined();
+  });
+
+  it('marks signal ERROR and continues when the order executor throws', async () => {
+    const session = makeSession();
+    const signal: any = { action: 'BUY', coinId: 'BTC', symbol: 'BTC/USD', quantity: 0.1, confidence: 0.85 };
+
+    portfolioService.loadAccounts.mockResolvedValue([{ currency: 'ETH', averageCost: 2800 }]);
+    portfolioService.updateWithPrices.mockReturnValue(
+      makePortfolio(100, new Map([['ETH', { averagePrice: 2800, quantity: 5 }]]), 20000)
+    );
+    portfolioService.refresh.mockResolvedValue({ accounts: [], portfolio: makePortfolio(100, new Map(), 20000) });
+    positionAnalysis.calculatePositionSellScore.mockReturnValue({ eligible: true, totalScore: 10 });
+    orderExecutor.execute.mockRejectedValue(new Error('boom'));
+
+    const result = await service.attempt(
+      session,
+      signal,
+      { 'BTC/USD': 50000, 'ETH/USD': 3000 },
+      'USD',
+      'binance',
+      new Date()
+    );
+
+    expect(result).toBe(0);
+    const processedArg = signalService.markProcessed.mock.calls[0][0];
+    expect(processedArg.status).toBe(PaperTradingSignalStatus.ERROR);
+  });
+
+  it('returns 0 when cashBalance already covers required amount (no shortfall)', async () => {
+    const session = makeSession();
+    const signal: any = {
+      action: 'BUY',
+      coinId: 'BTC',
+      symbol: 'BTC/USD',
+      quantity: 0.01,
+      confidence: 0.85
+    };
+
+    portfolioService.loadAccounts.mockResolvedValue([]);
+    portfolioService.updateWithPrices.mockReturnValue(makePortfolio(10000, new Map(), 20000));
+
+    const result = await service.attempt(session, signal, { 'BTC/USD': 50000 }, 'USD', 'binance', new Date());
+
+    expect(result).toBe(0);
+    expect(orderExecutor.execute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-opportunity-selling.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-opportunity-selling.service.ts
@@ -1,0 +1,184 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { getAllocationLimits, PipelineStage, SignalReasonCode } from '@chansey/api-interfaces';
+
+import { resolveOpportunitySellingConfig, TradingSignal } from './paper-trading-engine.utils';
+import { PaperTradingOrderExecutorService } from './paper-trading-order-executor.service';
+import { PaperTradingPortfolioService } from './paper-trading-portfolio.service';
+import { PaperTradingSignalService } from './paper-trading-signal.service';
+
+import { DEFAULT_RISK_LEVEL } from '../../../risk/risk.constants';
+import { toErrorInfo } from '../../../shared/error.util';
+import { FeeCalculatorService, PositionAnalysisService } from '../../backtest/shared';
+import { PaperTradingSession, PaperTradingSignalStatus } from '../entities';
+
+/**
+ * Attempts to sell weakest positions to free cash for a higher-confidence BUY signal.
+ * Mirrors the BacktestEngine pattern using PositionAnalysisService for scoring.
+ */
+@Injectable()
+export class PaperTradingOpportunitySellingService {
+  private readonly logger = new Logger(PaperTradingOpportunitySellingService.name);
+
+  constructor(
+    private readonly portfolioService: PaperTradingPortfolioService,
+    private readonly signalService: PaperTradingSignalService,
+    private readonly feeCalculator: FeeCalculatorService,
+    private readonly positionAnalysis: PositionAnalysisService,
+    private readonly orderExecutor: PaperTradingOrderExecutorService
+  ) {}
+
+  /**
+   * @returns number of sell orders executed
+   */
+  async attempt(
+    session: PaperTradingSession,
+    buySignal: TradingSignal,
+    priceMap: Record<string, number>,
+    quoteCurrency: string,
+    exchangeSlug: string,
+    timestamp: Date,
+    allocationOverrides?: { maxAllocation: number; minAllocation: number }
+  ): Promise<number> {
+    const { enabled, config } = resolveOpportunitySellingConfig(session.algorithmConfig);
+    if (!enabled) return 0;
+
+    const buyConfidence = buySignal.confidence ?? 0;
+    if (buyConfidence < config.minOpportunityConfidence) return 0;
+
+    const accounts = await this.portfolioService.loadAccounts(session.id);
+    const updatedPortfolio = this.portfolioService.updateWithPrices(
+      this.portfolioService.buildFromAccounts(accounts, quoteCurrency),
+      priceMap,
+      quoteCurrency
+    );
+
+    // Estimate the required buy amount
+    const buyPrice = priceMap[buySignal.symbol];
+    if (!buyPrice) return 0;
+
+    const { maxAllocation, minAllocation } = allocationOverrides ?? this.getSessionAllocationLimits(session);
+    let requiredAmount: number;
+    if (buySignal.quantity) {
+      requiredAmount = buySignal.quantity * buyPrice;
+    } else if (buySignal.percentage) {
+      requiredAmount = updatedPortfolio.totalValue * Math.min(buySignal.percentage, maxAllocation);
+    } else if (buySignal.confidence !== undefined) {
+      const alloc = minAllocation + buySignal.confidence * (maxAllocation - minAllocation);
+      requiredAmount = updatedPortfolio.totalValue * alloc;
+    } else {
+      requiredAmount = updatedPortfolio.totalValue * minAllocation;
+    }
+
+    // Fee estimate
+    const feeConfig = this.feeCalculator.fromFlatRate(session.tradingFee);
+    const estFee = this.feeCalculator.calculateFee({ tradeValue: requiredAmount }, feeConfig).fee;
+    const totalRequired = requiredAmount + estFee;
+
+    if (updatedPortfolio.cashBalance >= totalRequired) return 0; // No shortfall
+
+    const shortfall = totalRequired - updatedPortfolio.cashBalance;
+
+    // Score and rank eligible positions
+    const eligible: { coinId: string; score: number; quantity: number; price: number }[] = [];
+
+    for (const [coinId, position] of updatedPortfolio.positions) {
+      if (coinId === buySignal.coinId) continue;
+      if (config.protectedCoins.includes(coinId)) continue;
+
+      const symbol = `${coinId}/${quoteCurrency}`;
+      const currentPrice = priceMap[symbol];
+      if (!currentPrice || currentPrice <= 0) continue;
+
+      const account = accounts.find((a) => a.currency === coinId);
+      const score = this.positionAnalysis.calculatePositionSellScore(
+        {
+          coinId,
+          averagePrice: account?.averageCost ?? position.averagePrice,
+          quantity: position.quantity,
+          entryDate: account?.entryDate
+        },
+        currentPrice,
+        buyConfidence,
+        config,
+        timestamp
+      );
+
+      if (score.eligible) {
+        eligible.push({ coinId, score: score.totalScore, quantity: position.quantity, price: currentPrice });
+      }
+    }
+
+    if (eligible.length === 0) return 0;
+
+    // Sort by score ASC (lowest = sell first)
+    eligible.sort((a, b) => a.score - b.score);
+
+    // Execute sells to cover the shortfall, respecting maxLiquidationPercent cap
+    const maxSellValue = (updatedPortfolio.totalValue * config.maxLiquidationPercent) / 100;
+    let coveredAmount = 0;
+    let sellCount = 0;
+
+    for (const candidate of eligible) {
+      if (coveredAmount >= shortfall) break;
+      if (coveredAmount >= maxSellValue) break;
+
+      const remainingNeeded = Math.min(shortfall - coveredAmount, maxSellValue - coveredAmount);
+      const sellQuantity = Math.min(candidate.quantity, remainingNeeded / candidate.price);
+      if (sellQuantity <= 0) continue;
+
+      const sellSignal: TradingSignal = {
+        action: 'SELL',
+        coinId: candidate.coinId,
+        symbol: `${candidate.coinId}/${quoteCurrency}`,
+        quantity: sellQuantity,
+        reason: `Opportunity sell: freeing cash for ${buySignal.coinId} BUY (confidence ${buyConfidence.toFixed(2)})`,
+        confidence: buyConfidence,
+        metadata: { opportunitySell: true, targetBuyCoinId: buySignal.coinId }
+      };
+
+      const signalEntity = await this.signalService.save(session, sellSignal);
+
+      try {
+        const result = await this.orderExecutor.execute({
+          session,
+          signal: sellSignal,
+          signalEntity,
+          portfolio: updatedPortfolio,
+          prices: priceMap,
+          exchangeSlug,
+          quoteCurrency,
+          timestamp,
+          allocation: this.getSessionAllocationLimits(session)
+        });
+
+        if (result.order) {
+          coveredAmount += (result.order.totalValue ?? 0) - (result.order.fee ?? 0);
+          sellCount++;
+          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
+        } else {
+          signalEntity.status = PaperTradingSignalStatus.REJECTED;
+          signalEntity.rejectionCode = SignalReasonCode.INSUFFICIENT_FUNDS;
+        }
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        signalEntity.status = PaperTradingSignalStatus.ERROR;
+        this.logger.warn(`Opportunity sell failed for ${candidate.coinId}: ${err.message}`);
+      }
+
+      await this.signalService.markProcessed(signalEntity);
+    }
+
+    if (sellCount > 0) {
+      this.logger.log(
+        `Opportunity selling: executed ${sellCount} sells to free cash for ${buySignal.coinId} BUY (session ${session.id})`
+      );
+    }
+
+    return sellCount;
+  }
+
+  private getSessionAllocationLimits(session: PaperTradingSession) {
+    return getAllocationLimits(PipelineStage.PAPER_TRADE, session.riskLevel ?? DEFAULT_RISK_LEVEL);
+  }
+}

--- a/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.spec.ts
@@ -1,0 +1,305 @@
+import { PaperTradingOrderExecutorService, ExecuteOrderContext } from './paper-trading-order-executor.service';
+
+import { SignalType as AlgoSignalType } from '../../../algorithm/interfaces';
+import { PaperTradingOrderSide } from '../entities';
+
+type TxAccount = {
+  currency: string;
+  available: number;
+  averageCost?: number;
+  entryDate?: Date;
+  locked?: number;
+};
+
+interface HarnessOptions {
+  quote: TxAccount;
+  base?: TxAccount | null;
+  slippage?: { estimatedPrice?: number; slippageBps?: number; marketImpact?: number };
+  fee?: number;
+}
+
+const createHarness = (options: HarnessOptions) => {
+  const saved: any[] = [];
+
+  const txManager = {
+    findOne: jest.fn((_entity: any, query: any) => {
+      const currency = query?.where?.currency;
+      if (currency === options.quote.currency) return Promise.resolve(options.quote);
+      if (options.base && currency === options.base.currency) return Promise.resolve(options.base);
+      return Promise.resolve(null);
+    }),
+    create: jest.fn((_entity: any, data: any) => ({ ...data })),
+    save: jest.fn((entity: any) => {
+      saved.push(entity);
+      return Promise.resolve(entity);
+    })
+  };
+
+  const dataSource = {
+    transaction: jest.fn((cb: any) => cb(txManager))
+  };
+
+  const feeCalculator = {
+    fromFlatRate: jest.fn().mockReturnValue({ rate: 0.001 }),
+    calculateFee: jest.fn().mockReturnValue({ fee: options.fee ?? 10 })
+  };
+
+  const marketDataService = {
+    calculateRealisticSlippage: jest.fn().mockResolvedValue({
+      estimatedPrice: options.slippage?.estimatedPrice ?? 100,
+      slippageBps: options.slippage?.slippageBps ?? 0,
+      marketImpact: options.slippage?.marketImpact ?? 0
+    })
+  };
+
+  const executor = new PaperTradingOrderExecutorService(
+    dataSource as any,
+    feeCalculator as any,
+    marketDataService as any
+  );
+
+  return { executor, saved, txManager, feeCalculator, marketDataService };
+};
+
+const baseCtx = (overrides: Partial<ExecuteOrderContext> = {}): ExecuteOrderContext =>
+  ({
+    session: { id: 'sess-1', tradingFee: 0.001, algorithmConfig: {} },
+    signal: { action: 'BUY', symbol: 'BTC/USD', reason: 'test' },
+    signalEntity: { id: 'sig-1' },
+    portfolio: { totalValue: 10_000, cashBalance: 10_000, positions: new Map() },
+    prices: { 'BTC/USD': 100 },
+    exchangeSlug: 'binance',
+    quoteCurrency: 'USD',
+    timestamp: new Date('2024-01-01T00:00:00Z'),
+    allocation: { maxAllocation: 0.5, minAllocation: 0.01 },
+    ...overrides
+  }) as ExecuteOrderContext;
+
+const findOrder = (saved: any[], side: PaperTradingOrderSide) => saved.find((s) => s.side === side);
+
+describe('PaperTradingOrderExecutorService', () => {
+  describe('guard clauses', () => {
+    it('returns no_price when the symbol has no price', async () => {
+      const { executor } = createHarness({ quote: { currency: 'USD', available: 10_000 } });
+      const result = await executor.execute(baseCtx({ prices: {} }));
+      expect(result).toEqual({ status: 'no_price', order: null });
+    });
+
+    it('throws when the quote account is missing', async () => {
+      const { executor, txManager } = createHarness({ quote: { currency: 'USD', available: 10_000 } });
+      // Override: quote lookup returns null.
+      (txManager.findOne as jest.Mock).mockResolvedValue(null);
+      await expect(executor.execute(baseCtx())).rejects.toThrow(/Quote currency account/);
+    });
+  });
+
+  describe('BUY sizing', () => {
+    it('executes with explicit quantity and persists a FILLED order', async () => {
+      const { executor, saved } = createHarness({ quote: { currency: 'USD', available: 10_000 } });
+      const result = await executor.execute(
+        baseCtx({ signal: { action: 'BUY', coinId: 'btc', symbol: 'BTC/USD', quantity: 2, reason: 'entry' } as any })
+      );
+      expect(result.status).toBe('success');
+      const order = findOrder(saved, PaperTradingOrderSide.BUY);
+      expect(order.filledQuantity).toBe(2);
+      expect(order.totalValue).toBe(200);
+      expect(order.fee).toBe(10);
+    });
+
+    it('caps explicit BUY quantity to maxAllocation', async () => {
+      const { executor, saved } = createHarness({ quote: { currency: 'USD', available: 1_000_000 } });
+      // totalValue=10_000, maxAllocation=0.5 → max=50 units @ 100.
+      const result = await executor.execute(
+        baseCtx({ signal: { action: 'BUY', coinId: 'btc', symbol: 'BTC/USD', quantity: 999, reason: 'x' } as any })
+      );
+      expect(result.status).toBe('success');
+      expect(findOrder(saved, PaperTradingOrderSide.BUY).filledQuantity).toBe(50);
+    });
+
+    it('percentage → Math.min(percentage, maxAllocation) * totalValue / price', async () => {
+      const { executor, saved } = createHarness({ quote: { currency: 'USD', available: 10_000 } });
+      await executor.execute(
+        baseCtx({ signal: { action: 'BUY', coinId: 'btc', symbol: 'BTC/USD', percentage: 0.2, reason: 'x' } as any })
+      );
+      // 0.2 * 10_000 / 100 = 20
+      expect(findOrder(saved, PaperTradingOrderSide.BUY).filledQuantity).toBeCloseTo(20, 6);
+    });
+
+    it('confidence → interpolates between min and max allocation', async () => {
+      const { executor, saved } = createHarness({ quote: { currency: 'USD', available: 10_000 } });
+      await executor.execute(
+        baseCtx({ signal: { action: 'BUY', coinId: 'btc', symbol: 'BTC/USD', confidence: 0.5, reason: 'x' } as any })
+      );
+      // alloc = 0.01 + 0.5*(0.5-0.01) = 0.255 → 25.5 units
+      expect(findOrder(saved, PaperTradingOrderSide.BUY).filledQuantity).toBeCloseTo(25.5, 6);
+    });
+
+    it('no sizing hint → falls back to minAllocation', async () => {
+      const { executor, saved } = createHarness({ quote: { currency: 'USD', available: 10_000 } });
+      await executor.execute(
+        baseCtx({ signal: { action: 'BUY', coinId: 'btc', symbol: 'BTC/USD', reason: 'x' } as any })
+      );
+      // 0.01 * 10_000 / 100 = 1
+      expect(findOrder(saved, PaperTradingOrderSide.BUY).filledQuantity).toBeCloseTo(1, 6);
+    });
+
+    it('returns insufficient_funds when balance < total cost', async () => {
+      const { executor } = createHarness({ quote: { currency: 'USD', available: 50 } });
+      const result = await executor.execute(
+        baseCtx({ signal: { action: 'BUY', coinId: 'btc', symbol: 'BTC/USD', quantity: 2, reason: 'x' } as any })
+      );
+      expect(result.status).toBe('insufficient_funds');
+    });
+
+    it('computes weighted-average cost when adding to an existing position', async () => {
+      const base: TxAccount = {
+        currency: 'BTC',
+        available: 10,
+        averageCost: 80,
+        entryDate: new Date('2023-01-01')
+      };
+      const { executor, saved } = createHarness({ quote: { currency: 'USD', available: 10_000 }, base });
+      await executor.execute(
+        baseCtx({ signal: { action: 'BUY', coinId: 'btc', symbol: 'BTC/USD', quantity: 10, reason: 'add' } as any })
+      );
+      // (80*10 + 100*10) / 20 = 90
+      expect(base.averageCost).toBeCloseTo(90, 6);
+      expect(base.available).toBe(20);
+      // entryDate is preserved (not reset) when adding to a non-empty position
+      expect(base.entryDate).toEqual(new Date('2023-01-01'));
+      expect(findOrder(saved, PaperTradingOrderSide.BUY)).toBeDefined();
+    });
+  });
+
+  describe('SELL sizing (BUG #3)', () => {
+    const runSell = async (signalExtras: any, extras: { base?: TxAccount } = {}) => {
+      const base: TxAccount = extras.base ?? {
+        currency: 'BTC',
+        available: 10,
+        averageCost: 50,
+        entryDate: new Date('2020-01-01')
+      };
+      const { executor, saved } = createHarness({ quote: { currency: 'USD', available: 5_000 }, base });
+      const result = await executor.execute(
+        baseCtx({
+          signal: { action: 'SELL', coinId: 'btc', symbol: 'BTC/USD', reason: 'exit', ...signalExtras } as any
+        })
+      );
+      return { result, order: findOrder(saved, PaperTradingOrderSide.SELL), base };
+    };
+
+    it.each([
+      ['explicit quantity capped to held', { quantity: 7 }, 7],
+      ['explicit quantity exceeding held is capped', { quantity: 999 }, 10],
+      ['percentage → percentage * heldQty', { percentage: 0.4 }, 4],
+      ['confidence → confidence * heldQty (no legacy 0.25+0.75 blend)', { confidence: 0.8 }, 8],
+      ['no sizing hint → 100% of heldQty (no legacy 25% fallback)', {}, 10]
+    ])('%s', async (_name, extras, expected) => {
+      const { result, order } = await runSell(extras);
+      expect(result.status).toBe('success');
+      expect(order.filledQuantity).toBeCloseTo(expected, 6);
+    });
+
+    it('full sell zeroes balance and resets averageCost/entryDate', async () => {
+      const { base } = await runSell({ quantity: 10 });
+      expect(base.available).toBe(0);
+      expect(base.averageCost).toBeUndefined();
+      expect(base.entryDate).toBeUndefined();
+    });
+  });
+
+  describe('SELL guards', () => {
+    it('returns no_position when no base account exists', async () => {
+      const { executor } = createHarness({ quote: { currency: 'USD', available: 5_000 }, base: null });
+      const result = await executor.execute(
+        baseCtx({ signal: { action: 'SELL', coinId: 'btc', symbol: 'BTC/USD', reason: 'exit' } as any })
+      );
+      expect(result).toEqual({ status: 'no_position', order: null });
+    });
+
+    it('returns no_position when base account has zero balance', async () => {
+      const { executor } = createHarness({
+        quote: { currency: 'USD', available: 5_000 },
+        base: { currency: 'BTC', available: 0 }
+      });
+      const result = await executor.execute(
+        baseCtx({ signal: { action: 'SELL', coinId: 'btc', symbol: 'BTC/USD', reason: 'exit' } as any })
+      );
+      expect(result.status).toBe('no_position');
+    });
+
+    it('returns hold_period when min hold not met for a non-risk-control exit', async () => {
+      const entryDate = new Date('2023-12-31T23:00:00Z'); // 1h before ctx timestamp
+      const { executor } = createHarness({
+        quote: { currency: 'USD', available: 5_000 },
+        base: { currency: 'BTC', available: 10, averageCost: 50, entryDate }
+      });
+      const result = await executor.execute(
+        baseCtx({
+          // minHoldMs = 24h; only 1h has passed
+          session: { id: 'sess-1', tradingFee: 0.001, algorithmConfig: { minHoldMs: 24 * 3600 * 1000 } } as any,
+          signal: { action: 'SELL', coinId: 'btc', symbol: 'BTC/USD', reason: 'exit' } as any
+        })
+      );
+      expect(result.status).toBe('hold_period');
+    });
+
+    it('bypasses hold period for STOP_LOSS / TAKE_PROFIT', async () => {
+      const entryDate = new Date('2023-12-31T23:00:00Z');
+      const { executor, saved } = createHarness({
+        quote: { currency: 'USD', available: 5_000 },
+        base: { currency: 'BTC', available: 10, averageCost: 50, entryDate }
+      });
+      const result = await executor.execute(
+        baseCtx({
+          session: { id: 'sess-1', tradingFee: 0.001, algorithmConfig: { minHoldMs: 24 * 3600 * 1000 } } as any,
+          signal: {
+            action: 'SELL',
+            coinId: 'btc',
+            symbol: 'BTC/USD',
+            reason: 'sl',
+            originalType: AlgoSignalType.STOP_LOSS
+          } as any
+        })
+      );
+      expect(result.status).toBe('success');
+      expect(findOrder(saved, PaperTradingOrderSide.SELL)).toBeDefined();
+    });
+  });
+
+  describe('SELL realized PnL (BUG #4)', () => {
+    it('includes fee in realizedPnLPercent numerator', async () => {
+      const { executor, saved } = createHarness({
+        quote: { currency: 'USD', available: 0 },
+        base: { currency: 'BTC', available: 10, averageCost: 100, entryDate: new Date('2020-01-01') },
+        slippage: { estimatedPrice: 110 },
+        fee: 50
+      });
+      const result = await executor.execute(
+        baseCtx({
+          signal: { action: 'SELL', coinId: 'btc', symbol: 'BTC/USD', quantity: 10, reason: 'exit' } as any,
+          prices: { 'BTC/USD': 110 }
+        })
+      );
+      expect(result.status).toBe('success');
+      const order = findOrder(saved, PaperTradingOrderSide.SELL);
+      // proceeds=1100, fee=50, costBasisTotal=1000 → (1100-50-1000)/1000 = 0.05
+      expect(order.realizedPnLPercent).toBeCloseTo(0.05, 6);
+      // realizedPnL = (110-100)*10 - 50 = 50
+      expect(order.realizedPnL).toBeCloseTo(50, 6);
+    });
+
+    it('realizedPnLPercent is 0 when costBasis is 0', async () => {
+      const { executor, saved } = createHarness({
+        quote: { currency: 'USD', available: 0 },
+        base: { currency: 'BTC', available: 10, averageCost: 0, entryDate: new Date('2020-01-01') }
+      });
+      await executor.execute(
+        baseCtx({
+          signal: { action: 'SELL', coinId: 'btc', symbol: 'BTC/USD', quantity: 10, reason: 'exit' } as any
+        })
+      );
+      expect(findOrder(saved, PaperTradingOrderSide.SELL).realizedPnLPercent).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.ts
@@ -1,0 +1,353 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { Decimal } from 'decimal.js';
+import { DataSource, EntityManager } from 'typeorm';
+
+import { ExecuteOrderResult, TradingSignal, resolveMinHoldMs } from './paper-trading-engine.utils';
+
+import { SignalType as AlgoSignalType } from '../../../algorithm/interfaces';
+import { FeeCalculatorService, Portfolio } from '../../backtest/shared';
+import {
+  PaperTradingAccount,
+  PaperTradingExitType,
+  PaperTradingOrder,
+  PaperTradingOrderSide,
+  PaperTradingOrderStatus,
+  PaperTradingOrderType,
+  PaperTradingSession,
+  PaperTradingSignal
+} from '../entities';
+import { PaperTradingMarketDataService } from '../paper-trading-market-data.service';
+
+export interface ExecuteOrderContext {
+  session: PaperTradingSession;
+  signal: TradingSignal;
+  signalEntity: PaperTradingSignal;
+  portfolio: Portfolio;
+  prices: Record<string, number>;
+  exchangeSlug: string;
+  quoteCurrency: string;
+  timestamp: Date;
+  allocation: { maxAllocation: number; minAllocation: number };
+  exitType?: PaperTradingExitType;
+}
+
+/**
+ * Executes BUY/SELL paper trading orders atomically within a transaction.
+ * Extracted from PaperTradingEngineService as part of the engine refactor.
+ *
+ * Two intentional behavior changes vs. the legacy implementation:
+ *  - SELL sizing (BUG #3): no more `0.25 + confidence * 0.75` blend and no 25%
+ *    fallback. Priority is: explicit quantity → explicit percentage → confidence
+ *    (used directly as a fraction of held quantity) → 100% of held quantity.
+ *  - Realized PnL percent (BUG #4): numerator is now
+ *    `proceeds - fee - costBasisTotal`, so fees are included in the percent.
+ */
+@Injectable()
+export class PaperTradingOrderExecutorService {
+  private readonly logger = new Logger(PaperTradingOrderExecutorService.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly feeCalculator: FeeCalculatorService,
+    private readonly marketDataService: PaperTradingMarketDataService
+  ) {}
+
+  async execute(ctx: ExecuteOrderContext): Promise<ExecuteOrderResult> {
+    const { signal, prices, exchangeSlug, portfolio } = ctx;
+    const basePrice = prices[signal.symbol];
+    if (!basePrice) {
+      this.logger.warn(`No price data available for ${signal.symbol}`);
+      return { status: 'no_price', order: null };
+    }
+
+    const isBuy = signal.action === 'BUY';
+
+    const slippageResult = await this.marketDataService.calculateRealisticSlippage(
+      exchangeSlug,
+      signal.symbol,
+      signal.quantity ?? (portfolio.totalValue * 0.1) / basePrice,
+      isBuy ? 'BUY' : 'SELL'
+    );
+
+    const executionPrice =
+      slippageResult.estimatedPrice || basePrice * (1 + ((isBuy ? 1 : -1) * slippageResult.slippageBps) / 10000);
+    const slippageBps = slippageResult.slippageBps;
+
+    return this.dataSource.transaction(async (txManager) => {
+      const [baseCurrency] = signal.symbol.split('/');
+
+      const quoteAccount = await txManager.findOne(PaperTradingAccount, {
+        where: { session: { id: ctx.session.id }, currency: ctx.quoteCurrency },
+        lock: { mode: 'pessimistic_write' }
+      });
+
+      const baseAccount = await txManager.findOne(PaperTradingAccount, {
+        where: { session: { id: ctx.session.id }, currency: baseCurrency },
+        lock: { mode: 'pessimistic_write' }
+      });
+
+      if (!quoteAccount) {
+        throw new Error(`Quote currency account (${ctx.quoteCurrency}) not found`);
+      }
+
+      if (isBuy) {
+        return this.executeBuy(ctx, {
+          txManager,
+          baseCurrency,
+          basePrice,
+          executionPrice,
+          slippageBps,
+          quoteAccount,
+          baseAccount
+        });
+      }
+
+      return this.executeSell(ctx, {
+        txManager,
+        baseCurrency,
+        basePrice,
+        executionPrice,
+        slippageBps,
+        quoteAccount,
+        baseAccount
+      });
+    });
+  }
+
+  private calculateBuyQuantity(
+    signal: TradingSignal,
+    portfolio: Portfolio,
+    executionPrice: number,
+    allocation: { maxAllocation: number; minAllocation: number }
+  ): number {
+    const { maxAllocation, minAllocation } = allocation;
+
+    if (signal.quantity) {
+      const maxQuantity = (portfolio.totalValue * maxAllocation) / executionPrice;
+      if (signal.quantity > maxQuantity) {
+        this.logger.warn(
+          `Capping explicit BUY quantity from ${signal.quantity} to ${maxQuantity} (${maxAllocation * 100}% cap)`
+        );
+        return maxQuantity;
+      }
+      return signal.quantity;
+    }
+    if (signal.percentage) {
+      const investmentAmount = portfolio.totalValue * Math.min(signal.percentage, maxAllocation);
+      return investmentAmount / executionPrice;
+    }
+    if (signal.confidence !== undefined) {
+      const alloc = minAllocation + signal.confidence * (maxAllocation - minAllocation);
+      return (portfolio.totalValue * alloc) / executionPrice;
+    }
+    return (portfolio.totalValue * minAllocation) / executionPrice;
+  }
+
+  /**
+   * BUG #3 fix — SELL sizing.
+   * Priority:
+   *  1. `signal.quantity` (capped to held)
+   *  2. `signal.percentage` → percentage * heldQty
+   *  3. `signal.confidence` → confidence * heldQty
+   *  4. default → 100% of heldQty
+   */
+  private calculateSellQuantity(signal: TradingSignal, heldQty: number): number {
+    if (signal.quantity) return Math.min(signal.quantity, heldQty);
+    if (signal.percentage) return heldQty * Math.min(signal.percentage, 1);
+    if (signal.confidence !== undefined) return heldQty * Math.min(Math.max(signal.confidence, 0), 1);
+    return heldQty;
+  }
+
+  private async executeBuy(
+    ctx: ExecuteOrderContext,
+    args: {
+      txManager: EntityManager;
+      baseCurrency: string;
+      basePrice: number;
+      executionPrice: number;
+      slippageBps: number;
+      quoteAccount: PaperTradingAccount;
+      baseAccount: PaperTradingAccount | null;
+    }
+  ): Promise<ExecuteOrderResult> {
+    const { session, signal, signalEntity, portfolio, quoteCurrency, timestamp, exitType, allocation } = ctx;
+    const { txManager, baseCurrency, basePrice, executionPrice, slippageBps, quoteAccount } = args;
+    let { baseAccount } = args;
+
+    const quantity = this.calculateBuyQuantity(signal, portfolio, executionPrice, allocation);
+
+    const dQuantity = new Decimal(quantity);
+    const dExecutionPrice = new Decimal(executionPrice);
+    const totalValue = dQuantity.mul(dExecutionPrice).toNumber();
+
+    const feeConfig = this.feeCalculator.fromFlatRate(session.tradingFee);
+    const feeResult = this.feeCalculator.calculateFee({ tradeValue: totalValue }, feeConfig);
+    const fee = feeResult.fee;
+
+    const totalCost = new Decimal(totalValue).plus(fee);
+    if (new Decimal(quoteAccount.available).lt(totalCost)) {
+      this.logger.warn(
+        `Insufficient ${quoteCurrency} balance for BUY order: need ${totalCost.toFixed(2)}, have ${quoteAccount.available.toFixed(
+          2
+        )}`
+      );
+      return { status: 'insufficient_funds', order: null };
+    }
+
+    quoteAccount.available = new Decimal(quoteAccount.available).minus(totalCost).toNumber();
+    await txManager.save(quoteAccount);
+
+    if (!baseAccount) {
+      baseAccount = txManager.create(PaperTradingAccount, {
+        currency: baseCurrency,
+        available: 0,
+        locked: 0,
+        entryDate: timestamp,
+        session
+      });
+    }
+    const acct = baseAccount;
+    const oldQuantity = acct.available;
+    if (!acct.entryDate || oldQuantity === 0) {
+      acct.entryDate = timestamp;
+    }
+
+    const dOldCost = new Decimal(acct.averageCost ?? 0);
+    const dOldQuantity = new Decimal(oldQuantity);
+    const dNewQuantity = dOldQuantity.plus(dQuantity);
+    acct.averageCost = dOldQuantity.gt(0)
+      ? dOldCost.mul(dOldQuantity).plus(dExecutionPrice.mul(dQuantity)).div(dNewQuantity).toNumber()
+      : executionPrice;
+    acct.available = dNewQuantity.toNumber();
+    await txManager.save(acct);
+
+    const order = txManager.create(PaperTradingOrder, {
+      side: PaperTradingOrderSide.BUY,
+      orderType: PaperTradingOrderType.MARKET,
+      status: PaperTradingOrderStatus.FILLED,
+      symbol: signal.symbol,
+      baseCurrency,
+      quoteCurrency,
+      requestedQuantity: quantity,
+      filledQuantity: quantity,
+      executedPrice: executionPrice,
+      averagePrice: executionPrice,
+      slippageBps,
+      fee,
+      feeAsset: quoteCurrency,
+      totalValue,
+      executedAt: timestamp,
+      session,
+      signal: signalEntity,
+      ...(exitType && { exitType }),
+      metadata: {
+        reason: signal.reason,
+        confidence: signal.confidence,
+        basePrice
+      }
+    });
+
+    return { status: 'success', order: await txManager.save(order) };
+  }
+
+  private async executeSell(
+    ctx: ExecuteOrderContext,
+    args: {
+      txManager: EntityManager;
+      baseCurrency: string;
+      basePrice: number;
+      executionPrice: number;
+      slippageBps: number;
+      quoteAccount: PaperTradingAccount;
+      baseAccount: PaperTradingAccount | null;
+    }
+  ): Promise<ExecuteOrderResult> {
+    const { session, signal, signalEntity, quoteCurrency, timestamp, exitType } = ctx;
+    const { txManager, baseCurrency, basePrice, executionPrice, slippageBps, quoteAccount, baseAccount } = args;
+
+    if (!baseAccount || baseAccount.available <= 0) {
+      this.logger.warn(`No ${baseCurrency} position to sell`);
+      return { status: 'no_position', order: null };
+    }
+
+    const minHoldMs = resolveMinHoldMs(session.algorithmConfig);
+    const isRiskControl =
+      signal.originalType === AlgoSignalType.STOP_LOSS || signal.originalType === AlgoSignalType.TAKE_PROFIT;
+
+    if (!isRiskControl && minHoldMs > 0 && baseAccount.entryDate) {
+      const holdTimeMs = timestamp.getTime() - baseAccount.entryDate.getTime();
+      if (holdTimeMs < minHoldMs) {
+        this.logger.debug(
+          `Hold period not met for ${baseCurrency}: held ${Math.round(holdTimeMs / 3600000)}h, min ${Math.round(
+            minHoldMs / 3600000
+          )}h`
+        );
+        return { status: 'hold_period', order: null };
+      }
+    }
+
+    const costBasis = baseAccount.averageCost ?? 0;
+
+    const quantity = this.calculateSellQuantity(signal, baseAccount.available);
+
+    const dSellQuantity = new Decimal(quantity);
+    const dSellPrice = new Decimal(executionPrice);
+    const totalValue = dSellQuantity.mul(dSellPrice).toNumber();
+
+    const feeConfig = this.feeCalculator.fromFlatRate(session.tradingFee);
+    const feeResult = this.feeCalculator.calculateFee({ tradeValue: totalValue }, feeConfig);
+    const fee = feeResult.fee;
+
+    const dCostBasis = new Decimal(costBasis);
+    const dFee = new Decimal(fee);
+    const dCostBasisTotal = dCostBasis.mul(dSellQuantity);
+    const realizedPnL = dSellPrice.minus(dCostBasis).mul(dSellQuantity).minus(dFee).toNumber();
+    // BUG #4 fix: include fee in realizedPnLPercent numerator.
+    const realizedPnLPercent = dCostBasisTotal.gt(0)
+      ? new Decimal(totalValue).minus(dFee).minus(dCostBasisTotal).div(dCostBasisTotal).toNumber()
+      : 0;
+
+    baseAccount.available = new Decimal(baseAccount.available).minus(dSellQuantity).toNumber();
+    if (baseAccount.available < 0.00000001) {
+      baseAccount.available = 0;
+      baseAccount.averageCost = undefined;
+      baseAccount.entryDate = undefined;
+    }
+    await txManager.save(baseAccount);
+
+    quoteAccount.available = new Decimal(quoteAccount.available).plus(new Decimal(totalValue).minus(dFee)).toNumber();
+    await txManager.save(quoteAccount);
+
+    const order = txManager.create(PaperTradingOrder, {
+      side: PaperTradingOrderSide.SELL,
+      orderType: PaperTradingOrderType.MARKET,
+      status: PaperTradingOrderStatus.FILLED,
+      symbol: signal.symbol,
+      baseCurrency,
+      quoteCurrency,
+      requestedQuantity: quantity,
+      filledQuantity: quantity,
+      executedPrice: executionPrice,
+      averagePrice: executionPrice,
+      slippageBps,
+      fee,
+      feeAsset: quoteCurrency,
+      totalValue,
+      realizedPnL,
+      realizedPnLPercent,
+      costBasis,
+      executedAt: timestamp,
+      session,
+      signal: signalEntity,
+      ...(exitType && { exitType }),
+      metadata: {
+        reason: signal.reason,
+        confidence: signal.confidence,
+        basePrice
+      }
+    });
+
+    return { status: 'success', order: await txManager.save(order) };
+  }
+}

--- a/apps/api/src/order/paper-trading/engine/paper-trading-portfolio.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-portfolio.service.spec.ts
@@ -1,0 +1,111 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { PaperTradingPortfolioService } from './paper-trading-portfolio.service';
+
+import { PaperTradingAccount } from '../entities';
+
+describe('PaperTradingPortfolioService', () => {
+  let service: PaperTradingPortfolioService;
+  let repo: { find: jest.Mock };
+
+  const mkAccount = (overrides: Partial<PaperTradingAccount>): PaperTradingAccount =>
+    ({
+      currency: 'USD',
+      available: 0,
+      total: 0,
+      averageCost: 0,
+      ...overrides
+    }) as PaperTradingAccount;
+
+  beforeEach(async () => {
+    repo = { find: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PaperTradingPortfolioService, { provide: getRepositoryToken(PaperTradingAccount), useValue: repo }]
+    }).compile();
+    service = module.get(PaperTradingPortfolioService);
+  });
+
+  describe('buildFromAccounts', () => {
+    it('builds portfolio with cash and positions', () => {
+      const accounts = [
+        mkAccount({ currency: 'USD', available: 1000, total: 1000 }),
+        mkAccount({ currency: 'BTC', total: 0.5, averageCost: 50000 })
+      ];
+      const portfolio = service.buildFromAccounts(accounts, 'USD');
+      expect(portfolio.cashBalance).toBe(1000);
+      expect(portfolio.positions.size).toBe(1);
+      expect(portfolio.positions.get('BTC')?.quantity).toBe(0.5);
+      expect(portfolio.positions.get('BTC')?.averagePrice).toBe(50000);
+    });
+
+    it('skips zero-balance positions', () => {
+      const accounts = [
+        mkAccount({ currency: 'USD', available: 100, total: 100 }),
+        mkAccount({ currency: 'BTC', total: 0 })
+      ];
+      const portfolio = service.buildFromAccounts(accounts, 'USD');
+      expect(portfolio.positions.size).toBe(0);
+    });
+  });
+
+  describe('updateWithPrices', () => {
+    it('mutates portfolio totals from prices', () => {
+      const accounts = [
+        mkAccount({ currency: 'USD', available: 1000, total: 1000 }),
+        mkAccount({ currency: 'BTC', total: 0.5, averageCost: 50000 })
+      ];
+      const portfolio = service.buildFromAccounts(accounts, 'USD');
+      const result = service.updateWithPrices(portfolio, { 'BTC/USD': 60000 }, 'USD');
+      expect(result.positions.get('BTC')?.totalValue).toBe(30000);
+      expect(result.totalValue).toBe(31000);
+    });
+
+    it('treats missing prices as 0', () => {
+      const accounts = [
+        mkAccount({ currency: 'USD', available: 500, total: 500 }),
+        mkAccount({ currency: 'BTC', total: 1 })
+      ];
+      const portfolio = service.buildFromAccounts(accounts, 'USD');
+      const result = service.updateWithPrices(portfolio, {}, 'USD');
+      expect(result.totalValue).toBe(500);
+    });
+  });
+
+  describe('calculateValue', () => {
+    it('sums cash and priced positions without mutating portfolio', () => {
+      const accounts = [
+        mkAccount({ currency: 'USD', available: 200, total: 200 }),
+        mkAccount({ currency: 'ETH', total: 2 })
+      ];
+      const portfolio = service.buildFromAccounts(accounts, 'USD');
+      const value = service.calculateValue(portfolio, { 'ETH/USD': 2000 }, 'USD');
+      expect(value).toBe(4200);
+      expect(portfolio.positions.get('ETH')?.totalValue).toBe(0);
+    });
+  });
+
+  describe('buildPositionsContext', () => {
+    it('returns plain map of currency → quantity', () => {
+      const accounts = [
+        mkAccount({ currency: 'USD', total: 1000 }),
+        mkAccount({ currency: 'BTC', total: 0.1 }),
+        mkAccount({ currency: 'ETH', total: 0 })
+      ];
+      expect(service.buildPositionsContext(accounts, 'USD')).toEqual({ BTC: 0.1 });
+    });
+  });
+
+  describe('refresh', () => {
+    it('loads accounts and reprices portfolio', async () => {
+      repo.find.mockResolvedValueOnce([
+        mkAccount({ currency: 'USD', available: 500, total: 500 }),
+        mkAccount({ currency: 'BTC', total: 0.2, averageCost: 40000 })
+      ]);
+      const { accounts, portfolio } = await service.refresh('session-1', { 'BTC/USD': 50000 }, 'USD');
+      expect(repo.find).toHaveBeenCalledWith({ where: { session: { id: 'session-1' } } });
+      expect(accounts).toHaveLength(2);
+      expect(portfolio.totalValue).toBe(10500);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-portfolio.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-portfolio.service.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { getQuoteCurrency as getQuoteCurrencyUtil } from '../../../exchange/constants';
+import { Portfolio } from '../../backtest/shared';
+import { PaperTradingAccount } from '../entities';
+
+/**
+ * Encapsulates portfolio construction, repricing, and valuation for the paper-trading engine.
+ * Collapses the repeated "load accounts → build portfolio → reprice" sequence used throughout
+ * the engine tick loop.
+ */
+@Injectable()
+export class PaperTradingPortfolioService {
+  constructor(
+    @InjectRepository(PaperTradingAccount)
+    private readonly accountRepository: Repository<PaperTradingAccount>
+  ) {}
+
+  /** Fetch raw account rows for a session. */
+  loadAccounts(sessionId: string): Promise<PaperTradingAccount[]> {
+    return this.accountRepository.find({ where: { session: { id: sessionId } } });
+  }
+
+  /** Derive the quote currency from a set of accounts. */
+  getQuoteCurrency(accounts: PaperTradingAccount[]): string {
+    return getQuoteCurrencyUtil(accounts.map((a) => a.currency));
+  }
+
+  /** Build an unpriced Portfolio from accounts. Position values are set to 0 until repriced. */
+  buildFromAccounts(accounts: PaperTradingAccount[], quoteCurrency: string): Portfolio {
+    const quoteAccount = accounts.find((a) => a.currency === quoteCurrency);
+
+    const positions = new Map<string, { coinId: string; quantity: number; averagePrice: number; totalValue: number }>();
+
+    for (const account of accounts) {
+      if (account.currency !== quoteCurrency && account.total > 0) {
+        positions.set(account.currency, {
+          coinId: account.currency,
+          quantity: account.total,
+          averagePrice: account.averageCost ?? 0,
+          totalValue: 0
+        });
+      }
+    }
+
+    return {
+      cashBalance: quoteAccount?.available ?? 0,
+      positions,
+      totalValue: quoteAccount?.available ?? 0
+    };
+  }
+
+  /** Mutates a portfolio's position totalValue + totalValue based on current prices. */
+  updateWithPrices(portfolio: Portfolio, prices: Record<string, number>, quoteCurrency: string): Portfolio {
+    let positionsValue = 0;
+
+    for (const [coinId, position] of portfolio.positions) {
+      const symbol = `${coinId}/${quoteCurrency}`;
+      const price = prices[symbol] ?? 0;
+      position.totalValue = position.quantity * price;
+      positionsValue += position.totalValue;
+    }
+
+    portfolio.totalValue = portfolio.cashBalance + positionsValue;
+    return portfolio;
+  }
+
+  /** Calculate total portfolio value without mutating the portfolio. */
+  calculateValue(portfolio: Portfolio, prices: Record<string, number>, quoteCurrency: string): number {
+    let total = portfolio.cashBalance;
+
+    for (const [, position] of portfolio.positions) {
+      const symbol = `${position.coinId}/${quoteCurrency}`;
+      const price = prices[symbol] ?? 0;
+      total += position.quantity * price;
+    }
+
+    return total;
+  }
+
+  /** Build a plain-object positions context for algorithm consumption. */
+  buildPositionsContext(accounts: PaperTradingAccount[], quoteCurrency: string): Record<string, number> {
+    const positions: Record<string, number> = {};
+    for (const account of accounts) {
+      if (account.currency !== quoteCurrency && account.total > 0) {
+        positions[account.currency] = account.total;
+      }
+    }
+    return positions;
+  }
+
+  /**
+   * Refresh portfolio from the database: load accounts for the session, build portfolio,
+   * reprice with the supplied price map. Collapses the duplicated pattern in the engine.
+   */
+  async refresh(
+    sessionId: string,
+    priceMap: Record<string, number>,
+    quoteCurrency: string
+  ): Promise<{ accounts: PaperTradingAccount[]; portfolio: Portfolio }> {
+    const accounts = await this.accountRepository.find({ where: { session: { id: sessionId } } });
+    const portfolio = this.updateWithPrices(this.buildFromAccounts(accounts, quoteCurrency), priceMap, quoteCurrency);
+    return { accounts, portfolio };
+  }
+}

--- a/apps/api/src/order/paper-trading/engine/paper-trading-signal.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-signal.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { SignalReasonCode } from '@chansey/api-interfaces';
+
+import { TradingSignal } from './paper-trading-engine.utils';
+import { PaperTradingSignalService } from './paper-trading-signal.service';
+
+import {
+  PaperTradingSession,
+  PaperTradingSignal,
+  PaperTradingSignalDirection,
+  PaperTradingSignalStatus,
+  PaperTradingSignalType
+} from '../entities';
+
+describe('PaperTradingSignalService', () => {
+  let service: PaperTradingSignalService;
+  let repo: { create: jest.Mock; save: jest.Mock };
+
+  beforeEach(async () => {
+    repo = {
+      create: jest.fn((x: unknown) => x as PaperTradingSignal),
+      save: jest.fn((x: unknown) => Promise.resolve(x as PaperTradingSignal))
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PaperTradingSignalService, { provide: getRepositoryToken(PaperTradingSignal), useValue: repo }]
+    }).compile();
+    service = module.get(PaperTradingSignalService);
+  });
+
+  const session = { id: 'sess-1' } as PaperTradingSession;
+  const baseSignal: TradingSignal = {
+    action: 'BUY',
+    coinId: 'BTC',
+    symbol: 'BTC/USD',
+    reason: 'test',
+    confidence: 0.9,
+    quantity: 1
+  };
+
+  describe('save', () => {
+    it('creates and saves a LONG entity for BUY', async () => {
+      const result = await service.save(session, baseSignal);
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: PaperTradingSignalDirection.LONG,
+          signalType: PaperTradingSignalType.ENTRY,
+          instrument: 'BTC/USD',
+          quantity: 1,
+          processed: false,
+          session
+        })
+      );
+      expect(repo.save).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+
+    it('builds SHORT direction for SELL', async () => {
+      await service.save(session, { ...baseSignal, action: 'SELL' });
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ direction: PaperTradingSignalDirection.SHORT })
+      );
+    });
+
+    it('defaults quantity to 0 when missing', async () => {
+      await service.save(session, { ...baseSignal, quantity: undefined });
+      expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ quantity: 0 }));
+    });
+  });
+
+  describe('markRejected', () => {
+    it('sets status, rejectionCode, processed flags and saves', async () => {
+      const entity = {} as PaperTradingSignal;
+      await service.markRejected(entity, SignalReasonCode.SIGNAL_THROTTLED);
+      expect(entity.status).toBe(PaperTradingSignalStatus.REJECTED);
+      expect(entity.rejectionCode).toBe(SignalReasonCode.SIGNAL_THROTTLED);
+      expect(entity.processed).toBe(true);
+      expect(entity.processedAt).toBeInstanceOf(Date);
+      expect(repo.save).toHaveBeenCalledWith(entity);
+    });
+  });
+
+  describe('markSimulated', () => {
+    it('sets SIMULATED status and processed flags', async () => {
+      const entity = {} as PaperTradingSignal;
+      await service.markSimulated(entity);
+      expect(entity.status).toBe(PaperTradingSignalStatus.SIMULATED);
+      expect(entity.processed).toBe(true);
+      expect(repo.save).toHaveBeenCalledWith(entity);
+    });
+  });
+
+  describe('markError', () => {
+    it('sets ERROR status and processed flags', async () => {
+      const entity = {} as PaperTradingSignal;
+      await service.markError(entity);
+      expect(entity.status).toBe(PaperTradingSignalStatus.ERROR);
+      expect(entity.processed).toBe(true);
+    });
+  });
+
+  describe('markProcessed', () => {
+    it('sets processed flags without changing status', async () => {
+      const entity = { status: PaperTradingSignalStatus.SIMULATED } as PaperTradingSignal;
+      await service.markProcessed(entity);
+      expect(entity.status).toBe(PaperTradingSignalStatus.SIMULATED);
+      expect(entity.processed).toBe(true);
+      expect(entity.processedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-signal.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-signal.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { SignalReasonCode } from '@chansey/api-interfaces';
+
+import { classifySignalType, TradingSignal } from './paper-trading-engine.utils';
+
+import {
+  PaperTradingSession,
+  PaperTradingSignal,
+  PaperTradingSignalDirection,
+  PaperTradingSignalStatus
+} from '../entities';
+
+/**
+ * Persistence helper for PaperTradingSignal entities. Wraps the repeated
+ * "save signal → flip processed flags → save again" patterns used throughout
+ * the engine tick loop.
+ */
+@Injectable()
+export class PaperTradingSignalService {
+  constructor(
+    @InjectRepository(PaperTradingSignal)
+    private readonly signalRepository: Repository<PaperTradingSignal>
+  ) {}
+
+  /** Persist a new PaperTradingSignal row derived from an in-memory TradingSignal. */
+  async save(session: PaperTradingSession, signal: TradingSignal): Promise<PaperTradingSignal> {
+    const entity = this.signalRepository.create({
+      signalType: classifySignalType(signal),
+      direction:
+        signal.action === 'BUY'
+          ? PaperTradingSignalDirection.LONG
+          : signal.action === 'SELL' || signal.action === 'OPEN_SHORT' || signal.action === 'CLOSE_SHORT'
+            ? PaperTradingSignalDirection.SHORT
+            : PaperTradingSignalDirection.FLAT,
+      instrument: signal.symbol,
+      quantity: signal.quantity ?? 0,
+      price: undefined,
+      confidence: signal.confidence,
+      reason: signal.reason,
+      payload: signal.metadata,
+      processed: false,
+      session
+    });
+
+    return this.signalRepository.save(entity);
+  }
+
+  /** Mark a persisted signal as rejected with a given reason code. */
+  async markRejected(entity: PaperTradingSignal, code: SignalReasonCode): Promise<PaperTradingSignal> {
+    entity.status = PaperTradingSignalStatus.REJECTED;
+    entity.rejectionCode = code;
+    entity.processed = true;
+    entity.processedAt = new Date();
+    return this.signalRepository.save(entity);
+  }
+
+  /** Mark a persisted signal as simulated (intentional HOLD / no-op). */
+  async markSimulated(entity: PaperTradingSignal): Promise<PaperTradingSignal> {
+    entity.status = PaperTradingSignalStatus.SIMULATED;
+    entity.processed = true;
+    entity.processedAt = new Date();
+    return this.signalRepository.save(entity);
+  }
+
+  /** Mark a persisted signal as errored. */
+  async markError(entity: PaperTradingSignal): Promise<PaperTradingSignal> {
+    entity.status = PaperTradingSignalStatus.ERROR;
+    entity.processed = true;
+    entity.processedAt = new Date();
+    return this.signalRepository.save(entity);
+  }
+
+  /** Mark a persisted signal as processed without changing its status. */
+  async markProcessed(entity: PaperTradingSignal): Promise<PaperTradingSignal> {
+    entity.processed = true;
+    entity.processedAt = new Date();
+    return this.signalRepository.save(entity);
+  }
+}

--- a/apps/api/src/order/paper-trading/engine/paper-trading-snapshot.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-snapshot.service.spec.ts
@@ -1,0 +1,181 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { PaperTradingSnapshotService } from './paper-trading-snapshot.service';
+
+import { MetricsCalculatorService, Portfolio, TimeframeType } from '../../backtest/shared';
+import { PaperTradingOrder, PaperTradingOrderSide, PaperTradingSession, PaperTradingSnapshot } from '../entities';
+
+describe('PaperTradingSnapshotService', () => {
+  let service: PaperTradingSnapshotService;
+  let snapshotRepo: { create: jest.Mock; save: jest.Mock; find: jest.Mock };
+  let orderRepo: { find: jest.Mock; createQueryBuilder: jest.Mock };
+  let metricsCalculator: { calculateSharpeRatio: jest.Mock };
+
+  const buildSession = (overrides: Partial<PaperTradingSession> = {}): PaperTradingSession =>
+    ({
+      id: 'session-1',
+      initialCapital: 10_000,
+      peakPortfolioValue: 10_000,
+      ...overrides
+    }) as PaperTradingSession;
+
+  const buildPortfolio = (): Portfolio =>
+    ({
+      cashBalance: 5_000,
+      positions: new Map([
+        [
+          'BTC',
+          {
+            quantity: 0.1,
+            averagePrice: 40_000
+          } as unknown as Portfolio['positions'] extends Map<string, infer V> ? V : never
+        ]
+      ])
+    }) as unknown as Portfolio;
+
+  beforeEach(async () => {
+    snapshotRepo = {
+      create: jest.fn((x) => x),
+      save: jest.fn((x) => Promise.resolve({ ...x, id: 'snap-1' })),
+      find: jest.fn()
+    };
+    orderRepo = {
+      find: jest.fn(),
+      createQueryBuilder: jest.fn(() => ({
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 123 })
+      }))
+    };
+    metricsCalculator = { calculateSharpeRatio: jest.fn().mockReturnValue(1.5) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaperTradingSnapshotService,
+        { provide: getRepositoryToken(PaperTradingSnapshot), useValue: snapshotRepo },
+        { provide: getRepositoryToken(PaperTradingOrder), useValue: orderRepo },
+        { provide: MetricsCalculatorService, useValue: metricsCalculator }
+      ]
+    }).compile();
+
+    service = module.get(PaperTradingSnapshotService);
+  });
+
+  describe('save', () => {
+    it('creates and persists a snapshot with holdings, pnl, and drawdown', async () => {
+      const session = buildSession({ peakPortfolioValue: 11_000 });
+      const portfolio = buildPortfolio();
+      const prices = { 'BTC/USD': 45_000 };
+
+      const result = await service.save(session, portfolio, 9_500, prices, 'USD', new Date('2024-01-01'));
+
+      expect(snapshotRepo.create).toHaveBeenCalledTimes(1);
+      const created = snapshotRepo.create.mock.calls[0][0];
+      expect(created.portfolioValue).toBe(9_500);
+      expect(created.cashBalance).toBe(5_000);
+      expect(created.holdings.BTC.quantity).toBe(0.1);
+      expect(created.holdings.BTC.price).toBe(45_000);
+      // unrealized = (45000 - 40000) * 0.1 = 500
+      expect(created.holdings.BTC.unrealizedPnL).toBe(500);
+      expect(created.unrealizedPnL).toBe(500);
+      // cumulativeReturn = (9500 - 10000) / 10000 = -0.05
+      expect(created.cumulativeReturn).toBeCloseTo(-0.05);
+      // peak = max(11000, 9500) = 11000; drawdown = (11000-9500)/11000
+      expect(created.drawdown).toBeCloseTo(1500 / 11000);
+      expect(created.realizedPnL).toBe(123);
+      expect(result.id).toBe('snap-1');
+      expect(snapshotRepo.save).toHaveBeenCalled();
+    });
+
+    it('clamps drawdown to 0 when portfolio value exceeds stale peak', async () => {
+      const session = buildSession({ peakPortfolioValue: 10_000 });
+      await service.save(session, buildPortfolio(), 12_000, { 'BTC/USD': 45_000 }, 'USD', new Date());
+      expect(snapshotRepo.create.mock.calls[0][0].drawdown).toBe(0);
+    });
+
+    it('falls back to initialCapital when peakPortfolioValue is null', async () => {
+      const session = buildSession({ peakPortfolioValue: null as unknown as number });
+      await service.save(session, buildPortfolio(), 9_000, { 'BTC/USD': 45_000 }, 'USD', new Date());
+      // peak = max(10000, 9000) = 10000; dd = 1000/10000 = 0.1
+      expect(snapshotRepo.create.mock.calls[0][0].drawdown).toBeCloseTo(0.1);
+    });
+
+    it('treats averagePrice=0 positions as zero unrealized P&L', async () => {
+      const portfolio = {
+        cashBalance: 1_000,
+        positions: new Map([['BTC', { quantity: 0.1, averagePrice: 0 }]])
+      } as unknown as Portfolio;
+      await service.save(buildSession(), portfolio, 10_000, { 'BTC/USD': 45_000 }, 'USD', new Date());
+      const created = snapshotRepo.create.mock.calls[0][0];
+      expect(created.holdings.BTC.unrealizedPnL).toBe(0);
+      expect(created.holdings.BTC.unrealizedPnLPercent).toBe(0);
+      expect(created.unrealizedPnL).toBe(0);
+    });
+
+    it('falls back to price 0 when symbol missing from prices map', async () => {
+      await service.save(buildSession(), buildPortfolio(), 5_000, {}, 'USD', new Date());
+      const created = snapshotRepo.create.mock.calls[0][0];
+      expect(created.holdings.BTC.price).toBe(0);
+      expect(created.holdings.BTC.value).toBe(0);
+    });
+
+    it('defaults realizedPnL to 0 when query returns no rows', async () => {
+      orderRepo.createQueryBuilder.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue(undefined)
+      });
+      await service.save(buildSession(), buildPortfolio(), 10_000, { 'BTC/USD': 45_000 }, 'USD', new Date());
+      expect(snapshotRepo.create.mock.calls[0][0].realizedPnL).toBe(0);
+    });
+  });
+
+  describe('calculateSessionMetrics', () => {
+    it('computes win rate, trade counts, sharpe, and max drawdown', async () => {
+      const session = buildSession();
+      orderRepo.find.mockResolvedValue([
+        { side: PaperTradingOrderSide.BUY, realizedPnL: null },
+        { side: PaperTradingOrderSide.SELL, realizedPnL: 100 },
+        { side: PaperTradingOrderSide.SELL, realizedPnL: -50 },
+        { side: PaperTradingOrderSide.SELL, realizedPnL: 25 }
+      ]);
+      snapshotRepo.find.mockResolvedValue([
+        { portfolioValue: 10_000 },
+        { portfolioValue: 10_500 },
+        { portfolioValue: 10_200 },
+        { portfolioValue: 11_000 },
+        { portfolioValue: 9_900 }
+      ]);
+
+      const result = await service.calculateSessionMetrics(session);
+
+      expect(result.totalTrades).toBe(4);
+      expect(result.winningTrades).toBe(2);
+      expect(result.losingTrades).toBe(1);
+      expect(result.winRate).toBeCloseTo(2 / 3);
+      expect(metricsCalculator.calculateSharpeRatio).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ timeframe: TimeframeType.HOURLY, useCryptoCalendar: true, riskFreeRate: 0.02 })
+      );
+      expect(result.sharpeRatio).toBe(1.5);
+      // peak = 11000, min after = 9900, dd = 1100/11000 = 0.1
+      expect(result.maxDrawdown).toBeCloseTo(0.1);
+    });
+
+    it('returns sharpe 0 when insufficient return samples', async () => {
+      const session = buildSession();
+      orderRepo.find.mockResolvedValue([]);
+      snapshotRepo.find.mockResolvedValue([{ portfolioValue: 10_000 }, { portfolioValue: 10_100 }]);
+
+      const result = await service.calculateSessionMetrics(session);
+
+      expect(result.sharpeRatio).toBe(0);
+      expect(metricsCalculator.calculateSharpeRatio).not.toHaveBeenCalled();
+      expect(result.winRate).toBe(0);
+      expect(result.totalTrades).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-snapshot.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-snapshot.service.ts
@@ -1,0 +1,165 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { MetricsCalculatorService, Portfolio, TimeframeType } from '../../backtest/shared';
+import {
+  PaperTradingOrder,
+  PaperTradingOrderSide,
+  PaperTradingSession,
+  PaperTradingSnapshot,
+  SnapshotHolding
+} from '../entities';
+
+/**
+ * Encapsulates snapshot persistence and end-of-session metric aggregation
+ * for the paper-trading engine.
+ */
+@Injectable()
+export class PaperTradingSnapshotService {
+  constructor(
+    @InjectRepository(PaperTradingSnapshot)
+    private readonly snapshotRepository: Repository<PaperTradingSnapshot>,
+    @InjectRepository(PaperTradingOrder)
+    private readonly orderRepository: Repository<PaperTradingOrder>,
+    private readonly metricsCalculator: MetricsCalculatorService
+  ) {}
+
+  /**
+   * Save a portfolio snapshot
+   */
+  async save(
+    session: PaperTradingSession,
+    portfolio: Portfolio,
+    portfolioValue: number,
+    prices: Record<string, number>,
+    quoteCurrency: string,
+    timestamp: Date
+  ): Promise<PaperTradingSnapshot> {
+    const cumulativeReturn = (portfolioValue - session.initialCapital) / session.initialCapital;
+
+    // Calculate drawdown (clamp to 0 – portfolio may exceed stale peak before processor updates it)
+    const peakValue = Math.max(session.peakPortfolioValue ?? session.initialCapital, portfolioValue);
+    const drawdown = peakValue > 0 ? Math.min(1, Math.max(0, (peakValue - portfolioValue) / peakValue)) : 0;
+
+    // Build holdings map
+    const holdings: Record<string, SnapshotHolding> = {};
+    for (const [coinId, position] of portfolio.positions) {
+      const symbol = `${coinId}/${quoteCurrency}`;
+      const price = prices[symbol] ?? 0;
+      const value = position.quantity * price;
+      const unrealizedPnL = position.averagePrice > 0 ? (price - position.averagePrice) * position.quantity : 0;
+      const unrealizedPnLPercent =
+        position.averagePrice > 0 ? (price - position.averagePrice) / position.averagePrice : 0;
+
+      holdings[coinId] = {
+        quantity: position.quantity,
+        value,
+        price,
+        averageCost: position.averagePrice,
+        unrealizedPnL,
+        unrealizedPnLPercent
+      };
+    }
+
+    // Calculate unrealized P&L
+    let unrealizedPnL = 0;
+    for (const holding of Object.values(holdings)) {
+      unrealizedPnL += holding.unrealizedPnL ?? 0;
+    }
+
+    // Get realized P&L from orders
+    const realizedPnLResult = await this.orderRepository
+      .createQueryBuilder('order')
+      .select('SUM(order.realizedPnL)', 'totalRealizedPnL')
+      .where('order.sessionId = :sessionId', { sessionId: session.id })
+      .andWhere('order.realizedPnL IS NOT NULL')
+      .getRawOne();
+
+    const snapshot = this.snapshotRepository.create({
+      portfolioValue,
+      cashBalance: portfolio.cashBalance,
+      holdings,
+      cumulativeReturn,
+      drawdown,
+      unrealizedPnL,
+      realizedPnL: realizedPnLResult?.totalRealizedPnL ?? 0,
+      prices,
+      timestamp,
+      session
+    });
+
+    return this.snapshotRepository.save(snapshot);
+  }
+
+  /**
+   * Calculate final session metrics
+   */
+  async calculateSessionMetrics(session: PaperTradingSession): Promise<{
+    sharpeRatio: number;
+    winRate: number;
+    totalTrades: number;
+    winningTrades: number;
+    losingTrades: number;
+    maxDrawdown: number;
+  }> {
+    // Get all orders
+    const orders = await this.orderRepository.find({
+      where: { session: { id: session.id } }
+    });
+
+    const sellOrders = orders.filter((o) => o.side === PaperTradingOrderSide.SELL);
+    const winningTrades = sellOrders.filter((o) => (o.realizedPnL ?? 0) > 0).length;
+    const losingTrades = sellOrders.filter((o) => (o.realizedPnL ?? 0) < 0).length;
+    const totalTrades = orders.length;
+    const winRate = sellOrders.length > 0 ? winningTrades / sellOrders.length : 0;
+
+    // Get snapshots for Sharpe ratio
+    const snapshots = await this.snapshotRepository.find({
+      where: { session: { id: session.id } },
+      order: { timestamp: 'ASC' }
+    });
+
+    const returns: number[] = [];
+    for (let i = 1; i < snapshots.length; i++) {
+      const previous = snapshots[i - 1].portfolioValue;
+      const current = snapshots[i].portfolioValue;
+      if (previous > 0) {
+        returns.push((current - previous) / previous);
+      }
+    }
+
+    // Calculate Sharpe ratio using hourly intervals (crypto 24/7)
+    const sharpeRatio =
+      returns.length > 2
+        ? this.metricsCalculator.calculateSharpeRatio(returns, {
+            timeframe: TimeframeType.HOURLY,
+            useCryptoCalendar: true,
+            riskFreeRate: 0.02
+          })
+        : 0;
+
+    // Calculate max drawdown
+    let maxDrawdown = 0;
+    let peak = session.initialCapital;
+    for (const snapshot of snapshots) {
+      if (snapshot.portfolioValue > peak) {
+        peak = snapshot.portfolioValue;
+      }
+      const drawdown = peak > 0 ? Math.max(0, (peak - snapshot.portfolioValue) / peak) : 0;
+      if (drawdown > maxDrawdown) {
+        maxDrawdown = drawdown;
+      }
+    }
+
+    return {
+      sharpeRatio,
+      winRate,
+      totalTrades,
+      winningTrades,
+      losingTrades,
+      maxDrawdown
+    };
+  }
+}

--- a/apps/api/src/order/paper-trading/engine/paper-trading-throttle.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-throttle.service.spec.ts
@@ -1,0 +1,89 @@
+import { PaperTradingThrottleService } from './paper-trading-throttle.service';
+
+describe('PaperTradingThrottleService', () => {
+  const makeState = () => ({ lastSignalTime: {}, tradeTimestamps: [] });
+
+  const buildService = () => {
+    const signalThrottle = {
+      createState: jest.fn().mockImplementation(() => makeState()),
+      filterSignals: jest.fn().mockImplementation((signals: any[]) => ({
+        accepted: signals,
+        rejected: []
+      })),
+      serialize: jest.fn().mockImplementation((state: any) => ({ ...state, serialized: true })),
+      deserialize: jest.fn().mockImplementation((serialized: any) => ({ restored: true, from: serialized }))
+    };
+    const service = new PaperTradingThrottleService(signalThrottle as any);
+    return { service, signalThrottle };
+  };
+
+  it('getOrCreate creates state on first call and reuses it thereafter', () => {
+    const { service, signalThrottle } = buildService();
+    const a = service.getOrCreate('s1');
+    const b = service.getOrCreate('s1');
+    expect(a).toBe(b);
+    expect(signalThrottle.createState).toHaveBeenCalledTimes(1);
+    expect(service.has('s1')).toBe(true);
+  });
+
+  it('clear removes state', () => {
+    const { service } = buildService();
+    service.getOrCreate('s1');
+    service.clear('s1');
+    expect(service.has('s1')).toBe(false);
+  });
+
+  it('restore deserializes and stores state; skips if already present', () => {
+    const { service, signalThrottle } = buildService();
+    service.restore('s1', { foo: 1 } as any);
+    expect(signalThrottle.deserialize).toHaveBeenCalledTimes(1);
+    expect(service.has('s1')).toBe(true);
+
+    // Second restore should be a no-op (don't overwrite live state)
+    service.restore('s1', { foo: 2 } as any);
+    expect(signalThrottle.deserialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('getSerialized returns undefined when no state exists', () => {
+    const { service } = buildService();
+    expect(service.getSerialized('missing')).toBeUndefined();
+  });
+
+  it('getSerialized delegates to SignalThrottleService.serialize when state exists', () => {
+    const { service, signalThrottle } = buildService();
+    service.getOrCreate('s1');
+    const result = service.getSerialized('s1');
+    expect(signalThrottle.serialize).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expect.objectContaining({ serialized: true }));
+  });
+
+  it('filter get-or-creates state and delegates to SignalThrottleService.filterSignals', () => {
+    const { service, signalThrottle } = buildService();
+    const signals = [{ symbol: 'BTC', action: 'BUY' } as any];
+    const config = { cooldownMs: 0, maxTradesPerDay: 10, minSellPercent: 0 } as any;
+    const now = 1_700_000_000_000;
+
+    const result = service.filter('s1', signals, config, now);
+
+    expect(signalThrottle.createState).toHaveBeenCalledTimes(1);
+    expect(signalThrottle.filterSignals).toHaveBeenCalledWith(signals, expect.any(Object), config, now);
+    expect(result).toEqual({ accepted: signals, rejected: [] });
+
+    // Second call reuses existing state
+    service.filter('s1', signals, config, now + 1);
+    expect(signalThrottle.createState).toHaveBeenCalledTimes(1);
+  });
+
+  it('sweepOrphaned removes entries not in active set', () => {
+    const { service } = buildService();
+    service.getOrCreate('a');
+    service.getOrCreate('b');
+    service.getOrCreate('c');
+
+    const swept = service.sweepOrphaned(new Set(['b']));
+    expect(swept).toBe(2);
+    expect(service.has('a')).toBe(false);
+    expect(service.has('b')).toBe(true);
+    expect(service.has('c')).toBe(false);
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-throttle.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-throttle.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+
+import { TradingSignal } from './paper-trading-engine.utils';
+
+import {
+  SerializableThrottleState,
+  SignalThrottleConfig,
+  SignalThrottleService,
+  ThrottleState
+} from '../../backtest/shared';
+
+/**
+ * Owns per-session throttle state for the paper trading engine.
+ *
+ * Wraps the shared `SignalThrottleService` with a session-keyed `Map` so the
+ * engine does not need to track throttle lifecycles directly.
+ */
+@Injectable()
+export class PaperTradingThrottleService {
+  private readonly throttleStates = new Map<string, ThrottleState>();
+
+  constructor(private readonly signalThrottle: SignalThrottleService) {}
+
+  /** Get-or-create throttle state for a session. */
+  getOrCreate(sessionId: string): ThrottleState {
+    let state = this.throttleStates.get(sessionId);
+    if (!state) {
+      state = this.signalThrottle.createState();
+      this.throttleStates.set(sessionId, state);
+    }
+    return state;
+  }
+
+  /** Clean up throttle state when a session ends. */
+  clear(sessionId: string): void {
+    this.throttleStates.delete(sessionId);
+  }
+
+  /** Check if in-memory throttle state exists for a session. */
+  has(sessionId: string): boolean {
+    return this.throttleStates.has(sessionId);
+  }
+
+  /** Restore throttle state from a previously serialized form (e.g. from DB). */
+  restore(sessionId: string, serialized: SerializableThrottleState): void {
+    if (this.throttleStates.has(sessionId)) return;
+    const state = this.signalThrottle.deserialize(serialized);
+    this.throttleStates.set(sessionId, state);
+  }
+
+  /** Serialize current throttle state for DB persistence. */
+  getSerialized(sessionId: string): SerializableThrottleState | undefined {
+    const state = this.throttleStates.get(sessionId);
+    if (!state) return undefined;
+    return this.signalThrottle.serialize(state);
+  }
+
+  /**
+   * Filter signals through the throttle for the given session, get-or-creating
+   * its state as needed. Mirrors `SignalThrottleService.filterSignals`.
+   */
+  filter(
+    sessionId: string,
+    signals: TradingSignal[],
+    config: SignalThrottleConfig,
+    now: number
+  ): { accepted: TradingSignal[]; rejected: TradingSignal[] } {
+    const state = this.getOrCreate(sessionId);
+    return this.signalThrottle.filterSignals(signals, state, config, now) as {
+      accepted: TradingSignal[];
+      rejected: TradingSignal[];
+    };
+  }
+
+  /**
+   * Sweep state for sessions no longer in the active set. Returns number of
+   * entries removed. Used by the engine's orphaned-state sweeper.
+   */
+  sweepOrphaned(activeSessionIds: Set<string>): number {
+    let swept = 0;
+    for (const sessionId of this.throttleStates.keys()) {
+      if (!activeSessionIds.has(sessionId)) {
+        this.throttleStates.delete(sessionId);
+        swept++;
+      }
+    }
+    return swept;
+  }
+}

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
@@ -1,120 +1,183 @@
-import { CompositeRegimeType, MarketRegimeType } from '@chansey/api-interfaces';
+import { CompositeRegimeType, MarketRegimeType, SignalReasonCode } from '@chansey/api-interfaces';
 
-import { PaperTradingOrderSide } from './entities';
 import { PaperTradingEngineService } from './paper-trading-engine.service';
 
 import { SignalType } from '../../algorithm/interfaces';
 
-const createService = (overrides: Partial<any> = {}) => {
-  const accountRepository = {
-    find: jest.fn(),
-    findOne: jest.fn(),
-    save: jest.fn(),
-    create: jest.fn()
-  };
-  const orderRepository = {
-    find: jest.fn(),
-    save: jest.fn(),
-    create: jest.fn(),
-    createQueryBuilder: jest.fn()
-  };
-  const signalRepository = {
-    save: jest.fn(),
-    create: jest.fn()
-  };
-  const snapshotRepository = {
-    find: jest.fn(),
-    save: jest.fn(),
-    create: jest.fn()
+/**
+ * Engine-level orchestration tests only.
+ *
+ * Execution, sizing, hold periods, slippage, entry/exit dates, session metrics math,
+ * opportunity-sell scoring, throttle state, snapshot persistence, and signal mapping
+ * each have their own focused unit spec under `engine/*.spec.ts`. These tests assert
+ * how `PaperTradingEngineService.processTick` wires those collaborators together —
+ * the held-coin guard, exit → algo refresh, signal-loop counting, retry on
+ * insufficient funds, regime gate persistence, the try/catch wrapper, and
+ * per-signal `finally { markProcessed }`.
+ */
+
+type MockAccount = { currency: string; available: number; total: number; averageCost?: number };
+
+interface Overrides {
+  accounts?: MockAccount[];
+  prices?: Record<string, number>;
+  quoteCurrency?: string;
+  compositeRegime?: CompositeRegimeType;
+  signalFilterChainApply?: jest.Mock;
+  exitOrdersExecuted?: number;
+}
+
+const createService = (overrides: Overrides = {}) => {
+  const accounts = overrides.accounts ?? [{ currency: 'USD', available: 10000, total: 10000 }];
+  const prices = overrides.prices ?? { 'BTC/USD': 50000 };
+  const quoteCurrency = overrides.quoteCurrency ?? 'USD';
+
+  const buildPortfolio = (accs: MockAccount[]) => {
+    const cash = accs.find((a) => a.currency === quoteCurrency);
+    const positions = new Map<string, any>();
+    let posValue = 0;
+    for (const a of accs) {
+      if (a.currency !== quoteCurrency && a.total > 0) {
+        const price = prices[`${a.currency}/${quoteCurrency}`] ?? 0;
+        const totalValue = a.total * price;
+        posValue += totalValue;
+        positions.set(a.currency, {
+          coinId: a.currency,
+          quantity: a.total,
+          averagePrice: a.averageCost ?? 0,
+          totalValue
+        });
+      }
+    }
+    return {
+      cashBalance: cash?.available ?? 0,
+      positions,
+      totalValue: (cash?.available ?? 0) + posValue
+    };
   };
 
-  const dataSource = {};
+  const portfolioService = {
+    loadAccounts: jest.fn().mockResolvedValue(accounts),
+    getQuoteCurrency: jest.fn().mockReturnValue(quoteCurrency),
+    buildFromAccounts: jest.fn((a: MockAccount[]) => buildPortfolio(a)),
+    updateWithPrices: jest.fn((p: any) => p),
+    buildPositionsContext: jest.fn(() => ({})),
+    refresh: jest.fn().mockImplementation(async () => ({
+      accounts,
+      portfolio: buildPortfolio(accounts)
+    }))
+  };
+
+  const signalService = {
+    save: jest.fn().mockImplementation(async () => ({ status: null, rejectionCode: null })),
+    markRejected: jest.fn().mockResolvedValue(undefined),
+    markProcessed: jest.fn().mockResolvedValue(undefined)
+  };
+
+  const snapshotService = {
+    save: jest.fn().mockResolvedValue(undefined),
+    calculateSessionMetrics: jest.fn()
+  };
+
+  const throttleService = {
+    filter: jest.fn().mockImplementation((_id: string, signals: any[]) => ({ accepted: signals, rejected: [] })),
+    clear: jest.fn(),
+    has: jest.fn(),
+    restore: jest.fn(),
+    getSerialized: jest.fn(),
+    sweepOrphaned: jest.fn().mockReturnValue(0)
+  };
+
+  const orderExecutor = {
+    execute: jest.fn().mockResolvedValue({
+      status: 'success',
+      order: { id: 'o-1', executedPrice: 50000, filledQuantity: 0.1 }
+    })
+  };
+
+  const exitExecutor = {
+    getOrCreate: jest.fn(),
+    checkAndExecute: jest.fn().mockResolvedValue(overrides.exitOrdersExecuted ?? 0),
+    onBuyFill: jest.fn(),
+    onSellFill: jest.fn(),
+    serialize: jest.fn(),
+    clear: jest.fn(),
+    sweep: jest.fn().mockReturnValue(0)
+  };
+
+  const opportunitySelling = {
+    attempt: jest.fn().mockResolvedValue(0)
+  };
 
   const marketDataService = {
-    getPrices: jest.fn(),
-    getHistoricalCandles: jest.fn().mockResolvedValue([]),
-    calculateRealisticSlippage: jest.fn()
+    getPrices: jest.fn().mockResolvedValue(new Map(Object.entries(prices).map(([sym, p]) => [sym, { price: p }]))),
+    getHistoricalCandles: jest.fn().mockResolvedValue([])
   };
 
   const algorithmRegistry = {
-    executeAlgorithm: jest.fn()
-  };
-
-  const feeCalculator = {
-    fromFlatRate: jest.fn(),
-    calculateFee: jest.fn()
-  };
-  const positionManager = {};
-  const metricsCalculator = {
-    calculateSharpeRatio: jest.fn()
-  };
-  const portfolioState = {};
-  const signalThrottle = {
-    createState: jest.fn().mockReturnValue({ lastSignalTime: {}, tradeTimestamps: [] }),
-    filterSignals: jest.fn().mockImplementation((signals: any[]) => ({ accepted: signals, rejected: [] })),
-    resolveConfig: jest.fn().mockReturnValue({ cooldownMs: 86_400_000, maxTradesPerDay: 6, minSellPercent: 0.5 })
+    executeAlgorithm: jest.fn().mockResolvedValue({ success: true, signals: [] })
   };
 
   const compositeRegimeService = {
-    getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BULL),
+    getCompositeRegime: jest.fn().mockReturnValue(overrides.compositeRegime ?? CompositeRegimeType.BULL),
     getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
   };
 
   const signalFilterChain = {
-    apply: jest.fn().mockImplementation((signals: any[], _ctx: any, allocation: any) => ({
-      signals,
-      maxAllocation: allocation.maxAllocation,
-      minAllocation: allocation.minAllocation,
-      regimeGateBlockedCount: 0,
-      regimeMultiplier: 1
-    }))
+    apply:
+      overrides.signalFilterChainApply ??
+      jest.fn().mockImplementation((signals: any[], _ctx: any, alloc: any) => ({
+        signals,
+        maxAllocation: alloc.maxAllocation,
+        minAllocation: alloc.minAllocation,
+        regimeGateBlockedCount: 0,
+        regimeMultiplier: 1
+      }))
   };
 
-  const positionAnalysis = {
-    calculatePositionSellScore: jest.fn().mockReturnValue({
-      eligible: true,
-      totalScore: 10,
-      unrealizedPnLScore: 5,
-      protectedGainsScore: 0,
-      holdingPeriodScore: 5,
-      opportunityAdvantageScore: 0,
-      algorithmRankingScore: 0,
-      unrealizedPnLPercent: -5,
-      holdingPeriodHours: 72
-    })
-  };
+  const signalThrottle = { resolveConfig: jest.fn().mockReturnValue({}) };
+
+  const service = new PaperTradingEngineService(
+    marketDataService as any,
+    algorithmRegistry as any,
+    signalThrottle as any,
+    compositeRegimeService as any,
+    signalFilterChain as any,
+    portfolioService as any,
+    signalService as any,
+    snapshotService as any,
+    throttleService as any,
+    orderExecutor as any,
+    exitExecutor as any,
+    opportunitySelling as any
+  );
 
   return {
-    service: new PaperTradingEngineService(
-      overrides.accountRepository ?? (accountRepository as any),
-      overrides.orderRepository ?? (orderRepository as any),
-      overrides.signalRepository ?? (signalRepository as any),
-      overrides.snapshotRepository ?? (snapshotRepository as any),
-      overrides.dataSource ?? (dataSource as any),
-      overrides.marketDataService ?? (marketDataService as any),
-      overrides.algorithmRegistry ?? (algorithmRegistry as any),
-      overrides.feeCalculator ?? (feeCalculator as any),
-      overrides.positionManager ?? (positionManager as any),
-      overrides.metricsCalculator ?? (metricsCalculator as any),
-      overrides.portfolioState ?? (portfolioState as any),
-      overrides.signalThrottle ?? (signalThrottle as any),
-      overrides.compositeRegimeService ?? (compositeRegimeService as any),
-      overrides.signalFilterChain ?? (signalFilterChain as any),
-      overrides.positionAnalysis ?? (positionAnalysis as any)
-    ),
-    accountRepository,
-    orderRepository,
-    signalRepository,
-    snapshotRepository,
-    metricsCalculator,
+    service,
+    portfolioService,
+    signalService,
+    snapshotService,
+    throttleService,
+    orderExecutor,
+    exitExecutor,
+    opportunitySelling,
     marketDataService,
     algorithmRegistry,
-    feeCalculator,
-    compositeRegimeService,
     signalFilterChain,
-    positionAnalysis
+    compositeRegimeService
   };
 };
+
+const makeSession = (overrides: Record<string, any> = {}): any => ({
+  id: 'session-1',
+  initialCapital: 10000,
+  tickCount: 10,
+  user: { id: 'user-1' },
+  algorithm: { id: 'algo-1' },
+  ...overrides
+});
+
+const exchangeKey: any = { exchange: { slug: 'binance' } };
 
 describe('PaperTradingEngineService', () => {
   beforeEach(() => {
@@ -122,1428 +185,239 @@ describe('PaperTradingEngineService', () => {
   });
 
   it('returns a failed tick result when processing throws', async () => {
-    const { service, accountRepository } = createService();
-    accountRepository.find.mockRejectedValue(new Error('db down'));
+    const { service, portfolioService } = createService();
+    portfolioService.loadAccounts.mockRejectedValueOnce(new Error('db down'));
 
-    const session = {
-      id: 'session-1',
-      initialCapital: 1000,
-      currentPortfolioValue: 1100
-    } as any;
-
-    const result = await service.processTick(session, {} as any);
+    const session = makeSession({ currentPortfolioValue: 1100 });
+    const result = await service.processTick(session, exchangeKey);
 
     expect(result.processed).toBe(false);
     expect(result.errors).toEqual(['db down']);
     expect(result.portfolioValue).toBe(1100);
+    expect(result.prices).toEqual({});
   });
 
-  it('calculates session metrics from orders and snapshots', async () => {
-    const { service, orderRepository, snapshotRepository, metricsCalculator } = createService();
-
-    orderRepository.find.mockResolvedValue([
-      { side: PaperTradingOrderSide.BUY, realizedPnL: null },
-      { side: PaperTradingOrderSide.SELL, realizedPnL: 10 },
-      { side: PaperTradingOrderSide.SELL, realizedPnL: -5 }
-    ]);
-
-    snapshotRepository.find.mockResolvedValue([
-      { portfolioValue: 100, timestamp: new Date('2024-01-01T00:00:00Z') },
-      { portfolioValue: 120, timestamp: new Date('2024-01-01T00:01:00Z') },
-      { portfolioValue: 90, timestamp: new Date('2024-01-01T00:02:00Z') },
-      { portfolioValue: 95, timestamp: new Date('2024-01-01T00:03:00Z') }
-    ]);
-
-    metricsCalculator.calculateSharpeRatio.mockReturnValue(1.23);
-
-    const session = { id: 'session-1', initialCapital: 100 } as any;
-
-    const result = await service.calculateSessionMetrics(session);
-
-    expect(result).toEqual({
+  it('delegates calculateSessionMetrics to snapshotService', async () => {
+    const { service, snapshotService } = createService();
+    const metrics = {
       sharpeRatio: 1.23,
       winRate: 0.5,
       totalTrades: 3,
       winningTrades: 1,
       losingTrades: 1,
       maxDrawdown: 0.25
-    });
+    };
+    snapshotService.calculateSessionMetrics.mockResolvedValue(metrics);
+
+    const session = makeSession();
+    await expect(service.calculateSessionMetrics(session)).resolves.toEqual(metrics);
+    expect(snapshotService.calculateSessionMetrics).toHaveBeenCalledWith(session);
   });
 
-  it('defaults to common symbols and snapshots on interval ticks', async () => {
-    const { service, accountRepository, snapshotRepository, orderRepository, marketDataService, algorithmRegistry } =
-      createService();
+  it('defaults to BTC/ETH symbols when no holdings or config and takes a snapshot on interval ticks', async () => {
+    const { service, marketDataService, snapshotService } = createService({ accounts: [] });
 
-    accountRepository.find
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ currency: 'USD', available: 1000, total: 1000 }]);
-
-    const prices = new Map<string, { price: number }>([
-      ['BTC/USD', { price: 50000 }],
-      ['ETH/USD', { price: 3000 }]
-    ]);
-
-    marketDataService.getPrices.mockResolvedValue(prices);
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = { id: 'session-2', initialCapital: 1000, tickCount: 10, user: { id: 'user-1' } } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
+    const result = await service.processTick(makeSession({ tickCount: 10 }), exchangeKey);
 
     expect(marketDataService.getPrices).toHaveBeenCalledWith('binance', ['BTC/USD', 'ETH/USD']);
-    expect(snapshotRepository.save).toHaveBeenCalled();
+    expect(snapshotService.save).toHaveBeenCalledTimes(1);
     expect(result.processed).toBe(true);
   });
 
-  it('skips buy when balance is insufficient', async () => {
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService();
+  it('refreshes portfolio before running the algorithm when exits executed', async () => {
+    const { service, portfolioService, algorithmRegistry } = createService({ exitOrdersExecuted: 2 });
 
-    const quoteAccount = { currency: 'USD', available: 50, total: 50 };
+    const result = await service.processTick(makeSession(), exchangeKey);
 
-    accountRepository.find.mockResolvedValueOnce([quoteAccount]).mockResolvedValueOnce([quoteAccount]);
-    accountRepository.findOne.mockResolvedValueOnce(quoteAccount).mockResolvedValueOnce(null);
+    expect(result.ordersExecuted).toBe(2);
+    expect(portfolioService.refresh).toHaveBeenCalled();
+    // The refresh call triggered by exits must happen before the algorithm runs
+    const firstRefreshOrder = portfolioService.refresh.mock.invocationCallOrder[0];
+    const algoOrder = algorithmRegistry.executeAlgorithm.mock.invocationCallOrder[0];
+    expect(firstRefreshOrder).toBeLessThan(algoOrder);
+  });
 
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 100 }]]));
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 100,
-      slippageBps: 0,
-      marketImpact: 0
+  it('passes post-exit refreshed portfolio (not the pre-exit snapshot) into the signal loop', async () => {
+    // Starting accounts represent pre-exit state; refresh returns post-exit state with more cash.
+    const preExitAccounts = [
+      { currency: 'USD', available: 1000, total: 1000 },
+      { currency: 'BTC', available: 1, total: 1, averageCost: 40000 }
+    ];
+    const postExitAccounts = [{ currency: 'USD', available: 51000, total: 51000 }];
+    const { service, portfolioService, orderExecutor, algorithmRegistry } = createService({
+      accounts: preExitAccounts,
+      prices: { 'BTC/USD': 50000, 'ETH/USD': 3000 },
+      exitOrdersExecuted: 1
+    });
+
+    // After the exit fires, refresh returns a fresh, bigger portfolio.
+    portfolioService.refresh.mockResolvedValue({
+      accounts: postExitAccounts,
+      portfolio: { cashBalance: 51000, positions: new Map(), totalValue: 51000 }
     });
 
     algorithmRegistry.executeAlgorithm.mockResolvedValue({
       success: true,
-      signals: [
-        {
-          type: SignalType.BUY,
-          coinId: 'BTC',
-          strength: 0.5,
-          quantity: 1,
-          confidence: 0.5,
-          reason: 'test'
-        }
-      ]
+      signals: [{ type: SignalType.BUY, coinId: 'ETH', strength: 0.1, confidence: 0.5, reason: 'entry' }]
     });
 
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 1 });
+    await service.processTick(makeSession(), exchangeKey);
 
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-3',
-      initialCapital: 1000,
-      tickCount: 1,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
-    expect(orderRepository.save).not.toHaveBeenCalled();
-    expect(result.ordersExecuted).toBe(0);
-    expect(result.processed).toBe(true);
+    expect(orderExecutor.execute).toHaveBeenCalled();
+    const firstCallCtx = orderExecutor.execute.mock.calls[0][0];
+    expect(firstCallCtx.portfolio.totalValue).toBe(51000);
   });
 
-  it('skips BUY signal when position already held', async () => {
-    const { service, accountRepository, signalRepository, orderRepository, marketDataService, algorithmRegistry } =
-      createService();
-
-    // User already holds ETH
-    const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-    const ethAccount = { currency: 'ETH', available: 1.5, total: 1.5 };
-
-    accountRepository.find.mockResolvedValue([quoteAccount, ethAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(new Map([['ETH/USD', { price: 3000 }]]));
-
+  it('skips BUY signal when the position is already held', async () => {
+    const { service, orderExecutor, signalService, algorithmRegistry } = createService({
+      accounts: [
+        { currency: 'USD', available: 10000, total: 10000 },
+        { currency: 'ETH', available: 1.5, total: 1.5 }
+      ],
+      prices: { 'ETH/USD': 3000 }
+    });
     algorithmRegistry.executeAlgorithm.mockResolvedValue({
       success: true,
       signals: [
-        {
-          type: SignalType.BUY,
-          coinId: 'ETH',
-          strength: 0.8,
-          quantity: 0.5,
-          confidence: 0.9,
-          reason: 'bullish indicators'
-        }
+        { type: SignalType.BUY, coinId: 'ETH', strength: 0.1, quantity: 0.5, confidence: 0.9, reason: 'add to' }
       ]
     });
 
-    const session = {
-      id: 'session-dup',
-      initialCapital: 10000,
-      tickCount: 1,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
+    const result = await service.processTick(makeSession(), exchangeKey);
 
-    const result = await service.processTick(session, exchangeKey);
-
-    // Signal should NOT be saved (skipped before saveSignal)
-    expect(signalRepository.save).not.toHaveBeenCalled();
-    // No order should be executed
-    expect(orderRepository.save).not.toHaveBeenCalled();
-    expect(result.ordersExecuted).toBe(0);
-    expect(result.processed).toBe(true);
-  });
-
-  it('applies slippage to execution price for buy orders', async () => {
-    const dataSource = {
-      transaction: jest.fn((callback: any) =>
-        callback({
-          findOne: jest
-            .fn()
-            .mockResolvedValueOnce({ currency: 'USD', available: 10000, total: 10000 })
-            .mockResolvedValueOnce(null),
-          create: jest.fn((entity: any, data: any) => data),
-          save: jest.fn((entity: any) => Promise.resolve(entity))
-        })
-      )
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      snapshotRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-    accountRepository.find
-      .mockResolvedValueOnce([quoteAccount])
-      .mockResolvedValueOnce([quoteAccount]) // refresh after successful order
-      .mockResolvedValueOnce([quoteAccount, { currency: 'BTC', available: 0.1, total: 0.1 }]);
-
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-    // Slippage of 10 bps means price increases by 0.1% for BUY
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 50050, // 50000 * (1 + 10/10000)
-      slippageBps: 10,
-      marketImpact: 5
-    });
-
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({
-      success: true,
-      signals: [
-        {
-          type: SignalType.BUY,
-          coinId: 'BTC',
-          strength: 0.1,
-          quantity: 0.1,
-          confidence: 0.8,
-          reason: 'test slippage'
-        }
-      ]
-    });
-
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 5 });
-
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-slippage',
-      initialCapital: 10000,
-      tickCount: 10,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
-    expect(marketDataService.calculateRealisticSlippage).toHaveBeenCalledWith(
-      'binance',
-      'BTC/USD',
-      expect.any(Number),
-      'BUY'
-    );
-    expect(result.processed).toBe(true);
-    expect(result.ordersExecuted).toBe(1);
-  });
-
-  it('executes sell order and calculates realized PnL', async () => {
-    const btcAccount = { currency: 'BTC', available: 1, total: 1, averageCost: 40000 };
-    const quoteAccount = { currency: 'USD', available: 1000, total: 1000 };
-
-    const dataSource = {
-      transaction: jest.fn((callback: any) =>
-        callback({
-          findOne: jest.fn().mockResolvedValueOnce(quoteAccount).mockResolvedValueOnce(btcAccount),
-          create: jest.fn((entity: any, data: any) => data),
-          save: jest.fn((entity: any) => Promise.resolve(entity))
-        })
-      )
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      snapshotRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    accountRepository.find
-      .mockResolvedValueOnce([quoteAccount, btcAccount])
-      .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after successful order
-      .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-    // Slippage for SELL - price decreases
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 49950, // 50000 * (1 - 10/10000)
-      slippageBps: 10,
-      marketImpact: 5
-    });
-
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({
-      success: true,
-      signals: [
-        {
-          type: SignalType.SELL,
-          coinId: 'BTC',
-          strength: 0.5,
-          quantity: 0.5,
-          confidence: 0.9,
-          reason: 'take profit'
-        }
-      ]
-    });
-
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 25 });
-
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-sell',
-      initialCapital: 50000,
-      tickCount: 10,
-      tradingFee: 0.001,
-      peakPortfolioValue: 51000,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
-    expect(marketDataService.calculateRealisticSlippage).toHaveBeenCalledWith(
-      'binance',
-      'BTC/USD',
-      expect.any(Number),
-      'SELL'
-    );
-    expect(result.processed).toBe(true);
-    expect(result.ordersExecuted).toBe(1);
-  });
-
-  it('skips sell when no position to sell', async () => {
-    const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-
-    const dataSource = {
-      transaction: jest.fn((callback: any) =>
-        callback({
-          findOne: jest.fn().mockResolvedValueOnce(quoteAccount).mockResolvedValueOnce(null), // No BTC account
-          create: jest.fn((entity: any, data: any) => data),
-          save: jest.fn((entity: any) => Promise.resolve(entity))
-        })
-      )
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    accountRepository.find.mockResolvedValueOnce([quoteAccount]).mockResolvedValueOnce([quoteAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 49950,
-      slippageBps: 10,
-      marketImpact: 5
-    });
-
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({
-      success: true,
-      signals: [
-        {
-          type: SignalType.SELL,
-          coinId: 'BTC',
-          strength: 1.0,
-          quantity: 1,
-          confidence: 0.95,
-          reason: 'no position'
-        }
-      ]
-    });
-
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 50 });
-
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    const session = {
-      id: 'session-no-pos',
-      initialCapital: 10000,
-      tickCount: 1,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
+    expect(orderExecutor.execute).not.toHaveBeenCalled();
+    expect(signalService.save).not.toHaveBeenCalled();
     expect(result.ordersExecuted).toBe(0);
     expect(result.processed).toBe(true);
   });
 
   it('handles algorithm execution failure gracefully', async () => {
-    const { service, accountRepository, snapshotRepository, orderRepository, marketDataService, algorithmRegistry } =
-      createService();
+    const { service, algorithmRegistry } = createService();
+    algorithmRegistry.executeAlgorithm.mockRejectedValue(new Error('algo blew up'));
 
-    const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-    accountRepository.find.mockResolvedValueOnce([quoteAccount]).mockResolvedValueOnce([quoteAccount]);
+    const result = await service.processTick(makeSession(), exchangeKey);
 
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-
-    algorithmRegistry.executeAlgorithm.mockRejectedValue(new Error('Algorithm failed'));
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = { id: 'session-algo-fail', initialCapital: 10000, tickCount: 10, user: { id: 'user-1' } } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
+    expect(result.processed).toBe(true);
     expect(result.signalsReceived).toBe(0);
     expect(result.ordersExecuted).toBe(0);
-    expect(result.processed).toBe(true);
+    expect(result.errors).toEqual([]);
   });
 
-  it('caps sell quantity at available position size', async () => {
-    const btcAccount = { currency: 'BTC', available: 1, total: 1, averageCost: 40000 };
-    const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-
-    const savedEntities: any[] = [];
-    const dataSource = {
-      transaction: jest.fn((callback: any) =>
-        callback({
-          findOne: jest
-            .fn()
-            .mockResolvedValueOnce(quoteAccount)
-            .mockResolvedValueOnce({ ...btcAccount }),
-          create: jest.fn((_entity: any, data: any) => data),
-          save: jest.fn((entity: any) => {
-            savedEntities.push(entity);
-            return Promise.resolve(entity);
-          })
-        })
-      )
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      snapshotRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    accountRepository.find
-      .mockResolvedValueOnce([quoteAccount, btcAccount])
-      .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after successful order
-      .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 50000,
-      slippageBps: 0,
-      marketImpact: 0
-    });
-
+  it('marks the signal processed even when orderExecutor throws (finally block)', async () => {
+    const { service, orderExecutor, signalService, algorithmRegistry } = createService();
     algorithmRegistry.executeAlgorithm.mockResolvedValue({
       success: true,
-      signals: [
-        {
-          type: SignalType.SELL,
-          coinId: 'BTC',
-          strength: 1.0,
-          quantity: 10, // Requests 10 BTC but only 1 available
-          confidence: 0.9,
-          reason: 'sell all'
-        }
-      ]
+      signals: [{ type: SignalType.BUY, coinId: 'BTC', strength: 0.1, quantity: 0.1, confidence: 0.8, reason: 'entry' }]
     });
+    orderExecutor.execute.mockRejectedValueOnce(new Error('deadlock'));
 
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 50 });
-
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-cap',
-      initialCapital: 50000,
-      tickCount: 10,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
-    expect(result.ordersExecuted).toBe(1);
-    // The order entity should have quantity capped to 1 (available), not 10 (requested)
-    const orderEntity = savedEntities.find((e) => e.side === 'SELL');
-    expect(orderEntity).toBeDefined();
-    expect(orderEntity.filledQuantity).toBe(1);
-    expect(orderEntity.requestedQuantity).toBe(1);
-  });
-
-  it('captures order execution error but still completes tick successfully', async () => {
-    const dataSource = {
-      transaction: jest.fn().mockRejectedValue(new Error('Transaction deadlock'))
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      snapshotRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-    accountRepository.find.mockResolvedValueOnce([quoteAccount]).mockResolvedValueOnce([quoteAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 50000,
-      slippageBps: 0,
-      marketImpact: 0
-    });
-
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({
-      success: true,
-      signals: [
-        {
-          type: SignalType.BUY,
-          coinId: 'BTC',
-          strength: 0.1,
-          quantity: 0.1,
-          confidence: 0.8,
-          reason: 'buy signal'
-        }
-      ]
-    });
-
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-err',
-      initialCapital: 10000,
-      tickCount: 10,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
+    const result = await service.processTick(makeSession(), exchangeKey);
 
     expect(result.processed).toBe(true);
     expect(result.ordersExecuted).toBe(0);
-    expect(result.errors.length).toBe(1);
-    expect(result.errors[0]).toContain('Transaction deadlock');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('deadlock');
+    expect(signalService.markProcessed).toHaveBeenCalledTimes(1);
   });
 
-  it('calculates BUY quantity from percentage-based allocation', async () => {
-    const savedEntities: any[] = [];
-    const dataSource = {
-      transaction: jest.fn((callback: any) =>
-        callback({
-          findOne: jest
-            .fn()
-            .mockResolvedValueOnce({ currency: 'USD', available: 10000, total: 10000 })
-            .mockResolvedValueOnce(null),
-          create: jest.fn((_entity: any, data: any) => data),
-          save: jest.fn((entity: any) => {
-            savedEntities.push(entity);
-            return Promise.resolve(entity);
-          })
-        })
-      )
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      snapshotRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-    accountRepository.find
-      .mockResolvedValueOnce([quoteAccount])
-      .mockResolvedValueOnce([quoteAccount]) // refresh after successful order
-      .mockResolvedValueOnce([quoteAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 50000,
-      slippageBps: 0,
-      marketImpact: 0
+  it('processes multiple signals in a single tick and counts all executed orders', async () => {
+    const { service, orderExecutor, algorithmRegistry } = createService({
+      accounts: [
+        { currency: 'USD', available: 50000, total: 50000 },
+        { currency: 'BTC', available: 2, total: 2, averageCost: 40000 }
+      ],
+      prices: { 'BTC/USD': 50000, 'ETH/USD': 3000 }
     });
-
-    // Signal has strength (mapped to percentage) of 0.1 but no quantity
     algorithmRegistry.executeAlgorithm.mockResolvedValue({
       success: true,
       signals: [
-        {
-          type: SignalType.BUY,
-          coinId: 'BTC',
-          strength: 0.1, // maps to signal.percentage
-          // no quantity field
-          confidence: 0.8,
-          reason: 'percentage buy'
-        }
+        { type: SignalType.SELL, coinId: 'BTC', strength: 0.5, quantity: 0.5, confidence: 0.9, reason: 'partial' },
+        { type: SignalType.BUY, coinId: 'ETH', strength: 0.1, quantity: 1, confidence: 0.7, reason: 'entry' }
       ]
     });
 
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 1 });
+    const result = await service.processTick(makeSession(), exchangeKey);
 
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-pct',
-      initialCapital: 10000,
-      tickCount: 10,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
-    expect(result.ordersExecuted).toBe(1);
-    // portfolio.totalValue = 10000, percentage = 0.1, min(0.1, PAPER_TRADE risk-3 maxAlloc=0.08) = 0.08
-    // investmentAmount = 10000 * 0.08 = 800, quantity = 800 / 50000 = 0.016
-    const orderEntity = savedEntities.find((e) => e.side === 'BUY');
-    expect(orderEntity).toBeDefined();
-    expect(orderEntity.filledQuantity).toBeCloseTo(0.016, 6);
-  });
-
-  it('maps STOP_LOSS and TAKE_PROFIT signals to SELL action', async () => {
-    const btcAccount = { currency: 'BTC', available: 1, total: 1, averageCost: 40000 };
-    const ethAccount = { currency: 'ETH', available: 5, total: 5, averageCost: 2000 };
-    const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-
-    const dataSource = {
-      transaction: jest.fn((callback: any) =>
-        callback({
-          findOne: jest.fn().mockImplementation((_entity: any, opts: any) => {
-            const currency = opts?.where?.currency;
-            if (currency === 'USD') return Promise.resolve({ ...quoteAccount });
-            if (currency === 'BTC') return Promise.resolve({ ...btcAccount });
-            if (currency === 'ETH') return Promise.resolve({ ...ethAccount });
-            return Promise.resolve(null);
-          }),
-          create: jest.fn((_entity: any, data: any) => data),
-          save: jest.fn((entity: any) => Promise.resolve(entity))
-        })
-      )
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      snapshotRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    accountRepository.find
-      .mockResolvedValueOnce([quoteAccount, btcAccount, ethAccount])
-      .mockResolvedValueOnce([quoteAccount, btcAccount, ethAccount]) // refresh after 1st order
-      .mockResolvedValueOnce([quoteAccount, btcAccount, ethAccount]) // refresh after 2nd order
-      .mockResolvedValueOnce([quoteAccount, btcAccount, ethAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(
-      new Map([
-        ['BTC/USD', { price: 50000 }],
-        ['ETH/USD', { price: 3000 }]
-      ])
-    );
-    marketDataService.calculateRealisticSlippage.mockResolvedValue({
-      estimatedPrice: 50000,
-      slippageBps: 0,
-      marketImpact: 0
-    });
-
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({
-      success: true,
-      signals: [
-        {
-          type: SignalType.STOP_LOSS,
-          coinId: 'BTC',
-          strength: 1.0,
-          quantity: 0.5,
-          confidence: 1.0,
-          reason: 'stop loss triggered'
-        },
-        {
-          type: SignalType.TAKE_PROFIT,
-          coinId: 'ETH',
-          strength: 1.0,
-          quantity: 2,
-          confidence: 1.0,
-          reason: 'take profit triggered'
-        }
-      ]
-    });
-
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 10 });
-
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-risk',
-      initialCapital: 50000,
-      tickCount: 10,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
-    // Both STOP_LOSS and TAKE_PROFIT should be mapped to SELL and executed
     expect(result.signalsReceived).toBe(2);
     expect(result.ordersExecuted).toBe(2);
-    expect(result.processed).toBe(true);
-
-    // Verify slippage was called with 'SELL' for both (confirming STOP_LOSS/TAKE_PROFIT mapped to SELL)
-    expect(marketDataService.calculateRealisticSlippage).toHaveBeenCalledWith(
-      'binance',
-      'BTC/USD',
-      expect.any(Number),
-      'SELL'
-    );
-    expect(marketDataService.calculateRealisticSlippage).toHaveBeenCalledWith(
-      'binance',
-      'ETH/USD',
-      expect.any(Number),
-      'SELL'
-    );
+    expect(orderExecutor.execute).toHaveBeenCalledTimes(2);
   });
 
-  describe('hold period enforcement', () => {
-    it('blocks SELL when hold period not met', async () => {
-      const now = new Date();
-      const twelveHoursAgo = new Date(now.getTime() - 12 * 3600000);
-      const btcAccount = { currency: 'BTC', available: 1, total: 1, averageCost: 40000, entryDate: twelveHoursAgo };
-      const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
+  it('refreshes portfolio between successful orders so the second signal sees fresh cash', async () => {
+    const { service, portfolioService, algorithmRegistry } = createService({
+      prices: { 'BTC/USD': 50000, 'ETH/USD': 3000 }
+    });
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({
+      success: true,
+      signals: [
+        { type: SignalType.BUY, coinId: 'BTC', strength: 0.08, confidence: 0.8, reason: 'entry BTC' },
+        { type: SignalType.BUY, coinId: 'ETH', strength: 0.08, confidence: 0.8, reason: 'entry ETH' }
+      ]
+    });
 
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce(quoteAccount)
-              .mockResolvedValueOnce({ ...btcAccount }),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => Promise.resolve(entity))
-          })
-        )
-      };
+    const result = await service.processTick(makeSession(), exchangeKey);
 
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator
-      } = createService({ dataSource });
+    expect(result.ordersExecuted).toBe(2);
+    // 1 refresh after each of the 2 successful orders + 1 refresh in finalizeSnapshot
+    expect(portfolioService.refresh).toHaveBeenCalledTimes(3);
+  });
 
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, btcAccount])
-        .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
+  describe('opportunity selling orchestration', () => {
+    it('invokes opportunitySelling.attempt and retries BUY when sells free cash', async () => {
+      const { service, orderExecutor, opportunitySelling, algorithmRegistry } = createService();
       algorithmRegistry.executeAlgorithm.mockResolvedValue({
         success: true,
         signals: [
-          { type: SignalType.SELL, coinId: 'BTC', strength: 0.5, quantity: 0.5, confidence: 0.9, reason: 'exit' }
+          { type: SignalType.BUY, coinId: 'BTC', strength: 0.05, quantity: 0.1, confidence: 0.85, reason: 'entry' }
         ]
       });
+      // First attempt returns insufficient_funds, retry succeeds
+      orderExecutor.execute
+        .mockResolvedValueOnce({ status: 'insufficient_funds', order: null })
+        .mockResolvedValueOnce({ status: 'success', order: { id: 'o-2' } });
+      opportunitySelling.attempt.mockResolvedValue(1);
 
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 25 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      const session = {
-        id: 'session-hold-blocked',
-        initialCapital: 50000,
-        tickCount: 1,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
+      const session = makeSession({ algorithmConfig: { enableOpportunitySelling: true } });
       const result = await service.processTick(session, exchangeKey);
 
+      expect(opportunitySelling.attempt).toHaveBeenCalledTimes(1);
+      expect(orderExecutor.execute).toHaveBeenCalledTimes(2);
+      // 1 opp-sell + 1 retried BUY
+      expect(result.ordersExecuted).toBe(2);
+    });
+
+    it('does not invoke opportunitySelling.attempt when BUY fails for a non-funds reason', async () => {
+      const { service, orderExecutor, opportunitySelling, algorithmRegistry } = createService();
+      algorithmRegistry.executeAlgorithm.mockResolvedValue({
+        success: true,
+        signals: [
+          { type: SignalType.BUY, coinId: 'BTC', strength: 0.05, quantity: 0.1, confidence: 0.85, reason: 'entry' }
+        ]
+      });
+      orderExecutor.execute.mockResolvedValueOnce({ status: 'no_price', order: null });
+
+      const session = makeSession({ algorithmConfig: { enableOpportunitySelling: true } });
+      const result = await service.processTick(session, exchangeKey);
+
+      expect(opportunitySelling.attempt).not.toHaveBeenCalled();
       expect(result.ordersExecuted).toBe(0);
-      expect(result.processed).toBe(true);
-    });
-
-    it('allows SELL when hold period is met', async () => {
-      const now = new Date();
-      const fortyEightHoursAgo = new Date(now.getTime() - 48 * 3600000);
-      const btcAccount = {
-        currency: 'BTC',
-        available: 1,
-        total: 1,
-        averageCost: 40000,
-        entryDate: fortyEightHoursAgo
-      };
-      const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce(quoteAccount)
-              .mockResolvedValueOnce({ ...btcAccount }),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => Promise.resolve(entity))
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator
-      } = createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, btcAccount])
-        .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after successful order
-        .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.SELL, coinId: 'BTC', strength: 0.5, quantity: 0.5, confidence: 0.9, reason: 'exit' }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 25 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-hold-allowed',
-        initialCapital: 50000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.ordersExecuted).toBe(1);
-      expect(result.processed).toBe(true);
-    });
-
-    it('STOP_LOSS bypasses hold period', async () => {
-      const now = new Date();
-      const oneHourAgo = new Date(now.getTime() - 1 * 3600000);
-      const btcAccount = { currency: 'BTC', available: 1, total: 1, averageCost: 40000, entryDate: oneHourAgo };
-      const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce(quoteAccount)
-              .mockResolvedValueOnce({ ...btcAccount }),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => Promise.resolve(entity))
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator
-      } = createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, btcAccount])
-        .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after successful order
-        .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          {
-            type: SignalType.STOP_LOSS,
-            coinId: 'BTC',
-            strength: 1.0,
-            quantity: 1,
-            confidence: 1.0,
-            reason: 'stop loss triggered'
-          }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 50 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-hold-stoploss',
-        initialCapital: 50000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.ordersExecuted).toBe(1);
-      expect(result.processed).toBe(true);
-    });
-
-    it('sets entryDate on first BUY', async () => {
-      const savedEntities: any[] = [];
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce({ currency: 'USD', available: 10000, total: 10000 })
-              .mockResolvedValueOnce(null),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => {
-              savedEntities.push({ ...entity });
-              return Promise.resolve(entity);
-            })
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator
-      } = createService({ dataSource });
-
-      const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount])
-        .mockResolvedValueOnce([quoteAccount]) // refresh after successful order
-        .mockResolvedValueOnce([quoteAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.BUY, coinId: 'BTC', strength: 0.05, quantity: 0.01, confidence: 0.8, reason: 'entry' }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 0.5 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-entry-date',
-        initialCapital: 10000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.ordersExecuted).toBe(1);
-      // The new account should have entryDate set (created with entryDate in the create call)
-      const btcAccount = savedEntities.find((e) => e.currency === 'BTC');
-      expect(btcAccount).toBeDefined();
-      expect(btcAccount.entryDate).toBeInstanceOf(Date);
-    });
-
-    it('skips add-to BUY when position already held (duplicate guard)', async () => {
-      const existingBtcAccount = {
-        currency: 'BTC',
-        available: 0.5,
-        total: 0.5,
-        averageCost: 45000,
-        entryDate: new Date('2024-01-01T00:00:00Z')
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry
-      } = createService();
-
-      const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-      accountRepository.find.mockResolvedValue([quoteAccount, existingBtcAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.BUY, coinId: 'BTC', strength: 0.05, quantity: 0.01, confidence: 0.8, reason: 'add to' }
-        ]
-      });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-preserve-entry',
-        initialCapital: 10000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      // BUY should be skipped because BTC position is already held
-      expect(result.ordersExecuted).toBe(0);
-      // Signal should not be saved (skipped before saveSignal)
-      expect(signalRepository.save).not.toHaveBeenCalled();
-      expect(result.processed).toBe(true);
-    });
-
-    it('clears entryDate on full sell', async () => {
-      const now = new Date();
-      const twoDaysAgo = new Date(now.getTime() - 48 * 3600000);
-      const btcAccount = { currency: 'BTC', available: 0.5, total: 0.5, averageCost: 40000, entryDate: twoDaysAgo };
-      const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-
-      const savedEntities: any[] = [];
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce(quoteAccount)
-              .mockResolvedValueOnce({ ...btcAccount }),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => {
-              savedEntities.push({ ...entity });
-              return Promise.resolve(entity);
-            })
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator
-      } = createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, btcAccount])
-        .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after successful order
-        .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          {
-            type: SignalType.SELL,
-            coinId: 'BTC',
-            strength: 1.0,
-            quantity: 0.5,
-            confidence: 0.9,
-            reason: 'close position'
-          }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 25 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-clear-entry',
-        initialCapital: 50000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.ordersExecuted).toBe(1);
-      const baseAccountSave = savedEntities.find((e) => e.currency === 'BTC' && e.available === 0);
-      expect(baseAccountSave).toBeDefined();
-      expect(baseAccountSave.entryDate).toBeUndefined();
-      expect(baseAccountSave.averageCost).toBeUndefined();
-    });
-
-    it('uses custom minHoldMs from algorithmConfig', async () => {
-      const now = new Date();
-      const twoHoursAgo = new Date(now.getTime() - 2 * 3600000);
-      const btcAccount = { currency: 'BTC', available: 1, total: 1, averageCost: 40000, entryDate: twoHoursAgo };
-      const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce(quoteAccount)
-              .mockResolvedValueOnce({ ...btcAccount }),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => Promise.resolve(entity))
-          })
-        )
-      };
-
-      const { service, accountRepository, signalRepository, marketDataService, algorithmRegistry, feeCalculator } =
-        createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, btcAccount])
-        .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.SELL, coinId: 'BTC', strength: 0.5, quantity: 0.5, confidence: 0.9, reason: 'exit' }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 25 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      // Custom minHoldMs of 4 hours — held only 2h, should be rejected
-      const session = {
-        id: 'session-custom-hold',
-        initialCapital: 50000,
-        tickCount: 1,
-        tradingFee: 0.001,
-        algorithmConfig: { minHoldMs: 4 * 3600000 },
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.ordersExecuted).toBe(0);
-      expect(result.processed).toBe(true);
     });
   });
 
   describe('regime gate filtering', () => {
-    it('blocks BUY signals in BEAR regime', async () => {
-      const compositeRegimeService = {
-        getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BEAR),
-        getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
-      };
+    it('persists REGIME_GATE rejection for BUY signals blocked in BEAR regime', async () => {
+      const signalFilterChainApply = jest.fn().mockImplementation((signals: any[], _ctx: any, alloc: any) => ({
+        signals: signals.filter((s) => s.action !== 'BUY'),
+        maxAllocation: alloc.maxAllocation,
+        minAllocation: alloc.minAllocation,
+        regimeGateBlockedCount: signals.filter((s) => s.action === 'BUY').length,
+        regimeMultiplier: 0.1
+      }));
 
-      const signalFilterChain = {
-        apply: jest.fn().mockImplementation((signals: any[], _ctx: any, allocation: any) => ({
-          signals: signals.filter((s: any) => s.action !== 'BUY'),
-          maxAllocation: allocation.maxAllocation * 0.1,
-          minAllocation: allocation.minAllocation * 0.1,
-          regimeGateBlockedCount: signals.filter((s: any) => s.action === 'BUY').length,
-          regimeMultiplier: 0.1
-        }))
-      };
-
-      const {
-        service,
-        accountRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        signalRepository
-      } = createService({ compositeRegimeService, signalFilterChain });
-
-      const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-      accountRepository.find.mockResolvedValueOnce([quoteAccount]).mockResolvedValueOnce([quoteAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-
+      const { service, orderExecutor, signalService, algorithmRegistry } = createService({
+        compositeRegime: CompositeRegimeType.BEAR,
+        signalFilterChainApply
+      });
       algorithmRegistry.executeAlgorithm.mockResolvedValue({
         success: true,
         signals: [
@@ -1551,1021 +425,32 @@ describe('PaperTradingEngineService', () => {
         ]
       });
 
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
+      const result = await service.processTick(makeSession({ riskLevel: 3 }), exchangeKey);
 
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-bear',
-        initialCapital: 10000,
-        tickCount: 10,
-        riskLevel: 3,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(signalFilterChain.apply).toHaveBeenCalled();
+      expect(orderExecutor.execute).not.toHaveBeenCalled();
+      expect(signalService.markRejected).toHaveBeenCalledWith(expect.anything(), SignalReasonCode.REGIME_GATE);
       expect(result.ordersExecuted).toBe(0);
-      expect(result.processed).toBe(true);
     });
 
-    it('allows STOP_LOSS through in BEAR regime', async () => {
-      const btcAccount = { currency: 'BTC', available: 1, total: 1, averageCost: 40000 };
-      const quoteAccount = { currency: 'USD', available: 5000, total: 5000 };
-
-      const compositeRegimeService = {
-        getCompositeRegime: jest.fn().mockReturnValue(CompositeRegimeType.BEAR),
-        getVolatilityRegime: jest.fn().mockReturnValue(MarketRegimeType.NORMAL)
-      };
-
-      // Passthrough: STOP_LOSS mapped to SELL passes the gate
-      const signalFilterChain = {
-        apply: jest.fn().mockImplementation((signals: any[], _ctx: any, allocation: any) => ({
-          signals,
-          maxAllocation: allocation.maxAllocation * 0.1,
-          minAllocation: allocation.minAllocation * 0.1,
-          regimeGateBlockedCount: 0,
-          regimeMultiplier: 0.1
-        }))
-      };
-
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce(quoteAccount)
-              .mockResolvedValueOnce({ ...btcAccount }),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => Promise.resolve(entity))
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator
-      } = createService({ compositeRegimeService, signalFilterChain, dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, btcAccount])
-        .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after successful order
-        .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
+    it('allows STOP_LOSS to pass through the regime gate in BEAR regime', async () => {
+      const { service, orderExecutor, algorithmRegistry } = createService({
+        accounts: [
+          { currency: 'USD', available: 5000, total: 5000 },
+          { currency: 'BTC', available: 1, total: 1, averageCost: 40000 }
+        ],
+        compositeRegime: CompositeRegimeType.BEAR
       });
-
       algorithmRegistry.executeAlgorithm.mockResolvedValue({
         success: true,
         signals: [
-          {
-            type: SignalType.STOP_LOSS,
-            coinId: 'BTC',
-            strength: 1.0,
-            quantity: 0.5,
-            confidence: 1.0,
-            reason: 'stop loss'
-          }
+          { type: SignalType.STOP_LOSS, coinId: 'BTC', strength: 1.0, quantity: 0.5, confidence: 1.0, reason: 'sl' }
         ]
       });
 
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 25 });
+      const result = await service.processTick(makeSession({ riskLevel: 3 }), exchangeKey);
 
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-bear-sl',
-        initialCapital: 50000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        riskLevel: 3,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
+      expect(orderExecutor.execute).toHaveBeenCalledTimes(1);
       expect(result.ordersExecuted).toBe(1);
-      expect(result.processed).toBe(true);
     });
-  });
-
-  it('processes multiple signals in a single tick and counts all executed orders', async () => {
-    const btcAccount = { currency: 'BTC', available: 2, total: 2, averageCost: 40000 };
-    const quoteAccount = { currency: 'USD', available: 50000, total: 50000 };
-    let orderCount = 0;
-
-    const dataSource = {
-      transaction: jest.fn((callback: any) =>
-        callback({
-          findOne: jest.fn().mockImplementation((_entity: any, opts: any) => {
-            const currency = opts?.where?.currency;
-            if (currency === 'USD') return Promise.resolve({ ...quoteAccount });
-            if (currency === 'BTC') return Promise.resolve({ ...btcAccount });
-            if (currency === 'ETH') return Promise.resolve(null); // New position
-            return Promise.resolve(null);
-          }),
-          create: jest.fn((_entity: any, data: any) => data),
-          save: jest.fn((entity: any) => {
-            if (entity.side) orderCount++;
-            return Promise.resolve(entity);
-          })
-        })
-      )
-    };
-
-    const {
-      service,
-      accountRepository,
-      signalRepository,
-      snapshotRepository,
-      orderRepository,
-      marketDataService,
-      algorithmRegistry,
-      feeCalculator
-    } = createService({ dataSource });
-
-    accountRepository.find
-      .mockResolvedValueOnce([quoteAccount, btcAccount])
-      .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after 1st order
-      .mockResolvedValueOnce([quoteAccount, btcAccount]) // refresh after 2nd order
-      .mockResolvedValueOnce([quoteAccount, btcAccount]);
-
-    marketDataService.getPrices.mockResolvedValue(
-      new Map([
-        ['BTC/USD', { price: 50000 }],
-        ['ETH/USD', { price: 3000 }]
-      ])
-    );
-    marketDataService.calculateRealisticSlippage
-      .mockResolvedValueOnce({ estimatedPrice: 50000, slippageBps: 0, marketImpact: 0 })
-      .mockResolvedValueOnce({ estimatedPrice: 3000, slippageBps: 0, marketImpact: 0 });
-
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({
-      success: true,
-      signals: [
-        {
-          type: SignalType.SELL,
-          coinId: 'BTC',
-          strength: 0.5,
-          quantity: 0.5,
-          confidence: 0.9,
-          reason: 'partial exit'
-        },
-        {
-          type: SignalType.BUY,
-          coinId: 'ETH',
-          strength: 0.1,
-          quantity: 1,
-          confidence: 0.7,
-          reason: 'new entry'
-        }
-      ]
-    });
-
-    feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-    feeCalculator.calculateFee.mockReturnValue({ fee: 5 });
-
-    signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-    signalRepository.save.mockImplementation(async (value: any) => value);
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = {
-      id: 'session-multi',
-      initialCapital: 50000,
-      tickCount: 10,
-      tradingFee: 0.001,
-      user: { id: 'user-1' }
-    } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    const result = await service.processTick(session, exchangeKey);
-
-    expect(result.signalsReceived).toBe(2);
-    expect(result.ordersExecuted).toBe(2);
-    expect(result.processed).toBe(true);
-  });
-
-  describe('stale portfolio refresh', () => {
-    it('second BUY signal in same tick uses refreshed portfolio values', async () => {
-      const quoteAccount = { currency: 'USD', available: 10000, total: 10000 };
-      const savedOrders: any[] = [];
-
-      // Track portfolio.totalValue passed to executeOrder across calls
-      let txCallCount = 0;
-      const dataSource = {
-        transaction: jest.fn((callback: any) => {
-          txCallCount++;
-          // Both BUY transactions succeed
-          return callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce({
-                currency: 'USD',
-                available: txCallCount === 1 ? 10000 : 9200,
-                total: txCallCount === 1 ? 10000 : 9200
-              })
-              .mockResolvedValueOnce(
-                txCallCount === 1 ? null : { currency: 'ETH', available: 0, total: 0, averageCost: 0 }
-              ),
-            create: jest.fn((_entity: any, data: any) => data),
-            save: jest.fn((entity: any) => {
-              if (entity.side) savedOrders.push({ ...entity, txCall: txCallCount });
-              return Promise.resolve(entity);
-            })
-          });
-        })
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator
-      } = createService({ dataSource });
-
-      // Initial accounts, then refreshed after first BUY, refreshed after second BUY, then final
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount]) // step 1: initial
-        .mockResolvedValueOnce([
-          { currency: 'USD', available: 9200, total: 9200 },
-          { currency: 'BTC', available: 0.016, total: 0.016, averageCost: 50000 }
-        ]) // refresh after 1st BUY
-        .mockResolvedValueOnce([
-          { currency: 'USD', available: 8400, total: 8400 },
-          { currency: 'BTC', available: 0.016, total: 0.016 },
-          { currency: 'ETH', available: 0.27, total: 0.27 }
-        ]) // refresh after 2nd BUY
-        .mockResolvedValueOnce([
-          { currency: 'USD', available: 8400, total: 8400 },
-          { currency: 'BTC', available: 0.016, total: 0.016 },
-          { currency: 'ETH', available: 0.27, total: 0.27 }
-        ]); // final
-
-      marketDataService.getPrices.mockResolvedValue(
-        new Map([
-          ['BTC/USD', { price: 50000 }],
-          ['ETH/USD', { price: 3000 }]
-        ])
-      );
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.BUY, coinId: 'BTC', strength: 0.08, confidence: 0.8, reason: 'entry BTC' },
-          { type: SignalType.BUY, coinId: 'ETH', strength: 0.08, confidence: 0.8, reason: 'entry ETH' }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 1 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-refresh',
-        initialCapital: 10000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.ordersExecuted).toBe(2);
-      expect(result.processed).toBe(true);
-
-      // Portfolio should be refreshed between the two BUYs
-      // accountRepository.find should be called 4 times:
-      //   1. initial load, 2. refresh after 1st BUY, 3. refresh after 2nd BUY, 4. final accounts
-      expect(accountRepository.find).toHaveBeenCalledTimes(4);
-    });
-  });
-
-  describe('opportunity selling', () => {
-    it('attempts opportunity selling when BUY has insufficient cash and oppSelling enabled', async () => {
-      const now = new Date();
-      const threeDaysAgo = new Date(now.getTime() - 72 * 3600000);
-      const ethAccount = {
-        currency: 'ETH',
-        available: 5,
-        total: 5,
-        averageCost: 2800,
-        entryDate: threeDaysAgo
-      };
-      const quoteAccount = { currency: 'USD', available: 50, total: 50 };
-
-      // First call: executeOrder for BUY returns null (insufficient cash)
-      // Then opportunity sell executes, then retry BUY succeeds
-      let txCallCount = 0;
-      const dataSource = {
-        transaction: jest.fn((callback: any) => {
-          txCallCount++;
-          if (txCallCount === 1) {
-            // First BUY attempt — insufficient cash, returns null
-            return callback({
-              findOne: jest
-                .fn()
-                .mockResolvedValueOnce({ ...quoteAccount }) // quote
-                .mockResolvedValueOnce(null), // no BTC account
-              create: jest.fn((_e: any, d: any) => d),
-              save: jest.fn((e: any) => Promise.resolve(e))
-            });
-          }
-          if (txCallCount === 2) {
-            // Opportunity sell of ETH
-            return callback({
-              findOne: jest
-                .fn()
-                .mockResolvedValueOnce({ ...quoteAccount }) // quote
-                .mockResolvedValueOnce({ ...ethAccount }), // ETH to sell
-              create: jest.fn((_e: any, d: any) => d),
-              save: jest.fn((e: any) => Promise.resolve(e))
-            });
-          }
-          // Retry BUY — now has enough cash
-          return callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce({ currency: 'USD', available: 5000, total: 5000 })
-              .mockResolvedValueOnce(null),
-            create: jest.fn((_e: any, d: any) => d),
-            save: jest.fn((e: any) => Promise.resolve(e))
-          });
-        })
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator,
-        positionAnalysis
-      } = createService({ dataSource });
-
-      // processTick accounts (initial + opp selling + retry BUY + refresh + final)
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, ethAccount]) // step 1: initial accounts
-        .mockResolvedValueOnce([quoteAccount, ethAccount]) // opportunity selling: fresh accounts
-        .mockResolvedValueOnce([quoteAccount, ethAccount]) // opportunity selling: fresh accounts for executeOrder
-        .mockResolvedValueOnce([{ currency: 'USD', available: 5000, total: 5000 }]) // retry BUY: fresh accounts
-        .mockResolvedValueOnce([{ currency: 'USD', available: 4000, total: 4000 }]) // refresh after successful retry BUY
-        .mockResolvedValueOnce([{ currency: 'USD', available: 4000, total: 4000 }]); // step 7: final accounts
-
-      marketDataService.getPrices.mockResolvedValue(
-        new Map([
-          ['BTC/USD', { price: 50000 }],
-          ['ETH/USD', { price: 3000 }]
-        ])
-      );
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          {
-            type: SignalType.BUY,
-            coinId: 'BTC',
-            strength: 0.05,
-            quantity: 0.1,
-            confidence: 0.85,
-            reason: 'strong entry'
-          }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 5 });
-
-      positionAnalysis.calculatePositionSellScore.mockReturnValue({
-        eligible: true,
-        totalScore: 10,
-        unrealizedPnLScore: 5,
-        protectedGainsScore: 0,
-        holdingPeriodScore: 3,
-        opportunityAdvantageScore: 2,
-        algorithmRankingScore: 0,
-        unrealizedPnLPercent: 7.1,
-        holdingPeriodHours: 72
-      });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-oppsell',
-        initialCapital: 20000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        algorithmConfig: {
-          enableOpportunitySelling: true,
-          opportunitySellingConfig: {
-            minOpportunityConfidence: 0.7,
-            minHoldingPeriodHours: 48,
-            protectGainsAbovePercent: 15,
-            protectedCoins: [],
-            minOpportunityAdvantagePercent: 10,
-            maxLiquidationPercent: 30,
-            useAlgorithmRanking: true
-          }
-        },
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.processed).toBe(true);
-      expect(positionAnalysis.calculatePositionSellScore).toHaveBeenCalled();
-      // Should have executed at least 1 opportunity sell + the retry BUY
-      expect(result.ordersExecuted).toBeGreaterThanOrEqual(2);
-    });
-
-    it('skips opportunity selling when disabled', async () => {
-      const quoteAccount = { currency: 'USD', available: 50, total: 50 };
-      const ethAccount = { currency: 'ETH', available: 5, total: 5, averageCost: 2800 };
-
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce({ ...quoteAccount })
-              .mockResolvedValueOnce(null),
-            create: jest.fn((_e: any, d: any) => d),
-            save: jest.fn((e: any) => Promise.resolve(e))
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator,
-        positionAnalysis
-      } = createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, ethAccount])
-        .mockResolvedValueOnce([quoteAccount, ethAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(
-        new Map([
-          ['BTC/USD', { price: 50000 }],
-          ['ETH/USD', { price: 3000 }]
-        ])
-      );
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.BUY, coinId: 'BTC', strength: 0.05, quantity: 0.1, confidence: 0.85, reason: 'entry' }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 5 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      // No enableOpportunitySelling in config — defaults to disabled
-      const session = {
-        id: 'session-oppsell-disabled',
-        initialCapital: 20000,
-        tickCount: 1,
-        tradingFee: 0.001,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.processed).toBe(true);
-      expect(result.ordersExecuted).toBe(0);
-      expect(positionAnalysis.calculatePositionSellScore).not.toHaveBeenCalled();
-    });
-
-    it('does NOT trigger opportunity selling when BUY fails due to no price data', async () => {
-      const ethAccount = { currency: 'ETH', available: 5, total: 5, averageCost: 2800 };
-      const quoteAccount = { currency: 'USD', available: 50, total: 50 };
-
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce({ ...quoteAccount })
-              .mockResolvedValueOnce(null),
-            create: jest.fn((_e: any, d: any) => d),
-            save: jest.fn((e: any) => Promise.resolve(e))
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator,
-        positionAnalysis
-      } = createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, ethAccount])
-        .mockResolvedValueOnce([quoteAccount, ethAccount]);
-
-      // BTC has no price data — only ETH has a price
-      marketDataService.getPrices.mockResolvedValue(new Map([['ETH/USD', { price: 3000 }]]));
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.BUY, coinId: 'BTC', strength: 0.05, quantity: 0.1, confidence: 0.85, reason: 'entry' }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 5 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      const session = {
-        id: 'session-noprice-nooppsell',
-        initialCapital: 20000,
-        tickCount: 1,
-        tradingFee: 0.001,
-        algorithmConfig: { enableOpportunitySelling: true },
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.processed).toBe(true);
-      expect(result.ordersExecuted).toBe(0);
-      // Opportunity selling should NOT be triggered for no_price failures
-      expect(positionAnalysis.calculatePositionSellScore).not.toHaveBeenCalled();
-    });
-
-    it('triggers opportunity selling when BUY fails due to insufficient funds', async () => {
-      const now = new Date();
-      const threeDaysAgo = new Date(now.getTime() - 72 * 3600000);
-      const ethAccount = {
-        currency: 'ETH',
-        available: 5,
-        total: 5,
-        averageCost: 2800,
-        entryDate: threeDaysAgo
-      };
-      const quoteAccount = { currency: 'USD', available: 50, total: 50 };
-
-      let txCallCount = 0;
-      const dataSource = {
-        transaction: jest.fn((callback: any) => {
-          txCallCount++;
-          if (txCallCount === 1) {
-            // First BUY attempt — insufficient cash
-            return callback({
-              findOne: jest
-                .fn()
-                .mockResolvedValueOnce({ ...quoteAccount })
-                .mockResolvedValueOnce(null),
-              create: jest.fn((_e: any, d: any) => d),
-              save: jest.fn((e: any) => Promise.resolve(e))
-            });
-          }
-          if (txCallCount === 2) {
-            // Opportunity sell of ETH
-            return callback({
-              findOne: jest
-                .fn()
-                .mockResolvedValueOnce({ ...quoteAccount })
-                .mockResolvedValueOnce({ ...ethAccount }),
-              create: jest.fn((_e: any, d: any) => d),
-              save: jest.fn((e: any) => Promise.resolve(e))
-            });
-          }
-          // Retry BUY
-          return callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce({ currency: 'USD', available: 5000, total: 5000 })
-              .mockResolvedValueOnce(null),
-            create: jest.fn((_e: any, d: any) => d),
-            save: jest.fn((e: any) => Promise.resolve(e))
-          });
-        })
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        snapshotRepository,
-        orderRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator,
-        positionAnalysis
-      } = createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, ethAccount])
-        .mockResolvedValueOnce([quoteAccount, ethAccount])
-        .mockResolvedValueOnce([quoteAccount, ethAccount])
-        .mockResolvedValueOnce([{ currency: 'USD', available: 5000, total: 5000 }])
-        .mockResolvedValueOnce([{ currency: 'USD', available: 5000, total: 5000 }])
-        .mockResolvedValueOnce([{ currency: 'USD', available: 4000, total: 4000 }]);
-
-      marketDataService.getPrices.mockResolvedValue(
-        new Map([
-          ['BTC/USD', { price: 50000 }],
-          ['ETH/USD', { price: 3000 }]
-        ])
-      );
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          { type: SignalType.BUY, coinId: 'BTC', strength: 0.05, quantity: 0.1, confidence: 0.85, reason: 'entry' }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 5 });
-
-      positionAnalysis.calculatePositionSellScore.mockReturnValue({
-        eligible: true,
-        totalScore: 10,
-        unrealizedPnLScore: 5,
-        protectedGainsScore: 0,
-        holdingPeriodScore: 3,
-        opportunityAdvantageScore: 2,
-        algorithmRankingScore: 0,
-        unrealizedPnLPercent: 7.1,
-        holdingPeriodHours: 72
-      });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-insuff-oppsell',
-        initialCapital: 20000,
-        tickCount: 10,
-        tradingFee: 0.001,
-        algorithmConfig: {
-          enableOpportunitySelling: true,
-          opportunitySellingConfig: {
-            minOpportunityConfidence: 0.7,
-            minHoldingPeriodHours: 48,
-            protectGainsAbovePercent: 15,
-            protectedCoins: [],
-            minOpportunityAdvantagePercent: 10,
-            maxLiquidationPercent: 30,
-            useAlgorithmRanking: true
-          }
-        },
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.processed).toBe(true);
-      // Opportunity selling SHOULD be triggered for insufficient_funds
-      expect(positionAnalysis.calculatePositionSellScore).toHaveBeenCalled();
-      expect(result.ordersExecuted).toBeGreaterThanOrEqual(2);
-    });
-
-    it('skips opportunity selling when buy confidence below threshold', async () => {
-      const quoteAccount = { currency: 'USD', available: 50, total: 50 };
-      const ethAccount = { currency: 'ETH', available: 5, total: 5, averageCost: 2800 };
-
-      const dataSource = {
-        transaction: jest.fn((callback: any) =>
-          callback({
-            findOne: jest
-              .fn()
-              .mockResolvedValueOnce({ ...quoteAccount })
-              .mockResolvedValueOnce(null),
-            create: jest.fn((_e: any, d: any) => d),
-            save: jest.fn((e: any) => Promise.resolve(e))
-          })
-        )
-      };
-
-      const {
-        service,
-        accountRepository,
-        signalRepository,
-        marketDataService,
-        algorithmRegistry,
-        feeCalculator,
-        positionAnalysis
-      } = createService({ dataSource });
-
-      accountRepository.find
-        .mockResolvedValueOnce([quoteAccount, ethAccount])
-        .mockResolvedValueOnce([quoteAccount, ethAccount]);
-
-      marketDataService.getPrices.mockResolvedValue(
-        new Map([
-          ['BTC/USD', { price: 50000 }],
-          ['ETH/USD', { price: 3000 }]
-        ])
-      );
-      marketDataService.calculateRealisticSlippage.mockResolvedValue({
-        estimatedPrice: 50000,
-        slippageBps: 0,
-        marketImpact: 0
-      });
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({
-        success: true,
-        signals: [
-          {
-            type: SignalType.BUY,
-            coinId: 'BTC',
-            strength: 0.05,
-            quantity: 0.1,
-            confidence: 0.3, // Below default threshold of 0.7
-            reason: 'weak entry'
-          }
-        ]
-      });
-
-      feeCalculator.fromFlatRate.mockReturnValue({ rate: 0.001 });
-      feeCalculator.calculateFee.mockReturnValue({ fee: 5 });
-
-      signalRepository.create.mockReturnValue({ processed: false, rejectionCode: null });
-      signalRepository.save.mockImplementation(async (value: any) => value);
-
-      const session = {
-        id: 'session-oppsell-lowconf',
-        initialCapital: 20000,
-        tickCount: 1,
-        tradingFee: 0.001,
-        algorithmConfig: { enableOpportunitySelling: true },
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      expect(result.processed).toBe(true);
-      expect(result.ordersExecuted).toBe(0);
-      // positionAnalysis should not be called because confidence gate rejects first
-      expect(positionAnalysis.calculatePositionSellScore).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('getQuoteCurrency priority', () => {
-    it('selects USDT over BTC/ETH regardless of account array order', async () => {
-      const { service, accountRepository, marketDataService, algorithmRegistry, snapshotRepository, orderRepository } =
-        createService();
-
-      // Accounts in DB order: BTC first, then ETH, then USDT — bug would pick BTC
-      const accounts = [
-        { currency: 'BTC', available: 0.5, total: 0.5, averageCost: 60000 },
-        { currency: 'ETH', available: 2, total: 2, averageCost: 3000 },
-        { currency: 'USDT', available: 9729, total: 9729 }
-      ];
-
-      accountRepository.find
-        .mockResolvedValueOnce(accounts) // initial fetch
-        .mockResolvedValueOnce(accounts); // final fetch
-
-      marketDataService.getPrices.mockResolvedValue(
-        new Map([
-          ['BTC/USDT', { price: 62000 }],
-          ['ETH/USDT', { price: 3200 }]
-        ])
-      );
-
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-quote-priority',
-        initialCapital: 10000,
-        tickCount: 10,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      // Should request BTC/USDT and ETH/USDT (not BTC/BTC or ETH/BTC)
-      expect(marketDataService.getPrices).toHaveBeenCalledWith(
-        'binance',
-        expect.arrayContaining(['BTC/USDT', 'ETH/USDT'])
-      );
-      // Portfolio value should include USDT cash + positions, not near-zero
-      expect(result.portfolioValue).toBeGreaterThan(9000);
-      expect(result.processed).toBe(true);
-    });
-
-    it('selects USD over USDT when both present', async () => {
-      const { service, accountRepository, marketDataService, algorithmRegistry, snapshotRepository, orderRepository } =
-        createService();
-
-      const accounts = [
-        { currency: 'USDT', available: 500, total: 500 },
-        { currency: 'USD', available: 9500, total: 9500 }
-      ];
-
-      accountRepository.find.mockResolvedValueOnce(accounts).mockResolvedValueOnce(accounts);
-
-      marketDataService.getPrices.mockResolvedValue(new Map([['USDT/USD', { price: 1 }]]));
-      algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
-
-      orderRepository.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-      });
-
-      snapshotRepository.create.mockReturnValue({});
-      snapshotRepository.save.mockResolvedValue({});
-
-      const session = {
-        id: 'session-usd-priority',
-        initialCapital: 10000,
-        tickCount: 10,
-        user: { id: 'user-1' }
-      } as any;
-      const exchangeKey = { exchange: { slug: 'coinbase' } } as any;
-
-      const result = await service.processTick(session, exchangeKey);
-
-      // Should use USD as quote, so USDT becomes a position priced as USDT/USD
-      expect(marketDataService.getPrices).toHaveBeenCalledWith('coinbase', expect.arrayContaining(['USDT/USD']));
-      expect(result.processed).toBe(true);
-    });
-  });
-
-  it('does not produce duplicate signals when multiple symbols share a base currency', async () => {
-    const { service, accountRepository, snapshotRepository, orderRepository, marketDataService, algorithmRegistry } =
-      createService();
-
-    const quoteAccount = { currency: 'USDT', available: 10000, total: 10000 };
-
-    accountRepository.find.mockResolvedValueOnce([quoteAccount]).mockResolvedValueOnce([quoteAccount]);
-
-    // Two symbols sharing the same base currency (ETH)
-    marketDataService.getPrices.mockResolvedValue(
-      new Map([
-        ['ETH/USDT', { price: 1900 }],
-        ['ETH/BTC', { price: 0.05 }]
-      ])
-    );
-
-    algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
-
-    orderRepository.createQueryBuilder.mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ totalRealizedPnL: 0 })
-    });
-
-    snapshotRepository.create.mockReturnValue({});
-    snapshotRepository.save.mockResolvedValue({});
-
-    const session = { id: 'session-dedup', initialCapital: 10000, tickCount: 5, user: { id: 'user-1' } } as any;
-    const exchangeKey = { exchange: { slug: 'binance' } } as any;
-
-    await service.processTick(session, exchangeKey);
-
-    // Algorithm should receive only one coin entry for ETH, not two
-    const algorithmCall = algorithmRegistry.executeAlgorithm.mock.calls[0];
-    const context = algorithmCall[1]; // second argument is the AlgorithmContext
-    const ethCoins = context.coins.filter((c: any) => c.id === 'ETH');
-
-    expect(ethCoins).toHaveLength(1);
   });
 });

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
@@ -1,181 +1,79 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-
-import { Decimal } from 'decimal.js';
-import { DataSource, Repository } from 'typeorm';
 
 import { getAllocationLimits, PipelineStage, SignalReasonCode } from '@chansey/api-interfaces';
 
 import {
-  PaperTradingAccount,
-  PaperTradingExitType,
-  PaperTradingOrder,
-  PaperTradingOrderSide,
-  PaperTradingOrderStatus,
-  PaperTradingOrderType,
-  PaperTradingSession,
-  PaperTradingSignal,
-  PaperTradingSignalDirection,
-  PaperTradingSignalStatus,
-  PaperTradingSignalType,
-  PaperTradingSnapshot,
-  SnapshotHolding
-} from './entities';
+  buildPriceDataContext,
+  extractCoinsFromPrices,
+  extractSymbolsFromConfig,
+  mapStrategySignal,
+  TickResult,
+  TradingSignal
+} from './engine/paper-trading-engine.utils';
+import { PaperTradingExitExecutorService } from './engine/paper-trading-exit-executor.service';
+import { PaperTradingOpportunitySellingService } from './engine/paper-trading-opportunity-selling.service';
+import { PaperTradingOrderExecutorService } from './engine/paper-trading-order-executor.service';
+import { PaperTradingPortfolioService } from './engine/paper-trading-portfolio.service';
+import { PaperTradingSignalService } from './engine/paper-trading-signal.service';
+import { PaperTradingSnapshotService } from './engine/paper-trading-snapshot.service';
+import { PaperTradingThrottleService } from './engine/paper-trading-throttle.service';
+import { PaperTradingAccount, PaperTradingSession, PaperTradingSignalStatus } from './entities';
 import { PaperTradingMarketDataService } from './paper-trading-market-data.service';
 
-import {
-  AlgorithmContext,
-  AlgorithmResult,
-  SignalType as AlgoSignalType,
-  TradingSignal as StrategySignal
-} from '../../algorithm/interfaces';
+import { AlgorithmContext, AlgorithmResult } from '../../algorithm/interfaces';
 import { AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
-import { getQuoteCurrency as getQuoteCurrencyUtil } from '../../exchange/constants';
 import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { CompositeRegimeService } from '../../market-regime/composite-regime.service';
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { DEFAULT_RISK_LEVEL } from '../../risk/risk.constants';
 import { toErrorInfo } from '../../shared/error.util';
 import {
-  BacktestExitTracker,
-  computeAtrFromOHLC,
-  DEFAULT_OPPORTUNITY_SELLING_CONFIG,
-  FeeCalculatorService,
-  MetricsCalculatorService,
-  OpportunitySellingUserConfig,
   Portfolio,
-  PortfolioStateService,
-  PositionAnalysisService,
-  PositionManagerService,
   SerializableExitTrackerState,
   SignalFilterChainService,
   SerializableThrottleState,
-  SignalThrottleService,
-  ThrottleState,
-  TimeframeType
+  SignalThrottleService
 } from '../backtest/shared';
-import { resolveExitConfig } from '../utils/exit-config-merge.util';
 
-export interface TradingSignal {
-  action: 'BUY' | 'SELL' | 'HOLD' | 'OPEN_SHORT' | 'CLOSE_SHORT';
-  coinId: string;
-  symbol: string;
-  quantity?: number;
-  percentage?: number;
-  reason: string;
-  confidence?: number;
-  metadata?: Record<string, any>;
-  /** Preserves the original algorithm signal type (e.g. STOP_LOSS, TAKE_PROFIT) */
-  originalType?: AlgoSignalType;
+interface MarketData {
+  accounts: PaperTradingAccount[];
+  quoteCurrency: string;
+  exchangeSlug: string;
+  priceMap: Record<string, number>;
+  historicalCandles: Record<string, CandleData[]>;
+  allSymbols: string[];
 }
 
-export interface TickResult {
-  processed: boolean;
-  signalsReceived: number;
+interface FilteredSignals {
+  signals: TradingSignal[];
+  allocation: { maxAllocation: number; minAllocation: number };
+}
+
+interface SignalLoopResult {
   ordersExecuted: number;
   errors: string[];
-  portfolioValue: number;
-  prices: Record<string, number>;
 }
-
-export type ExecuteOrderStatus = 'success' | 'insufficient_funds' | 'no_price' | 'no_position' | 'hold_period';
-
-export interface ExecuteOrderResult {
-  status: ExecuteOrderStatus;
-  order: PaperTradingOrder | null;
-}
-
-const VALID_EXIT_TYPES = new Set(Object.values(PaperTradingExitType));
-
-/** Safely convert an unknown string to PaperTradingExitType, returning undefined for invalid values */
-function toExitType(value: string | undefined | null): PaperTradingExitType | undefined {
-  if (!value) return undefined;
-  return VALID_EXIT_TYPES.has(value as PaperTradingExitType) ? (value as PaperTradingExitType) : undefined;
-}
-
-const mapStrategySignal = (signal: StrategySignal, quoteCurrency: string): TradingSignal => {
-  let action: TradingSignal['action'];
-  switch (signal.type) {
-    case AlgoSignalType.BUY:
-      action = 'BUY';
-      break;
-    case AlgoSignalType.SELL:
-    case AlgoSignalType.STOP_LOSS:
-    case AlgoSignalType.TAKE_PROFIT:
-      action = 'SELL';
-      break;
-    case AlgoSignalType.SHORT_ENTRY:
-      action = 'OPEN_SHORT';
-      break;
-    case AlgoSignalType.SHORT_EXIT:
-      action = 'CLOSE_SHORT';
-      break;
-    default:
-      action = 'HOLD';
-  }
-
-  // Extract symbol from coinId using session's quote currency
-  const symbol = `${signal.coinId}/${quoteCurrency}`;
-
-  return {
-    action,
-    coinId: signal.coinId,
-    symbol,
-    quantity: signal.quantity,
-    percentage: signal.strength,
-    reason: signal.reason,
-    confidence: signal.confidence,
-    metadata: signal.metadata as Record<string, any>,
-    originalType: signal.type
-  };
-};
-
-const classifySignalType = (signal: TradingSignal): PaperTradingSignalType => {
-  if (signal.originalType === AlgoSignalType.STOP_LOSS || signal.originalType === AlgoSignalType.TAKE_PROFIT) {
-    return PaperTradingSignalType.RISK_CONTROL;
-  }
-  if (signal.action === 'BUY' || signal.action === 'OPEN_SHORT') return PaperTradingSignalType.ENTRY;
-  if (signal.action === 'SELL' || signal.action === 'CLOSE_SHORT') return PaperTradingSignalType.EXIT;
-  return PaperTradingSignalType.ADJUSTMENT;
-};
 
 @Injectable()
 export class PaperTradingEngineService {
   private readonly logger = new Logger(PaperTradingEngineService.name);
 
-  /** In-memory throttle state per session (survives across ticks, resets on restart) */
-  private readonly throttleStates = new Map<string, ThrottleState>();
-
-  /** In-memory exit tracker per session (SL/TP/trailing stop monitoring) */
-  private readonly exitTrackers = new Map<string, BacktestExitTracker>();
-
   constructor(
-    @InjectRepository(PaperTradingAccount)
-    private readonly accountRepository: Repository<PaperTradingAccount>,
-    @InjectRepository(PaperTradingOrder)
-    private readonly orderRepository: Repository<PaperTradingOrder>,
-    @InjectRepository(PaperTradingSignal)
-    private readonly signalRepository: Repository<PaperTradingSignal>,
-    @InjectRepository(PaperTradingSnapshot)
-    private readonly snapshotRepository: Repository<PaperTradingSnapshot>,
-    private readonly dataSource: DataSource,
     private readonly marketDataService: PaperTradingMarketDataService,
     private readonly algorithmRegistry: AlgorithmRegistry,
-    // Shared backtest services
-    private readonly feeCalculator: FeeCalculatorService,
-    private readonly positionManager: PositionManagerService,
-    private readonly metricsCalculator: MetricsCalculatorService,
-    private readonly portfolioState: PortfolioStateService,
     private readonly signalThrottle: SignalThrottleService,
     private readonly compositeRegimeService: CompositeRegimeService,
     private readonly signalFilterChain: SignalFilterChainService,
-    private readonly positionAnalysis: PositionAnalysisService
+    private readonly portfolioService: PaperTradingPortfolioService,
+    private readonly signalService: PaperTradingSignalService,
+    private readonly snapshotService: PaperTradingSnapshotService,
+    private readonly throttleService: PaperTradingThrottleService,
+    private readonly orderExecutor: PaperTradingOrderExecutorService,
+    private readonly exitExecutor: PaperTradingExitExecutorService,
+    private readonly opportunitySelling: PaperTradingOpportunitySellingService
   ) {}
 
-  /**
-   * Process a single tick for a paper trading session
-   * This is the main entry point called by the processor
-   */
+  /** Process a single tick for a paper trading session. */
   async processTick(session: PaperTradingSession, exchangeKey: ExchangeKey): Promise<TickResult> {
     const errors: string[] = [];
     let signalsReceived = 0;
@@ -183,329 +81,64 @@ export class PaperTradingEngineService {
     const now = new Date();
 
     try {
-      // 1. Get current portfolio state
-      const accounts = await this.accountRepository.find({
-        where: { session: { id: session.id } }
-      });
+      const market = await this.fetchMarketData(session, exchangeKey);
+      const { accounts, quoteCurrency, exchangeSlug, priceMap, historicalCandles } = market;
 
-      const quoteCurrency = this.getQuoteCurrency(accounts);
-      const portfolio = this.buildPortfolioFromAccounts(accounts, quoteCurrency);
+      const portfolio = this.portfolioService.buildFromAccounts(accounts, quoteCurrency);
+      const updatedPortfolio = this.portfolioService.updateWithPrices(portfolio, priceMap, quoteCurrency);
 
-      // 2. Determine which symbols to fetch prices for
-      const holdingSymbols = accounts
-        .filter((a) => a.currency !== quoteCurrency && a.total > 0)
-        .map((a) => `${a.currency}/${quoteCurrency}`);
-
-      // Add symbols from algorithm config if any
-      const configSymbols = this.extractSymbolsFromConfig(session.algorithmConfig);
-      const allSymbols = [...new Set([...holdingSymbols, ...configSymbols])];
-
-      if (allSymbols.length === 0) {
-        // Default to common trading pairs using session's quote currency
-        allSymbols.push(`BTC/${quoteCurrency}`, `ETH/${quoteCurrency}`);
-      }
-
-      // 3. Fetch current prices
-      const exchangeSlug = exchangeKey.exchange?.slug ?? 'binance_us';
-      const prices = await this.marketDataService.getPrices(exchangeSlug, allSymbols);
-
-      const priceMap: Record<string, number> = {};
-      for (const [symbol, priceData] of prices) {
-        priceMap[symbol] = priceData.price;
-      }
-
-      // 3b. Fetch historical candles for algorithm indicator computation
-      const historicalCandles: Record<string, CandleData[]> = {};
-      const candleResults = await Promise.all(
-        allSymbols.map(async (symbol) => {
-          const candles = await this.marketDataService.getHistoricalCandles(
-            exchangeSlug,
-            symbol,
-            '1h',
-            100,
-            session.user
-          );
-          return { symbol, candles };
-        })
+      this.exitExecutor.getOrCreate(session);
+      const exitOrdersExecuted = await this.runExits(
+        session,
+        priceMap,
+        historicalCandles,
+        quoteCurrency,
+        exchangeSlug,
+        now
       );
-      for (const { symbol, candles } of candleResults) {
-        if (candles.length > 0) {
-          historicalCandles[symbol] = candles;
-        }
-      }
+      ordersExecuted += exitOrdersExecuted;
 
-      // 4. Update portfolio values with current prices
-      const updatedPortfolio = this.updatePortfolioWithPrices(portfolio, priceMap, quoteCurrency);
-
-      // 4b. Check exit levels (SL/TP/trailing) before running algorithm
-      const exitTracker = this.getOrCreateExitTracker(session);
-      let exitOrdersExecuted = 0;
-      if (exitTracker && exitTracker.size > 0) {
-        exitOrdersExecuted = await this.checkAndExecuteExits(
-          session,
-          exitTracker,
-          priceMap,
-          historicalCandles,
-          quoteCurrency,
-          exchangeSlug,
-          now
-        );
-        ordersExecuted += exitOrdersExecuted;
-      }
-
-      // 4c. Refresh portfolio after exits so algorithm sees accurate state
       let algoPortfolio = updatedPortfolio;
+      let activeAccounts = accounts;
       if (exitOrdersExecuted > 0) {
-        const refreshedAccounts = await this.accountRepository.find({
-          where: { session: { id: session.id } }
-        });
-        algoPortfolio = this.updatePortfolioWithPrices(
-          this.buildPortfolioFromAccounts(refreshedAccounts, quoteCurrency),
+        ({ portfolio: algoPortfolio, accounts: activeAccounts } = await this.portfolioService.refresh(
+          session.id,
           priceMap,
           quoteCurrency
-        );
+        ));
       }
 
-      // 5. Run algorithm to get signals
       const signals = await this.runAlgorithm(
         session,
         algoPortfolio,
         priceMap,
-        accounts,
+        activeAccounts,
         quoteCurrency,
         historicalCandles
       );
       signalsReceived = signals.length;
 
-      // 5b. Apply signal throttle: cooldowns, daily cap, min sell %
-      const throttleState = this.getOrCreateThrottleState(session.id);
-      const throttleConfig = this.signalThrottle.resolveConfig(session.algorithmConfig);
-      const { accepted: filteredSignals, rejected: throttledSignals } = this.signalThrottle.filterSignals(
-        signals,
-        throttleState,
-        throttleConfig,
-        Date.now()
-      ) as { accepted: TradingSignal[]; rejected: TradingSignal[] };
+      const filtered = await this.filterSignals(session, signals);
 
-      if (throttledSignals.length > 0) {
-        this.logger.debug(`Throttled ${throttledSignals.length}/${signals.length} signals for session ${session.id}`);
-        for (const blocked of throttledSignals) {
-          const entity = await this.saveSignal(session, blocked);
-          entity.status = PaperTradingSignalStatus.REJECTED;
-          entity.rejectionCode = SignalReasonCode.SIGNAL_THROTTLED;
-          entity.processed = true;
-          entity.processedAt = new Date();
-          await this.signalRepository.save(entity);
-        }
-      }
-
-      // 5c. Apply regime filter chain: gate BUY in bear/extreme, scale allocations
-      const compositeRegime = this.compositeRegimeService.getCompositeRegime();
-      const { maxAllocation, minAllocation } = this.getSessionAllocationLimits(session);
-      const regimeResult = this.signalFilterChain.apply(
-        filteredSignals,
-        {
-          compositeRegime,
-          riskLevel: session.riskLevel ?? DEFAULT_RISK_LEVEL,
-          regimeGateEnabled: true,
-          regimeScaledSizingEnabled: true,
-          tradingContext: 'paper'
-        },
-        { maxAllocation, minAllocation }
-      );
-
-      const regimeFilteredSignals = regimeResult.signals as TradingSignal[];
-      const adjustedAllocation = {
-        maxAllocation: regimeResult.maxAllocation,
-        minAllocation: regimeResult.minAllocation
-      };
-
-      if (regimeResult.regimeGateBlockedCount > 0) {
-        this.logger.debug(
-          `Regime gate blocked ${regimeResult.regimeGateBlockedCount} signals in ${compositeRegime} regime for session ${session.id}`
-        );
-        // Persist regime-gated signals as REJECTED with reason code (use object identity to handle duplicate symbols)
-        const regimePassedSignals = new Set<TradingSignal>(regimeFilteredSignals);
-        const regimeBlockedSignals = filteredSignals.filter((s: TradingSignal) => !regimePassedSignals.has(s));
-        for (const blocked of regimeBlockedSignals) {
-          const entity = await this.saveSignal(session, blocked);
-          entity.status = PaperTradingSignalStatus.REJECTED;
-          entity.rejectionCode = SignalReasonCode.REGIME_GATE;
-          entity.processed = true;
-          entity.processedAt = new Date();
-          await this.signalRepository.save(entity);
-        }
-      }
-
-      // 6. Process signals and execute orders
-      // Build set of currently-held coins to prevent duplicate BUY signals
-      const activeAccounts =
-        exitOrdersExecuted > 0
-          ? await this.accountRepository.find({ where: { session: { id: session.id } } })
-          : accounts;
       const heldCoins = new Set(
         activeAccounts.filter((a) => a.currency !== quoteCurrency && a.total > 1e-8).map((a) => a.currency)
       );
 
-      let currentPortfolio = updatedPortfolio;
-      for (const signal of regimeFilteredSignals) {
-        // Skip BUY if position already held for this symbol
-        if (signal.action === 'BUY') {
-          const [baseCurrency] = signal.symbol.split('/');
-          if (heldCoins.has(baseCurrency)) {
-            this.logger.debug(`Skipped duplicate BUY for ${signal.symbol}: position already held`);
-            continue;
-          }
-        }
+      const loopResult = await this.processSignalLoop(
+        session,
+        filtered,
+        algoPortfolio,
+        heldCoins,
+        priceMap,
+        historicalCandles,
+        quoteCurrency,
+        exchangeSlug,
+        now
+      );
+      ordersExecuted += loopResult.ordersExecuted;
+      errors.push(...loopResult.errors);
 
-        // Save signal to database
-        const signalEntity = await this.saveSignal(session, signal);
-
-        if (signal.action !== 'HOLD') {
-          try {
-            let result = await this.executeOrder(
-              session,
-              signal,
-              signalEntity,
-              currentPortfolio,
-              priceMap,
-              exchangeSlug,
-              quoteCurrency,
-              now,
-              adjustedAllocation
-            );
-
-            // Opportunity selling: only when BUY fails due to insufficient funds
-            let opportunitySellingAttempted = false;
-            if (result.status === 'insufficient_funds' && signal.action === 'BUY') {
-              opportunitySellingAttempted = true;
-              const oppSellCount = await this.attemptOpportunitySelling(
-                session,
-                signal,
-                priceMap,
-                quoteCurrency,
-                exchangeSlug,
-                now,
-                adjustedAllocation
-              );
-
-              if (oppSellCount > 0) {
-                ordersExecuted += oppSellCount;
-
-                // Re-fetch fresh portfolio after sells, then retry BUY
-                const retryAccounts = await this.accountRepository.find({
-                  where: { session: { id: session.id } }
-                });
-                const retryPortfolio = this.buildPortfolioFromAccounts(retryAccounts, quoteCurrency);
-                const updatedRetryPortfolio = this.updatePortfolioWithPrices(retryPortfolio, priceMap, quoteCurrency);
-
-                result = await this.executeOrder(
-                  session,
-                  signal,
-                  signalEntity,
-                  updatedRetryPortfolio,
-                  priceMap,
-                  exchangeSlug,
-                  quoteCurrency,
-                  now,
-                  adjustedAllocation
-                );
-              }
-            }
-
-            if (result.order) {
-              ordersExecuted++;
-              signalEntity.status = PaperTradingSignalStatus.SIMULATED;
-
-              // Track newly bought coin to block subsequent same-tick BUY signals
-              if (signal.action === 'BUY') {
-                const [bought] = signal.symbol.split('/');
-                heldCoins.add(bought);
-              }
-
-              // Remove sold coin so it can be re-bought by a later signal in the same tick
-              if (signal.action === 'SELL') {
-                const [sold] = signal.symbol.split('/');
-                heldCoins.delete(sold);
-              }
-
-              // Register position in exit tracker on BUY fill
-              if (exitTracker && signal.action === 'BUY') {
-                const [baseCurrency] = signal.symbol.split('/');
-                const candles = historicalCandles[signal.symbol];
-                let atr: number | undefined;
-                if (candles && candles.length > 0) {
-                  const highs = candles.map((c) => c.high);
-                  const lows = candles.map((c) => c.low);
-                  const closes = candles.map((c) => c.avg);
-                  atr = computeAtrFromOHLC(highs, lows, closes, session.exitConfig?.atrPeriod ?? 14);
-                }
-                if (result.order.executedPrice != null && result.order.executedPrice > 0) {
-                  exitTracker.onBuy(baseCurrency, result.order.executedPrice, result.order.filledQuantity, atr);
-                } else {
-                  this.logger.warn(
-                    `Skipping exit tracker registration for ${baseCurrency}: executedPrice is ${result.order.executedPrice}`
-                  );
-                }
-              }
-
-              // Update exit tracker on SELL fill
-              if (exitTracker && signal.action === 'SELL') {
-                const [baseCurrency] = signal.symbol.split('/');
-                exitTracker.onSell(baseCurrency, result.order.filledQuantity);
-              }
-
-              // Refresh portfolio for next signal iteration
-              const refreshedAccounts = await this.accountRepository.find({
-                where: { session: { id: session.id } }
-              });
-              currentPortfolio = this.updatePortfolioWithPrices(
-                this.buildPortfolioFromAccounts(refreshedAccounts, quoteCurrency),
-                priceMap,
-                quoteCurrency
-              );
-            } else {
-              // No order produced — rejected (insufficient_funds, no_position, no_price, hold_period)
-              signalEntity.status = PaperTradingSignalStatus.REJECTED;
-              if (result.status === 'insufficient_funds') {
-                signalEntity.rejectionCode = opportunitySellingAttempted
-                  ? SignalReasonCode.OPPORTUNITY_SELLING_REJECTED
-                  : SignalReasonCode.INSUFFICIENT_FUNDS;
-              } else if (result.status === 'no_price') {
-                signalEntity.rejectionCode = SignalReasonCode.SYMBOL_RESOLUTION_FAILED;
-              } else if (result.status === 'hold_period') {
-                signalEntity.rejectionCode = SignalReasonCode.TRADE_COOLDOWN;
-              }
-            }
-          } catch (error: unknown) {
-            const err = toErrorInfo(error);
-            errors.push(`Failed to execute ${signal.action} order for ${signal.symbol}: ${err.message}`);
-            this.logger.warn(`Order execution failed: ${err.message}`);
-            signalEntity.status = PaperTradingSignalStatus.ERROR;
-          }
-        } else {
-          // HOLD action — valid intentional no-op
-          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
-        }
-
-        // Mark signal as processed
-        signalEntity.processed = true;
-        signalEntity.processedAt = new Date();
-        await this.signalRepository.save(signalEntity);
-      }
-
-      // 7. Calculate current portfolio value
-      const finalAccounts = await this.accountRepository.find({
-        where: { session: { id: session.id } }
-      });
-      const finalPortfolio = this.buildPortfolioFromAccounts(finalAccounts, quoteCurrency);
-      const finalPortfolioValue = this.calculatePortfolioValue(finalPortfolio, priceMap, quoteCurrency);
-
-      // 8. Take snapshot (periodically)
-      const shouldSnapshot = session.tickCount % 10 === 0 || ordersExecuted > 0;
-      if (shouldSnapshot) {
-        await this.saveSnapshot(session, finalPortfolio, finalPortfolioValue, priceMap, quoteCurrency, now);
-      }
+      const finalPortfolioValue = await this.finalizeSnapshot(session, priceMap, quoteCurrency, ordersExecuted, now);
 
       return {
         processed: true,
@@ -519,7 +152,6 @@ export class PaperTradingEngineService {
       const err = toErrorInfo(error);
       this.logger.error(`Tick processing failed for session ${session.id}: ${err.message}`, err.stack);
       errors.push(err.message);
-
       return {
         processed: false,
         signalsReceived,
@@ -531,9 +163,254 @@ export class PaperTradingEngineService {
     }
   }
 
-  /**
-   * Run the algorithm and get trading signals
-   */
+  /** Fetch accounts, prices, and historical candles for the tick. */
+  private async fetchMarketData(session: PaperTradingSession, exchangeKey: ExchangeKey): Promise<MarketData> {
+    const accounts = await this.portfolioService.loadAccounts(session.id);
+    const quoteCurrency = this.portfolioService.getQuoteCurrency(accounts);
+
+    const holdingSymbols = accounts
+      .filter((a) => a.currency !== quoteCurrency && a.total > 0)
+      .map((a) => `${a.currency}/${quoteCurrency}`);
+    const configSymbols = extractSymbolsFromConfig(session.algorithmConfig);
+    const allSymbols = [...new Set([...holdingSymbols, ...configSymbols])];
+    if (allSymbols.length === 0) {
+      allSymbols.push(`BTC/${quoteCurrency}`, `ETH/${quoteCurrency}`);
+    }
+
+    const exchangeSlug = exchangeKey.exchange?.slug ?? 'binance_us';
+    const prices = await this.marketDataService.getPrices(exchangeSlug, allSymbols);
+    const priceMap: Record<string, number> = {};
+    for (const [symbol, priceData] of prices) {
+      priceMap[symbol] = priceData.price;
+    }
+
+    const historicalCandles: Record<string, CandleData[]> = {};
+    const candleResults = await Promise.all(
+      allSymbols.map(async (symbol) => {
+        const candles = await this.marketDataService.getHistoricalCandles(
+          exchangeSlug,
+          symbol,
+          '1h',
+          100,
+          session.user
+        );
+        return { symbol, candles };
+      })
+    );
+    for (const { symbol, candles } of candleResults) {
+      if (candles.length > 0) historicalCandles[symbol] = candles;
+    }
+
+    return { accounts, quoteCurrency, exchangeSlug, priceMap, historicalCandles, allSymbols };
+  }
+
+  /** Thin delegate to exit executor. */
+  private async runExits(
+    session: PaperTradingSession,
+    priceMap: Record<string, number>,
+    historicalCandles: Record<string, CandleData[]>,
+    quoteCurrency: string,
+    exchangeSlug: string,
+    now: Date
+  ): Promise<number> {
+    return this.exitExecutor.checkAndExecute(session, priceMap, historicalCandles, quoteCurrency, exchangeSlug, now);
+  }
+
+  /** Apply throttle + regime filter chain; persist rejected signals. */
+  private async filterSignals(session: PaperTradingSession, signals: TradingSignal[]): Promise<FilteredSignals> {
+    const throttleConfig = this.signalThrottle.resolveConfig(session.algorithmConfig);
+    const { accepted: throttleAccepted, rejected: throttledSignals } = this.throttleService.filter(
+      session.id,
+      signals,
+      throttleConfig,
+      Date.now()
+    );
+
+    if (throttledSignals.length > 0) {
+      this.logger.debug(`Throttled ${throttledSignals.length}/${signals.length} signals for session ${session.id}`);
+      for (const blocked of throttledSignals) {
+        const entity = await this.signalService.save(session, blocked);
+        await this.signalService.markRejected(entity, SignalReasonCode.SIGNAL_THROTTLED);
+      }
+    }
+
+    const compositeRegime = this.compositeRegimeService.getCompositeRegime();
+    const { maxAllocation, minAllocation } = this.getSessionAllocationLimits(session);
+    const regimeResult = this.signalFilterChain.apply(
+      throttleAccepted,
+      {
+        compositeRegime,
+        riskLevel: session.riskLevel ?? DEFAULT_RISK_LEVEL,
+        regimeGateEnabled: true,
+        regimeScaledSizingEnabled: true,
+        tradingContext: 'paper'
+      },
+      { maxAllocation, minAllocation }
+    );
+
+    const regimeFilteredSignals = regimeResult.signals as TradingSignal[];
+
+    if (regimeResult.regimeGateBlockedCount > 0) {
+      this.logger.debug(
+        `Regime gate blocked ${regimeResult.regimeGateBlockedCount} signals in ${compositeRegime} regime for session ${session.id}`
+      );
+      const regimePassedSignals = new Set<TradingSignal>(regimeFilteredSignals);
+      const regimeBlockedSignals = throttleAccepted.filter((s: TradingSignal) => !regimePassedSignals.has(s));
+      for (const blocked of regimeBlockedSignals) {
+        const entity = await this.signalService.save(session, blocked);
+        await this.signalService.markRejected(entity, SignalReasonCode.REGIME_GATE);
+      }
+    }
+
+    return {
+      signals: regimeFilteredSignals,
+      allocation: { maxAllocation: regimeResult.maxAllocation, minAllocation: regimeResult.minAllocation }
+    };
+  }
+
+  /** Iterate filtered signals, execute orders, handle opportunity selling and exit tracking. */
+  private async processSignalLoop(
+    session: PaperTradingSession,
+    filtered: FilteredSignals,
+    initialPortfolio: Portfolio,
+    heldCoins: Set<string>,
+    priceMap: Record<string, number>,
+    historicalCandles: Record<string, CandleData[]>,
+    quoteCurrency: string,
+    exchangeSlug: string,
+    now: Date
+  ): Promise<SignalLoopResult> {
+    const errors: string[] = [];
+    let ordersExecuted = 0;
+    let currentPortfolio = initialPortfolio;
+    const adjustedAllocation = filtered.allocation;
+
+    for (const signal of filtered.signals) {
+      if (signal.action === 'BUY') {
+        const [baseCurrency] = signal.symbol.split('/');
+        if (heldCoins.has(baseCurrency)) {
+          this.logger.debug(`Skipped duplicate BUY for ${signal.symbol}: position already held`);
+          continue;
+        }
+      }
+
+      const signalEntity = await this.signalService.save(session, signal);
+
+      try {
+        if (signal.action !== 'HOLD') {
+          let result = await this.orderExecutor.execute({
+            session,
+            signal,
+            signalEntity,
+            portfolio: currentPortfolio,
+            prices: priceMap,
+            exchangeSlug,
+            quoteCurrency,
+            timestamp: now,
+            allocation: adjustedAllocation
+          });
+
+          let opportunitySellingAttempted = false;
+          if (result.status === 'insufficient_funds' && signal.action === 'BUY') {
+            opportunitySellingAttempted = true;
+            const oppSellCount = await this.opportunitySelling.attempt(
+              session,
+              signal,
+              priceMap,
+              quoteCurrency,
+              exchangeSlug,
+              now,
+              adjustedAllocation
+            );
+
+            if (oppSellCount > 0) {
+              ordersExecuted += oppSellCount;
+              const { portfolio: updatedRetryPortfolio } = await this.portfolioService.refresh(
+                session.id,
+                priceMap,
+                quoteCurrency
+              );
+              result = await this.orderExecutor.execute({
+                session,
+                signal,
+                signalEntity,
+                portfolio: updatedRetryPortfolio,
+                prices: priceMap,
+                exchangeSlug,
+                quoteCurrency,
+                timestamp: now,
+                allocation: adjustedAllocation
+              });
+            }
+          }
+
+          if (result.order) {
+            ordersExecuted++;
+            signalEntity.status = PaperTradingSignalStatus.SIMULATED;
+
+            if (signal.action === 'BUY') {
+              const [bought] = signal.symbol.split('/');
+              heldCoins.add(bought);
+              this.exitExecutor.onBuyFill(session, signal, result.order, historicalCandles);
+            }
+            if (signal.action === 'SELL') {
+              const [sold] = signal.symbol.split('/');
+              heldCoins.delete(sold);
+              this.exitExecutor.onSellFill(session, signal, result.order);
+            }
+
+            ({ portfolio: currentPortfolio } = await this.portfolioService.refresh(
+              session.id,
+              priceMap,
+              quoteCurrency
+            ));
+          } else {
+            signalEntity.status = PaperTradingSignalStatus.REJECTED;
+            if (result.status === 'insufficient_funds') {
+              signalEntity.rejectionCode = opportunitySellingAttempted
+                ? SignalReasonCode.OPPORTUNITY_SELLING_REJECTED
+                : SignalReasonCode.INSUFFICIENT_FUNDS;
+            } else if (result.status === 'no_price') {
+              signalEntity.rejectionCode = SignalReasonCode.SYMBOL_RESOLUTION_FAILED;
+            } else if (result.status === 'hold_period') {
+              signalEntity.rejectionCode = SignalReasonCode.TRADE_COOLDOWN;
+            }
+          }
+        } else {
+          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
+        }
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        errors.push(`Failed to execute ${signal.action} order for ${signal.symbol}: ${err.message}`);
+        this.logger.warn(`Order execution failed: ${err.message}`);
+        signalEntity.status = PaperTradingSignalStatus.ERROR;
+      } finally {
+        // BUG FIX #5: always mark processed, even if an error is thrown mid-block
+        await this.signalService.markProcessed(signalEntity);
+      }
+    }
+
+    return { ordersExecuted, errors };
+  }
+
+  /** Refresh portfolio and optionally take a snapshot. */
+  private async finalizeSnapshot(
+    session: PaperTradingSession,
+    priceMap: Record<string, number>,
+    quoteCurrency: string,
+    ordersExecuted: number,
+    now: Date
+  ): Promise<number> {
+    const { portfolio: finalPortfolio } = await this.portfolioService.refresh(session.id, priceMap, quoteCurrency);
+    const finalPortfolioValue = finalPortfolio.totalValue;
+    const shouldSnapshot = session.tickCount % 10 === 0 || ordersExecuted > 0;
+    if (shouldSnapshot) {
+      await this.snapshotService.save(session, finalPortfolio, finalPortfolioValue, priceMap, quoteCurrency, now);
+    }
+    return finalPortfolioValue;
+  }
+
+  /** Run the algorithm and get trading signals. */
   private async runAlgorithm(
     session: PaperTradingSession,
     portfolio: Portfolio,
@@ -543,10 +420,9 @@ export class PaperTradingEngineService {
     historicalCandles: Record<string, CandleData[]> = {}
   ): Promise<TradingSignal[]> {
     try {
-      // Build context for algorithm
-      const coins = this.extractCoinsFromPrices(prices);
-      const priceData = this.buildPriceDataContext(prices, historicalCandles);
-      const positions = this.buildPositionsContext(accounts, quoteCurrency);
+      const coins = extractCoinsFromPrices(prices);
+      const priceData = buildPriceDataContext(prices, historicalCandles);
+      const positions = this.portfolioService.buildPositionsContext(accounts, quoteCurrency);
 
       const context: AlgorithmContext = {
         coins,
@@ -555,10 +431,7 @@ export class PaperTradingEngineService {
         config: session.algorithmConfig ?? {},
         positions,
         availableBalance: portfolio.cashBalance,
-        metadata: {
-          sessionId: session.id,
-          isPaperTrading: true
-        },
+        metadata: { sessionId: session.id, isPaperTrading: true },
         compositeRegime: this.compositeRegimeService.getCompositeRegime(),
         volatilityRegime: this.compositeRegimeService.getVolatilityRegime()
       };
@@ -573,7 +446,6 @@ export class PaperTradingEngineService {
           .map((signal) => mapStrategySignal(signal, quoteCurrency))
           .filter((signal) => signal.action !== 'HOLD');
       }
-
       return [];
     } catch (error: unknown) {
       const err = toErrorInfo(error);
@@ -582,363 +454,6 @@ export class PaperTradingEngineService {
     }
   }
 
-  /**
-   * Execute a paper trading order using atomic transactions
-   */
-  private async executeOrder(
-    session: PaperTradingSession,
-    signal: TradingSignal,
-    signalEntity: PaperTradingSignal,
-    portfolio: Portfolio,
-    prices: Record<string, number>,
-    exchangeSlug: string,
-    quoteCurrency: string,
-    timestamp: Date,
-    allocationOverrides?: { maxAllocation: number; minAllocation: number },
-    exitType?: PaperTradingExitType
-  ): Promise<ExecuteOrderResult> {
-    const basePrice = prices[signal.symbol];
-    if (!basePrice) {
-      this.logger.warn(`No price data available for ${signal.symbol}`);
-      return { status: 'no_price', order: null };
-    }
-
-    const [baseCurrency] = signal.symbol.split('/');
-    const isBuy = signal.action === 'BUY';
-
-    // Calculate slippage before transaction
-    const slippageResult = await this.marketDataService.calculateRealisticSlippage(
-      exchangeSlug,
-      signal.symbol,
-      signal.quantity ?? (portfolio.totalValue * 0.1) / basePrice,
-      isBuy ? 'BUY' : 'SELL'
-    );
-
-    const executionPrice =
-      slippageResult.estimatedPrice || basePrice * (1 + ((isBuy ? 1 : -1) * slippageResult.slippageBps) / 10000);
-    const slippageBps = slippageResult.slippageBps;
-
-    // Use transaction with pessimistic locking for atomic account updates
-    return this.dataSource.transaction(async (transactionalEntityManager) => {
-      // Get accounts with pessimistic write lock to prevent race conditions
-      const quoteAccount = await transactionalEntityManager.findOne(PaperTradingAccount, {
-        where: { session: { id: session.id }, currency: quoteCurrency },
-        lock: { mode: 'pessimistic_write' }
-      });
-
-      let baseAccount = await transactionalEntityManager.findOne(PaperTradingAccount, {
-        where: { session: { id: session.id }, currency: baseCurrency },
-        lock: { mode: 'pessimistic_write' }
-      });
-
-      if (!quoteAccount) {
-        throw new Error(`Quote currency account (${quoteCurrency}) not found`);
-      }
-
-      let quantity = 0;
-      let totalValue = 0;
-
-      // Resolve allocation limits: use regime-adjusted overrides if provided
-      const { maxAllocation, minAllocation } = allocationOverrides ?? this.getSessionAllocationLimits(session);
-
-      if (isBuy) {
-        // Calculate quantity based on signal
-        if (signal.quantity) {
-          quantity = signal.quantity;
-          // Cap explicit quantity to maxAllocation of portfolio value
-          const maxQuantity = (portfolio.totalValue * maxAllocation) / executionPrice;
-          if (quantity > maxQuantity) {
-            this.logger.warn(
-              `Capping explicit BUY quantity from ${quantity} to ${maxQuantity} (${maxAllocation * 100}% cap)`
-            );
-            quantity = maxQuantity;
-          }
-        } else if (signal.percentage) {
-          const investmentAmount = portfolio.totalValue * Math.min(signal.percentage, maxAllocation);
-          quantity = investmentAmount / executionPrice;
-        } else if (signal.confidence !== undefined) {
-          const allocation = minAllocation + signal.confidence * (maxAllocation - minAllocation);
-          const investmentAmount = portfolio.totalValue * allocation;
-          quantity = investmentAmount / executionPrice;
-        } else {
-          const investmentAmount = portfolio.totalValue * minAllocation;
-          quantity = investmentAmount / executionPrice;
-        }
-
-        const dQuantity = new Decimal(quantity);
-        const dExecutionPrice = new Decimal(executionPrice);
-        totalValue = dQuantity.mul(dExecutionPrice).toNumber();
-
-        // Calculate fee
-        const feeConfig = this.feeCalculator.fromFlatRate(session.tradingFee);
-        const feeResult = this.feeCalculator.calculateFee({ tradeValue: totalValue }, feeConfig);
-        const fee = feeResult.fee;
-
-        // Check if we have enough balance
-        const totalCost = new Decimal(totalValue).plus(fee);
-        if (new Decimal(quoteAccount.available).lt(totalCost)) {
-          this.logger.warn(
-            `Insufficient ${quoteCurrency} balance for BUY order: need ${totalCost.toFixed(2)}, have ${quoteAccount.available.toFixed(2)}`
-          );
-          return { status: 'insufficient_funds', order: null };
-        }
-
-        // Update quote account atomically
-        quoteAccount.available = new Decimal(quoteAccount.available).minus(totalCost).toNumber();
-        await transactionalEntityManager.save(quoteAccount);
-
-        // Update or create base account atomically
-        if (!baseAccount) {
-          baseAccount = transactionalEntityManager.create(PaperTradingAccount, {
-            currency: baseCurrency,
-            available: 0,
-            locked: 0,
-            entryDate: timestamp,
-            session
-          });
-        }
-
-        // Set entry date on first buy or when position was previously closed
-        const oldQuantity = baseAccount.available;
-        if (!baseAccount.entryDate || oldQuantity === 0) {
-          baseAccount.entryDate = timestamp;
-        }
-
-        // Update average cost using Decimal to avoid floating-point drift
-        const dOldCost = new Decimal(baseAccount.averageCost ?? 0);
-        const dOldQuantity = new Decimal(oldQuantity);
-        const dNewQuantity = dOldQuantity.plus(dQuantity);
-        baseAccount.averageCost = dOldQuantity.gt(0)
-          ? dOldCost.mul(dOldQuantity).plus(dExecutionPrice.mul(dQuantity)).div(dNewQuantity).toNumber()
-          : executionPrice;
-        baseAccount.available = dNewQuantity.toNumber();
-        await transactionalEntityManager.save(baseAccount);
-
-        // Create order record
-        const order = transactionalEntityManager.create(PaperTradingOrder, {
-          side: PaperTradingOrderSide.BUY,
-          orderType: PaperTradingOrderType.MARKET,
-          status: PaperTradingOrderStatus.FILLED,
-          symbol: signal.symbol,
-          baseCurrency,
-          quoteCurrency,
-          requestedQuantity: quantity,
-          filledQuantity: quantity,
-          executedPrice: executionPrice,
-          averagePrice: executionPrice,
-          slippageBps,
-          fee,
-          feeAsset: quoteCurrency,
-          totalValue,
-          executedAt: timestamp,
-          session,
-          signal: signalEntity,
-          ...(exitType && { exitType }),
-          metadata: {
-            reason: signal.reason,
-            confidence: signal.confidence,
-            basePrice
-          }
-        });
-
-        return { status: 'success', order: await transactionalEntityManager.save(order) };
-      }
-
-      // SELL order
-      if (!baseAccount || baseAccount.available <= 0) {
-        this.logger.warn(`No ${baseCurrency} position to sell`);
-        return { status: 'no_position', order: null };
-      }
-
-      // Enforce minimum hold period (risk-control signals always bypass)
-      const minHoldMs = this.resolveMinHoldMs(session.algorithmConfig);
-      const isRiskControl =
-        signal.originalType === AlgoSignalType.STOP_LOSS || signal.originalType === AlgoSignalType.TAKE_PROFIT;
-
-      if (!isRiskControl && minHoldMs > 0 && baseAccount.entryDate) {
-        const holdTimeMs = timestamp.getTime() - baseAccount.entryDate.getTime();
-        if (holdTimeMs < minHoldMs) {
-          this.logger.debug(
-            `Hold period not met for ${baseCurrency}: held ${Math.round(holdTimeMs / 3600000)}h, min ${Math.round(minHoldMs / 3600000)}h`
-          );
-          return { status: 'hold_period', order: null };
-        }
-      }
-
-      const costBasis = baseAccount.averageCost ?? 0;
-
-      // Calculate quantity to sell
-      if (signal.quantity) {
-        quantity = Math.min(signal.quantity, baseAccount.available);
-      } else if (signal.percentage) {
-        quantity = baseAccount.available * Math.min(signal.percentage, 1);
-      } else if (signal.confidence !== undefined) {
-        const sellPercent = 0.25 + signal.confidence * 0.75;
-        quantity = baseAccount.available * sellPercent;
-      } else {
-        this.logger.warn(
-          `No quantity/percentage/confidence for SELL signal on ${baseCurrency}/${quoteCurrency}, using 25% conservative fallback`
-        );
-        quantity = baseAccount.available * 0.25;
-      }
-
-      const dSellQuantity = new Decimal(quantity);
-      const dSellPrice = new Decimal(executionPrice);
-      totalValue = dSellQuantity.mul(dSellPrice).toNumber();
-
-      // Calculate fee
-      const feeConfig = this.feeCalculator.fromFlatRate(session.tradingFee);
-      const feeResult = this.feeCalculator.calculateFee({ tradeValue: totalValue }, feeConfig);
-      const fee = feeResult.fee;
-
-      // Calculate realized P&L using Decimal to preserve precision
-      const dCostBasis = new Decimal(costBasis);
-      const dFee = new Decimal(fee);
-      const realizedPnL = dSellPrice.minus(dCostBasis).mul(dSellQuantity).minus(dFee).toNumber();
-      const realizedPnLPercent = costBasis > 0 ? dSellPrice.minus(dCostBasis).div(dCostBasis).toNumber() : 0;
-
-      // Update base account atomically
-      baseAccount.available = new Decimal(baseAccount.available).minus(dSellQuantity).toNumber();
-      if (baseAccount.available < 0.00000001) {
-        baseAccount.available = 0;
-        baseAccount.averageCost = undefined;
-        baseAccount.entryDate = undefined;
-      }
-      await transactionalEntityManager.save(baseAccount);
-
-      // Update quote account atomically
-      quoteAccount.available = new Decimal(quoteAccount.available).plus(new Decimal(totalValue).minus(dFee)).toNumber();
-      await transactionalEntityManager.save(quoteAccount);
-
-      // Create order record
-      const order = transactionalEntityManager.create(PaperTradingOrder, {
-        side: PaperTradingOrderSide.SELL,
-        orderType: PaperTradingOrderType.MARKET,
-        status: PaperTradingOrderStatus.FILLED,
-        symbol: signal.symbol,
-        baseCurrency,
-        quoteCurrency,
-        requestedQuantity: quantity,
-        filledQuantity: quantity,
-        executedPrice: executionPrice,
-        averagePrice: executionPrice,
-        slippageBps,
-        fee,
-        feeAsset: quoteCurrency,
-        totalValue,
-        realizedPnL,
-        realizedPnLPercent,
-        costBasis,
-        executedAt: timestamp,
-        session,
-        signal: signalEntity,
-        ...(exitType && { exitType }),
-        metadata: {
-          reason: signal.reason,
-          confidence: signal.confidence,
-          basePrice
-        }
-      });
-
-      return { status: 'success', order: await transactionalEntityManager.save(order) };
-    });
-  }
-
-  /**
-   * Save a signal to the database
-   */
-  private async saveSignal(session: PaperTradingSession, signal: TradingSignal): Promise<PaperTradingSignal> {
-    const signalEntity = this.signalRepository.create({
-      signalType: classifySignalType(signal),
-      direction:
-        signal.action === 'BUY'
-          ? PaperTradingSignalDirection.LONG
-          : signal.action === 'SELL' || signal.action === 'OPEN_SHORT' || signal.action === 'CLOSE_SHORT'
-            ? PaperTradingSignalDirection.SHORT
-            : PaperTradingSignalDirection.FLAT,
-      instrument: signal.symbol,
-      quantity: signal.quantity ?? 0,
-      price: undefined, // Will be filled by market data
-      confidence: signal.confidence,
-      reason: signal.reason,
-      payload: signal.metadata,
-      processed: false,
-      session
-    });
-
-    return this.signalRepository.save(signalEntity);
-  }
-
-  /**
-   * Save a portfolio snapshot
-   */
-  private async saveSnapshot(
-    session: PaperTradingSession,
-    portfolio: Portfolio,
-    portfolioValue: number,
-    prices: Record<string, number>,
-    quoteCurrency: string,
-    timestamp: Date
-  ): Promise<PaperTradingSnapshot> {
-    const cumulativeReturn = (portfolioValue - session.initialCapital) / session.initialCapital;
-
-    // Calculate drawdown (clamp to 0 – portfolio may exceed stale peak before processor updates it)
-    const peakValue = Math.max(session.peakPortfolioValue ?? session.initialCapital, portfolioValue);
-    const drawdown = peakValue > 0 ? Math.min(1, Math.max(0, (peakValue - portfolioValue) / peakValue)) : 0;
-
-    // Build holdings map
-    const holdings: Record<string, SnapshotHolding> = {};
-    for (const [coinId, position] of portfolio.positions) {
-      const symbol = `${coinId}/${quoteCurrency}`;
-      const price = prices[symbol] ?? 0;
-      const value = position.quantity * price;
-      const unrealizedPnL = position.averagePrice > 0 ? (price - position.averagePrice) * position.quantity : 0;
-      const unrealizedPnLPercent =
-        position.averagePrice > 0 ? (price - position.averagePrice) / position.averagePrice : 0;
-
-      holdings[coinId] = {
-        quantity: position.quantity,
-        value,
-        price,
-        averageCost: position.averagePrice,
-        unrealizedPnL,
-        unrealizedPnLPercent
-      };
-    }
-
-    // Calculate unrealized P&L
-    let unrealizedPnL = 0;
-    for (const holding of Object.values(holdings)) {
-      unrealizedPnL += holding.unrealizedPnL ?? 0;
-    }
-
-    // Get realized P&L from orders
-    const realizedPnLResult = await this.orderRepository
-      .createQueryBuilder('order')
-      .select('SUM(order.realizedPnL)', 'totalRealizedPnL')
-      .where('order.sessionId = :sessionId', { sessionId: session.id })
-      .andWhere('order.realizedPnL IS NOT NULL')
-      .getRawOne();
-
-    const snapshot = this.snapshotRepository.create({
-      portfolioValue,
-      cashBalance: portfolio.cashBalance,
-      holdings,
-      cumulativeReturn,
-      drawdown,
-      unrealizedPnL,
-      realizedPnL: realizedPnLResult?.totalRealizedPnL ?? 0,
-      prices,
-      timestamp,
-      session
-    });
-
-    return this.snapshotRepository.save(snapshot);
-  }
-
-  /**
-   * Calculate final session metrics
-   */
   async calculateSessionMetrics(session: PaperTradingSession): Promise<{
     sharpeRatio: number;
     winRate: number;
@@ -947,678 +462,44 @@ export class PaperTradingEngineService {
     losingTrades: number;
     maxDrawdown: number;
   }> {
-    // Get all orders
-    const orders = await this.orderRepository.find({
-      where: { session: { id: session.id } }
-    });
-
-    const sellOrders = orders.filter((o) => o.side === PaperTradingOrderSide.SELL);
-    const winningTrades = sellOrders.filter((o) => (o.realizedPnL ?? 0) > 0).length;
-    const losingTrades = sellOrders.filter((o) => (o.realizedPnL ?? 0) < 0).length;
-    const totalTrades = orders.length;
-    const winRate = sellOrders.length > 0 ? winningTrades / sellOrders.length : 0;
-
-    // Get snapshots for Sharpe ratio
-    const snapshots = await this.snapshotRepository.find({
-      where: { session: { id: session.id } },
-      order: { timestamp: 'ASC' }
-    });
-
-    const returns: number[] = [];
-    for (let i = 1; i < snapshots.length; i++) {
-      const previous = snapshots[i - 1].portfolioValue;
-      const current = snapshots[i].portfolioValue;
-      if (previous > 0) {
-        returns.push((current - previous) / previous);
-      }
-    }
-
-    // Calculate Sharpe ratio using 30-second intervals (crypto 24/7)
-    // Using HOURLY as approximation since we have high-frequency data
-    const sharpeRatio =
-      returns.length > 2
-        ? this.metricsCalculator.calculateSharpeRatio(returns, {
-            timeframe: TimeframeType.HOURLY, // Closest approximation for high-frequency data
-            useCryptoCalendar: true,
-            riskFreeRate: 0.02
-          })
-        : 0;
-
-    // Calculate max drawdown
-    let maxDrawdown = 0;
-    let peak = session.initialCapital;
-    for (const snapshot of snapshots) {
-      if (snapshot.portfolioValue > peak) {
-        peak = snapshot.portfolioValue;
-      }
-      const drawdown = peak > 0 ? Math.max(0, (peak - snapshot.portfolioValue) / peak) : 0;
-      if (drawdown > maxDrawdown) {
-        maxDrawdown = drawdown;
-      }
-    }
-
-    return {
-      sharpeRatio,
-      winRate,
-      totalTrades,
-      winningTrades,
-      losingTrades,
-      maxDrawdown
-    };
-  }
-
-  /**
-   * Helper: Build portfolio from account entities
-   */
-  private buildPortfolioFromAccounts(accounts: PaperTradingAccount[], quoteCurrency: string): Portfolio {
-    const quoteAccount = accounts.find((a) => a.currency === quoteCurrency);
-
-    const positions = new Map<string, { coinId: string; quantity: number; averagePrice: number; totalValue: number }>();
-
-    for (const account of accounts) {
-      if (account.currency !== quoteCurrency && account.total > 0) {
-        positions.set(account.currency, {
-          coinId: account.currency,
-          quantity: account.total,
-          averagePrice: account.averageCost ?? 0,
-          totalValue: 0 // Will be calculated with prices
-        });
-      }
-    }
-
-    return {
-      cashBalance: quoteAccount?.available ?? 0,
-      positions,
-      totalValue: quoteAccount?.available ?? 0 // Will be updated with positions
-    };
-  }
-
-  /**
-   * Helper: Get quote currency from accounts
-   * Supports common quote currencies including fiat and crypto bases
-   */
-  private getQuoteCurrency(accounts: PaperTradingAccount[]): string {
-    return getQuoteCurrencyUtil(accounts.map((a) => a.currency));
-  }
-
-  /**
-   * Helper: Update portfolio with current prices
-   */
-  private updatePortfolioWithPrices(
-    portfolio: Portfolio,
-    prices: Record<string, number>,
-    quoteCurrency: string
-  ): Portfolio {
-    let positionsValue = 0;
-
-    for (const [coinId, position] of portfolio.positions) {
-      const symbol = `${coinId}/${quoteCurrency}`;
-      const price = prices[symbol] ?? 0;
-      position.totalValue = position.quantity * price;
-      positionsValue += position.totalValue;
-    }
-
-    portfolio.totalValue = portfolio.cashBalance + positionsValue;
-    return portfolio;
-  }
-
-  /**
-   * Helper: Calculate total portfolio value
-   */
-  private calculatePortfolioValue(portfolio: Portfolio, prices: Record<string, number>, quoteCurrency: string): number {
-    let total = portfolio.cashBalance;
-
-    for (const [coinId, position] of portfolio.positions) {
-      const symbol = `${coinId}/${quoteCurrency}`;
-      const price = prices[symbol] ?? 0;
-      total += position.quantity * price;
-    }
-
-    return total;
-  }
-
-  /**
-   * Helper: Extract symbols from algorithm config
-   */
-  private extractSymbolsFromConfig(config?: Record<string, any>): string[] {
-    if (!config) return [];
-
-    const symbols: string[] = [];
-
-    if (config.symbols && Array.isArray(config.symbols)) {
-      symbols.push(...config.symbols);
-    }
-    if (config.tradingPairs && Array.isArray(config.tradingPairs)) {
-      symbols.push(...config.tradingPairs);
-    }
-
-    return symbols;
-  }
-
-  /**
-   * Helper: Extract coins from prices map
-   */
-  private extractCoinsFromPrices(prices: Record<string, number>): Array<{ id: string; symbol: string }> {
-    const seen = new Set<string>();
-    const coins: Array<{ id: string; symbol: string }> = [];
-
-    for (const symbol of Object.keys(prices)) {
-      const [baseCurrency] = symbol.split('/');
-      if (!seen.has(baseCurrency)) {
-        seen.add(baseCurrency);
-        coins.push({ id: baseCurrency, symbol: baseCurrency });
-      }
-    }
-
-    return coins;
-  }
-
-  /**
-   * Build price data context with historical candles for algorithm indicator calculations.
-   * Fetches OHLCV history so strategies (e.g. Confluence) have enough data for MACD, Bollinger Bands, ATR, etc.
-   */
-  private buildPriceDataContext(
-    prices: Record<string, number>,
-    historicalCandles: Record<string, CandleData[]> = {}
-  ): Record<string, CandleData[]> {
-    const priceData: Record<string, CandleData[]> = {};
-    const now = new Date();
-
-    for (const [symbol, price] of Object.entries(prices)) {
-      const [baseCurrency] = symbol.split('/');
-      const candles = historicalCandles[symbol] ?? [];
-      const candidate =
-        candles.length > 0
-          ? [...candles, { avg: price, high: price, low: price, date: now }]
-          : [{ avg: price, high: price, low: price, date: now }];
-
-      // Keep the entry with the most candles (richest indicator data)
-      if (!priceData[baseCurrency] || candidate.length > priceData[baseCurrency].length) {
-        priceData[baseCurrency] = candidate;
-      }
-    }
-
-    return priceData;
-  }
-
-  /**
-   * Helper: Build positions context for algorithm
-   */
-  private buildPositionsContext(accounts: PaperTradingAccount[], quoteCurrency: string): Record<string, number> {
-    const positions: Record<string, number> = {};
-
-    for (const account of accounts) {
-      if (account.currency !== quoteCurrency && account.total > 0) {
-        positions[account.currency] = account.total;
-      }
-    }
-
-    return positions;
+    return this.snapshotService.calculateSessionMetrics(session);
   }
 
   private getSessionAllocationLimits(session: PaperTradingSession) {
     return getAllocationLimits(PipelineStage.PAPER_TRADE, session.riskLevel ?? DEFAULT_RISK_LEVEL);
   }
 
-  private getOrCreateThrottleState(sessionId: string): ThrottleState {
-    let state = this.throttleStates.get(sessionId);
-    if (!state) {
-      state = this.signalThrottle.createState();
-      this.throttleStates.set(sessionId, state);
-    }
-    return state;
-  }
-
-  /** Clean up throttle state when session ends */
   clearThrottleState(sessionId: string): void {
-    this.throttleStates.delete(sessionId);
+    this.throttleService.clear(sessionId);
   }
 
-  /** Check if in-memory throttle state exists for a session */
   hasThrottleState(sessionId: string): boolean {
-    return this.throttleStates.has(sessionId);
+    return this.throttleService.has(sessionId);
   }
 
-  /** Restore throttle state from a previously serialized form (e.g. from DB) */
   restoreThrottleState(sessionId: string, serializedState: SerializableThrottleState): void {
-    if (this.throttleStates.has(sessionId)) return;
-    const state = this.signalThrottle.deserialize(serializedState);
-    this.throttleStates.set(sessionId, state);
+    this.throttleService.restore(sessionId, serializedState);
   }
 
-  /** Serialize current throttle state for DB persistence */
   getSerializedThrottleState(sessionId: string): SerializableThrottleState | undefined {
-    const state = this.throttleStates.get(sessionId);
-    if (!state) return undefined;
-    return this.signalThrottle.serialize(state);
+    return this.throttleService.getSerialized(sessionId);
   }
 
-  private resolveMinHoldMs(algorithmConfig?: Record<string, any>): number {
-    const DEFAULT_MIN_HOLD_MS = 24 * 60 * 60 * 1000;
-    const val = algorithmConfig?.minHoldMs;
-    if (typeof val !== 'number' || !isFinite(val) || val < 0) return DEFAULT_MIN_HOLD_MS;
-    return val;
-  }
-
-  // ─── Exit Tracker Lifecycle ─────────────────────────────────────────────────
-
-  /**
-   * Get or create exit tracker for a session.
-   * Returns null if session has no exitConfig (feature flag — backward compatible).
-   */
-  private getOrCreateExitTracker(session: PaperTradingSession): BacktestExitTracker | null {
-    if (!session.exitConfig) return null;
-
-    let tracker = this.exitTrackers.get(session.id);
-    if (!tracker) {
-      const config = resolveExitConfig(session.exitConfig);
-      if (session.exitTrackerState) {
-        tracker = BacktestExitTracker.deserialize(session.exitTrackerState, config);
-      } else {
-        tracker = new BacktestExitTracker(config);
-      }
-      this.exitTrackers.set(session.id, tracker);
-    }
-    return tracker;
-  }
-
-  /** Serialize exit tracker state for DB persistence */
   getSerializedExitTrackerState(sessionId: string): SerializableExitTrackerState | undefined {
-    const tracker = this.exitTrackers.get(sessionId);
-    if (!tracker) return undefined;
-    return tracker.serialize();
+    return this.exitExecutor.serialize(sessionId);
   }
 
-  /** Clean up exit tracker when session ends */
   clearExitTracker(sessionId: string): void {
-    this.exitTrackers.delete(sessionId);
+    this.exitExecutor.clear(sessionId);
   }
 
   /**
    * Sweep in-memory state for sessions that are no longer active.
-   * Prevents memory leaks if a session fails to reach a terminal state.
    * @param activeSessionIds Set of session IDs that are still RUNNING or PAUSED
    */
   sweepOrphanedState(activeSessionIds: Set<string>): number {
-    let swept = 0;
-    for (const sessionId of this.exitTrackers.keys()) {
-      if (!activeSessionIds.has(sessionId)) {
-        this.exitTrackers.delete(sessionId);
-        swept++;
-      }
-    }
-    for (const sessionId of this.throttleStates.keys()) {
-      if (!activeSessionIds.has(sessionId)) {
-        this.throttleStates.delete(sessionId);
-        swept++;
-      }
-    }
+    let swept = this.exitExecutor.sweep(activeSessionIds);
+    swept += this.throttleService.sweepOrphaned(activeSessionIds);
     return swept;
-  }
-
-  /**
-   * Check exit levels and execute exit orders for triggered positions.
-   * Runs before algorithm so exits mirror live trading behavior.
-   */
-  private async checkAndExecuteExits(
-    session: PaperTradingSession,
-    exitTracker: BacktestExitTracker,
-    priceMap: Record<string, number>,
-    historicalCandles: Record<string, CandleData[]>,
-    quoteCurrency: string,
-    exchangeSlug: string,
-    timestamp: Date
-  ): Promise<number> {
-    // Build close/low/high price maps from current prices + last candle data
-    const closePrices = new Map<string, number>();
-    const lowPrices = new Map<string, number>();
-    const highPrices = new Map<string, number>();
-
-    for (const [symbol, price] of Object.entries(priceMap)) {
-      const [baseCurrency] = symbol.split('/');
-      closePrices.set(baseCurrency, price);
-
-      const candles = historicalCandles[symbol];
-      if (candles && candles.length > 0) {
-        const lastCandle = candles[candles.length - 1];
-        // Use the wider range: last candle's high/low vs current price
-        lowPrices.set(baseCurrency, Math.min(lastCandle.low, price));
-        highPrices.set(baseCurrency, Math.max(lastCandle.high, price));
-      } else {
-        lowPrices.set(baseCurrency, price);
-        highPrices.set(baseCurrency, price);
-      }
-    }
-
-    const exitSignals = exitTracker.checkExits(closePrices, lowPrices, highPrices);
-    if (exitSignals.length === 0) return 0;
-
-    // Fetch accounts once before the loop
-    let accounts = await this.accountRepository.find({ where: { session: { id: session.id } } });
-    let currentPortfolio = this.updatePortfolioWithPrices(
-      this.buildPortfolioFromAccounts(accounts, quoteCurrency),
-      priceMap,
-      quoteCurrency
-    );
-
-    const { maxAllocation, minAllocation } = this.getSessionAllocationLimits(session);
-
-    let ordersExecuted = 0;
-    for (const exit of exitSignals) {
-      // Declare signalEntity outside try so catch block can access it
-      let signalEntity: PaperTradingSignal | undefined;
-      try {
-        // Convert exit signal to trading signal
-        const exitTradingSignal: TradingSignal = {
-          action: 'SELL',
-          coinId: exit.coinId,
-          symbol: `${exit.coinId}/${quoteCurrency}`,
-          quantity: exit.quantity,
-          reason: exit.reason,
-          metadata: exit.metadata as Record<string, any>,
-          originalType:
-            exit.exitType === 'STOP_LOSS'
-              ? AlgoSignalType.STOP_LOSS
-              : exit.exitType === 'TAKE_PROFIT'
-                ? AlgoSignalType.TAKE_PROFIT
-                : AlgoSignalType.STOP_LOSS // trailing stop treated as SL for signal classification
-        };
-
-        // Save signal as RISK_CONTROL type
-        signalEntity = await this.saveSignal(session, exitTradingSignal);
-
-        // Execute at the exit's execution price by temporarily overriding the price map
-        const exitPriceMap = { ...priceMap, [`${exit.coinId}/${quoteCurrency}`]: exit.executionPrice };
-
-        // Pass exitType into transaction so it's set atomically
-        const result = await this.executeOrder(
-          session,
-          exitTradingSignal,
-          signalEntity,
-          currentPortfolio,
-          exitPriceMap,
-          exchangeSlug,
-          quoteCurrency,
-          timestamp,
-          { maxAllocation, minAllocation },
-          toExitType(exit.exitType)
-        );
-
-        if (result.status === 'success') {
-          ordersExecuted++;
-          // Refresh portfolio after successful exit for next iteration
-          accounts = await this.accountRepository.find({ where: { session: { id: session.id } } });
-          currentPortfolio = this.updatePortfolioWithPrices(
-            this.buildPortfolioFromAccounts(accounts, quoteCurrency),
-            priceMap,
-            quoteCurrency
-          );
-          exitTracker.removePosition(exit.coinId);
-          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
-          signalEntity.processed = true;
-          signalEntity.processedAt = new Date();
-          await this.signalRepository.save(signalEntity);
-          this.logger.log(
-            `Exit triggered for ${exit.coinId} in session ${session.id}: ${exit.exitType} at ${exit.executionPrice.toFixed(2)}`
-          );
-        } else if (result.status === 'no_position') {
-          // Position already gone — clean up tracker and mark signal processed
-          exitTracker.removePosition(exit.coinId);
-          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
-          signalEntity.processed = true;
-          signalEntity.processedAt = new Date();
-          await this.signalRepository.save(signalEntity);
-          this.logger.log(
-            `Exit cleanup for ${exit.coinId} in session ${session.id}: position already closed (${result.status})`
-          );
-        } else {
-          // Transient failure (no_price, insufficient_funds, hold_period) — keep position tracked for retry
-          signalEntity.status = PaperTradingSignalStatus.REJECTED;
-          if (result.status === 'no_price') {
-            signalEntity.rejectionCode = SignalReasonCode.SYMBOL_RESOLUTION_FAILED;
-          } else if (result.status === 'insufficient_funds') {
-            signalEntity.rejectionCode = SignalReasonCode.INSUFFICIENT_FUNDS;
-          } else if (result.status === 'hold_period') {
-            signalEntity.rejectionCode = SignalReasonCode.TRADE_COOLDOWN;
-          }
-          signalEntity.processed = true;
-          signalEntity.processedAt = new Date();
-          await this.signalRepository.save(signalEntity);
-          this.logger.warn(
-            `Exit deferred for ${exit.coinId} in session ${session.id}: ${result.status} — will retry next tick`
-          );
-        }
-      } catch (error: unknown) {
-        const err = toErrorInfo(error);
-        if (signalEntity) {
-          signalEntity.status = PaperTradingSignalStatus.ERROR;
-          signalEntity.processed = true;
-          signalEntity.processedAt = new Date();
-          await this.signalRepository.save(signalEntity);
-        }
-        this.logger.warn(`Failed to execute exit order for ${exit.coinId}: ${err.message}`);
-      }
-    }
-
-    return ordersExecuted;
-  }
-
-  /**
-   * Attempt to sell weakest positions to free cash for a higher-confidence BUY signal.
-   * Mirrors the BacktestEngine pattern using PositionAnalysisService for scoring.
-   *
-   * @returns number of sell orders executed
-   */
-  private async attemptOpportunitySelling(
-    session: PaperTradingSession,
-    buySignal: TradingSignal,
-    priceMap: Record<string, number>,
-    quoteCurrency: string,
-    exchangeSlug: string,
-    timestamp: Date,
-    allocationOverrides?: { maxAllocation: number; minAllocation: number },
-    cachedAccounts?: PaperTradingAccount[]
-  ): Promise<number> {
-    const { enabled, config } = this.resolveOpportunitySellingConfig(session.algorithmConfig);
-    if (!enabled) return 0;
-
-    const buyConfidence = buySignal.confidence ?? 0;
-    if (buyConfidence < config.minOpportunityConfidence) return 0;
-
-    // Use cached accounts if provided, otherwise fetch from DB
-    const accounts = cachedAccounts ?? (await this.accountRepository.find({ where: { session: { id: session.id } } }));
-    const portfolio = this.buildPortfolioFromAccounts(accounts, quoteCurrency);
-    const updatedPortfolio = this.updatePortfolioWithPrices(portfolio, priceMap, quoteCurrency);
-
-    // Estimate the required buy amount
-    const buyPrice = priceMap[buySignal.symbol];
-    if (!buyPrice) return 0;
-
-    const { maxAllocation, minAllocation } = allocationOverrides ?? this.getSessionAllocationLimits(session);
-    let requiredAmount: number;
-    if (buySignal.quantity) {
-      requiredAmount = buySignal.quantity * buyPrice;
-    } else if (buySignal.percentage) {
-      requiredAmount = updatedPortfolio.totalValue * Math.min(buySignal.percentage, maxAllocation);
-    } else if (buySignal.confidence !== undefined) {
-      const alloc = minAllocation + buySignal.confidence * (maxAllocation - minAllocation);
-      requiredAmount = updatedPortfolio.totalValue * alloc;
-    } else {
-      requiredAmount = updatedPortfolio.totalValue * minAllocation;
-    }
-
-    // Fee estimate
-    const feeConfig = this.feeCalculator.fromFlatRate(session.tradingFee);
-    const estFee = this.feeCalculator.calculateFee({ tradeValue: requiredAmount }, feeConfig).fee;
-    const totalRequired = requiredAmount + estFee;
-
-    if (updatedPortfolio.cashBalance >= totalRequired) return 0; // No shortfall
-
-    const shortfall = totalRequired - updatedPortfolio.cashBalance;
-
-    // Score and rank eligible positions
-    const eligible: { coinId: string; score: number; quantity: number; price: number }[] = [];
-
-    for (const [coinId, position] of updatedPortfolio.positions) {
-      if (coinId === buySignal.coinId) continue;
-      if (config.protectedCoins.includes(coinId)) continue;
-
-      const symbol = `${coinId}/${quoteCurrency}`;
-      const currentPrice = priceMap[symbol];
-      if (!currentPrice || currentPrice <= 0) continue;
-
-      const account = accounts.find((a) => a.currency === coinId);
-      const score = this.positionAnalysis.calculatePositionSellScore(
-        {
-          coinId,
-          averagePrice: account?.averageCost ?? position.averagePrice,
-          quantity: position.quantity,
-          entryDate: account?.entryDate
-        },
-        currentPrice,
-        buyConfidence,
-        config,
-        timestamp
-      );
-
-      if (score.eligible) {
-        eligible.push({ coinId, score: score.totalScore, quantity: position.quantity, price: currentPrice });
-      }
-    }
-
-    if (eligible.length === 0) return 0;
-
-    // Sort by score ASC (lowest = sell first)
-    eligible.sort((a, b) => a.score - b.score);
-
-    // Execute sells to cover the shortfall, respecting maxLiquidationPercent cap
-    const maxSellValue = (updatedPortfolio.totalValue * config.maxLiquidationPercent) / 100;
-    let coveredAmount = 0;
-    let sellCount = 0;
-
-    for (const candidate of eligible) {
-      if (coveredAmount >= shortfall) break;
-      if (coveredAmount >= maxSellValue) break;
-
-      const remainingNeeded = Math.min(shortfall - coveredAmount, maxSellValue - coveredAmount);
-      const sellQuantity = Math.min(candidate.quantity, remainingNeeded / candidate.price);
-      if (sellQuantity <= 0) continue;
-
-      const sellSignal: TradingSignal = {
-        action: 'SELL',
-        coinId: candidate.coinId,
-        symbol: `${candidate.coinId}/${quoteCurrency}`,
-        quantity: sellQuantity,
-        reason: `Opportunity sell: freeing cash for ${buySignal.coinId} BUY (confidence ${buyConfidence.toFixed(2)})`,
-        confidence: buyConfidence,
-        metadata: { opportunitySell: true, targetBuyCoinId: buySignal.coinId }
-      };
-
-      const signalEntity = await this.saveSignal(session, sellSignal);
-
-      try {
-        // Build fresh portfolio for each sell (accounts may have changed)
-        const freshAccounts = await this.accountRepository.find({
-          where: { session: { id: session.id } }
-        });
-        const freshPortfolio = this.buildPortfolioFromAccounts(freshAccounts, quoteCurrency);
-        const updatedFreshPortfolio = this.updatePortfolioWithPrices(freshPortfolio, priceMap, quoteCurrency);
-
-        const result = await this.executeOrder(
-          session,
-          sellSignal,
-          signalEntity,
-          updatedFreshPortfolio,
-          priceMap,
-          exchangeSlug,
-          quoteCurrency,
-          timestamp
-        );
-
-        if (result.order) {
-          coveredAmount += (result.order.totalValue ?? 0) - (result.order.fee ?? 0);
-          sellCount++;
-          signalEntity.status = PaperTradingSignalStatus.SIMULATED;
-        } else {
-          signalEntity.status = PaperTradingSignalStatus.REJECTED;
-          signalEntity.rejectionCode = SignalReasonCode.INSUFFICIENT_FUNDS;
-        }
-      } catch (error: unknown) {
-        const err = toErrorInfo(error);
-        signalEntity.status = PaperTradingSignalStatus.ERROR;
-        this.logger.warn(`Opportunity sell failed for ${candidate.coinId}: ${err.message}`);
-      }
-
-      signalEntity.processed = true;
-      signalEntity.processedAt = new Date();
-      await this.signalRepository.save(signalEntity);
-    }
-
-    if (sellCount > 0) {
-      this.logger.log(
-        `Opportunity selling: executed ${sellCount} sells to free cash for ${buySignal.coinId} BUY (session ${session.id})`
-      );
-    }
-
-    return sellCount;
-  }
-
-  private resolveOpportunitySellingConfig(algorithmConfig?: Record<string, any>): {
-    enabled: boolean;
-    config: OpportunitySellingUserConfig;
-  } {
-    const params = algorithmConfig ?? {};
-    const enabled = params.enableOpportunitySelling === true;
-    const userConfig = params.opportunitySellingConfig;
-
-    if (!enabled || !userConfig || typeof userConfig !== 'object') {
-      return { enabled, config: { ...DEFAULT_OPPORTUNITY_SELLING_CONFIG } };
-    }
-
-    const num = (val: unknown, fallback: number, min: number, max: number): number => {
-      const n = typeof val === 'number' && isFinite(val) ? val : fallback;
-      return Math.max(min, Math.min(max, n));
-    };
-
-    return {
-      enabled,
-      config: {
-        minOpportunityConfidence: num(
-          userConfig.minOpportunityConfidence,
-          DEFAULT_OPPORTUNITY_SELLING_CONFIG.minOpportunityConfidence,
-          0,
-          1
-        ),
-        minHoldingPeriodHours: num(
-          userConfig.minHoldingPeriodHours,
-          DEFAULT_OPPORTUNITY_SELLING_CONFIG.minHoldingPeriodHours,
-          0,
-          8760
-        ),
-        protectGainsAbovePercent: num(
-          userConfig.protectGainsAbovePercent,
-          DEFAULT_OPPORTUNITY_SELLING_CONFIG.protectGainsAbovePercent,
-          0,
-          1000
-        ),
-        protectedCoins: Array.isArray(userConfig.protectedCoins) ? userConfig.protectedCoins : [],
-        minOpportunityAdvantagePercent: num(
-          userConfig.minOpportunityAdvantagePercent,
-          DEFAULT_OPPORTUNITY_SELLING_CONFIG.minOpportunityAdvantagePercent,
-          0,
-          100
-        ),
-        maxLiquidationPercent: num(
-          userConfig.maxLiquidationPercent,
-          DEFAULT_OPPORTUNITY_SELLING_CONFIG.maxLiquidationPercent,
-          1,
-          100
-        ),
-        useAlgorithmRanking:
-          typeof userConfig.useAlgorithmRanking === 'boolean'
-            ? userConfig.useAlgorithmRanking
-            : DEFAULT_OPPORTUNITY_SELLING_CONFIG.useAlgorithmRanking
-      }
-    };
   }
 }

--- a/apps/api/src/order/paper-trading/paper-trading.module.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.module.ts
@@ -4,6 +4,13 @@ import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { PaperTradingExitExecutorService } from './engine/paper-trading-exit-executor.service';
+import { PaperTradingOpportunitySellingService } from './engine/paper-trading-opportunity-selling.service';
+import { PaperTradingOrderExecutorService } from './engine/paper-trading-order-executor.service';
+import { PaperTradingPortfolioService } from './engine/paper-trading-portfolio.service';
+import { PaperTradingSignalService } from './engine/paper-trading-signal.service';
+import { PaperTradingSnapshotService } from './engine/paper-trading-snapshot.service';
+import { PaperTradingThrottleService } from './engine/paper-trading-throttle.service';
 import {
   PaperTradingAccount,
   PaperTradingOrder,
@@ -67,6 +74,13 @@ const PAPER_TRADING_CONFIG = paperTradingConfig();
     PaperTradingService,
     PaperTradingJobService,
     PaperTradingEngineService,
+    PaperTradingPortfolioService,
+    PaperTradingSignalService,
+    PaperTradingSnapshotService,
+    PaperTradingThrottleService,
+    PaperTradingOrderExecutorService,
+    PaperTradingExitExecutorService,
+    PaperTradingOpportunitySellingService,
     PaperTradingMarketDataService,
     PaperTradingStreamService,
     PaperTradingProcessor,


### PR DESCRIPTION
## Summary
- Decompose the monolithic `PaperTradingEngineService` into focused, independently testable services (signal, throttle, portfolio, snapshot, order executor, exit executor, opportunity selling)
- Extract shared engine utilities into a dedicated module
- Slim `PaperTradingEngineService` down to pure orchestration

## Changes
- New services under `order/paper-trading/engine/`: signal, throttle, portfolio, snapshot, order executor, exit executor, opportunity selling — each with spec coverage
- New `paper-trading-engine.utils.ts` shared helpers + tests
- `paper-trading-engine.service.ts` reduced to orchestration; unused DI params removed
- Post-exit refreshed portfolio now passed into the signal loop (with regression test)
- Module wiring updated in `paper-trading.module.ts`

## Test Plan
- [ ] \`npx nx test api -- --testPathPattern='paper-trading'\` passes
- [ ] Paper trading session runs end-to-end without behavior regressions

Closes #335