### PR TITLE
fix(api): fix paper trading signal throttle blocking 99.5% of signals

### DIFF
--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.interface.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.interface.ts
@@ -26,6 +26,11 @@ export const DEFAULT_THROTTLE_CONFIG: Readonly<SignalThrottleConfig> = {
   minSellPercent: 0.5
 };
 
+export const PAPER_TRADING_DEFAULT_THROTTLE_CONFIG: Readonly<SignalThrottleConfig> = {
+  ...DEFAULT_THROTTLE_CONFIG,
+  cooldownMs: 0 // No cooldown — paper trading ticks frequently (default 30s), not daily candles
+};
+
 /** Key for per-coin per-direction cooldown tracking */
 export type CooldownKey = `${string}:${'BUY' | 'SELL'}`;
 
@@ -57,7 +62,8 @@ export interface ThrottleResult {
 /** Algorithm signal types that bypass throttling (risk-control signals). */
 export const THROTTLE_BYPASS_TYPES: ReadonlySet<AlgoSignalType> = new Set([
   AlgoSignalType.STOP_LOSS,
-  AlgoSignalType.TAKE_PROFIT
+  AlgoSignalType.TAKE_PROFIT,
+  AlgoSignalType.SHORT_EXIT
 ]);
 
 /** Maps each algorithm signal type to the backtest TradingSignal action. */

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.spec.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_THROTTLE_CONFIG, SignalThrottleConfig } from './signal-throttle.interface';
+import {
+  DEFAULT_THROTTLE_CONFIG,
+  PAPER_TRADING_DEFAULT_THROTTLE_CONFIG,
+  SignalThrottleConfig
+} from './signal-throttle.interface';
 import { SignalThrottleService } from './signal-throttle.service';
 
 import { SignalType as AlgoSignalType } from '../../../../algorithm/interfaces';
@@ -169,12 +173,21 @@ describe('SignalThrottleService', () => {
       });
     });
 
