### PR TITLE
feat(api): auto-trigger BTC OHLC backfill when regime data is insufficient

### DIFF
--- a/apps/api/src/market-regime/composite-regime.service.spec.ts
+++ b/apps/api/src/market-regime/composite-regime.service.spec.ts
@@ -11,6 +11,7 @@ import { AuditService } from '../audit/audit.service';
 import { CoinService } from '../coin/coin.service';
 import { NOTIFICATION_EVENTS } from '../notification/interfaces/notification-events.interface';
 import { OHLCService } from '../ohlc/ohlc.service';
+import { OHLCBackfillService } from '../ohlc/services/ohlc-backfill.service';
 
 describe('CompositeRegimeService', () => {
   let service: CompositeRegimeService;
@@ -18,10 +19,12 @@ describe('CompositeRegimeService', () => {
   let mockOhlcService: jest.Mocked<Pick<OHLCService, 'findAllByDay'>>;
   let mockCoinService: jest.Mocked<Pick<CoinService, 'getCoinBySlug'>>;
   let mockAuditService: jest.Mocked<Pick<AuditService, 'createAuditLog'>>;
+  let mockBackfillService: jest.Mocked<Pick<OHLCBackfillService, 'getProgress' | 'startBackfill'>>;
   let mockCacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
   let mockEventEmitter: { emit: jest.Mock };
 
   const BTC_COIN_ID = 'btc-uuid';
+  const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
 
   beforeEach(async () => {
     mockMarketRegimeService = {
@@ -38,6 +41,11 @@ describe('CompositeRegimeService', () => {
 
     mockAuditService = {
       createAuditLog: jest.fn().mockResolvedValue(undefined)
+    };
+
+    mockBackfillService = {
+      getProgress: jest.fn().mockResolvedValue(null),
+      startBackfill: jest.fn().mockResolvedValue('job-123')
     };
 
     mockCacheManager = {
@@ -57,6 +65,7 @@ describe('CompositeRegimeService', () => {
         { provide: OHLCService, useValue: mockOhlcService },
         { provide: CoinService, useValue: mockCoinService },
         { provide: AuditService, useValue: mockAuditService },
+        { provide: OHLCBackfillService, useValue: mockBackfillService },
         { provide: CACHE_MANAGER, useValue: mockCacheManager },
         { provide: EventEmitter2, useValue: mockEventEmitter }
       ]
@@ -90,6 +99,7 @@ describe('CompositeRegimeService', () => {
         mockOhlcService as any,
         mockCoinService as any,
         mockAuditService as any,
+        mockBackfillService as any,
         mockCacheManager as any,
         mockEventEmitter as any
       );
@@ -128,6 +138,55 @@ describe('CompositeRegimeService', () => {
 
       expect(result).toBe(CompositeRegimeType.NEUTRAL);
       expect(mockMarketRegimeService.getCurrentRegime).not.toHaveBeenCalled();
+    });
+
+    it('should trigger backfill when data is insufficient', async () => {
+      const summaries = generatePriceSummaries(100, 50000, 0.001);
+      mockOhlcService.findAllByDay.mockResolvedValue({ [BTC_COIN_ID]: summaries });
+
+      await service.refresh();
+      await flushPromises();
+
+      expect(mockBackfillService.getProgress).toHaveBeenCalledWith(BTC_COIN_ID);
+      expect(mockBackfillService.startBackfill).toHaveBeenCalledWith(BTC_COIN_ID);
+    });
+
+    it.each(['pending', 'in_progress', 'failed', 'completed'] as const)(
+      'should skip backfill when status is %s',
+      async (status) => {
+        const summaries = generatePriceSummaries(100, 50000, 0.001);
+        mockOhlcService.findAllByDay.mockResolvedValue({ [BTC_COIN_ID]: summaries });
+        mockBackfillService.getProgress.mockResolvedValue({ status } as any);
+
+        await service.refresh();
+        await flushPromises();
+
+        expect(mockBackfillService.startBackfill).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should not break refresh when startBackfill rejects', async () => {
+      const summaries = generatePriceSummaries(100, 50000, 0.001);
+      mockOhlcService.findAllByDay.mockResolvedValue({ [BTC_COIN_ID]: summaries });
+      mockBackfillService.startBackfill.mockRejectedValue(new Error('Queue unavailable'));
+
+      const result = await service.refresh();
+      await flushPromises();
+
+      expect(result).toBe(CompositeRegimeType.NEUTRAL);
+      expect(mockBackfillService.startBackfill).toHaveBeenCalledWith(BTC_COIN_ID);
+    });
+
+    it('should handle getProgress errors gracefully', async () => {
+      const summaries = generatePriceSummaries(100, 50000, 0.001);
+      mockOhlcService.findAllByDay.mockResolvedValue({ [BTC_COIN_ID]: summaries });
+      mockBackfillService.getProgress.mockRejectedValue(new Error('Redis down'));
+
+      const result = await service.refresh();
+      await flushPromises();
+
+      expect(result).toBe(CompositeRegimeType.NEUTRAL);
+      expect(mockBackfillService.startBackfill).not.toHaveBeenCalled();
     });
 
     it('should default to NORMAL volatility when getCurrentRegime returns null', async () => {
@@ -228,6 +287,7 @@ describe('CompositeRegimeService', () => {
         mockOhlcService as any,
         mockCoinService as any,
         mockAuditService as any,
+        mockBackfillService as any,
         mockCacheManager as any,
         mockEventEmitter as any
       );
@@ -243,6 +303,7 @@ describe('CompositeRegimeService', () => {
         mockOhlcService as any,
         mockCoinService as any,
         mockAuditService as any,
+        mockBackfillService as any,
         mockCacheManager as any,
         mockEventEmitter as any
       );
@@ -277,12 +338,14 @@ describe('CompositeRegimeService', () => {
       });
     });
 
-    it('should store forceAllow=false correctly', async () => {
+    it('should persist forceAllow=false to Redis', async () => {
       await service.enableOverride('user-789', false, 'Test');
 
-      const status = service.getStatus();
-      expect(status.override.active).toBe(true);
-      expect(status.override.forceAllow).toBe(false);
+      expect(mockCacheManager.set).toHaveBeenCalledWith(
+        'regime:override',
+        expect.objectContaining({ forceAllow: false }),
+        86_400_000
+      );
     });
   });
 
@@ -348,6 +411,7 @@ describe('CompositeRegimeService', () => {
         mockOhlcService as any,
         mockCoinService as any,
         mockAuditService as any,
+        mockBackfillService as any,
         mockCacheManager as any,
         mockEventEmitter as any
       );
@@ -489,6 +553,7 @@ describe('CompositeRegimeService', () => {
         mockOhlcService as any,
         mockCoinService as any,
         mockAuditService as any,
+        mockBackfillService as any,
         mockCacheManager as any,
         mockEventEmitter as any
       );

--- a/apps/api/src/market-regime/composite-regime.service.ts
+++ b/apps/api/src/market-regime/composite-regime.service.ts
@@ -18,6 +18,7 @@ import { AuditService } from '../audit/audit.service';
 import { CoinService } from '../coin/coin.service';
 import { NOTIFICATION_EVENTS } from '../notification/interfaces/notification-events.interface';
 import { OHLCService } from '../ohlc/ohlc.service';
+import { OHLCBackfillService } from '../ohlc/services/ohlc-backfill.service';
 import { toErrorInfo } from '../shared/error.util';
 
 /** Minimum data points required to compute the 200-period SMA */
@@ -72,6 +73,7 @@ export class CompositeRegimeService implements OnModuleInit {
     private readonly ohlcService: OHLCService,
     private readonly coinService: CoinService,
     private readonly auditService: AuditService,
+    private readonly backfillService: OHLCBackfillService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly eventEmitter: EventEmitter2
   ) {}
@@ -168,6 +170,7 @@ export class CompositeRegimeService implements OnModuleInit {
           `Only ${closes.length} BTC price points available (need ${SMA_PERIOD}) — keeping previous regime`
         );
         this.trackFailure();
+        void this.triggerBackfillIfNeeded(btcCoin.id);
         return this.getCompositeRegime();
       }
 
@@ -329,6 +332,37 @@ export class CompositeRegimeService implements OnModuleInit {
         consecutiveFailures: this.consecutiveFailures,
         cachedRegime: this.cached?.regime ?? 'NONE'
       });
+    }
+  }
+
+  /**
+   * Fire-and-forget BTC OHLC backfill when insufficient data is available.
+   * Skips if a backfill is already pending, in progress, failed, or recently
+   * completed (Redis TTL acts as a 7-day cooldown).
+   */
+  private async triggerBackfillIfNeeded(coinId: string): Promise<void> {
+    try {
+      const progress = await this.backfillService.getProgress(coinId);
+
+      if (
+        progress &&
+        (progress.status === 'pending' ||
+          progress.status === 'in_progress' ||
+          progress.status === 'failed' ||
+          progress.status === 'completed')
+      ) {
+        this.logger.debug(`BTC backfill already ${progress.status} — skipping trigger`);
+        return;
+      }
+
+      this.logger.log('Triggering BTC OHLC backfill to gather sufficient data for 200-day SMA');
+      this.backfillService.startBackfill(coinId).catch((err: unknown) => {
+        const info = toErrorInfo(err);
+        this.logger.warn(`BTC backfill trigger failed: ${info.message}`);
+      });
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Failed to check backfill progress: ${err.message}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Auto-trigger BTC OHLC backfill when the composite regime service detects fewer than 200 price points for SMA calculation
- Backfill is skipped if one is already pending, in progress, or failed
- Fail-safe design ensures the regime refresh path is never blocked

## Changes
- `apps/api/src/market-regime/composite-regime.service.ts` — add backfill trigger when BTC data is insufficient
- `apps/api/src/market-regime/composite-regime.service.spec.ts` — update and expand tests for backfill trigger logic

## Test plan
- [ ] Unit tests pass (`nx test api -- --testPathPattern='composite-regime'`)
- [ ] Regime refresh completes normally when BTC data is sufficient (no backfill triggered)
- [ ] Backfill is triggered when BTC price points < 200
- [ ] Duplicate backfill jobs are not enqueued