### PR TITLE
refactor(api): extract strategy evaluation logic into StrategyEvaluationService

### DIFF
--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -125,7 +125,8 @@ const BACKTEST_DEFAULTS = backtestConfig();
     PositionManagementService,
     OrderStateMachineService,
     OpportunitySellService,
-    BacktestSharedModule
+    BacktestSharedModule,
+    CoinResolverService
   ],
   imports: [
     ConfigModule.forFeature(backtestConfig),

--- a/apps/api/src/tasks/strategy-evaluation.processor.ts
+++ b/apps/api/src/tasks/strategy-evaluation.processor.ts
@@ -31,7 +31,7 @@ export class StrategyEvaluationProcessor extends WorkerHost {
         case 'evaluate-strategy': {
           const { strategyConfigId } = job.data as EvaluateStrategyJob;
           this.logger.log(`Processing strategy evaluation job ${job.id} for strategy ${strategyConfigId}`);
-          await this.strategyEvaluationTask.processStrategyEvaluation(strategyConfigId);
+          await this.strategyEvaluationTask.processStrategyEvaluation(strategyConfigId, job);
           break;
         }
 

--- a/apps/api/src/tasks/strategy-evaluation.service.spec.ts
+++ b/apps/api/src/tasks/strategy-evaluation.service.spec.ts
@@ -1,0 +1,373 @@
+import { PASS_THRESHOLD, StrategyEvaluationService } from './strategy-evaluation.service';
+
+import type { BacktestFinalMetrics } from '../order/backtest/backtest-result.service';
+import { BacktestStatus } from '../order/backtest/backtest.entity';
+
+describe('StrategyEvaluationService', () => {
+  const createService = () => {
+    const backtestRepo = {
+      create: jest.fn((data: any) => ({ ...data, id: 'backtest-1' })),
+      save: jest.fn((entity: any) => Promise.resolve({ ...entity, id: entity.id ?? 'backtest-1' }))
+    };
+
+    const backtestRunRepo = {
+      create: jest.fn((data: any) => ({ ...data, id: 'run-1' })),
+      save: jest.fn((entity: any) => Promise.resolve({ ...entity, id: entity.id ?? 'run-1' }))
+    };
+
+    const strategyConfigRepo = {
+      findOne: jest.fn()
+    };
+
+    const userRepo = {
+      findOne: jest.fn()
+    };
+
+    const strategyService = {
+      getStrategyInstance: jest.fn().mockResolvedValue({ config: { param1: 'value1' } })
+    };
+
+    const backtestEngine = {
+      executeHistoricalBacktest: jest.fn()
+    };
+
+    const backtestResultService = {
+      persistSuccess: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined)
+    };
+
+    const backtestDatasetService = {
+      ensureDefaultDatasetExists: jest.fn()
+    };
+
+    const coinResolver = {
+      resolveCoins: jest.fn()
+    };
+
+    const scoringService = {
+      calculateScore: jest.fn()
+    };
+
+    const service = new StrategyEvaluationService(
+      backtestRepo as any,
+      backtestRunRepo as any,
+      strategyConfigRepo as any,
+      userRepo as any,
+      strategyService as any,
+      backtestEngine as any,
+      backtestResultService as any,
+      backtestDatasetService as any,
+      coinResolver as any,
+      scoringService as any
+    );
+
+    return {
+      service,
+      backtestRepo,
+      backtestRunRepo,
+      strategyConfigRepo,
+      userRepo,
+      strategyService,
+      backtestEngine,
+      backtestResultService,
+      backtestDatasetService,
+      coinResolver,
+      scoringService
+    };
+  };
+
+  const mockDataset = {
+    id: 'dataset-1',
+    startAt: '2024-01-01T00:00:00Z',
+    endAt: '2024-06-01T00:00:00Z'
+  };
+
+  const mockStrategy = {
+    id: 'strategy-1',
+    name: 'Test Strategy',
+    algorithm: { id: 'algo-1', strategyId: 'rsi-momentum-001' },
+    creator: { id: 'user-1', algoTradingEnabled: true }
+  };
+
+  const mockMetrics: BacktestFinalMetrics = {
+    finalValue: 11000,
+    totalReturn: 0.1,
+    annualizedReturn: 0.2,
+    sharpeRatio: 1.5,
+    maxDrawdown: -0.15,
+    totalTrades: 50,
+    winningTrades: 30,
+    losingTrades: 20,
+    winRate: 0.6,
+    profitFactor: 1.8,
+    volatility: 0.12
+  };
+
+  /** Sets up all mocks for a successful full evaluation flow. */
+  const setupHappyPath = (overrides: { score?: number; metrics?: BacktestFinalMetrics } = {}) => {
+    const ctx = createService();
+    const { strategyConfigRepo, backtestDatasetService, coinResolver, backtestEngine, scoringService } = ctx;
+
+    strategyConfigRepo.findOne.mockResolvedValue(mockStrategy);
+    backtestDatasetService.ensureDefaultDatasetExists.mockResolvedValue(mockDataset);
+    coinResolver.resolveCoins.mockResolvedValue({ coins: [{ id: 'btc' }] });
+    backtestEngine.executeHistoricalBacktest.mockResolvedValue({
+      finalMetrics: overrides.metrics ?? mockMetrics,
+      trades: []
+    });
+    scoringService.calculateScore.mockResolvedValue({ overallScore: overrides.score ?? 50 });
+
+    return ctx;
+  };
+
+  describe('evaluate()', () => {
+    describe('early exit conditions', () => {
+      it('should return score=null when strategy not found or missing algorithm', async () => {
+        const { service, strategyConfigRepo } = createService();
+        strategyConfigRepo.findOne.mockResolvedValue(null);
+
+        const result = await service.evaluate('missing-id');
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            score: null,
+            passed: false,
+            reason: expect.stringContaining('not found or missing algorithm')
+          })
+        );
+      });
+
+      it('should return score=null when no eligible user found (creator=null, no fallback)', async () => {
+        const { service, strategyConfigRepo, userRepo } = createService();
+        strategyConfigRepo.findOne.mockResolvedValue({ ...mockStrategy, creator: null });
+        userRepo.findOne.mockResolvedValue(null);
+
+        const result = await service.evaluate('strategy-1');
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            score: null,
+            passed: false,
+            reason: expect.stringContaining('No eligible user found')
+          })
+        );
+      });
+
+      it('should return score=null when no dataset available', async () => {
+        const { service, strategyConfigRepo, backtestDatasetService } = createService();
+        strategyConfigRepo.findOne.mockResolvedValue(mockStrategy);
+        backtestDatasetService.ensureDefaultDatasetExists.mockResolvedValue(null);
+
+        const result = await service.evaluate('strategy-1');
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            score: null,
+            passed: false,
+            reason: expect.stringContaining('No dataset available')
+          })
+        );
+      });
+    });
+
+    describe('coin resolution failures', () => {
+      it('should return score=null and mark backtest FAILED when coin resolution throws', async () => {
+        const {
+          service,
+          strategyConfigRepo,
+          backtestDatasetService,
+          coinResolver,
+          backtestRepo,
+          backtestResultService
+        } = createService();
+        strategyConfigRepo.findOne.mockResolvedValue(mockStrategy);
+        backtestDatasetService.ensureDefaultDatasetExists.mockResolvedValue(mockDataset);
+        coinResolver.resolveCoins.mockRejectedValue(new Error('CCXT timeout'));
+
+        const result = await service.evaluate('strategy-1');
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            score: null,
+            passed: false,
+            reason: expect.stringContaining('Coin resolution failed')
+          })
+        );
+
+        // Verify completedAt was set on save
+        const saveCalls = backtestRepo.save.mock.calls;
+        const lastSave = saveCalls[saveCalls.length - 1][0];
+        expect(lastSave.completedAt).toBeInstanceOf(Date);
+
+        // Verify markFailed was called with error details
+        expect(backtestResultService.markFailed).toHaveBeenCalledWith(
+          'backtest-1',
+          expect.stringContaining('CCXT timeout')
+        );
+      });
+
+      it('should return score=null and mark backtest FAILED when no coins resolved', async () => {
+        const { service, strategyConfigRepo, backtestDatasetService, coinResolver, backtestResultService } =
+          createService();
+        strategyConfigRepo.findOne.mockResolvedValue(mockStrategy);
+        backtestDatasetService.ensureDefaultDatasetExists.mockResolvedValue(mockDataset);
+        coinResolver.resolveCoins.mockResolvedValue({ coins: [] });
+
+        const result = await service.evaluate('strategy-1');
+
+        expect(result).toEqual(
+          expect.objectContaining({ score: null, passed: false, reason: expect.stringContaining('No coins resolved') })
+        );
+
+        expect(backtestResultService.markFailed).toHaveBeenCalledWith('backtest-1', 'No coins resolved from dataset');
+      });
+    });
+
+    describe('backtest execution', () => {
+      it('should re-throw engine errors for BullMQ retry and mark backtest FAILED', async () => {
+        const {
+          service,
+          strategyConfigRepo,
+          backtestDatasetService,
+          coinResolver,
+          backtestEngine,
+          backtestResultService
+        } = createService();
+        strategyConfigRepo.findOne.mockResolvedValue(mockStrategy);
+        backtestDatasetService.ensureDefaultDatasetExists.mockResolvedValue(mockDataset);
+        coinResolver.resolveCoins.mockResolvedValue({ coins: [{ id: 'btc' }] });
+        backtestEngine.executeHistoricalBacktest.mockRejectedValue(new Error('Engine crash'));
+
+        await expect(service.evaluate('strategy-1')).rejects.toThrow('Engine crash');
+
+        // Verify backtest was marked FAILED via backtestResultService before re-throw
+        expect(backtestResultService.markFailed).toHaveBeenCalledWith('backtest-1', 'Engine crash');
+      });
+
+      it('should set backtest status to RUNNING before executing engine', async () => {
+        const { service, backtestRepo, backtestEngine } = setupHappyPath();
+
+        await service.evaluate('strategy-1');
+
+        // Find the save call that set RUNNING status
+        const runningSave = backtestRepo.save.mock.calls.find(
+          (call: any[]) => call[0].status === BacktestStatus.RUNNING
+        );
+        expect(runningSave).toBeDefined();
+        expect(backtestEngine.executeHistoricalBacktest).toHaveBeenCalled();
+      });
+    });
+
+    describe('scoring and pass/fail', () => {
+      it('should call persistSuccess after successful backtest', async () => {
+        const { service, backtestResultService } = setupHappyPath();
+
+        await service.evaluate('strategy-1');
+
+        expect(backtestResultService.persistSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      it.each([
+        { score: PASS_THRESHOLD, expectedPassed: true, label: 'at threshold' },
+        { score: PASS_THRESHOLD + 10, expectedPassed: true, label: 'above threshold' },
+        { score: PASS_THRESHOLD - 1, expectedPassed: false, label: 'below threshold' },
+        { score: 0, expectedPassed: false, label: 'zero score' }
+      ])('should return passed=$expectedPassed when score is $label ($score)', async ({ score, expectedPassed }) => {
+        const { service } = setupHappyPath({ score });
+
+        const result = await service.evaluate('strategy-1');
+
+        expect(result.passed).toBe(expectedPassed);
+        expect(result.score).toBeDefined();
+      });
+    });
+
+    describe('resolveUser fallback', () => {
+      it('should use creator when available without querying userRepo', async () => {
+        const { service, userRepo } = setupHappyPath();
+
+        await service.evaluate('strategy-1');
+
+        expect(userRepo.findOne).not.toHaveBeenCalled();
+      });
+
+      it('should fall back to any algo-enabled user when creator is null', async () => {
+        const {
+          service,
+          strategyConfigRepo,
+          userRepo,
+          backtestDatasetService,
+          coinResolver,
+          backtestEngine,
+          scoringService
+        } = createService();
+        const fallbackUser = { id: 'fallback-user', algoTradingEnabled: true };
+
+        strategyConfigRepo.findOne.mockResolvedValue({ ...mockStrategy, creator: null });
+        userRepo.findOne.mockResolvedValue(fallbackUser);
+        backtestDatasetService.ensureDefaultDatasetExists.mockResolvedValue(mockDataset);
+        coinResolver.resolveCoins.mockResolvedValue({ coins: [{ id: 'btc' }] });
+        backtestEngine.executeHistoricalBacktest.mockResolvedValue({ finalMetrics: mockMetrics, trades: [] });
+        scoringService.calculateScore.mockResolvedValue({ overallScore: 50 });
+
+        const result = await service.evaluate('strategy-1');
+
+        expect(userRepo.findOne).toHaveBeenCalledWith({ where: { algoTradingEnabled: true } });
+        expect(result.passed).toBe(true);
+      });
+    });
+  });
+
+  describe('createBacktestRun()', () => {
+    it('should correctly map BacktestFinalMetrics to BacktestResults', async () => {
+      const { service, backtestRunRepo } = setupHappyPath();
+
+      await service.evaluate('strategy-1');
+
+      const createCall = backtestRunRepo.create.mock.calls[0][0];
+      const results = createCall.results;
+
+      expect(results).toEqual(
+        expect.objectContaining({
+          totalReturn: mockMetrics.totalReturn,
+          annualizedReturn: mockMetrics.annualizedReturn,
+          sharpeRatio: mockMetrics.sharpeRatio,
+          maxDrawdown: mockMetrics.maxDrawdown,
+          winRate: mockMetrics.winRate,
+          profitFactor: mockMetrics.profitFactor,
+          totalTrades: mockMetrics.totalTrades,
+          volatility: mockMetrics.volatility
+        })
+      );
+
+      // Derived fields
+      expect(results.calmarRatio).toBeCloseTo(mockMetrics.annualizedReturn / Math.abs(mockMetrics.maxDrawdown));
+      expect(results.avgTradeReturn).toBeCloseTo(mockMetrics.totalReturn / mockMetrics.totalTrades);
+    });
+
+    it.each([
+      {
+        field: 'maxDrawdown',
+        value: 0,
+        derived: 'calmarRatio',
+        expected: 0,
+        label: 'zero maxDrawdown → calmarRatio=0'
+      },
+      {
+        field: 'totalTrades',
+        value: 0,
+        derived: 'avgTradeReturn',
+        expected: 0,
+        label: 'zero totalTrades → avgTradeReturn=0'
+      }
+    ])('should handle $label', async ({ field, value, derived, expected }) => {
+      const overrideMetrics = { ...mockMetrics, [field]: value };
+      const { service, backtestRunRepo } = setupHappyPath({ metrics: overrideMetrics });
+
+      await service.evaluate('strategy-1');
+
+      const results = backtestRunRepo.create.mock.calls[0][0].results;
+      expect(results[derived]).toBe(expected);
+    });
+  });
+});

