### PR TITLE
fix(api): connect coin selections to paper trading symbol universe

### DIFF
--- a/apps/api/src/order/paper-trading/engine/paper-trading-engine.utils.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-engine.utils.ts
@@ -1,7 +1,7 @@
 import { SignalType as AlgoSignalType, TradingSignal as StrategySignal } from '../../../algorithm/interfaces';
 import { CandleData } from '../../../ohlc/ohlc-candle.entity';
 import { DEFAULT_OPPORTUNITY_SELLING_CONFIG, OpportunitySellingUserConfig } from '../../backtest/shared';
-import { PaperTradingExitType, PaperTradingOrder, PaperTradingSignalType } from '../entities';
+import { PaperTradingAccount, PaperTradingExitType, PaperTradingOrder, PaperTradingSignalType } from '../entities';
 
 // ─── Public Types ───────────────────────────────────────────────────────────
 
@@ -32,6 +32,27 @@ export type ExecuteOrderStatus = 'success' | 'insufficient_funds' | 'no_price' |
 export interface ExecuteOrderResult {
   status: ExecuteOrderStatus;
   order: PaperTradingOrder | null;
+}
+
+// ─── Engine-Internal Result Types ───────────────────────────────────────────
+
+export interface EngineMarketData {
+  accounts: PaperTradingAccount[];
+  quoteCurrency: string;
+  exchangeSlug: string;
+  priceMap: Record<string, number>;
+  historicalCandles: Record<string, CandleData[]>;
+  allSymbols: string[];
+}
+
+export interface FilteredSignals {
+  signals: TradingSignal[];
+  allocation: { maxAllocation: number; minAllocation: number };
+}
+
+export interface SignalLoopResult {
+  ordersExecuted: number;
+  errors: string[];
 }
 
 // ─── Exit Type Helpers ──────────────────────────────────────────────────────

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
@@ -27,6 +27,7 @@ interface Overrides {
   signalFilterChainApply?: jest.Mock;
   exitOrdersExecuted?: number;
   signalThrottle?: Record<string, jest.Mock>;
+  resolveSymbolUniverse?: jest.Mock;
 }
 
 const createService = (overrides: Overrides = {}) => {
@@ -113,7 +114,16 @@ const createService = (overrides: Overrides = {}) => {
 
   const marketDataService = {
     getPrices: jest.fn().mockResolvedValue(new Map(Object.entries(prices).map(([sym, p]) => [sym, { price: p }]))),
-    getHistoricalCandles: jest.fn().mockResolvedValue([])
+    getHistoricalCandles: jest.fn().mockResolvedValue([]),
+    resolveSymbolUniverse:
+      overrides.resolveSymbolUniverse ??
+      jest
+        .fn()
+        .mockResolvedValue(
+          Object.keys(prices).length > 0 ? Object.keys(prices) : [`BTC/${quoteCurrency}`, `ETH/${quoteCurrency}`]
+        ),
+    clearSymbolCache: jest.fn(),
+    sweepOrphaned: jest.fn().mockReturnValue(0)
   };
 
   const algorithmRegistry = {
@@ -217,13 +227,49 @@ describe('PaperTradingEngineService', () => {
   });
 
   it('defaults to BTC/ETH symbols when no holdings or config and takes a snapshot on interval ticks', async () => {
-    const { service, marketDataService, snapshotService } = createService({ accounts: [] });
+    const resolveSymbolUniverse = jest.fn().mockResolvedValue(['BTC/USD', 'ETH/USD']);
+    const prices = { 'BTC/USD': 50000, 'ETH/USD': 3000 };
+    const { service, marketDataService, snapshotService } = createService({
+      accounts: [],
+      prices,
+      resolveSymbolUniverse
+    });
 
     const result = await service.processTick(makeSession({ tickCount: 10 }), exchangeKey);
 
+    expect(resolveSymbolUniverse).toHaveBeenCalledTimes(1);
     expect(marketDataService.getPrices).toHaveBeenCalledWith('binance', ['BTC/USD', 'ETH/USD']);
     expect(snapshotService.save).toHaveBeenCalledTimes(1);
     expect(result.processed).toBe(true);
+  });
+
+  it('uses resolved symbols from marketDataService when no holdings', async () => {
+    const resolveSymbolUniverse = jest.fn().mockResolvedValue(['BNB/USD', 'BTC/USD', 'ETH/USD']);
+    const prices = { 'BNB/USD': 300, 'BTC/USD': 50000, 'ETH/USD': 3000 };
+    const { service, marketDataService } = createService({ accounts: [], prices, resolveSymbolUniverse });
+
+    await service.processTick(makeSession(), exchangeKey);
+
+    expect(resolveSymbolUniverse).toHaveBeenCalledTimes(1);
+    expect(marketDataService.getPrices).toHaveBeenCalledWith(
+      'binance',
+      expect.arrayContaining(['BNB/USD', 'BTC/USD', 'ETH/USD'])
+    );
+  });
+
+  describe('validSymbols exchange filtering', () => {
+    it('only fetches candles for symbols present in the price map', async () => {
+      // Exchange returns prices only for BTC/USD; UNKNOWN/USD is absent from the price response
+      const resolveSymbolUniverse = jest.fn().mockResolvedValue(['BTC/USD', 'UNKNOWN/USD']);
+      const prices = { 'BTC/USD': 50000 }; // UNKNOWN/USD intentionally absent
+      const { service, marketDataService } = createService({ accounts: [], prices, resolveSymbolUniverse });
+
+      await service.processTick(makeSession(), exchangeKey);
+
+      const candleCalls = marketDataService.getHistoricalCandles.mock.calls.map((c: any[]) => c[1]);
+      expect(candleCalls).toContain('BTC/USD');
+      expect(candleCalls).not.toContain('UNKNOWN/USD');
+    });
   });
 
   it('refreshes portfolio before running the algorithm when exits executed', async () => {

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
@@ -6,7 +6,10 @@ import {
   buildPriceDataContext,
   extractCoinsFromPrices,
   extractSymbolsFromConfig,
+  EngineMarketData,
+  FilteredSignals,
   mapStrategySignal,
+  SignalLoopResult,
   TickResult,
   TradingSignal
 } from './engine/paper-trading-engine.utils';
@@ -36,25 +39,6 @@ import {
   SignalThrottleService
 } from '../backtest/shared';
 
-interface MarketData {
-  accounts: PaperTradingAccount[];
-  quoteCurrency: string;
-  exchangeSlug: string;
-  priceMap: Record<string, number>;
-  historicalCandles: Record<string, CandleData[]>;
-  allSymbols: string[];
-}
-
-interface FilteredSignals {
-  signals: TradingSignal[];
-  allocation: { maxAllocation: number; minAllocation: number };
-}
-
-interface SignalLoopResult {
-  ordersExecuted: number;
-  errors: string[];
-}
-
 @Injectable()
 export class PaperTradingEngineService {
   private readonly logger = new Logger(PaperTradingEngineService.name);
@@ -74,6 +58,10 @@ export class PaperTradingEngineService {
     private readonly opportunitySelling: PaperTradingOpportunitySellingService
   ) {}
 
+  clearSymbolCache(sessionId: string): void {
+    this.marketDataService.clearSymbolCache(sessionId);
+  }
+
   /** Process a single tick for a paper trading session. */
   async processTick(session: PaperTradingSession, exchangeKey: ExchangeKey): Promise<TickResult> {
     const errors: string[] = [];
@@ -89,7 +77,7 @@ export class PaperTradingEngineService {
       const updatedPortfolio = this.portfolioService.updateWithPrices(portfolio, priceMap, quoteCurrency);
 
       this.exitExecutor.getOrCreate(session);
-      const exitOrdersExecuted = await this.runExits(
+      const exitOrdersExecuted = await this.exitExecutor.checkAndExecute(
         session,
         priceMap,
         historicalCandles,
@@ -165,7 +153,7 @@ export class PaperTradingEngineService {
   }
 
   /** Fetch accounts, prices, and historical candles for the tick. */
-  private async fetchMarketData(session: PaperTradingSession, exchangeKey: ExchangeKey): Promise<MarketData> {
+  private async fetchMarketData(session: PaperTradingSession, exchangeKey: ExchangeKey): Promise<EngineMarketData> {
     const accounts = await this.portfolioService.loadAccounts(session.id);
     const quoteCurrency = this.portfolioService.getQuoteCurrency(accounts);
 
@@ -175,7 +163,8 @@ export class PaperTradingEngineService {
     const configSymbols = extractSymbolsFromConfig(session.algorithmConfig);
     const allSymbols = [...new Set([...holdingSymbols, ...configSymbols])];
     if (allSymbols.length === 0) {
-      allSymbols.push(`BTC/${quoteCurrency}`, `ETH/${quoteCurrency}`);
+      const resolved = await this.marketDataService.resolveSymbolUniverse(session, quoteCurrency);
+      allSymbols.push(...resolved);
     }
 
     const exchangeSlug = exchangeKey.exchange?.slug ?? 'binance_us';
@@ -185,9 +174,12 @@ export class PaperTradingEngineService {
       priceMap[symbol] = priceData.price;
     }
 
+    // Filter to symbols the exchange actually prices — implicitly validates against exchange symbol map
+    const validSymbols = allSymbols.filter((s) => s in priceMap);
+
     const historicalCandles: Record<string, CandleData[]> = {};
     const candleResults = await Promise.all(
-      allSymbols.map(async (symbol) => {
+      validSymbols.map(async (symbol) => {
         const candles = await this.marketDataService.getHistoricalCandles(
           exchangeSlug,
           symbol,
@@ -202,19 +194,7 @@ export class PaperTradingEngineService {
       if (candles.length > 0) historicalCandles[symbol] = candles;
     }
 
-    return { accounts, quoteCurrency, exchangeSlug, priceMap, historicalCandles, allSymbols };
-  }
-
-  /** Thin delegate to exit executor. */
-  private async runExits(
-    session: PaperTradingSession,
-    priceMap: Record<string, number>,
-    historicalCandles: Record<string, CandleData[]>,
-    quoteCurrency: string,
-    exchangeSlug: string,
-    now: Date
-  ): Promise<number> {
-    return this.exitExecutor.checkAndExecute(session, priceMap, historicalCandles, quoteCurrency, exchangeSlug, now);
+    return { accounts, quoteCurrency, exchangeSlug, priceMap, historicalCandles, allSymbols: validSymbols };
   }
 
   /** Apply throttle + regime filter chain; persist rejected signals. */
@@ -236,7 +216,10 @@ export class PaperTradingEngineService {
     }
 
     const compositeRegime = this.compositeRegimeService.getCompositeRegime();
-    const { maxAllocation, minAllocation } = this.getSessionAllocationLimits(session);
+    const { maxAllocation, minAllocation } = getAllocationLimits(
+      PipelineStage.PAPER_TRADE,
+      session.riskLevel ?? DEFAULT_RISK_LEVEL
+    );
     const regimeResult = this.signalFilterChain.apply(
       throttleAccepted,
       {
@@ -466,10 +449,6 @@ export class PaperTradingEngineService {
     return this.snapshotService.calculateSessionMetrics(session);
   }
 
-  private getSessionAllocationLimits(session: PaperTradingSession) {
-    return getAllocationLimits(PipelineStage.PAPER_TRADE, session.riskLevel ?? DEFAULT_RISK_LEVEL);
-  }
-
   clearThrottleState(sessionId: string): void {
     this.throttleService.clear(sessionId);
   }
@@ -501,6 +480,7 @@ export class PaperTradingEngineService {
   sweepOrphanedState(activeSessionIds: Set<string>): number {
     let swept = this.exitExecutor.sweep(activeSessionIds);
     swept += this.throttleService.sweepOrphaned(activeSessionIds);
+    swept += this.marketDataService.sweepOrphaned(activeSessionIds);
     return swept;
   }
 }

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -5,7 +5,15 @@ import { PaperTradingMarketDataService, PriceData } from './paper-trading-market
 import type { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import * as retryUtil from '../../shared/retry.util';
 
-const createService = (overrides: Partial<{ cacheManager: any; exchangeManager: any; config: any }> = {}) => {
+const createService = (
+  overrides: Partial<{
+    cacheManager: any;
+    exchangeManager: any;
+    config: any;
+    coinSelectionService: any;
+    coinService: any;
+  }> = {}
+) => {
   const cacheManager = overrides.cacheManager ?? {
     get: jest.fn(),
     set: jest.fn(),
@@ -20,10 +28,26 @@ const createService = (overrides: Partial<{ cacheManager: any; exchangeManager: 
 
   const config = overrides.config ?? { priceCacheTtlMs: 1000 };
 
+  const coinSelectionService = overrides.coinSelectionService ?? {
+    getCoinSelectionsByUser: jest.fn().mockResolvedValue([])
+  };
+
+  const coinService = overrides.coinService ?? {
+    getCoinsByRiskLevel: jest.fn().mockResolvedValue([])
+  };
+
   return {
-    service: new PaperTradingMarketDataService(config as any, cacheManager, exchangeManager as ExchangeManagerService),
+    service: new PaperTradingMarketDataService(
+      config as any,
+      cacheManager,
+      exchangeManager as ExchangeManagerService,
+      coinSelectionService as any,
+      coinService as any
+    ),
     cacheManager,
-    exchangeManager
+    exchangeManager,
+    coinSelectionService,
+    coinService
   };
 };
 
@@ -231,40 +255,6 @@ describe('PaperTradingMarketDataService', () => {
   });
 
   describe('getCurrentPrice retry + stale-cache fallback', () => {
-    it('retries on transient error and succeeds on 2nd attempt', async () => {
-      const ticker = { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 };
-
-      const client = { fetchTicker: jest.fn() };
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
-        getPublicClient: jest.fn().mockResolvedValue(client)
-      };
-
-      withRateLimitRetrySpy.mockResolvedValue({
-        success: true,
-        result: ticker,
-        attempts: 2,
-        totalDelayMs: 2000
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      const result = await service.getCurrentPrice('binance', 'BTC/USDT');
-
-      expect(result.price).toBe(45000);
-      expect(withRateLimitRetrySpy).toHaveBeenCalledWith(
-        expect.any(Function),
-        expect.objectContaining({
-          operationName: expect.stringContaining('fetchTicker')
-        })
-      );
-    });
-
     it('falls back to stale cache when all retries exhausted', async () => {
       const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
 
@@ -674,12 +664,12 @@ describe('PaperTradingMarketDataService', () => {
 
   describe('checkExchangeHealth', () => {
     it('returns healthy with latency when exchange responds', async () => {
-      const client = { fetchTime: jest.fn().mockResolvedValue(1700000000000) };
-
       const exchangeManager = {
         formatSymbol: jest.fn(),
-        getPublicClient: jest.fn().mockResolvedValue(client)
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTime: jest.fn() })
       };
+
+      withRateLimitRetrySpy.mockResolvedValue({ success: true, result: 1700000000000, attempts: 1, totalDelayMs: 0 });
 
       const { service } = createService({ exchangeManager });
       const result = await service.checkExchangeHealth('binance');
@@ -689,13 +679,18 @@ describe('PaperTradingMarketDataService', () => {
       expect(result.error).toBeUndefined();
     });
 
-    it('returns unhealthy with error message when exchange fails', async () => {
-      const client = { fetchTime: jest.fn().mockRejectedValue(new Error('connection refused')) };
-
+    it('returns unhealthy when retry wrapper reports failure', async () => {
       const exchangeManager = {
         formatSymbol: jest.fn(),
-        getPublicClient: jest.fn().mockResolvedValue(client)
+        getPublicClient: jest.fn().mockResolvedValue({ fetchTime: jest.fn() })
       };
+
+      withRateLimitRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('connection refused'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
 
       const { service } = createService({ exchangeManager });
       const result = await service.checkExchangeHealth('binance');
@@ -703,6 +698,193 @@ describe('PaperTradingMarketDataService', () => {
       expect(result.healthy).toBe(false);
       expect(result.error).toBe('connection refused');
       expect(result.latencyMs).toBeUndefined();
+    });
+
+    it('returns unhealthy when getPublicClient throws', async () => {
+      const exchangeManager = {
+        formatSymbol: jest.fn(),
+        getPublicClient: jest.fn().mockRejectedValue(new Error('no such exchange'))
+      };
+
+      const { service } = createService({ exchangeManager });
+      const result = await service.checkExchangeHealth('binance');
+
+      expect(result.healthy).toBe(false);
+      expect(result.error).toBe('no such exchange');
+    });
+  });
+
+  describe('resolveSymbolUniverse', () => {
+    const makeSession = (id = 'sess-1', userId = 'user-1'): any => ({ id, user: { id: userId } });
+
+    it('returns coin selection symbols and caches them', async () => {
+      const coinSelectionService = {
+        getCoinSelectionsByUser: jest.fn().mockResolvedValue([{ coin: { symbol: 'btc' } }, { coin: { symbol: 'eth' } }])
+      };
+      const { service, coinSelectionService: mockCs } = createService({ coinSelectionService });
+      const session = makeSession();
+
+      const result = await service.resolveSymbolUniverse(session, 'USD');
+
+      expect(result).toEqual(['BTC/USD', 'ETH/USD']);
+      expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(1);
+
+      // Second call must be served from cache
+      await service.resolveSymbolUniverse(session, 'USD');
+      expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to risk-level coins when selections empty', async () => {
+      const coinSelectionService = { getCoinSelectionsByUser: jest.fn().mockResolvedValue([]) };
+      const coinService = { getCoinsByRiskLevel: jest.fn().mockResolvedValue([{ symbol: 'sol' }, { symbol: 'dot' }]) };
+      const { service } = createService({ coinSelectionService, coinService });
+
+      const result = await service.resolveSymbolUniverse(makeSession(), 'USD');
+
+      expect(result).toEqual(['SOL/USD', 'DOT/USD']);
+    });
+
+    it('re-queries after cache TTL expires', async () => {
+      let fakeNow = 1_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+
+      const coinSelectionService = {
+        getCoinSelectionsByUser: jest.fn().mockResolvedValue([{ coin: { symbol: 'btc' } }])
+      };
+      const { service, coinSelectionService: mockCs } = createService({ coinSelectionService });
+      const session = makeSession();
+
+      await service.resolveSymbolUniverse(session, 'USD');
+
+      fakeNow += 5 * 60 * 1000 + 1; // past TTL
+
+      await service.resolveSymbolUniverse(session, 'USD');
+
+      expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(2);
+
+      jest.restoreAllMocks();
+    });
+
+    it('does not cache the BTC/ETH fallback — re-queries DB on every tick until real selections exist', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      const coinSelectionService = { getCoinSelectionsByUser: jest.fn().mockResolvedValue([]) };
+      const coinService = { getCoinsByRiskLevel: jest.fn().mockResolvedValue([]) };
+      const {
+        service,
+        coinSelectionService: mockCs,
+        coinService: mockCv
+      } = createService({
+        coinSelectionService,
+        coinService
+      });
+      const session = makeSession('s-x', 'u-99');
+
+      const result = await service.resolveSymbolUniverse(session, 'USD');
+      await service.resolveSymbolUniverse(session, 'USD');
+
+      expect(result).toEqual(['BTC/USD', 'ETH/USD']);
+      expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(2);
+      expect(mockCv.getCoinsByRiskLevel).toHaveBeenCalledTimes(2);
+      // Verify log includes userId for debugging
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('u-99'));
+      loggerSpy.mockRestore();
+    });
+
+    it('clearSymbolCache removes the cached entry so next call re-queries', async () => {
+      const coinSelectionService = {
+        getCoinSelectionsByUser: jest.fn().mockResolvedValue([{ coin: { symbol: 'btc' } }])
+      };
+      const { service, coinSelectionService: mockCs } = createService({ coinSelectionService });
+      const session = makeSession();
+
+      await service.resolveSymbolUniverse(session, 'USD');
+      service.clearSymbolCache(session.id);
+      await service.resolveSymbolUniverse(session, 'USD');
+
+      expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns BTC/ETH fallback when session.user is null', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      const { service, coinSelectionService: mockCs } = createService();
+      const session = { id: 'sess-no-user', user: null } as any;
+
+      const result = await service.resolveSymbolUniverse(session, 'USD');
+
+      expect(result).toEqual(['BTC/USD', 'ETH/USD']);
+      expect(mockCs.getCoinSelectionsByUser).not.toHaveBeenCalled();
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('no user attached'));
+      loggerSpy.mockRestore();
+    });
+
+    it('falls through to risk-level coins when coin selection service throws', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      const coinSelectionService = {
+        getCoinSelectionsByUser: jest.fn().mockRejectedValue(new Error('DB connection lost'))
+      };
+      const coinService = { getCoinsByRiskLevel: jest.fn().mockResolvedValue([{ symbol: 'sol' }]) };
+      const { service } = createService({ coinSelectionService, coinService });
+
+      const result = await service.resolveSymbolUniverse(makeSession(), 'USD');
+
+      expect(result).toEqual(['SOL/USD']);
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('coin selection fetch failed'));
+      loggerSpy.mockRestore();
+    });
+
+    it('returns BTC/ETH fallback when both services throw', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      const coinSelectionService = {
+        getCoinSelectionsByUser: jest.fn().mockRejectedValue(new Error('DB down'))
+      };
+      const coinService = { getCoinsByRiskLevel: jest.fn().mockRejectedValue(new Error('DB down')) };
+      const { service } = createService({ coinSelectionService, coinService });
+
+      const result = await service.resolveSymbolUniverse(makeSession(), 'USD');
+
+      expect(result).toEqual(['BTC/USD', 'ETH/USD']);
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('risk-level coin fetch failed'));
+      loggerSpy.mockRestore();
+    });
+  });
+
+  describe('sweepOrphaned', () => {
+    const makeSession = (id: string): any => ({ id, user: { id: 'u-1' } });
+
+    it('removes cached entries for sessions not in active set', async () => {
+      const coinSelectionService = {
+        getCoinSelectionsByUser: jest.fn().mockResolvedValue([{ coin: { symbol: 'btc' } }])
+      };
+      const { service } = createService({ coinSelectionService });
+
+      // Populate caches for 3 sessions
+      await service.resolveSymbolUniverse(makeSession('s-1'), 'USD');
+      await service.resolveSymbolUniverse(makeSession('s-2'), 'USD');
+      await service.resolveSymbolUniverse(makeSession('s-3'), 'USD');
+
+      const swept = service.sweepOrphaned(new Set(['s-2']));
+
+      expect(swept).toBe(2);
+
+      // s-2 should still be cached (no re-query needed)
+      coinSelectionService.getCoinSelectionsByUser.mockClear();
+      await service.resolveSymbolUniverse(makeSession('s-2'), 'USD');
+      expect(coinSelectionService.getCoinSelectionsByUser).not.toHaveBeenCalled();
+
+      // s-1 should be gone (re-query needed)
+      await service.resolveSymbolUniverse(makeSession('s-1'), 'USD');
+      expect(coinSelectionService.getCoinSelectionsByUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 0 when all sessions are active', async () => {
+      const coinSelectionService = {
+        getCoinSelectionsByUser: jest.fn().mockResolvedValue([{ coin: { symbol: 'btc' } }])
+      };
+      const { service } = createService({ coinSelectionService });
+
+      await service.resolveSymbolUniverse(makeSession('s-1'), 'USD');
+
+      expect(service.sweepOrphaned(new Set(['s-1']))).toBe(0);
     });
   });
 

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -4,8 +4,12 @@ import { ConfigType } from '@nestjs/config';
 
 import { Cache } from 'cache-manager';
 
+import { PaperTradingSession } from './entities';
 import { paperTradingConfig } from './paper-trading.config';
 
+import { CoinService } from '../../coin/coin.service';
+import { CoinSelectionRelations } from '../../coin-selection/coin-selection.entity';
+import { CoinSelectionService } from '../../coin-selection/coin-selection.service';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { toErrorInfo } from '../../shared/error.util';
@@ -43,13 +47,89 @@ export interface RealisticSlippageResult {
 export class PaperTradingMarketDataService {
   private readonly logger = new Logger(PaperTradingMarketDataService.name);
   private readonly cacheTtlMs: number;
+  private readonly symbolUniverseCache = new Map<string, { symbols: string[]; cachedAt: number }>();
+  private readonly SYMBOL_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
   constructor(
     @Inject(paperTradingConfig.KEY) private readonly config: ConfigType<typeof paperTradingConfig>,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
-    private readonly exchangeManager: ExchangeManagerService
+    private readonly exchangeManager: ExchangeManagerService,
+    private readonly coinSelectionService: CoinSelectionService,
+    private readonly coinService: CoinService
   ) {
     this.cacheTtlMs = config.priceCacheTtlMs;
+  }
+
+  /** Resolve symbol universe from user's coin selections, falling back to risk-level coins. */
+  async resolveSymbolUniverse(session: PaperTradingSession, quoteCurrency: string): Promise<string[]> {
+    const fallback = [`BTC/${quoteCurrency}`, `ETH/${quoteCurrency}`];
+
+    const cacheKey = `${session.id}:${quoteCurrency}`;
+    const cached = this.symbolUniverseCache.get(cacheKey);
+    if (cached && Date.now() - cached.cachedAt < this.SYMBOL_CACHE_TTL_MS) {
+      return cached.symbols;
+    }
+
+    if (!session.user) {
+      this.logger.warn(`Session ${session.id}: no user attached, using BTC/ETH fallback`);
+      return fallback;
+    }
+
+    // Tier 1: user's explicit coin selections
+    try {
+      const selections = await this.coinSelectionService.getCoinSelectionsByUser(session.user, [
+        CoinSelectionRelations.COIN
+      ]);
+      if (selections.length > 0) {
+        const symbols = selections.map((s) => `${s.coin.symbol.toUpperCase()}/${quoteCurrency}`);
+        this.symbolUniverseCache.set(cacheKey, { symbols, cachedAt: Date.now() });
+        return symbols;
+      }
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Session ${session.id}: coin selection fetch failed (${err.message}), trying risk-level coins`);
+    }
+
+    // Tier 2: risk-level based coins
+    try {
+      const coins = await this.coinService.getCoinsByRiskLevel(session.user);
+      if (coins.length > 0) {
+        const symbols = coins.map((c) => `${c.symbol.toUpperCase()}/${quoteCurrency}`);
+        this.symbolUniverseCache.set(cacheKey, { symbols, cachedAt: Date.now() });
+        return symbols;
+      }
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Session ${session.id}: risk-level coin fetch failed (${err.message}), using BTC/ETH fallback`);
+      return fallback;
+    }
+
+    this.logger.warn(
+      `Session ${session.id} (user: ${session.user?.id}): no coin selections or risk-level coins found, using BTC/ETH fallback`
+    );
+    // Do not cache the fallback — retry next tick so real selections are picked up
+    return fallback;
+  }
+
+  /** Remove cached symbol universes for sessions that are no longer active. */
+  sweepOrphaned(activeSessionIds: Set<string>): number {
+    let swept = 0;
+    for (const key of this.symbolUniverseCache.keys()) {
+      const sessionId = key.split(':')[0];
+      if (!activeSessionIds.has(sessionId)) {
+        this.symbolUniverseCache.delete(key);
+        swept++;
+      }
+    }
+    return swept;
+  }
+
+  clearSymbolCache(sessionId: string): void {
+    for (const key of this.symbolUniverseCache.keys()) {
+      if (key.startsWith(`${sessionId}:`)) {
+        this.symbolUniverseCache.delete(key);
+      }
+    }
   }
 
   /**

--- a/apps/api/src/order/paper-trading/paper-trading.module.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.module.ts
@@ -32,6 +32,8 @@ import { PaperTradingService } from './paper-trading.service';
 import { Algorithm } from '../../algorithm/algorithm.entity';
 import { AlgorithmModule } from '../../algorithm/algorithm.module';
 import { AuthenticationModule } from '../../authentication/authentication.module';
+import { CoinModule } from '../../coin/coin.module';
+import { CoinSelectionModule } from '../../coin-selection/coin-selection.module';
 import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { ExchangeKeyModule } from '../../exchange/exchange-key/exchange-key.module';
 import { ExchangeModule } from '../../exchange/exchange.module';
@@ -67,6 +69,8 @@ const PAPER_TRADING_CONFIG = paperTradingConfig();
     forwardRef(() => UsersModule),
     forwardRef(() => OHLCModule),
     forwardRef(() => MarketRegimeModule),
+    forwardRef(() => CoinModule),
+    forwardRef(() => CoinSelectionModule),
     MetricsModule
   ],
   controllers: [PaperTradingController],


### PR DESCRIPTION
## Summary

- Wire user coin selections into paper trading so the engine monitors the right symbols instead of always defaulting to BTC/ETH
- Implement a 3-tier symbol resolution fallback: user coin selections → risk-level coins → BTC/ETH last resort
- Add `validSymbols` filtering so only exchange-priced symbols are used for candle fetches, preventing spurious API calls

## Changes

**`paper-trading-market-data.service.ts`**
- Add `resolveSymbolUniverse(session, quoteCurrency)` with 3-tier fallback logic
- Inject `CoinSelectionService` and `CoinService` as dependencies
- In-memory symbol universe cache (5-min TTL per session); fallback result is intentionally not cached so real selections are picked up on the next tick
- Add `clearSymbolCache(sessionId)` to allow forced invalidation

**`paper-trading-engine.service.ts`**
- Delegate symbol resolution to `marketDataService.resolveSymbolUniverse()` instead of hardcoding BTC/ETH
- Filter `allSymbols` → `validSymbols` using the exchange price map before fetching historical candles
- Remove private `runExits` and `getSessionAllocationLimits` wrappers (inlined to reduce indirection)
- Expose `clearSymbolCache()` as a thin delegate to market data service

**`paper-trading-engine.utils.ts`**
- Export `EngineMarketData`, `FilteredSignals`, `SignalLoopResult` interfaces (previously defined inline in the engine service)

**`paper-trading.module.ts`**
- Import `CoinModule` and `CoinSelectionModule` (via `forwardRef`) to satisfy new dependencies

**Tests**
- `paper-trading-market-data.service.spec.ts`: 6 new cases covering coin-selection path, risk-level fallback, TTL expiry, BTC/ETH fallback (uncached), `clearSymbolCache`, and warn logging
- `paper-trading-engine.service.spec.ts`: Updated mocks to include `resolveSymbolUniverse` and `clearSymbolCache`; new cases for resolved-symbol routing and `validSymbols` exchange filtering

## Test Plan

- [ ] `npx nx test api -- --testPathPattern='paper-trading-market-data.service.spec'`
- [ ] `npx nx test api -- --testPathPattern='paper-trading-engine.service.spec'`
- [ ] Manual: start a paper trading session — verify traded symbols reflect user's coin selections, not just BTC/ETH