### PR TITLE
fix(api): skip sell signals for unheld coins in paper trading

### DIFF
--- a/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.ts
@@ -267,7 +267,7 @@ export class PaperTradingOrderExecutorService {
     const { txManager, baseCurrency, basePrice, executionPrice, slippageBps, quoteAccount, baseAccount } = args;
 
     if (!baseAccount || baseAccount.available <= 0) {
-      this.logger.warn(`No ${baseCurrency} position to sell`);
+      this.logger.debug(`No ${baseCurrency} position to sell`);
       return { status: 'no_position', order: null };
     }
 

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
@@ -199,7 +199,10 @@ export class PaperTradingEngineService {
 
   /** Apply throttle + regime filter chain; persist rejected signals. */
   private async filterSignals(session: PaperTradingSession, signals: TradingSignal[]): Promise<FilteredSignals> {
-    const throttleConfig = this.signalThrottle.resolveConfig(session.algorithmConfig, PAPER_TRADING_DEFAULT_THROTTLE_CONFIG);
+    const throttleConfig = this.signalThrottle.resolveConfig(
+      session.algorithmConfig,
+      PAPER_TRADING_DEFAULT_THROTTLE_CONFIG
+    );
     const { accepted: throttleAccepted, rejected: throttledSignals } = this.throttleService.filter(
       session.id,
       signals,
@@ -276,6 +279,11 @@ export class PaperTradingEngineService {
           this.logger.debug(`Skipped duplicate BUY for ${signal.symbol}: position already held`);
           continue;
         }
+      }
+
+      if (signal.action === 'SELL' && !heldCoins.has(signal.coinId)) {
+        this.logger.debug(`Skipping SELL for ${signal.symbol}: no position held`);
+        continue;
       }
 
       const signalEntity = await this.signalService.save(session, signal);


### PR DESCRIPTION
## Summary
- Skip SELL signals in paper trading when no position exists for the coin, preventing unnecessary order execution attempts
- Downgrade "no position to sell" log from `warn` to `debug` to reduce noise

## Changes
- `paper-trading-engine.service.ts` — Add `heldCoins` set from open positions; filter out SELL signals for coins not in the set before processing
- `paper-trading-order-executor.service.ts` — Change "no position to sell" log level from `warn` to `debug`

## Test Plan
- [ ] Paper trading session processes BUY signals normally
- [ ] SELL signals for unheld coins are skipped with debug log
- [ ] SELL signals for held coins execute normally
- [ ] Lint passes (`nx run api:lint`)