--- a/apps/api/src/tasks/strategy-evaluation.service.ts
+++ b/apps/api/src/tasks/strategy-evaluation.service.ts
@@ -1,0 +1,238 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { createHash } from 'crypto';
+
+import { BacktestConfiguration, BacktestResults, BacktestRunStatus } from '@chansey/api-interfaces';
+
+import { BACKTEST_STANDARD_CAPITAL } from './dto/backtest-orchestration.dto';
+
+import { Coin } from '../coin/coin.entity';
+import { BacktestDatasetService } from '../order/backtest/backtest-dataset.service';
+import { BacktestEngine } from '../order/backtest/backtest-engine.service';
+import { BacktestFinalMetrics, BacktestResultService } from '../order/backtest/backtest-result.service';
+import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
+import { CoinResolverService } from '../order/backtest/coin-resolver.service';
+import { MarketDataSet } from '../order/backtest/market-data-set.entity';
+import { ScoringService } from '../scoring/scoring.service';
+import { toErrorInfo } from '../shared/error.util';
+import { BacktestRun } from '../strategy/entities/backtest-run.entity';
+import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
+import { StrategyScore } from '../strategy/entities/strategy-score.entity';
+import { StrategyService } from '../strategy/strategy.service';
+import { User } from '../users/users.entity';
+
+export interface EvaluationResult {
+  score: StrategyScore | null;
+  passed: boolean;
+  /** Human-readable reason when score is null (for operator diagnostics). */
+  reason?: string;
+}
+
+/** Score below which a strategy is permanently failed (no point retrying). */
+export const CRITICAL_FAIL_THRESHOLD = 20;
+
+/** Minimum score required to pass evaluation and become VALIDATED. */
+export const PASS_THRESHOLD = 40;
+
+@Injectable()
+export class StrategyEvaluationService {
+  private readonly logger = new Logger(StrategyEvaluationService.name);
+
+  constructor(
+    @InjectRepository(Backtest) private readonly backtestRepo: Repository<Backtest>,
+    @InjectRepository(BacktestRun) private readonly backtestRunRepo: Repository<BacktestRun>,
+    @InjectRepository(StrategyConfig) private readonly strategyConfigRepo: Repository<StrategyConfig>,
+    @InjectRepository(User) private readonly userRepo: Repository<User>,
+    private readonly strategyService: StrategyService,
+    private readonly backtestEngine: BacktestEngine,
+    private readonly backtestResultService: BacktestResultService,
+    private readonly backtestDatasetService: BacktestDatasetService,
+    private readonly coinResolver: CoinResolverService,
+    private readonly scoringService: ScoringService
+  ) {}
+
+  /**
+   * Run a full evaluation for a strategy:
+   * backtest → persist results → score → return pass/fail.
+   */
+  async evaluate(strategyConfigId: string): Promise<EvaluationResult> {
+    // 1. Load strategy config with relations
+    const strategyConfig = await this.strategyConfigRepo.findOne({
+      where: { id: strategyConfigId },
+      relations: ['algorithm', 'creator']
+    });
+
+    if (!strategyConfig?.algorithm) {
+      const reason = `Strategy config ${strategyConfigId} not found or missing algorithm`;
+      this.logger.warn(reason);
+      return { score: null, passed: false, reason };
+    }
+
+    // 2. Get strategy instance (validates registry + merges params)
+    const { config: mergedParams } = await this.strategyService.getStrategyInstance(strategyConfigId);
+
+    // 3. Resolve user — prefer creator, fallback to any algo-enabled user
+    const user = await this.resolveUser(strategyConfig);
+    if (!user) {
+      const reason = `No eligible user found for strategy ${strategyConfigId}`;
+      this.logger.warn(`${reason}, skipping evaluation`);
+      return { score: null, passed: false, reason };
+    }
+
+    // 4. Get default dataset
+    const dataset = await this.backtestDatasetService.ensureDefaultDatasetExists();
+    if (!dataset) {
+      const reason = `No dataset available for strategy ${strategyConfigId}`;
+      this.logger.warn(`${reason}, skipping evaluation`);
+      return { score: null, passed: false, reason };
+    }
+
+    // 5. Create Backtest entity
+    const deterministicSeed = createHash('sha256').update(`${strategyConfigId}:${dataset.id}`).digest('hex');
+    const startDate = new Date(dataset.startAt);
+    const endDate = new Date(dataset.endAt);
+    const dateStr = new Date().toISOString().slice(0, 10);
+
+    const backtest = this.backtestRepo.create({
+      name: `Eval-${strategyConfig.name}-${dateStr}`,
+      description: `Automated evaluation for strategy ${strategyConfig.name}`,
+      type: BacktestType.HISTORICAL,
+      status: BacktestStatus.PENDING,
+      initialCapital: BACKTEST_STANDARD_CAPITAL,
+      tradingFee: 0.001,
+      startDate,
+      endDate,
+      user,
+      algorithm: strategyConfig.algorithm,
+      marketDataSet: dataset,
+      strategyParams: mergedParams,
+      deterministicSeed,
+      warningFlags: [],
+      processedTimestampCount: 0,
+      totalTimestampCount: 0
+    });
+
+    const savedBacktest = await this.backtestRepo.save(backtest);
+
+    // 6. Resolve coins
+    let coins: Coin[] = [];
+    try {
+      const resolved = await this.coinResolver.resolveCoins(dataset, { startDate, endDate });
+      coins = resolved.coins;
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      const reason = `Coin resolution failed for strategy ${strategyConfigId}: ${err.message}`;
+      this.logger.error(reason);
+      await this.markBacktestFailed(savedBacktest, `Coin resolution failed: ${err.message}`);
+      return { score: null, passed: false, reason };
+    }
+
+    if (coins.length === 0) {
+      const reason = `No coins resolved for strategy ${strategyConfigId}`;
+      this.logger.warn(reason);
+      await this.markBacktestFailed(savedBacktest, 'No coins resolved from dataset');
+      return { score: null, passed: false, reason };
+    }
+
+    // 7. Execute backtest
+    let results: Awaited<ReturnType<BacktestEngine['executeHistoricalBacktest']>>;
+    try {
+      savedBacktest.status = BacktestStatus.RUNNING;
+      await this.backtestRepo.save(savedBacktest);
+
+      results = await this.backtestEngine.executeHistoricalBacktest(savedBacktest, coins, {
+        dataset,
+        deterministicSeed
+      });
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Backtest execution failed for strategy ${strategyConfigId}: ${err.message}`);
+      await this.markBacktestFailed(savedBacktest, err.message);
+      throw error; // Re-throw for BullMQ retry
+    }
+
+    // 8. Persist backtest results
+    await this.backtestResultService.persistSuccess(savedBacktest, results);
+
+    // 9. Create BacktestRun for scoring
+    const backtestRun = await this.createBacktestRun(
+      strategyConfigId,
+      dataset,
+      startDate,
+      endDate,
+      results.finalMetrics
+    );
+
+    // 10. Calculate score
+    const score = await this.scoringService.calculateScore(strategyConfigId, backtestRun, 0);
+
+    const passed = Number(score.overallScore) >= PASS_THRESHOLD;
+    this.logger.log(`Strategy ${strategyConfigId} evaluation: score=${score.overallScore}, passed=${passed}`);
+
+    return { score, passed };
+  }
+
+  private async resolveUser(strategyConfig: StrategyConfig): Promise<User | null> {
+    if (strategyConfig.creator) {
+      return strategyConfig.creator;
+    }
+
+    // Fallback: find any user with algo trading enabled
+    return this.userRepo.findOne({
+      where: { algoTradingEnabled: true }
+    });
+  }
+
+  private async markBacktestFailed(backtest: Backtest, errorMessage: string): Promise<void> {
+    backtest.completedAt = new Date();
+    await this.backtestRepo.save(backtest);
+    await this.backtestResultService.markFailed(backtest.id, errorMessage);
+  }
+
+  private async createBacktestRun(
+    strategyConfigId: string,
+    dataset: MarketDataSet,
+    startDate: Date,
+    endDate: Date,
+    metrics: BacktestFinalMetrics
+  ): Promise<BacktestRun> {
+    const config: BacktestConfiguration = {
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      initialCapital: BACKTEST_STANDARD_CAPITAL
+    };
+
+    const results: BacktestResults = {
+      totalReturn: metrics.totalReturn,
+      annualizedReturn: metrics.annualizedReturn,
+      sharpeRatio: metrics.sharpeRatio,
+      calmarRatio: metrics.maxDrawdown !== 0 ? metrics.annualizedReturn / Math.abs(metrics.maxDrawdown) : 0,
+      maxDrawdown: metrics.maxDrawdown,
+      winRate: metrics.winRate,
+      profitFactor: metrics.profitFactor,
+      totalTrades: metrics.totalTrades,
+      avgTradeReturn: metrics.totalTrades > 0 ? metrics.totalReturn / metrics.totalTrades : 0,
+      volatility: metrics.volatility
+    };
+
+    const datasetChecksum = createHash('sha256')
+      .update(JSON.stringify({ datasetId: dataset.id, startDate, endDate }))
+      .digest('hex');
+
+    const backtestRun = this.backtestRunRepo.create({
+      strategyConfigId,
+      startedAt: new Date(),
+      completedAt: new Date(),
+      status: BacktestRunStatus.COMPLETED,
+      config,
+      datasetChecksum,
+      windowCount: 1,
+      results
+    });
+
+    return this.backtestRunRepo.save(backtestRun);
+  }
+}

--- a/apps/api/src/tasks/strategy-evaluation.task.ts
+++ b/apps/api/src/tasks/strategy-evaluation.task.ts
@@ -3,25 +3,29 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Queue } from 'bullmq';
+import { Job, Queue } from 'bullmq';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 
 import { StrategyStatus } from '@chansey/api-interfaces';
 
+import { CRITICAL_FAIL_THRESHOLD, StrategyEvaluationService } from './strategy-evaluation.service';
+
 import { BaseAlgorithmStrategy } from '../algorithm/base/base-algorithm-strategy';
 import { AlgorithmRegistry } from '../algorithm/registry/algorithm-registry.service';
-import { BacktestEngine } from '../order/backtest/backtest-engine.service';
 import { Risk } from '../risk/risk.entity';
-import { ScoringService } from '../scoring/scoring.service';
 import { toErrorInfo } from '../shared/error.util';
 import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
-import { RiskPoolMappingService } from '../strategy/risk-pool-mapping.service';
+import { StrategyScore } from '../strategy/entities/strategy-score.entity';
 import { StrategyService } from '../strategy/strategy.service';
+
+/** Maximum number of live strategies allowed per risk level. */
+const MAX_STRATEGIES_PER_LEVEL = 30;
 
 /**
  * Strategy Evaluation Task
  * Automated background job for evaluating strategies
- * Injects AlgorithmRegistry and BacktestEngine to execute strategies
+ * Delegates actual evaluation to StrategyEvaluationService which runs
+ * a real backtest, persists results, and calculates a score.
  */
 @Injectable()
 export class StrategyEvaluationTask {
@@ -35,9 +39,7 @@ export class StrategyEvaluationTask {
     private readonly riskRepo: Repository<Risk>,
     private readonly strategyService: StrategyService,
     private readonly algorithmRegistry: AlgorithmRegistry,
-    private readonly backtestEngine: BacktestEngine,
-    private readonly scoringService: ScoringService,
-    private readonly riskPoolMapping: RiskPoolMappingService,
+    private readonly evaluationService: StrategyEvaluationService,
     private readonly dataSource: DataSource
   ) {}
 
@@ -93,35 +95,47 @@ export class StrategyEvaluationTask {
   }
 
   /**
-   * Process strategy evaluation job
-   * This would be called by a BullMQ processor
+   * Process strategy evaluation job.
+   * Delegates to StrategyEvaluationService which runs a real backtest,
+   * persists results, and calculates a score.
    */
-  async processStrategyEvaluation(strategyConfigId: string): Promise<void> {
+  async processStrategyEvaluation(strategyConfigId: string, job: Job): Promise<void> {
     this.logger.log(`Processing evaluation for strategy ${strategyConfigId}`);
 
     try {
-      // Get strategy instance with merged parameters
-      // TODO: Use returned strategy/config when full backtest implementation is added
-      await this.strategyService.getStrategyInstance(strategyConfigId);
+      const { score, passed, reason } = await this.evaluationService.evaluate(strategyConfigId);
 
-      // Execute backtest using BacktestEngine
-      // Note: This is a simplified version - full implementation would:
-      // 1. Load market data
-      // 2. Execute walk-forward analysis
-      // 3. Calculate scores
-      // 4. Store results
+      if (!score) {
+        this.logger.warn(
+          `No score produced for strategy ${strategyConfigId}, keeping in TESTING for next cycle` +
+            (reason ? ` (reason: ${reason})` : '')
+        );
+        return;
+      }
 
-      this.logger.log(`Strategy ${strategyConfigId} evaluation complete`);
+      const overallScore = Number(score.overallScore);
 
-      // Update strategy status to validated
-      await this.strategyService.updateStatus(strategyConfigId, StrategyStatus.VALIDATED);
-
-      // Assign strategy to risk pool based on performance metrics
-      await this.assignStrategyToRiskPool(strategyConfigId);
+      if (passed) {
+        await this.strategyService.updateStatus(strategyConfigId, StrategyStatus.VALIDATED);
+        await this.assignStrategyToRiskPool(strategyConfigId, score);
+      } else if (overallScore < CRITICAL_FAIL_THRESHOLD) {
+        this.logger.log(
+          `Strategy ${strategyConfigId} scored ${overallScore} (below ${CRITICAL_FAIL_THRESHOLD}), marking FAILED`
+        );
+        await this.strategyService.updateStatus(strategyConfigId, StrategyStatus.FAILED);
+      } else {
+        this.logger.log(`Strategy ${strategyConfigId} scored ${overallScore}, keeping in TESTING for retry`);
+      }
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Failed to evaluate strategy ${strategyConfigId}: ${err.message}`);
-      await this.strategyService.updateStatus(strategyConfigId, StrategyStatus.FAILED);
+
+      // Only mark FAILED on the final BullMQ attempt — earlier attempts should retry
+      const maxAttempts = job.opts?.attempts ?? 3;
+      if (job.attemptsMade >= maxAttempts) {
+        await this.strategyService.updateStatus(strategyConfigId, StrategyStatus.FAILED);
+      }
+
       throw error;
     }
   }
