### PR TITLE
refactor(api): remove unused strategyConfig param from promotion gates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,6 +82,7 @@
         "@typescript-eslint/no-unused-vars": [
           "warn",
           {
+            "args": "all",
             "argsIgnorePattern": "^_",
             "varsIgnorePattern": "^_",
             "caughtErrorsIgnorePattern": "^_"

--- a/apps/api/src/admin/backtest-monitoring/optimization-analytics.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/optimization-analytics.service.ts
@@ -126,7 +126,7 @@ export class OptimizationAnalyticsService {
 
   /** Status filter intentionally omitted — returns full status breakdown */
   private async getOptStatusCounts(
-    filters: OptimizationFiltersDto,
+    _filters: OptimizationFiltersDto,
     dateRange: DateRange
   ): Promise<Record<OptimizationStatus, number>> {
     const qb = this.optimizationRunRepo
@@ -166,7 +166,7 @@ export class OptimizationAnalyticsService {
   }
 
   private async getOptAvgMetrics(
-    filters: OptimizationFiltersDto,
+    _filters: OptimizationFiltersDto,
     dateRange: DateRange
   ): Promise<{ avgImprovement: number; avgBestScore: number; avgCombinationsTested: number }> {
     const qb = this.optimizationRunRepo
@@ -189,7 +189,7 @@ export class OptimizationAnalyticsService {
   }
 
   private async getOptTopStrategies(
-    filters: OptimizationFiltersDto,
+    _filters: OptimizationFiltersDto,
     dateRange: DateRange
   ): Promise<OptimizationAnalyticsDto['topStrategies']> {
     const qb = this.optimizationRunRepo
@@ -223,7 +223,7 @@ export class OptimizationAnalyticsService {
   }
 
   private async getOptResultSummary(
-    filters: OptimizationFiltersDto,
+    _filters: OptimizationFiltersDto,
     dateRange: DateRange
   ): Promise<OptimizationAnalyticsDto['resultSummary']> {
     const runSubQuery = this.optimizationRunRepo

--- a/apps/api/src/admin/backtest-monitoring/paper-trading-monitoring.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/paper-trading-monitoring.service.ts
@@ -203,7 +203,7 @@ export class PaperTradingMonitoringService {
   }
 
   private async getPtTopAlgorithms(
-    filters: PaperTradingFiltersDto,
+    _filters: PaperTradingFiltersDto,
     dateRange: DateRange
   ): Promise<PaperTradingMonitoringDto['topAlgorithms']> {
     const qb = this.paperSessionRepo

--- a/apps/api/src/admin/live-trade-monitoring/live-trade-slippage.service.ts
+++ b/apps/api/src/admin/live-trade-monitoring/live-trade-slippage.service.ts
@@ -113,7 +113,7 @@ export class LiveTradeSlippageService {
   }
 
   private async getSlippageByAlgorithm(
-    filters: LiveTradeFiltersDto,
+    _filters: LiveTradeFiltersDto,
     dateRange: DateRange
   ): Promise<SlippageByAlgorithmDto[]> {
     const qb = this.orderRepo

--- a/apps/api/src/algorithm/algorithm-performance.controller.ts
+++ b/apps/api/src/algorithm/algorithm-performance.controller.ts
@@ -52,7 +52,7 @@ export class AlgorithmPerformanceController {
   })
   async getPerformance(
     @Param('id', ParseUUIDPipe) algorithmId: string,
-    @Query() query: AlgorithmPerformanceQueryDto,
+    @Query() _query: AlgorithmPerformanceQueryDto,
     @Req() request: any
   ) {
     const userId = request.user.id;

--- a/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
@@ -301,7 +301,7 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
    * Calculate confidence based on bandwidth expansion and momentum
    */
   private calculateConfidence(
-    prices: CandleData[],
+    _prices: CandleData[],
     pb: number[],
     bandwidth: number[],
     direction: 'bullish' | 'bearish',

--- a/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
+++ b/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
@@ -309,8 +309,8 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
    */
   private calculateConfidence(
     prices: CandleData[],
-    fastEMA: number[],
-    slowEMA: number[],
+    _fastEMA: number[],
+    _slowEMA: number[],
     rsi: number[],
     config: EMARSIFilterConfig,
     direction: 'bullish' | 'bearish',

--- a/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
@@ -323,8 +323,8 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
    */
   private calculateSignalStrength(
     rsi: number[],
-    macd: number[],
-    macdSignalLine: number[],
+    _macd: number[],
+    _macdSignalLine: number[],
     histogram: number[],
     config: RSIMACDComboConfig,
     direction: 'bullish' | 'bearish',

--- a/apps/api/src/algorithm/strategies/rsi.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.ts
@@ -205,7 +205,7 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
   /**
    * Calculate confidence based on RSI trend consistency
    */
-  private calculateConfidence(rsi: number[], config: RSIConfig, condition: 'oversold' | 'overbought'): number {
+  private calculateConfidence(rsi: number[], _config: RSIConfig, condition: 'oversold' | 'overbought'): number {
     const recentPeriod = 5;
     const startIndex = Math.max(0, rsi.length - recentPeriod);
 

--- a/apps/api/src/authentication/decorator/get-user.decorator.ts
+++ b/apps/api/src/authentication/decorator/get-user.decorator.ts
@@ -1,6 +1,6 @@
 import { type ExecutionContext, createParamDecorator } from '@nestjs/common';
 
-const GetUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+const GetUser = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();
   return request.user;
 });

--- a/apps/api/src/market-regime/regime-change.detector.ts
+++ b/apps/api/src/market-regime/regime-change.detector.ts
@@ -73,7 +73,7 @@ export class RegimeChangeDetector {
   /**
    * Find strategies that may be affected by regime change
    */
-  private async findAffectedStrategies(asset: string, newRegime: MarketRegimeType): Promise<StrategyConfig[]> {
+  private async findAffectedStrategies(_asset: string, newRegime: MarketRegimeType): Promise<StrategyConfig[]> {
     // Get all active deployments
     const activeDeployments = await this.deploymentRepo.find({
       where: { status: DeploymentStatus.ACTIVE },

--- a/apps/api/src/ohlc/tasks/ohlc-sync.task.spec.ts
+++ b/apps/api/src/ohlc/tasks/ohlc-sync.task.spec.ts
@@ -271,7 +271,7 @@ describe('OHLCSyncTask', () => {
     } as ExchangeSymbolMap;
 
     symbolMapService.getActiveSymbolMaps.mockResolvedValue([mappingLowPriority, mappingHighPriority]);
-    exchangeOHLC.fetchOHLC.mockImplementation(async (slug, symbol) => {
+    exchangeOHLC.fetchOHLC.mockImplementation(async (_slug, symbol) => {
       if (symbol === 'BTC/USD') {
         return {
           success: false,

--- a/apps/api/src/order/backtest/shared/execution/backtest-bar-processor.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/backtest-bar-processor.service.ts
@@ -151,7 +151,7 @@ export class BacktestBarProcessor {
     i: number,
     timestamp: Date,
     priceData: ReturnType<PriceWindowService['advancePriceWindows']>,
-    marketData: MarketData,
+    _marketData: MarketData,
     currentPrices: OHLCCandle[]
   ): Promise<void> {
     const warmupRegime = ctx.btcCoin

--- a/apps/api/src/order/backtest/shared/execution/forced-exit.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/forced-exit.service.ts
@@ -30,7 +30,7 @@ export class ForcedExitService {
   checkAndApplyLiquidations(
     portfolio: Portfolio,
     marketData: MarketData,
-    tradingFee: number,
+    _tradingFee: number,
     coinMap: Map<string, Coin>,
     quoteCoin: Coin
   ): Partial<BacktestTrade>[] {

--- a/apps/api/src/order/tasks/position-monitor.task.spec.ts
+++ b/apps/api/src/order/tasks/position-monitor.task.spec.ts
@@ -99,8 +99,8 @@ describe('PositionMonitorTask', () => {
   };
 
   const mockManager = {
-    save: jest.fn((entityClass, entity) => Promise.resolve({ ...entity, id: entity.id || 'new-order-uuid' })),
-    create: jest.fn((entityClass, dto) => dto)
+    save: jest.fn((_entityClass, entity) => Promise.resolve({ ...entity, id: entity.id || 'new-order-uuid' })),
+    create: jest.fn((_entityClass, dto) => dto)
   };
 
   const mockDataSource = {

--- a/apps/api/src/strategy/gates/README.md
+++ b/apps/api/src/strategy/gates/README.md
@@ -2,20 +2,23 @@
 
 ## Overview
 
-Promotion gates are quality checks evaluated before a strategy can advance through the pipeline toward live trading. Each gate inspects a specific criterion (score, drawdown, trade count, etc.) and returns a pass/fail result. `PromotionGateService` orchestrates all gates in priority order -- if any critical gate fails, promotion is blocked entirely. Non-critical failures produce warnings but still allow promotion.
+Promotion gates are quality checks evaluated before a strategy can advance through the pipeline toward live trading.
+Each gate inspects a specific criterion (score, drawdown, trade count, etc.) and returns a pass/fail result.
+`PromotionGateService` orchestrates all gates in priority order -- if any critical gate fails, promotion is blocked
+entirely. Non-critical failures produce warnings but still allow promotion.
 
 ## Gates
 
-| Name | Priority | Critical | Threshold | Description |
-| ---- | -------- | -------- | --------- | ----------- |
-| `minimum-score` | 1 | Yes | >= 70 | Overall strategy score out of 100 |
-| `minimum-trades` | 2 | Yes | >= 30 | Total trades executed during backtest |
-| `maximum-drawdown` | 3 | Yes | < 40% | Maximum drawdown during backtest |
-| `wfa-consistency` | 4 | Yes | < 30% degradation | Walk-forward train/test performance gap |
-| `positive-returns` | 5 | Yes | > 0% | Total backtest return must be positive |
-| `correlation-limit` | 6 | No | < 0.7 | Correlation with existing deployments |
-| `volatility-cap` | 7 | No | < 150% annualized | Annualized strategy volatility |
-| `portfolio-capacity` | 8 | Yes | < 35 strategies | Active deployment count limit |
+| Name                 | Priority | Critical | Threshold         | Description                             |
+| -------------------- | -------- | -------- | ----------------- | --------------------------------------- |
+| `minimum-score`      | 1        | Yes      | >= 70             | Overall strategy score out of 100       |
+| `minimum-trades`     | 2        | Yes      | >= 30             | Total trades executed during backtest   |
+| `maximum-drawdown`   | 3        | Yes      | < 40%             | Maximum drawdown during backtest        |
+| `wfa-consistency`    | 4        | Yes      | < 30% degradation | Walk-forward train/test performance gap |
+| `positive-returns`   | 5        | Yes      | > 0%              | Total backtest return must be positive  |
+| `correlation-limit`  | 6        | No       | < 0.7             | Correlation with existing deployments   |
+| `volatility-cap`     | 7        | No       | < 150% annualized | Annualized strategy volatility          |
+| `portfolio-capacity` | 8        | Yes      | < 35 strategies   | Active deployment count limit           |
 
 ## Interface
 
@@ -23,25 +26,28 @@ All gates implement `IPromotionGate` from `promotion-gate.interface.ts`:
 
 ```typescript
 evaluate(
-  strategyConfig: StrategyConfig,
   strategyScore: StrategyScore,
   backtestRun: BacktestRun,
   context?: PromotionGateContext
 ): Promise<PromotionGateResult>
 ```
 
-Each result contains: `gateName`, `passed`, `actualValue`, `requiredValue`, `message`, `severity` (`'warning'` | `'critical'`), and optional `metadata`.
+Each result contains: `gateName`, `passed`, `actualValue`, `requiredValue`, `message`, `severity` (`'warning'` |
+`'critical'`), and optional `metadata`.
 
 ## How to Add a New Gate
 
-1. Create a new `@Injectable()` class in `gates/` implementing `IPromotionGate`. Set `priority` (lower = runs first) and `isCritical`.
+1. Create a new `@Injectable()` class in `gates/` implementing `IPromotionGate`. Set `priority` (lower = runs first) and
+   `isCritical`.
 2. Register the class in the `providers` array of `strategy.module.ts`.
-3. Inject it into `PromotionGateService` constructor and add it to the gates array. The constructor auto-sorts by priority.
+3. Inject it into `PromotionGateService` constructor and add it to the gates array. The constructor auto-sorts by
+   priority.
 
 ## Gotchas
 
 - A single critical gate failure blocks promotion. Non-critical failures are surfaced as warnings only.
-- `PromotionGateContext` provides `existingDeployments`, `currentMarketRegime`, `totalAllocation`, and user `overrides`. Gates like `correlation-limit` and `portfolio-capacity` depend on this context.
+- `PromotionGateContext` provides `existingDeployments`, `currentMarketRegime`, `totalAllocation`, and user `overrides`.
+  Gates like `correlation-limit` and `portfolio-capacity` depend on this context.
 - If a gate's `evaluate()` throws, the service catches the error and records it as a critical failure.
 - All gate evaluations are audit-logged under `AuditEventType.GATE_EVALUATION`.
 - Gates are distinct from runtime risk checks (`risk/`). Gates run pre-promotion; risk checks monitor post-live.

--- a/apps/api/src/strategy/gates/correlation-limit.gate.ts
+++ b/apps/api/src/strategy/gates/correlation-limit.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -25,7 +24,6 @@ export class CorrelationLimitGate implements IPromotionGate {
   private readonly MAXIMUM_CORRELATION = 0.7;
 
   async evaluate(
-    strategyConfig: StrategyConfig,
     strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     context?: PromotionGateContext

--- a/apps/api/src/strategy/gates/correlation-limit.gate.ts
+++ b/apps/api/src/strategy/gates/correlation-limit.gate.ts
@@ -25,7 +25,7 @@ export class CorrelationLimitGate implements IPromotionGate {
 
   async evaluate(
     strategyScore: StrategyScore,
-    backtestRun: BacktestRun,
+    _backtestRun: BacktestRun,
     context?: PromotionGateContext
   ): Promise<PromotionGateResult> {
     // Get correlation score (calculated against existing deployments)

--- a/apps/api/src/strategy/gates/maximum-drawdown.gate.ts
+++ b/apps/api/src/strategy/gates/maximum-drawdown.gate.ts
@@ -24,7 +24,7 @@ export class MaximumDrawdownGate implements IPromotionGate {
   private readonly MAXIMUM_DRAWDOWN = 0.4; // 40%
 
   async evaluate(
-    strategyScore: StrategyScore,
+    _strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     _context?: PromotionGateContext
   ): Promise<PromotionGateResult> {

--- a/apps/api/src/strategy/gates/maximum-drawdown.gate.ts
+++ b/apps/api/src/strategy/gates/maximum-drawdown.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -25,7 +24,6 @@ export class MaximumDrawdownGate implements IPromotionGate {
   private readonly MAXIMUM_DRAWDOWN = 0.4; // 40%
 
   async evaluate(
-    strategyConfig: StrategyConfig,
     strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     _context?: PromotionGateContext

--- a/apps/api/src/strategy/gates/minimum-score.gate.ts
+++ b/apps/api/src/strategy/gates/minimum-score.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -25,7 +24,6 @@ export class MinimumScoreGate implements IPromotionGate {
   private readonly MINIMUM_SCORE = 70;
 
   async evaluate(
-    strategyConfig: StrategyConfig,
     strategyScore: StrategyScore,
     _backtestRun: BacktestRun,
     _context?: PromotionGateContext

--- a/apps/api/src/strategy/gates/minimum-trades.gate.ts
+++ b/apps/api/src/strategy/gates/minimum-trades.gate.ts
@@ -24,7 +24,7 @@ export class MinimumTradesGate implements IPromotionGate {
   private readonly MINIMUM_TRADES = 30;
 
   async evaluate(
-    strategyScore: StrategyScore,
+    _strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     _context?: PromotionGateContext
   ): Promise<PromotionGateResult> {

--- a/apps/api/src/strategy/gates/minimum-trades.gate.ts
+++ b/apps/api/src/strategy/gates/minimum-trades.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -25,7 +24,6 @@ export class MinimumTradesGate implements IPromotionGate {
   private readonly MINIMUM_TRADES = 30;
 
   async evaluate(
-    strategyConfig: StrategyConfig,
     strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     _context?: PromotionGateContext

--- a/apps/api/src/strategy/gates/portfolio-capacity.gate.ts
+++ b/apps/api/src/strategy/gates/portfolio-capacity.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -25,9 +24,8 @@ export class PortfolioCapacityGate implements IPromotionGate {
   private readonly MAXIMUM_STRATEGIES = 35;
 
   async evaluate(
-    strategyConfig: StrategyConfig,
-    strategyScore: StrategyScore,
-    backtestRun: BacktestRun,
+    _strategyScore: StrategyScore,
+    _backtestRun: BacktestRun,
     context?: PromotionGateContext
   ): Promise<PromotionGateResult> {
     const activeDeployments = context?.existingDeployments?.length || 0;

--- a/apps/api/src/strategy/gates/positive-returns.gate.ts
+++ b/apps/api/src/strategy/gates/positive-returns.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -23,8 +22,7 @@ export class PositiveReturnsGate implements IPromotionGate {
   readonly isCritical = true;
 
   async evaluate(
-    strategyConfig: StrategyConfig,
-    strategyScore: StrategyScore,
+    _strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     _context?: PromotionGateContext
   ): Promise<PromotionGateResult> {

--- a/apps/api/src/strategy/gates/promotion-gate.interface.ts
+++ b/apps/api/src/strategy/gates/promotion-gate.interface.ts
@@ -1,5 +1,4 @@
 import { type BacktestRun } from '../entities/backtest-run.entity';
-import { type StrategyConfig } from '../entities/strategy-config.entity';
 import { type StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -53,14 +52,12 @@ export interface IPromotionGate {
 
   /**
    * Evaluate the gate
-   * @param strategyConfig - Strategy configuration
    * @param strategyScore - Latest strategy score
    * @param backtestRun - Latest backtest run
    * @param context - Additional context for gate evaluation
    * @returns Gate evaluation result
    */
   evaluate(
-    strategyConfig: StrategyConfig,
     strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     context?: PromotionGateContext

--- a/apps/api/src/strategy/gates/promotion-gate.service.ts
+++ b/apps/api/src/strategy/gates/promotion-gate.service.ts
@@ -23,7 +23,6 @@ import { MarketRegimeService } from '../../market-regime/market-regime.service';
 import { toErrorInfo } from '../../shared/error.util';
 import { BacktestRun } from '../entities/backtest-run.entity';
 import { Deployment } from '../entities/deployment.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 // Import all gate implementations
@@ -83,8 +82,7 @@ export class PromotionGateService {
     this.logger.log(`Evaluating promotion gates for strategy ${strategyConfigId}`);
 
     // Load required data
-    const [strategyConfig, latestScore, latestBacktest, context] = await Promise.all([
-      this.loadStrategyConfig(strategyConfigId),
+    const [latestScore, latestBacktest, context] = await Promise.all([
       this.loadLatestScore(strategyConfigId),
       this.loadLatestBacktest(strategyConfigId),
       this.buildGateContext()
@@ -111,7 +109,7 @@ export class PromotionGateService {
 
     for (const gate of this.gates) {
       try {
-        const result = await gate.evaluate(strategyConfig, latestScore, latestBacktest, context);
+        const result = await gate.evaluate(latestScore, latestBacktest, context);
         gateResults.push(result);
 
         this.logger.debug(`Gate ${gate.name}: ${result.passed ? 'PASS' : 'FAIL'} - ${result.message}`);
@@ -217,15 +215,6 @@ export class PromotionGateService {
       totalAllocation,
       currentMarketRegime
     };
-  }
-
-  /**
-   * Load strategy configuration
-   */
-  private async loadStrategyConfig(_strategyConfigId: string): Promise<StrategyConfig> {
-    // This would use StrategyService in real implementation
-    // For now, return a placeholder
-    return {} as StrategyConfig;
   }
 
   /**

--- a/apps/api/src/strategy/gates/volatility-cap.gate.ts
+++ b/apps/api/src/strategy/gates/volatility-cap.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -25,8 +24,7 @@ export class VolatilityCapGate implements IPromotionGate {
   private readonly MAXIMUM_VOLATILITY = 1.5; // 150% annualized
 
   async evaluate(
-    strategyConfig: StrategyConfig,
-    strategyScore: StrategyScore,
+    _strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     _context?: PromotionGateContext
   ): Promise<PromotionGateResult> {

--- a/apps/api/src/strategy/gates/wfa-consistency.gate.ts
+++ b/apps/api/src/strategy/gates/wfa-consistency.gate.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { IPromotionGate, PromotionGateResult, PromotionGateContext } from './promotion-gate.interface';
 
 import { BacktestRun } from '../entities/backtest-run.entity';
-import { StrategyConfig } from '../entities/strategy-config.entity';
 import { StrategyScore } from '../entities/strategy-score.entity';
 
 /**
@@ -25,7 +24,6 @@ export class WFAConsistencyGate implements IPromotionGate {
   private readonly MAXIMUM_DEGRADATION = 0.3; // 30%
 
   async evaluate(
-    strategyConfig: StrategyConfig,
     strategyScore: StrategyScore,
     backtestRun: BacktestRun,
     _context?: PromotionGateContext

--- a/apps/api/src/strategy/risk/consecutive-losses.check.ts
+++ b/apps/api/src/strategy/risk/consecutive-losses.check.ts
@@ -26,8 +26,8 @@ export class ConsecutiveLossesCheck implements IRiskCheck {
   private readonly CRITICAL_THRESHOLD = 15;
 
   async evaluate(
-    deployment: Deployment,
-    latestMetric: PerformanceMetric | null,
+    _deployment: Deployment,
+    _latestMetric: PerformanceMetric | null,
     historicalMetrics?: PerformanceMetric[]
   ): Promise<RiskCheckResult> {
     if (!historicalMetrics || historicalMetrics.length < this.WARNING_THRESHOLD) {


### PR DESCRIPTION
## Summary

- Remove the unused `strategyConfig` parameter from the `IPromotionGate.evaluate()` interface and all 8 gate implementations
- Clean up the `PromotionGateService` orchestrator to stop passing the unnecessary argument
- Prefix unused interface-required params with `_` to satisfy lint rules

## Changes

- **`promotion-gate.interface.ts`** — Remove `strategyConfig` from `IPromotionGate.evaluate()` signature
- **`promotion-gate.service.ts`** — Stop fetching and passing `strategyConfig` to gates, simplifying the evaluation loop
- **8 gate classes** — Remove the unused parameter from each `evaluate()` implementation
- **`README.md`** — Fix formatting inconsistencies

## Test Plan

- [ ] `nx run api:build` compiles without errors
- [ ] `nx run api:lint` passes
- [ ] Existing gate and promotion tests pass