-    describe('bypass signals (STOP_LOSS / TAKE_PROFIT)', () => {
+    describe('bypass signals (STOP_LOSS / TAKE_PROFIT / SHORT_EXIT)', () => {
+      const makeShortExit = (coinId = 'btc'): TradingSignal => ({
+        action: 'CLOSE_SHORT',
+        coinId,
+        reason: 'short exit triggered',
+        confidence: 1.0,
+        originalType: AlgoSignalType.SHORT_EXIT
+      });
+
       const strictConfig: SignalThrottleConfig = { cooldownMs: ONE_DAY, maxTradesPerDay: 1, minSellPercent: 0.5 };
 
       it.each([
         ['STOP_LOSS', AlgoSignalType.STOP_LOSS, () => makeStopLoss('btc')],
-        ['TAKE_PROFIT', AlgoSignalType.TAKE_PROFIT, () => makeTakeProfit('btc')]
+        ['TAKE_PROFIT', AlgoSignalType.TAKE_PROFIT, () => makeTakeProfit('btc')],
+        ['SHORT_EXIT', AlgoSignalType.SHORT_EXIT, () => makeShortExit('btc')]
       ] as const)('%s bypasses daily limit', (_label, expectedType, makeSignal) => {
         const state = service.createState();
         // Fill daily cap with a normal trade
@@ -343,6 +356,18 @@ describe('SignalThrottleService', () => {
         minSellPercent: -Infinity
       });
       expect(config).toEqual({ cooldownMs: 86_400_000, maxTradesPerDay: 6, minSellPercent: 0.5 });
+    });
+
+    it('uses paper trading defaults when passed as second argument', () => {
+      const config = service.resolveConfig(undefined, PAPER_TRADING_DEFAULT_THROTTLE_CONFIG);
+      expect(config.cooldownMs).toBe(0);
+      expect(config.maxTradesPerDay).toBe(6);
+      expect(config.minSellPercent).toBe(0.5);
+    });
+
+    it('PAPER_TRADING_DEFAULT_THROTTLE_CONFIG: explicit param overrides default cooldownMs=0', () => {
+      const config = service.resolveConfig({ cooldownMs: 3_600_000 }, PAPER_TRADING_DEFAULT_THROTTLE_CONFIG);
+      expect(config.cooldownMs).toBe(3_600_000);
     });
   });
 

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.ts
@@ -43,15 +43,18 @@ export class SignalThrottleService {
    * Resolve throttle config from strategy/algorithm parameters, falling back to defaults.
    * Clamps each value to its valid range.
    */
-  resolveConfig(params?: Record<string, unknown>): SignalThrottleConfig {
+  resolveConfig(
+    params?: Record<string, unknown>,
+    defaults: SignalThrottleConfig = DEFAULT_THROTTLE_CONFIG
+  ): SignalThrottleConfig {
     const clamp = (val: unknown, fallback: number, min: number, max: number): number => {
       const n = typeof val === 'number' && isFinite(val) ? val : fallback;
       return Math.max(min, Math.min(max, n));
     };
     return {
-      cooldownMs: clamp(params?.cooldownMs, DEFAULT_THROTTLE_CONFIG.cooldownMs, 0, 604_800_000),
-      maxTradesPerDay: clamp(params?.maxTradesPerDay, DEFAULT_THROTTLE_CONFIG.maxTradesPerDay, 0, 50),
-      minSellPercent: clamp(params?.minSellPercent, DEFAULT_THROTTLE_CONFIG.minSellPercent, 0, 1)
+      cooldownMs: clamp(params?.cooldownMs, defaults.cooldownMs, 0, 604_800_000),
+      maxTradesPerDay: clamp(params?.maxTradesPerDay, defaults.maxTradesPerDay, 0, 50),
+      minSellPercent: clamp(params?.minSellPercent, defaults.minSellPercent, 0, 1)
     };
   }
 

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
@@ -3,6 +3,7 @@ import { CompositeRegimeType, MarketRegimeType, SignalReasonCode } from '@chanse
 import { PaperTradingEngineService } from './paper-trading-engine.service';
 
 import { SignalType } from '../../algorithm/interfaces';
+import { PAPER_TRADING_DEFAULT_THROTTLE_CONFIG } from '../backtest/shared';
 
 /**
  * Engine-level orchestration tests only.
@@ -25,6 +26,7 @@ interface Overrides {
   compositeRegime?: CompositeRegimeType;
   signalFilterChainApply?: jest.Mock;
   exitOrdersExecuted?: number;
+  signalThrottle?: Record<string, jest.Mock>;
 }
 
 const createService = (overrides: Overrides = {}) => {
@@ -135,7 +137,7 @@ const createService = (overrides: Overrides = {}) => {
       }))
   };
 
-  const signalThrottle = { resolveConfig: jest.fn().mockReturnValue({}) };
+  const signalThrottle = overrides.signalThrottle ?? { resolveConfig: jest.fn().mockReturnValue({}) };
 
   const service = new PaperTradingEngineService(
     marketDataService as any,
@@ -452,5 +454,63 @@ describe('PaperTradingEngineService', () => {
       expect(orderExecutor.execute).toHaveBeenCalledTimes(1);
       expect(result.ordersExecuted).toBe(1);
     });
+  });
+
+  it('passes PAPER_TRADING_DEFAULT_THROTTLE_CONFIG as defaults to resolveConfig', async () => {
+    const signalThrottle = {
+      createState: jest.fn().mockReturnValue({ lastSignalTime: {}, tradeTimestamps: [] }),
+      filterSignals: jest.fn().mockImplementation((signals: any[]) => ({ accepted: signals, rejected: [] })),
+      resolveConfig: jest.fn().mockReturnValue({ cooldownMs: 0, maxTradesPerDay: 6, minSellPercent: 0.5 }),
+      toThrottleSignal: jest.fn().mockImplementation((s: any) => s)
+    };
+    const { service, marketDataService, algorithmRegistry } = createService({ signalThrottle });
+
+    marketDataService.getPrices.mockResolvedValue(new Map([['BTC/USD', { price: 50000 }]]));
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
+
+    const session = {
+      id: 'session-throttle-check',
+      initialCapital: 10000,
+      tickCount: 1,
+      user: { id: 'user-1' }
+    } as any;
+    await service.processTick(session, { exchange: { slug: 'binance' } } as any);
+
+    expect(signalThrottle.resolveConfig).toHaveBeenCalledWith(
+      session.algorithmConfig,
+      PAPER_TRADING_DEFAULT_THROTTLE_CONFIG
+    );
+  });
+
+  it('does not produce duplicate signals when multiple symbols share a base currency', async () => {
+    const prices = { 'ETH/USDT': 1900, 'ETH/BTC': 0.05 };
+    const accounts = [{ currency: 'USDT', available: 10000, total: 10000 }];
+    const { service, marketDataService, algorithmRegistry } = createService({
+      accounts,
+      prices,
+      quoteCurrency: 'USDT'
+    });
+
+    // Override getPrices to return both ETH symbols
+    marketDataService.getPrices.mockResolvedValue(
+      new Map([
+        ['ETH/USDT', { price: 1900 }],
+        ['ETH/BTC', { price: 0.05 }]
+      ])
+    );
+
+    algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
+
+    const session = { id: 'session-dedup', initialCapital: 10000, tickCount: 5, user: { id: 'user-1' } } as any;
+    const exchangeKey = { exchange: { slug: 'binance' } } as any;
+
+    await service.processTick(session, exchangeKey);
+
+    // Algorithm should receive only one coin entry for ETH, not two
+    const algorithmCall = algorithmRegistry.executeAlgorithm.mock.calls[0];
+    const context = algorithmCall[1]; // second argument is the AlgorithmContext
+    const ethCoins = context.coins.filter((c: any) => c.id === 'ETH');
+
+    expect(ethCoins).toHaveLength(1);
   });
 });

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
@@ -28,6 +28,7 @@ import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { DEFAULT_RISK_LEVEL } from '../../risk/risk.constants';
 import { toErrorInfo } from '../../shared/error.util';
 import {
+  PAPER_TRADING_DEFAULT_THROTTLE_CONFIG,
   Portfolio,
   SerializableExitTrackerState,
   SignalFilterChainService,
@@ -218,7 +219,7 @@ export class PaperTradingEngineService {
 
   /** Apply throttle + regime filter chain; persist rejected signals. */
   private async filterSignals(session: PaperTradingSession, signals: TradingSignal[]): Promise<FilteredSignals> {
-    const throttleConfig = this.signalThrottle.resolveConfig(session.algorithmConfig);
+    const throttleConfig = this.signalThrottle.resolveConfig(session.algorithmConfig, PAPER_TRADING_DEFAULT_THROTTLE_CONFIG);
     const { accepted: throttleAccepted, rejected: throttledSignals } = this.throttleService.filter(
       session.id,
       signals,


### PR DESCRIPTION
## Summary
- Paper trading reused `BacktestSharedModule`'s `SignalThrottleService` with `DEFAULT_THROTTLE_CONFIG` (`cooldownMs=24h`), but paper trading ticks every 30s — after the first signal per coin+direction, everything else got rejected as `SIGNAL_THROTTLED` (83k/83.7k across 17 active sessions).
- Introduce `PAPER_TRADING_DEFAULT_THROTTLE_CONFIG` with `cooldownMs=0` (daily cap of 6 trades still applies) and plumb it through a new optional `defaults` arg on `resolveConfig()` so backtest behavior is untouched.
- Add `SHORT_EXIT` to `THROTTLE_BYPASS_TYPES` so trailing-stop exits are never blocked by the daily trade cap.

## Changes
- `apps/api/src/order/backtest/shared/throttle/signal-throttle.interface.ts` — add `PAPER_TRADING_DEFAULT_THROTTLE_CONFIG`, bypass `SHORT_EXIT`
- `apps/api/src/order/backtest/shared/throttle/signal-throttle.service.ts` — parameterize `resolveConfig()` defaults
- `apps/api/src/order/paper-trading/paper-trading-engine.service.ts` — pass paper-trading defaults at call site
- Unit tests for throttle service and paper trading engine

## Test Plan
- [ ] `nx test api` — throttle + paper trading engine specs pass
- [ ] Verify live paper trading sessions execute signals beyond the first per coin/direction