@@ -142,17 +156,10 @@ export class StrategyEvaluationTask {
    * 3. Check capacity limit (max 30 strategies per level)
    * 4. Update strategy with riskPoolId and set shadowStatus to 'live'
    */
-  private async assignStrategyToRiskPool(strategyConfigId: string): Promise<void> {
+  private async assignStrategyToRiskPool(strategyConfigId: string, score: StrategyScore): Promise<void> {
     this.logger.log(`Assigning strategy ${strategyConfigId} to risk level`);
 
     try {
-      // Get latest score
-      const score = await this.scoringService.getLatestScore(strategyConfigId);
-      if (!score) {
-        this.logger.warn(`No score found for strategy ${strategyConfigId}, skipping assignment`);
-        return;
-      }
-
       // Get strategy config
       const strategy = await this.strategyConfigRepo.findOne({
         where: { id: strategyConfigId },
@@ -187,8 +194,6 @@ export class StrategyEvaluationTask {
       }
 
       // Wrap capacity check + rotation/promotion in a transaction with pessimistic locking
-      const MAX_STRATEGIES_PER_LEVEL = 30;
-
       await this.dataSource.transaction(async (manager) => {
         // Lock all live strategies in pool with pessimistic_write (SELECT ... FOR UPDATE)
         // This serializes concurrent evaluations for the same risk level

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -18,6 +18,7 @@ import { PromotionTask } from './promotion.task';
 import { RedisMaintenanceTask } from './redis-maintenance.task';
 import { RiskMonitoringTask } from './risk-monitoring.task';
 import { StrategyEvaluationProcessor } from './strategy-evaluation.processor';
+import { StrategyEvaluationService } from './strategy-evaluation.service';
 import { StrategyEvaluationTask } from './strategy-evaluation.task';
 
 import { AlgorithmActivation } from '../algorithm/algorithm-activation.entity';
@@ -110,6 +111,7 @@ const BACKTEST_QUEUE_NAMES = backtestConfig();
   ],
   providers: [
     StrategyEvaluationTask,
+    StrategyEvaluationService,
     StrategyEvaluationProcessor,
     MarketRegimeTask,
     MarketRegimeProcessor,


### PR DESCRIPTION
## Summary

- Extract strategy evaluation pipeline from `StrategyEvaluationTask` into a dedicated `StrategyEvaluationService`
- New service encapsulates the full evaluate() pipeline: backtest → persist results → score → return pass/fail
- Add comprehensive unit tests for the extracted service

## Changes

- **`apps/api/src/tasks/strategy-evaluation.service.ts`** — New service with `evaluateStrategy()` pipeline, score-based outcome handling (VALIDATED/FAILED/retry), and retry-aware failure logic
- **`apps/api/src/tasks/strategy-evaluation.task.ts`** — Simplified to delegate to `StrategyEvaluationService`; reduced from orchestration logic to thin task wrapper
- **`apps/api/src/tasks/strategy-evaluation.service.spec.ts`** — Comprehensive unit tests covering success, failure, retry, and edge case scenarios
- **`apps/api/src/tasks/tasks.module.ts`** — Register `StrategyEvaluationService`
- **`apps/api/src/order/order.module.ts`** — Export `CoinResolverService` for dataset coin resolution
- **`apps/api/src/tasks/strategy-evaluation.processor.ts`** — Minor update for new service integration

## Test Plan

- [ ] Unit tests pass: `npx nx test api -- --testPathPattern='strategy-evaluation.service'`
- [ ] Existing strategy evaluation task tests still pass
- [ ] Strategy evaluation pipeline runs correctly in dev environment

Closes #367