### PR TITLE
fix(api): use risk-level-aware deployment limits instead of hardcoded values

### DIFF
--- a/apps/api/src/strategy/deployment.service.spec.ts
+++ b/apps/api/src/strategy/deployment.service.spec.ts
@@ -74,14 +74,18 @@ describe('DeploymentService', () => {
       componentScores: { sharpeRatio: { value: 0.25 } }
     };
 
-    it('should create a deployment with correct risk limits', async () => {
-      strategyConfigRepo.findOne.mockResolvedValue(validStrategy);
-      strategyScoreRepo.findOne.mockResolvedValue(validScore);
-      deploymentRepo.findOne.mockResolvedValue(null); // no existing deployment
+    function setupHappyPath(overrides?: { score?: typeof validScore; strategy?: typeof validStrategy }) {
+      strategyConfigRepo.findOne.mockResolvedValue(overrides?.strategy ?? validStrategy);
+      strategyScoreRepo.findOne.mockResolvedValue(overrides?.score ?? validScore);
+      deploymentRepo.findOne.mockResolvedValue(null);
       deploymentRepo.count.mockResolvedValue(0);
       deploymentRepo.create.mockImplementation((dto) => dto);
       deploymentRepo.save.mockImplementation((d) => Promise.resolve({ id: 'dep-1', ...d }));
       auditService.createAuditLog.mockResolvedValue({});
+    }
+
+    it('should create a deployment with correct risk limits (default risk level 3)', async () => {
+      setupHappyPath();
 
       const result = await service.createDeployment('sc-1', 10, 'High score', 'user-1');
 
@@ -89,20 +93,42 @@ describe('DeploymentService', () => {
       expect(result.allocationPercent).toBe(10);
       // maxDrawdownLimit = min(0.25 * 1.5, 0.4) = 0.375
       expect(result.maxDrawdownLimit).toBeCloseTo(0.375);
-      expect(result.dailyLossLimit).toBe(0.05);
-      expect(result.positionSizeLimit).toBe(0.1);
+      // Defaults to risk level 3 (moderate): dailyLossLimit=10%, maxSinglePosition=35%
+      expect(result.dailyLossLimit).toBe(0.1);
+      expect(result.positionSizeLimit).toBe(0.35);
       expect(result.approvedBy).toBe('user-1');
     });
 
+    it.each([
+      [1, 0.05, 0.25],
+      [2, 0.075, 0.3],
+      [3, 0.1, 0.35],
+      [4, 0.125, 0.45],
+      [5, 0.15, 0.55]
+    ])(
+      'should use correct limits for risk level %i (dailyLoss=%s, positionSize=%s)',
+      async (riskLevel, expectedDailyLoss, expectedPositionSize) => {
+        setupHappyPath();
+
+        const result = await service.createDeployment('sc-1', 10, 'High score', 'user-1', riskLevel);
+
+        expect(result.dailyLossLimit).toBe(expectedDailyLoss);
+        expect(result.positionSizeLimit).toBe(expectedPositionSize);
+      }
+    );
+
+    it('should fallback to default risk level when invalid risk level is provided', async () => {
+      setupHappyPath();
+
+      const result = await service.createDeployment('sc-1', 10, 'High score', 'user-1', 99);
+
+      // Invalid risk level falls back to DEFAULT_RISK_LEVEL (3)
+      expect(result.dailyLossLimit).toBe(0.1);
+      expect(result.positionSizeLimit).toBe(0.35);
+    });
+
     it('should cap maxDrawdownLimit at 0.4', async () => {
-      const highSharpe = { ...validScore, componentScores: { sharpeRatio: { value: 0.5 } } };
-      strategyConfigRepo.findOne.mockResolvedValue(validStrategy);
-      strategyScoreRepo.findOne.mockResolvedValue(highSharpe);
-      deploymentRepo.findOne.mockResolvedValue(null);
-      deploymentRepo.count.mockResolvedValue(0);
-      deploymentRepo.create.mockImplementation((dto) => dto);
-      deploymentRepo.save.mockImplementation((d) => Promise.resolve({ id: 'dep-1', ...d }));
-      auditService.createAuditLog.mockResolvedValue({});
+      setupHappyPath({ score: { ...validScore, componentScores: { sharpeRatio: { value: 0.5 } } } });
 
       const result = await service.createDeployment('sc-1', 10, 'High score');
 

--- a/apps/api/src/strategy/deployment.service.ts
+++ b/apps/api/src/strategy/deployment.service.ts
@@ -9,7 +9,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import { AuditEventType, type CreateAuditLogDto, DeploymentStatus, StrategyStatus } from '@chansey/api-interfaces';
+import {
+  AuditEventType,
+  type CreateAuditLogDto,
+  DEFAULT_RISK_LEVEL,
+  DeploymentStatus,
+  StrategyStatus,
+  TRADING_STYLE_PROFILES
+} from '@chansey/api-interfaces';
 
 import { DeploymentMetricsService } from './deployment-metrics.service';
 import { Deployment } from './entities/deployment.entity';
@@ -57,7 +64,8 @@ export class DeploymentService {
     strategyConfigId: string,
     allocationPercent: number,
     promotionReason: string,
-    approvedBy?: string
+    approvedBy?: string,
+    riskLevel?: number
   ): Promise<Deployment> {
     try {
       // Verify strategy exists and is eligible
@@ -110,15 +118,20 @@ export class DeploymentService {
       const sharpeValue = Number(latestScore.componentScores.sharpeRatio.value ?? 0.4);
       const maxDrawdownLimit = Math.min(sharpeValue * 1.5, 0.4); // Cap at 40%
 
-      // Create deployment with conservative risk limits
+      // Use risk-level-aware limits from TRADING_STYLE_PROFILES
+      const effectiveRiskLevel =
+        riskLevel != null && TRADING_STYLE_PROFILES[riskLevel] ? riskLevel : DEFAULT_RISK_LEVEL;
+      const profile = TRADING_STYLE_PROFILES[effectiveRiskLevel];
+
+      // Create deployment with risk-appropriate limits
       const deployment = this.deploymentRepo.create({
         strategyConfigId,
         status: DeploymentStatus.PENDING_APPROVAL,
         allocationPercent,
         initialAllocationPercent: allocationPercent,
         maxDrawdownLimit,
-        dailyLossLimit: 0.05, // 5% daily loss limit
-        positionSizeLimit: 0.1, // 10% position size limit
+        dailyLossLimit: profile.dailyLossLimit / 100,
+        positionSizeLimit: profile.maxSinglePosition / 100,
         maxLeverage: strategyConfig.parameters?.maxLeverage || null,
         promotionReason,
         approvedBy,
@@ -144,6 +157,9 @@ export class DeploymentService {
           allocationPercent,
           status: DeploymentStatus.PENDING_APPROVAL,
           maxDrawdownLimit,
+          dailyLossLimit: profile.dailyLossLimit / 100,
+          positionSizeLimit: profile.maxSinglePosition / 100,
+          riskLevel: effectiveRiskLevel,
           promotionReason
         },
         metadata: {

--- a/apps/api/src/tasks/promotion.task.ts
+++ b/apps/api/src/tasks/promotion.task.ts
@@ -6,6 +6,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Queue } from 'bullmq';
 import { Repository } from 'typeorm';
 
+import { DEFAULT_RISK_LEVEL } from '@chansey/api-interfaces';
+
 import { toErrorInfo } from '../shared/error.util';
 import { DeploymentService } from '../strategy/deployment.service';
 import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
@@ -81,11 +83,13 @@ export class PromotionTask {
             }
 
             // Auto-promote with conservative 1% allocation
+            const riskLevel = strategy.riskPool?.level ?? DEFAULT_RISK_LEVEL;
             const deployment = await this.deploymentService.createDeployment(
               strategy.id,
               1.0, // 1% initial allocation
               `Automatic promotion: ${evaluation.summary}`,
-              'system'
+              'system',
+              riskLevel
             );
 
             this.logger.log(
@@ -176,11 +180,13 @@ export class PromotionTask {
 
     if (evaluation.canPromote) {
       // Create deployment (but don't auto-activate for manual requests)
+      const riskLevel = strategy.riskPool?.level ?? DEFAULT_RISK_LEVEL;
       const deployment = await this.deploymentService.createDeployment(
         strategyConfigId,
         1.0,
         `Manual promotion request by ${userId || 'system'}`,
-        userId
+        userId,
+        riskLevel
       );
 
       return {


### PR DESCRIPTION
## Summary

- Replace hardcoded `dailyLossLimit` (5%) and `positionSizeLimit` (10%) in `DeploymentService` with dynamic values from `TRADING_STYLE_PROFILES` based on the user's risk level
- Pass `riskLevel` through from `PromotionTask` to `DeploymentService.createDeployment()`
- Add tests verifying conservative (level 1) and aggressive (level 5) produce different limits

## Changes

- **`deployment.service.ts`** — `createDeployment()` now accepts `riskLevel` param and looks up `dailyLossLimit`/`positionSizeLimit` from `TRADING_STYLE_PROFILES`
- **`promotion.task.ts`** — Reads user's risk level and passes it to deployment creation
- **`deployment.service.spec.ts`** — Updated tests for risk-aware limits with conservative and aggressive scenarios

## Test Plan

- [ ] `nx test api -- --testPathPattern='deployment.service'` passes
- [ ] Verify conservative (level 1) deployments get tighter limits than aggressive (level 5)
- [ ] Existing promotion flow works end-to-end