### PR TITLE
refactor(api): extract BacktestContextFactory

### DIFF
--- a/apps/api/src/order/backtest/backtest-engine.service.spec.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.spec.ts
@@ -4,6 +4,7 @@ import { BacktestEngine } from './backtest-engine.service';
 import { ReplaySpeed } from './backtest-pacing.interface';
 import {
   BacktestBarProcessor,
+  BacktestContextFactory,
   BacktestLoopRunner,
   BacktestSignalTradeService,
   CheckpointService,
@@ -120,9 +121,7 @@ const createTestEngine = (
     opportunitySellService,
     signalTradeService
   );
-  const loopRunner = new BacktestLoopRunner(
-    backtestStream,
-    algorithmRegistry,
+  const contextFactory = new BacktestContextFactory(
     ohlcService,
     marketDataReader,
     quoteCurrencyResolver,
@@ -133,13 +132,15 @@ const createTestEngine = (
     priceWindowService,
     compositeRegimeService,
     slippageContextService,
-    checkpointService,
     exitSignalProcessor,
-    forcedExitService,
-    tradeExecutor,
+    metricsAccumulatorService
+  );
+  const loopRunner = new BacktestLoopRunner(
+    backtestStream,
+    priceWindowService,
     metricsAccumulatorService,
-    opportunitySellService,
-    barProcessor
+    barProcessor,
+    contextFactory
   );
   const optimizationCore = overrides.optimizationCore ?? ({} as any);
   return new BacktestEngine(checkpointService, optimizationCore, loopRunner);
@@ -1619,20 +1620,20 @@ describe('BacktestEngine checkpointing', () => {
       ])
     };
 
-    return checkpointService.buildCheckpointState(
-      1,
-      '2024-01-02T00:00:00.000Z',
+    return checkpointService.buildCheckpointState({
+      lastProcessedIndex: 1,
+      lastProcessedTimestamp: '2024-01-02T00:00:00.000Z',
       portfolio,
-      1250,
-      0.1,
-      12345,
-      2,
-      3,
-      4,
-      5,
-      0,
-      0
-    );
+      peakValue: 1250,
+      maxDrawdown: 0.1,
+      rngState: 12345,
+      tradesCount: 2,
+      signalsCount: 3,
+      fillsCount: 4,
+      snapshotsCount: 5,
+      sellsCount: 0,
+      winningSellsCount: 0
+    });
   };
 
   it('validates checkpoints with matching checksum', () => {

--- a/apps/api/src/order/backtest/backtest-engine.service.ts
+++ b/apps/api/src/order/backtest/backtest-engine.service.ts
@@ -21,15 +21,6 @@ import { SimulatedOrderFill } from './simulated-order-fill.entity';
 import { Coin } from '../../coin/coin.entity';
 import { OHLCCandle } from '../../ohlc/ohlc-candle.entity';
 
-export { MarketData, TradingSignal } from './shared';
-export {
-  ExecuteOptions,
-  ImmutablePriceTrackingData,
-  OptimizationBacktestConfig,
-  OptimizationBacktestResult,
-  PrecomputedWindowData
-} from './shared';
-
 @Injectable()
 export class BacktestEngine {
   constructor(
@@ -73,42 +64,7 @@ export class BacktestEngine {
   }
 
   validateCheckpoint(checkpoint: BacktestCheckpointState, timestamps: string[]): { valid: boolean; reason?: string } {
-    // Check if the checkpoint index is within bounds
-    if (checkpoint.lastProcessedIndex < 0 || checkpoint.lastProcessedIndex >= timestamps.length) {
-      return {
-        valid: false,
-        reason: `Checkpoint index ${checkpoint.lastProcessedIndex} out of bounds (0-${timestamps.length - 1})`
-      };
-    }
-
-    // Verify the timestamp at the checkpoint index matches
-    const expectedTimestamp = timestamps[checkpoint.lastProcessedIndex];
-    if (checkpoint.lastProcessedTimestamp !== expectedTimestamp) {
-      return {
-        valid: false,
-        reason: `Timestamp mismatch at index ${checkpoint.lastProcessedIndex}: expected ${expectedTimestamp}, got ${checkpoint.lastProcessedTimestamp}`
-      };
-    }
-
-    // Verify checksum integrity using centralized helper for consistency
-    const throttleStateJson = checkpoint.throttleState ? JSON.stringify(checkpoint.throttleState) : undefined;
-    const checksumData = this.checkpointSvc.buildChecksumData(
-      checkpoint.lastProcessedIndex,
-      checkpoint.lastProcessedTimestamp,
-      checkpoint.portfolio.cashBalance,
-      checkpoint.portfolio.positions.length,
-      checkpoint.peakValue,
-      checkpoint.maxDrawdown,
-      checkpoint.rngState,
-      throttleStateJson
-    );
-    const expectedChecksum = this.checkpointSvc.computeChecksum(checksumData);
-
-    if (checkpoint.checksum !== expectedChecksum) {
-      return { valid: false, reason: 'Checkpoint checksum validation failed - data may be corrupted' };
-    }
-
-    return { valid: true };
+    return this.checkpointSvc.validateCheckpoint(checkpoint, timestamps);
   }
 
   /**

--- a/apps/api/src/order/backtest/shared/checkpoint/checkpoint.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/checkpoint/checkpoint.service.spec.ts
@@ -123,25 +123,39 @@ describe('CheckpointService', () => {
       } as unknown as Portfolio;
     };
 
-    it('should produce a valid checkpoint state with checksum', () => {
-      const portfolio = createMockPortfolio();
+    const defaultOpts = (overrides: Partial<Parameters<CheckpointService['buildCheckpointState']>[0]> = {}) => ({
+      lastProcessedIndex: 0,
+      lastProcessedTimestamp: '2024-01-01T00:00:00Z',
+      portfolio: createMockPortfolio(),
+      peakValue: 25000,
+      maxDrawdown: 0,
+      rngState: 1,
+      tradesCount: 0,
+      signalsCount: 0,
+      fillsCount: 0,
+      snapshotsCount: 0,
+      sellsCount: 0,
+      winningSellsCount: 0,
+      ...overrides
+    });
 
+    it('should produce a valid checkpoint state with checksum', () => {
       const state = service.buildCheckpointState(
-        100,
-        '2024-06-01T00:00:00Z',
-        portfolio,
-        26000,
-        0.05,
-        42,
-        10,
-        5,
-        8,
-        50,
-        4,
-        3,
-        undefined,
-        500,
-        100
+        defaultOpts({
+          lastProcessedIndex: 100,
+          lastProcessedTimestamp: '2024-06-01T00:00:00Z',
+          peakValue: 26000,
+          maxDrawdown: 0.05,
+          rngState: 42,
+          tradesCount: 10,
+          signalsCount: 5,
+          fillsCount: 8,
+          snapshotsCount: 50,
+          sellsCount: 4,
+          winningSellsCount: 3,
+          grossProfit: 500,
+          grossLoss: 100
+        })
       );
 
       expect(state.lastProcessedIndex).toBe(100);
@@ -163,9 +177,7 @@ describe('CheckpointService', () => {
     });
 
     it('should serialize portfolio positions from Map to array', () => {
-      const portfolio = createMockPortfolio();
-
-      const state = service.buildCheckpointState(0, '2024-01-01T00:00:00Z', portfolio, 25000, 0, 1, 0, 0, 0, 0, 0, 0);
+      const state = service.buildCheckpointState(defaultOpts());
 
       expect(state.portfolio.cashBalance).toBe(5000);
       expect(state.portfolio.positions).toHaveLength(1);
@@ -176,96 +188,46 @@ describe('CheckpointService', () => {
     });
 
     it('should produce consistent checksums for the same input', () => {
-      const portfolio = createMockPortfolio();
-
-      const state1 = service.buildCheckpointState(
-        50,
-        '2024-03-01T00:00:00Z',
-        portfolio,
-        25000,
-        0.02,
-        99,
-        5,
-        3,
-        4,
-        25,
-        2,
-        1
-      );
-      const state2 = service.buildCheckpointState(
-        50,
-        '2024-03-01T00:00:00Z',
-        portfolio,
-        25000,
-        0.02,
-        99,
-        5,
-        3,
-        4,
-        25,
-        2,
-        1
-      );
+      const opts = defaultOpts({
+        lastProcessedIndex: 50,
+        lastProcessedTimestamp: '2024-03-01T00:00:00Z',
+        peakValue: 25000,
+        maxDrawdown: 0.02,
+        rngState: 99,
+        tradesCount: 5,
+        signalsCount: 3,
+        fillsCount: 4,
+        snapshotsCount: 25,
+        sellsCount: 2,
+        winningSellsCount: 1
+      });
+      const state1 = service.buildCheckpointState(opts);
+      const state2 = service.buildCheckpointState(opts);
 
       expect(state1.checksum).toBe(state2.checksum);
     });
 
     it('should include throttle state when provided', () => {
-      const portfolio = createMockPortfolio();
       const throttleState = { lastSignalTime: { 'btc:BUY': 1000 }, tradeTimestamps: [500, 1000] };
 
-      const state = service.buildCheckpointState(
-        0,
-        '2024-01-01T00:00:00Z',
-        portfolio,
-        25000,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        throttleState
-      );
+      const state = service.buildCheckpointState(defaultOpts({ serializedThrottleState: throttleState }));
 
       expect(state.throttleState).toEqual(throttleState);
     });
 
     it('should omit throttle state when not provided', () => {
-      const portfolio = createMockPortfolio();
-
-      const state = service.buildCheckpointState(0, '2024-01-01T00:00:00Z', portfolio, 25000, 0, 1, 0, 0, 0, 0, 0, 0);
+      const state = service.buildCheckpointState(defaultOpts());
 
       expect(state).not.toHaveProperty('throttleState');
     });
 
     it('should include exit tracker state when provided', () => {
-      const portfolio = createMockPortfolio();
       const exitTrackerState = {
         positions: {},
         configHash: 'abc'
       } as unknown as import('../exits').SerializableExitTrackerState;
 
-      const state = service.buildCheckpointState(
-        0,
-        '2024-01-01T00:00:00Z',
-        portfolio,
-        25000,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        undefined,
-        0,
-        0,
-        exitTrackerState
-      );
+      const state = service.buildCheckpointState(defaultOpts({ exitTrackerState }));
 
       expect(state.exitTrackerState).toBeDefined();
     });
@@ -273,7 +235,7 @@ describe('CheckpointService', () => {
     it('should handle empty positions map', () => {
       const portfolio = createMockPortfolio(10000, new Map());
 
-      const state = service.buildCheckpointState(0, '2024-01-01T00:00:00Z', portfolio, 10000, 0, 1, 0, 0, 0, 0, 0, 0);
+      const state = service.buildCheckpointState(defaultOpts({ portfolio, peakValue: 10000 }));
 
       expect(state.portfolio.positions).toEqual([]);
       expect(state.portfolio.cashBalance).toBe(10000);
@@ -292,7 +254,7 @@ describe('CheckpointService', () => {
       ]);
       const portfolio = createMockPortfolio(5000, positions);
 
-      const state = service.buildCheckpointState(0, '2024-01-01T00:00:00Z', portfolio, 8000, 0, 1, 0, 0, 0, 0, 0, 0);
+      const state = service.buildCheckpointState(defaultOpts({ portfolio, peakValue: 8000 }));
 
       expect(state.portfolio.positions).toHaveLength(1);
       expect(state.portfolio.positions[0].coinId).toBe('eth');
@@ -306,7 +268,7 @@ describe('CheckpointService', () => {
       ]);
       const portfolio = createMockPortfolio(5000, positions);
 
-      const state = service.buildCheckpointState(0, '2024-01-01T00:00:00Z', portfolio, 30000, 0, 1, 0, 0, 0, 0, 0, 0);
+      const state = service.buildCheckpointState(defaultOpts({ portfolio, peakValue: 30000 }));
 
       expect(state.portfolio.positions).toHaveLength(2);
       expect(state.portfolio.positions[0].coinId).toBe('btc');

--- a/apps/api/src/order/backtest/shared/checkpoint/checkpoint.service.ts
+++ b/apps/api/src/order/backtest/shared/checkpoint/checkpoint.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { Decimal } from 'decimal.js';
+
 import { createHash } from 'crypto';
 
 import { BacktestCheckpointState, CheckpointPortfolio } from '../../backtest-checkpoint.interface';
@@ -38,6 +40,28 @@ export interface EmergencyCheckpointParams {
   throttleState: ThrottleState;
   exitTracker: BacktestExitTracker | null | undefined;
   tradingTimestampCount: number;
+}
+
+/**
+ * Options for building a checkpoint state object.
+ */
+export interface BuildCheckpointStateOptions {
+  lastProcessedIndex: number;
+  lastProcessedTimestamp: string;
+  portfolio: Portfolio;
+  peakValue: number;
+  maxDrawdown: number;
+  rngState: number;
+  tradesCount: number;
+  signalsCount: number;
+  fillsCount: number;
+  snapshotsCount: number;
+  sellsCount: number;
+  winningSellsCount: number;
+  serializedThrottleState?: SerializableThrottleState;
+  grossProfit?: number;
+  grossLoss?: number;
+  exitTrackerState?: SerializableExitTrackerState;
 }
 
 /**
@@ -104,9 +128,9 @@ export class CheckpointService {
         const pnl = t.realizedPnL ?? 0;
         if (pnl > 0) {
           winningSells++;
-          grossProfit += pnl;
+          grossProfit = new Decimal(grossProfit).plus(pnl).toNumber();
         } else if (pnl < 0) {
-          grossLoss += Math.abs(pnl);
+          grossLoss = new Decimal(grossLoss).plus(new Decimal(pnl).abs()).toNumber();
         }
       }
     }
@@ -117,28 +141,55 @@ export class CheckpointService {
    * Build a checkpoint state object for persistence.
    * Includes all state needed to resume execution from this point.
    */
-  buildCheckpointState(
-    lastProcessedIndex: number,
-    lastProcessedTimestamp: string,
-    portfolio: Portfolio,
-    peakValue: number,
-    maxDrawdown: number,
-    rngState: number,
-    tradesCount: number,
-    signalsCount: number,
-    fillsCount: number,
-    snapshotsCount: number,
-    sellsCount: number,
-    winningSellsCount: number,
-    serializedThrottleState?: SerializableThrottleState,
-    grossProfit = 0,
-    grossLoss = 0,
-    exitTrackerState?: SerializableExitTrackerState
-  ): BacktestCheckpointState {
+  /**
+   * Validate a checkpoint against the current timestamp array.
+   * Checks index bounds, timestamp match, and checksum integrity.
+   */
+  validateCheckpoint(checkpoint: BacktestCheckpointState, timestamps: string[]): { valid: boolean; reason?: string } {
+    if (checkpoint.lastProcessedIndex < 0 || checkpoint.lastProcessedIndex >= timestamps.length) {
+      return {
+        valid: false,
+        reason: `Checkpoint index ${checkpoint.lastProcessedIndex} out of bounds (0-${timestamps.length - 1})`
+      };
+    }
+
+    const expectedTimestamp = timestamps[checkpoint.lastProcessedIndex];
+    if (checkpoint.lastProcessedTimestamp !== expectedTimestamp) {
+      return {
+        valid: false,
+        reason: `Timestamp mismatch at index ${checkpoint.lastProcessedIndex}: expected ${expectedTimestamp}, got ${checkpoint.lastProcessedTimestamp}`
+      };
+    }
+
+    const throttleStateJson = checkpoint.throttleState ? JSON.stringify(checkpoint.throttleState) : undefined;
+    const checksumData = this.buildChecksumData(
+      checkpoint.lastProcessedIndex,
+      checkpoint.lastProcessedTimestamp,
+      checkpoint.portfolio.cashBalance,
+      checkpoint.portfolio.positions.length,
+      checkpoint.peakValue,
+      checkpoint.maxDrawdown,
+      checkpoint.rngState,
+      throttleStateJson
+    );
+    const expectedChecksum = this.computeChecksum(checksumData);
+
+    if (checkpoint.checksum !== expectedChecksum) {
+      return { valid: false, reason: 'Checkpoint checksum validation failed - data may be corrupted' };
+    }
+
+    return { valid: true };
+  }
+
+  /**
+   * Build a checkpoint state object for persistence.
+   * Includes all state needed to resume execution from this point.
+   */
+  buildCheckpointState(opts: BuildCheckpointStateOptions): BacktestCheckpointState {
     // Convert Map-based positions to array format for JSON serialization
     const checkpointPortfolio: CheckpointPortfolio = {
-      cashBalance: portfolio.cashBalance,
-      positions: Array.from(portfolio.positions.entries()).map(([coinId, pos]) => ({
+      cashBalance: opts.portfolio.cashBalance,
+      positions: Array.from(opts.portfolio.positions.entries()).map(([coinId, pos]) => ({
         coinId,
         quantity: pos.quantity,
         averagePrice: pos.averagePrice,
@@ -147,41 +198,44 @@ export class CheckpointService {
     };
 
     // Serialize throttle state to JSON for checksum inclusion (before computing checksum)
-    const throttleStateJson = serializedThrottleState ? JSON.stringify(serializedThrottleState) : undefined;
+    const throttleStateJson = opts.serializedThrottleState ? JSON.stringify(opts.serializedThrottleState) : undefined;
 
     // Build checksum for data integrity verification using centralized helper
     const checksumData = this.buildChecksumData(
-      lastProcessedIndex,
-      lastProcessedTimestamp,
-      portfolio.cashBalance,
-      portfolio.positions.size,
-      peakValue,
-      maxDrawdown,
-      rngState,
+      opts.lastProcessedIndex,
+      opts.lastProcessedTimestamp,
+      opts.portfolio.cashBalance,
+      opts.portfolio.positions.size,
+      opts.peakValue,
+      opts.maxDrawdown,
+      opts.rngState,
       throttleStateJson
     );
     const checksum = this.computeChecksum(checksumData);
 
+    const grossProfit = opts.grossProfit ?? 0;
+    const grossLoss = opts.grossLoss ?? 0;
+
     return {
-      lastProcessedIndex,
-      lastProcessedTimestamp,
+      lastProcessedIndex: opts.lastProcessedIndex,
+      lastProcessedTimestamp: opts.lastProcessedTimestamp,
       portfolio: checkpointPortfolio,
-      peakValue,
-      maxDrawdown,
-      rngState,
+      peakValue: opts.peakValue,
+      maxDrawdown: opts.maxDrawdown,
+      rngState: opts.rngState,
       persistedCounts: {
-        trades: tradesCount,
-        signals: signalsCount,
-        fills: fillsCount,
-        snapshots: snapshotsCount,
-        sells: sellsCount,
-        winningSells: winningSellsCount,
+        trades: opts.tradesCount,
+        signals: opts.signalsCount,
+        fills: opts.fillsCount,
+        snapshots: opts.snapshotsCount,
+        sells: opts.sellsCount,
+        winningSells: opts.winningSellsCount,
         grossProfit,
         grossLoss
       },
       checksum,
-      ...(serializedThrottleState && { throttleState: serializedThrottleState }),
-      ...(exitTrackerState && { exitTrackerState })
+      ...(opts.serializedThrottleState && { throttleState: opts.serializedThrottleState }),
+      ...(opts.exitTrackerState && { exitTrackerState: opts.exitTrackerState })
     };
   }
 }

--- a/apps/api/src/order/backtest/shared/execution/backtest-bar-processor.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/backtest-bar-processor.service.ts
@@ -45,7 +45,6 @@ const MAX_CONSECUTIVE_PAUSE_FAILURES = 3;
 @Injectable()
 export class BacktestBarProcessor {
   private readonly logger = new Logger(BacktestBarProcessor.name);
-  private readonly reusablePriceMap = new Map<string, number>();
 
   constructor(
     @Optional() private readonly backtestStream: BacktestStreamService,
@@ -83,13 +82,13 @@ export class BacktestBarProcessor {
     const currentPrices = ctx.pricesByTimestamp[ctx.timestamps[i]];
     const isWarmup = i < ctx.effectiveTradingStartIndex;
 
-    this.reusablePriceMap.clear();
+    const priceMap = new Map<string, number>();
     for (const price of currentPrices) {
-      this.reusablePriceMap.set(price.coinId, this.priceWindow.getPriceValue(price));
+      priceMap.set(price.coinId, this.priceWindow.getPriceValue(price));
     }
     const marketData: MarketData = {
       timestamp,
-      prices: this.reusablePriceMap
+      prices: priceMap
     };
 
     // Always update portfolio values and advance price windows (needed for indicator warmup)
@@ -481,24 +480,24 @@ export class BacktestBarProcessor {
    */
   private buildCheckpointSnapshot(ctx: LoopContext, index: number, timestampStr: string): BacktestCheckpointState {
     const currentSells = this.checkpointSvc.countSells(ctx.trades);
-    return this.checkpointSvc.buildCheckpointState(
-      index,
-      timestampStr,
-      ctx.portfolio,
-      ctx.peakValue,
-      ctx.maxDrawdown,
-      ctx.rng.getState(),
-      ctx.totalPersistedCounts.trades + ctx.trades.length,
-      ctx.totalPersistedCounts.signals + ctx.signals.length,
-      ctx.totalPersistedCounts.fills + ctx.simulatedFills.length,
-      ctx.totalPersistedCounts.snapshots + ctx.snapshots.length,
-      ctx.metricsAcc.totalSellCount + currentSells.sells,
-      ctx.metricsAcc.totalWinningSellCount + currentSells.winningSells,
-      this.signalThrottle.serialize(ctx.throttleState),
-      ctx.metricsAcc.grossProfit + currentSells.grossProfit,
-      ctx.metricsAcc.grossLoss + currentSells.grossLoss,
-      ctx.exitTracker?.serialize()
-    );
+    return this.checkpointSvc.buildCheckpointState({
+      lastProcessedIndex: index,
+      lastProcessedTimestamp: timestampStr,
+      portfolio: ctx.portfolio,
+      peakValue: ctx.peakValue,
+      maxDrawdown: ctx.maxDrawdown,
+      rngState: ctx.rng.getState(),
+      tradesCount: ctx.totalPersistedCounts.trades + ctx.trades.length,
+      signalsCount: ctx.totalPersistedCounts.signals + ctx.signals.length,
+      fillsCount: ctx.totalPersistedCounts.fills + ctx.simulatedFills.length,
+      snapshotsCount: ctx.totalPersistedCounts.snapshots + ctx.snapshots.length,
+      sellsCount: ctx.metricsAcc.totalSellCount + currentSells.sells,
+      winningSellsCount: ctx.metricsAcc.totalWinningSellCount + currentSells.winningSells,
+      serializedThrottleState: this.signalThrottle.serialize(ctx.throttleState),
+      grossProfit: ctx.metricsAcc.grossProfit + currentSells.grossProfit,
+      grossLoss: ctx.metricsAcc.grossLoss + currentSells.grossLoss,
+      exitTrackerState: ctx.exitTracker?.serialize()
+    });
   }
 
   /**

--- a/apps/api/src/order/backtest/shared/execution/backtest-context-factory.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/backtest-context-factory.service.ts
@@ -1,0 +1,427 @@
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+
+import { getAllocationLimits, PipelineStage } from '@chansey/api-interfaces';
+
+import { LoopContext } from './backtest-loop-context';
+import { ExecuteOptions, LoopRunnerOptions } from './backtest-loop-runner.types';
+
+import { CoinListingEventService } from '../../../../coin/coin-listing-event.service';
+import { Coin } from '../../../../coin/coin.entity';
+import { DEFAULT_QUOTE_CURRENCY } from '../../../../exchange/constants';
+import { OHLCCandle } from '../../../../ohlc/ohlc-candle.entity';
+import { OHLCService } from '../../../../ohlc/ohlc.service';
+import { DEFAULT_OPPORTUNITY_SELLING_CONFIG } from '../../../interfaces/opportunity-selling.interface';
+import { AlgorithmWatchdog } from '../../algorithm-watchdog';
+import { DEFAULT_CHECKPOINT_CONFIG } from '../../backtest-checkpoint.interface';
+import {
+  calculateReplayDelay,
+  DEFAULT_BASE_INTERVAL_MS,
+  DEFAULT_LIVE_REPLAY_CHECKPOINT_INTERVAL,
+  LiveReplayExecuteOptions,
+  ReplaySpeed
+} from '../../backtest-pacing.interface';
+import { Backtest } from '../../backtest.entity';
+import { IncrementalSma } from '../../incremental-sma';
+import { MarketDataReaderService, OHLCVData } from '../../market-data-reader.service';
+import { QuoteCurrencyResolverService } from '../../quote-currency-resolver.service';
+import { SeededRandom } from '../../seeded-random';
+import { ExitSignalProcessorService } from '../exit-signals';
+import { MetricsAccumulatorService } from '../metrics-accumulator';
+import { Portfolio, PortfolioStateService } from '../portfolio';
+import { PriceWindowService } from '../price-window';
+import { CompositeRegimeService } from '../regime';
+import { DEFAULT_SLIPPAGE_CONFIG, mapSlippageModelType, SlippageModelType, SlippageService } from '../slippage';
+import { SlippageContextService } from '../slippage-context';
+import { SignalThrottleService } from '../throttle';
+
+/** Default minimum hold period before allowing SELL (24 hours in ms) */
+const DEFAULT_MIN_HOLD_MS = 24 * 60 * 60 * 1000;
+/** Wall-clock algorithm stall timeout (ms) */
+const ALGORITHM_STALL_TIMEOUT_MS = 300_000;
+/** BTC SMA period for regime detection */
+const REGIME_SMA_PERIOD = 200;
+
+/**
+ * BacktestContextFactory
+ *
+ * Owns all context initialization for backtest runs: config resolution,
+ * data loading, portfolio restoration, and checkpoint fast-forwarding.
+ * Produces a fully-initialized LoopContext ready for the simulation loop.
+ */
+@Injectable()
+export class BacktestContextFactory {
+  private readonly logger = new Logger(BacktestContextFactory.name);
+
+  constructor(
+    @Inject(forwardRef(() => OHLCService))
+    private readonly ohlcService: OHLCService,
+    private readonly marketDataReader: MarketDataReaderService,
+    private readonly quoteCurrencyResolver: QuoteCurrencyResolverService,
+    private readonly slippageService: SlippageService,
+    private readonly portfolioState: PortfolioStateService,
+    private readonly signalThrottle: SignalThrottleService,
+    private readonly coinListingEventService: CoinListingEventService,
+    private readonly priceWindow: PriceWindowService,
+    private readonly compositeRegimeSvc: CompositeRegimeService,
+    private readonly slippageCtxSvc: SlippageContextService,
+    private readonly exitSignalProcessorSvc: ExitSignalProcessorService,
+    private readonly metricsAccSvc: MetricsAccumulatorService
+  ) {}
+
+  /**
+   * Create a fully-initialized LoopContext for a backtest run.
+   */
+  async create(backtest: Backtest, coins: Coin[], options: LoopRunnerOptions): Promise<LoopContext> {
+    const isLiveReplay = options.mode === 'live-replay';
+    const liveReplayOpts = isLiveReplay ? (options as LiveReplayExecuteOptions & { mode: 'live-replay' }) : null;
+    const isResuming = !!options.resumeFrom;
+
+    const checkpointInterval = isLiveReplay
+      ? (options.checkpointInterval ?? DEFAULT_LIVE_REPLAY_CHECKPOINT_INTERVAL)
+      : (options.checkpointInterval ?? DEFAULT_CHECKPOINT_CONFIG.checkpointInterval);
+
+    // Live-replay pacing
+    const replaySpeed = liveReplayOpts?.replaySpeed ?? ReplaySpeed.FAST_5X;
+    const baseIntervalMs = liveReplayOpts?.baseIntervalMs ?? DEFAULT_BASE_INTERVAL_MS;
+    const delayMs = isLiveReplay ? calculateReplayDelay(replaySpeed, baseIntervalMs) : 0;
+
+    const modeLabel = isLiveReplay ? 'live replay' : 'historical';
+    this.logger.log(
+      `Starting ${modeLabel} backtest: ${backtest.name} (dataset=${options.dataset.id}, seed=${options.deterministicSeed}, resuming=${isResuming}` +
+        (isLiveReplay ? `, speed=${ReplaySpeed[replaySpeed]}, delay=${delayMs}ms` : '') +
+        ')'
+    );
+
+    // Phase 1: Restore state + load data
+    const { rng, portfolio, peakValue, maxDrawdown } = this.restoreState(backtest, options, isResuming);
+    const { coinMap, quoteCoin, pricesByTimestamp, timestamps, priceCtx, delistingDates, boundaries } =
+      await this.loadAndPrepareData(backtest, coins, options, isLiveReplay);
+
+    this.logger.log(
+      `Processing ${timestamps.length} time periods` +
+        (isLiveReplay ? ` with ${delayMs}ms delay` : '') +
+        ` (warmup: ${boundaries.effectiveTradingStartIndex}, trading: ${boundaries.tradingTimestampCount})`
+    );
+
+    // Phase 2: Trade config
+    const { slippageConfig, minHoldMs, allocLimits, exitTracker, oppSellingEnabled, oppSellingConfig } =
+      this.resolveTradeConfig(backtest, options, isLiveReplay, isResuming);
+
+    // Phase 3: Signal config
+    const { regimeConfig, throttleConfig, throttleState } = this.resolveSignalConfig(
+      backtest,
+      options,
+      coins,
+      isResuming
+    );
+
+    // Phase 4: Accumulators + metadata
+    const totalPersistedCounts =
+      isResuming && options.resumeFrom
+        ? { ...options.resumeFrom.persistedCounts }
+        : { trades: 0, signals: 0, fills: 0, snapshots: 0, sells: 0, winningSells: 0, grossProfit: 0, grossLoss: 0 };
+
+    const metricsAcc = this.metricsAccSvc.createMetricsAccumulator(
+      totalPersistedCounts.trades,
+      totalPersistedCounts.sells ?? 0,
+      totalPersistedCounts.winningSells ?? 0,
+      totalPersistedCounts.grossProfit ?? 0,
+      totalPersistedCounts.grossLoss ?? 0
+    );
+
+    const startIndex = isResuming && options.resumeFrom ? options.resumeFrom.lastProcessedIndex + 1 : 0;
+
+    const algoMetadata = isLiveReplay
+      ? {
+          datasetId: options.dataset.id,
+          deterministicSeed: options.deterministicSeed,
+          backtestId: backtest.id,
+          isLiveReplay: true,
+          replaySpeed
+        }
+      : { datasetId: options.dataset.id, deterministicSeed: options.deterministicSeed, backtestId: backtest.id };
+
+    // Assemble context
+    const ctx = LoopContext.create({
+      isLiveReplay,
+      liveReplayOpts,
+      checkpointInterval,
+      delayMs,
+      slippageConfig,
+      minHoldMs,
+      maxAllocation: allocLimits.maxAllocation,
+      minAllocation: allocLimits.minAllocation,
+      oppSellingEnabled,
+      oppSellingConfig,
+      algoMetadata,
+      replaySpeed,
+      enableRegimeScaledSizing: regimeConfig.enableRegimeScaledSizing,
+      riskLevel: regimeConfig.riskLevel,
+      regimeGateEnabled: regimeConfig.regimeGateEnabled,
+      btcCoin: regimeConfig.btcCoin,
+      rng,
+      portfolio,
+      peakValue,
+      maxDrawdown,
+      exitTracker,
+      throttleState,
+      throttleConfig,
+      totalPersistedCounts,
+      metricsAcc,
+      lastCheckpointCounts: {
+        trades: 0,
+        signals: 0,
+        fills: 0,
+        snapshots: 0,
+        sells: 0,
+        winningSells: 0,
+        grossProfit: 0,
+        grossLoss: 0
+      },
+      lastCheckpointIndex: startIndex - 1,
+      watchdog: new AlgorithmWatchdog(ALGORITHM_STALL_TIMEOUT_MS),
+      backtest,
+      coins,
+      coinMap,
+      quoteCoin,
+      priceCtx,
+      pricesByTimestamp,
+      timestamps,
+      delistingDates,
+      ...boundaries,
+      options
+    });
+
+    // Initialize incremental SMA for BTC regime detection
+    if (ctx.btcCoin) {
+      ctx.priceCtx.btcRegimeSma = new IncrementalSma(REGIME_SMA_PERIOD);
+      ctx.priceCtx.btcCoinId = ctx.btcCoin.id;
+    }
+
+    // Fast-forward price windows on resume
+    if (isResuming) {
+      this.fastForwardForResume(ctx, startIndex, boundaries.effectiveTimestampCount, coins, timestamps);
+    }
+
+    return ctx;
+  }
+
+  // ---- Private helpers ----
+
+  private async loadAndPrepareData(
+    backtest: Backtest,
+    coins: Coin[],
+    options: LoopRunnerOptions,
+    isLiveReplay: boolean
+  ) {
+    const coinMap = new Map<string, Coin>(coins.map((coin) => [coin.id, coin]));
+
+    const preferredQuoteCurrency = (backtest.configSnapshot?.run?.quoteCurrency as string) ?? DEFAULT_QUOTE_CURRENCY;
+    const quoteCoin = await this.quoteCurrencyResolver.resolveQuoteCurrency(preferredQuoteCurrency);
+
+    const dataLoadStartDate = options.dataset.startAt ?? backtest.startDate;
+    const dataLoadEndDate = options.dataset.endAt ?? backtest.endDate;
+    const tradingStartDate = backtest.startDate;
+    const tradingEndDate = backtest.endDate;
+
+    let historicalPrices = await this.loadPriceData(options, coins, dataLoadStartDate, dataLoadEndDate);
+    if (historicalPrices.length === 0) {
+      throw new Error('No historical price data available for the specified date range');
+    }
+
+    const pricesByTimestamp = this.priceWindow.groupPricesByTimestamp(historicalPrices);
+    const timestamps = Object.keys(pricesByTimestamp).sort();
+    const priceCtx = this.priceWindow.initPriceTracking(
+      historicalPrices,
+      coins.map((c) => c.id)
+    );
+    historicalPrices = [];
+
+    const delistingDates =
+      options.enableDelistingExit !== false
+        ? await this.coinListingEventService.getActiveDelistingsAsOf(
+            coins.map((c) => c.id),
+            tradingEndDate
+          )
+        : new Map<string, Date>();
+
+    if (delistingDates.size > 0) {
+      this.logger.log(
+        `Loaded ${delistingDates.size} delisting events for forced-exit simulation` +
+          (isLiveReplay ? ' (live-replay)' : '')
+      );
+    }
+
+    const boundaries = this.calculateBoundaries(timestamps, tradingStartDate, tradingEndDate);
+
+    return { coinMap, quoteCoin, pricesByTimestamp, timestamps, priceCtx, delistingDates, boundaries };
+  }
+
+  private resolveTradeConfig(
+    backtest: Backtest,
+    options: LoopRunnerOptions,
+    isLiveReplay: boolean,
+    isResuming: boolean
+  ) {
+    const slippageConfig = this.buildSlippageConfig(backtest);
+    const minHoldMs = options.minHoldMs ?? DEFAULT_MIN_HOLD_MS;
+
+    const defaultStage = isLiveReplay ? PipelineStage.LIVE_REPLAY : PipelineStage.HISTORICAL;
+    const allocLimits = getAllocationLimits(options.pipelineStage ?? defaultStage, options.riskLevel, {
+      maxAllocation: options.maxAllocation,
+      minAllocation: options.minAllocation
+    });
+
+    const exitTracker = this.exitSignalProcessorSvc.resolveExitTracker({
+      exitConfig: options.exitConfig,
+      enableHardStopLoss: options.enableHardStopLoss !== false,
+      hardStopLossPercent: options.hardStopLossPercent ?? 0.05,
+      resumeExitTrackerState: isResuming ? options.resumeFrom?.exitTrackerState : undefined
+    });
+
+    const oppSellingEnabled = !isLiveReplay && ((options as ExecuteOptions).enableOpportunitySelling ?? false);
+    const oppSellingConfig = (options as ExecuteOptions).opportunitySellingConfig ?? DEFAULT_OPPORTUNITY_SELLING_CONFIG;
+
+    return { slippageConfig, minHoldMs, allocLimits, exitTracker, oppSellingEnabled, oppSellingConfig };
+  }
+
+  private resolveSignalConfig(backtest: Backtest, options: LoopRunnerOptions, coins: Coin[], isResuming: boolean) {
+    const regimeConfig = this.compositeRegimeSvc.resolveRegimeConfig(options, coins);
+    const throttleConfig = this.signalThrottle.resolveConfig(
+      backtest.configSnapshot?.parameters as Record<string, unknown> | undefined
+    );
+    const throttleState =
+      isResuming && options.resumeFrom?.throttleState
+        ? this.signalThrottle.deserialize(options.resumeFrom.throttleState)
+        : this.signalThrottle.createState();
+
+    return { regimeConfig, throttleConfig, throttleState };
+  }
+
+  private restoreState(
+    backtest: Backtest,
+    options: LoopRunnerOptions,
+    isResuming: boolean
+  ): { rng: SeededRandom; portfolio: Portfolio; peakValue: number; maxDrawdown: number } {
+    if (isResuming && options.resumeFrom) {
+      const rng = SeededRandom.fromState(options.resumeFrom.rngState);
+      this.logger.log(`Restored RNG state from checkpoint at index ${options.resumeFrom.lastProcessedIndex}`);
+      const portfolio = this.portfolioState.deserialize(options.resumeFrom.portfolio);
+      const peakValue = options.resumeFrom.peakValue;
+      const maxDrawdown = options.resumeFrom.maxDrawdown;
+      this.logger.log(
+        `Restored portfolio: cash=${portfolio.cashBalance.toFixed(2)}, positions=${portfolio.positions.size}, peak=${peakValue.toFixed(2)}`
+      );
+      return { rng, portfolio, peakValue, maxDrawdown };
+    }
+
+    return {
+      rng: new SeededRandom(options.deterministicSeed),
+      portfolio: {
+        cashBalance: backtest.initialCapital,
+        positions: new Map(),
+        totalValue: backtest.initialCapital
+      },
+      peakValue: backtest.initialCapital,
+      maxDrawdown: 0
+    };
+  }
+
+  private async loadPriceData(
+    options: LoopRunnerOptions,
+    coins: Coin[],
+    startDate: Date,
+    endDate: Date
+  ): Promise<OHLCCandle[]> {
+    if (this.marketDataReader.hasStorageLocation(options.dataset)) {
+      this.logger.log(`Reading market data from storage: ${options.dataset.storageLocation}`);
+      const marketDataResult = await this.marketDataReader.readMarketData(options.dataset, startDate, endDate);
+      const candles = this.convertOHLCVToCandles(marketDataResult.data);
+      this.logger.log(
+        `Loaded ${candles.length} candle records from storage (${marketDataResult.dateRange.start.toISOString()} to ${marketDataResult.dateRange.end.toISOString()})`
+      );
+      return candles;
+    }
+
+    return this.ohlcService.getCandlesByDateRange(
+      coins.map((c) => c.id),
+      startDate,
+      endDate
+    );
+  }
+
+  private calculateBoundaries(
+    timestamps: string[],
+    tradingStartDate: Date,
+    tradingEndDate: Date
+  ): { effectiveTradingStartIndex: number; effectiveTimestampCount: number; tradingTimestampCount: number } {
+    const tradingStartIndex = timestamps.findIndex((ts) => new Date(ts) >= tradingStartDate);
+    const tradingEndIdx = (() => {
+      let lastIdx = timestamps.length - 1;
+      while (lastIdx >= 0 && new Date(timestamps[lastIdx]) > tradingEndDate) lastIdx--;
+      return lastIdx;
+    })();
+    const effectiveTradingStartIndex = tradingStartIndex >= 0 ? tradingStartIndex : 0;
+    const effectiveTimestampCount = tradingEndIdx + 1;
+    const tradingTimestampCount = effectiveTimestampCount - effectiveTradingStartIndex;
+
+    return { effectiveTradingStartIndex, effectiveTimestampCount, tradingTimestampCount };
+  }
+
+  private buildSlippageConfig(backtest: Backtest) {
+    const slippageSnapshot = backtest.configSnapshot?.slippage;
+    const slippageModel = slippageSnapshot
+      ? mapSlippageModelType(slippageSnapshot.model as string)
+      : SlippageModelType.FIXED;
+    const riskDefaults =
+      slippageModel === SlippageModelType.VOLUME_BASED
+        ? this.slippageCtxSvc.getParticipationDefaults(backtest.configSnapshot?.regime?.riskLevel ?? 3)
+        : undefined;
+    return slippageSnapshot
+      ? this.slippageService.buildConfig({
+          type: slippageModel,
+          fixedBps: slippageSnapshot.fixedBps ?? 5,
+          baseSlippageBps: slippageSnapshot.baseSlippageBps ?? 5,
+          participationRateLimit: slippageSnapshot.participationRateLimit ?? riskDefaults?.participationRateLimit,
+          rejectParticipationRate: slippageSnapshot.rejectParticipationRate ?? riskDefaults?.rejectParticipationRate,
+          volatilityFactor: slippageSnapshot.volatilityFactor,
+          spreadCalibrationFactor: slippageSnapshot.spreadCalibrationFactor ?? 1.0,
+          minSpreadBps: slippageSnapshot.minSpreadBps ?? 2
+        })
+      : DEFAULT_SLIPPAGE_CONFIG;
+  }
+
+  private fastForwardForResume(
+    ctx: LoopContext,
+    startIndex: number,
+    effectiveTimestampCount: number,
+    coins: Coin[],
+    timestamps: string[]
+  ): void {
+    this.logger.log(
+      `Resuming from index ${startIndex} of ${effectiveTimestampCount} (${((startIndex / effectiveTimestampCount) * 100).toFixed(1)}% complete)`
+    );
+
+    if (startIndex > 0) {
+      for (let j = 0; j < startIndex; j++) {
+        this.priceWindow.advancePriceWindows(ctx.priceCtx, coins, new Date(timestamps[j]));
+      }
+      this.logger.log(`Fast-forwarded price windows through ${startIndex} timestamps for resume`);
+    }
+  }
+
+  private convertOHLCVToCandles(ohlcvData: OHLCVData[]): OHLCCandle[] {
+    return ohlcvData.map(
+      (data) =>
+        new OHLCCandle({
+          coinId: data.coinId,
+          timestamp: data.timestamp,
+          open: data.open,
+          high: data.high,
+          low: data.low,
+          close: data.close,
+          volume: data.volume
+        })
+    );
+  }
+}

--- a/apps/api/src/order/backtest/shared/execution/backtest-loop-context.ts
+++ b/apps/api/src/order/backtest/shared/execution/backtest-loop-context.ts
@@ -16,7 +16,7 @@ import { type MetricsAccumulator } from '../metrics-accumulator';
 import { type Portfolio } from '../portfolio';
 import { type PriceTrackingContext } from '../price-window';
 import { type SlippageConfig } from '../slippage';
-import { type ThrottleState } from '../throttle';
+import { type SignalThrottleConfig, type ThrottleState } from '../throttle';
 
 /** Persisted counts across checkpoints for incremental persistence */
 export interface PersistedCounts {
@@ -60,7 +60,7 @@ export interface LoopContextInit {
   maxDrawdown: number;
   exitTracker: BacktestExitTracker | null;
   throttleState: ThrottleState;
-  throttleConfig: ReturnType<import('../throttle').SignalThrottleService['resolveConfig']>;
+  throttleConfig: SignalThrottleConfig;
   // Accumulators
   totalPersistedCounts: PersistedCounts;
   metricsAcc: MetricsAccumulator;
@@ -117,7 +117,7 @@ export class LoopContext {
   maxDrawdown: number;
   exitTracker: BacktestExitTracker | null;
   throttleState: ThrottleState;
-  throttleConfig: ReturnType<import('../throttle').SignalThrottleService['resolveConfig']>;
+  throttleConfig: SignalThrottleConfig;
 
   // Accumulators
   trades: Partial<BacktestTrade>[] = [];

--- a/apps/api/src/order/backtest/shared/execution/backtest-loop-runner.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/backtest-loop-runner.service.ts
@@ -1,51 +1,21 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
-
-import { getAllocationLimits, PipelineStage } from '@chansey/api-interfaces';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { BacktestBarProcessor } from './backtest-bar-processor.service';
+import { BacktestContextFactory } from './backtest-context-factory.service';
 import { LoopContext } from './backtest-loop-context';
-import { ExecuteOptions, LoopRunnerOptions } from './backtest-loop-runner.types';
-import { ForcedExitService } from './forced-exit.service';
-import { TradeExecutorService } from './trade-executor.service';
+import { LoopRunnerOptions } from './backtest-loop-runner.types';
 
-import { AlgorithmRegistry } from '../../../../algorithm/registry/algorithm-registry.service';
-import { CoinListingEventService } from '../../../../coin/coin-listing-event.service';
 import { Coin } from '../../../../coin/coin.entity';
-import { DEFAULT_QUOTE_CURRENCY } from '../../../../exchange/constants';
-import { OHLCCandle } from '../../../../ohlc/ohlc-candle.entity';
-import { OHLCService } from '../../../../ohlc/ohlc.service';
-import { DEFAULT_OPPORTUNITY_SELLING_CONFIG } from '../../../interfaces/opportunity-selling.interface';
-import { AlgorithmWatchdog } from '../../algorithm-watchdog';
-import { DEFAULT_CHECKPOINT_CONFIG } from '../../backtest-checkpoint.interface';
-import {
-  calculateReplayDelay,
-  DEFAULT_BASE_INTERVAL_MS,
-  DEFAULT_LIVE_REPLAY_CHECKPOINT_INTERVAL,
-  LiveReplayExecuteOptions,
-  LiveReplayExecuteResult,
-  ReplaySpeed
-} from '../../backtest-pacing.interface';
+import { LiveReplayExecuteResult } from '../../backtest-pacing.interface';
 import { BacktestPerformanceSnapshot } from '../../backtest-performance-snapshot.entity';
 import { BacktestFinalMetrics } from '../../backtest-result.service';
 import { BacktestSignal } from '../../backtest-signal.entity';
 import { BacktestStreamService } from '../../backtest-stream.service';
 import { BacktestTrade } from '../../backtest-trade.entity';
 import { Backtest } from '../../backtest.entity';
-import { IncrementalSma } from '../../incremental-sma';
-import { MarketDataReaderService, OHLCVData } from '../../market-data-reader.service';
-import { QuoteCurrencyResolverService } from '../../quote-currency-resolver.service';
-import { SeededRandom } from '../../seeded-random';
 import { SimulatedOrderFill } from '../../simulated-order-fill.entity';
-import { CheckpointService } from '../checkpoint';
-import { ExitSignalProcessorService } from '../exit-signals';
 import { MetricsAccumulatorService } from '../metrics-accumulator';
-import { OpportunitySellService } from '../opportunity-selling';
-import { Portfolio, PortfolioStateService } from '../portfolio';
 import { PriceWindowService } from '../price-window';
-import { CompositeRegimeService } from '../regime';
-import { DEFAULT_SLIPPAGE_CONFIG, SlippageModelType, SlippageService } from '../slippage';
-import { SlippageContextService } from '../slippage-context';
-import { SignalThrottleService } from '../throttle';
 
 // Re-export types and functions for backwards compatibility
 export { ExecuteOptions, LoopRunnerOptions, classifySignalType, mapStrategySignal } from './backtest-loop-runner.types';
@@ -54,42 +24,19 @@ export { ExecuteOptions, LoopRunnerOptions, classifySignalType, mapStrategySigna
  * BacktestLoopRunner
  *
  * Orchestrates the main simulation loop for both historical and live-replay
- * backtest modes. Handles initialization (config, data loading, portfolio setup)
- * and post-loop cleanup (metrics, telemetry). Per-bar iteration is delegated
- * to BacktestBarProcessor.
+ * backtest modes. Context initialization is delegated to BacktestContextFactory.
+ * Per-bar iteration is delegated to BacktestBarProcessor.
  */
 @Injectable()
 export class BacktestLoopRunner {
   private readonly logger = new Logger(BacktestLoopRunner.name);
 
-  /** Default minimum hold period before allowing SELL (24 hours in ms) */
-  private static readonly DEFAULT_MIN_HOLD_MS = 24 * 60 * 60 * 1000;
-  /** Wall-clock algorithm stall timeout (ms) */
-  private static readonly ALGORITHM_STALL_TIMEOUT_MS = 300_000;
-  /** BTC SMA period for regime detection */
-  private static readonly REGIME_SMA_PERIOD = 200;
-
   constructor(
     private readonly backtestStream: BacktestStreamService,
-    private readonly algorithmRegistry: AlgorithmRegistry,
-    @Inject(forwardRef(() => OHLCService))
-    private readonly ohlcService: OHLCService,
-    private readonly marketDataReader: MarketDataReaderService,
-    private readonly quoteCurrencyResolver: QuoteCurrencyResolverService,
-    private readonly slippageService: SlippageService,
-    private readonly portfolioState: PortfolioStateService,
-    private readonly signalThrottle: SignalThrottleService,
-    private readonly coinListingEventService: CoinListingEventService,
     private readonly priceWindow: PriceWindowService,
-    private readonly compositeRegimeSvc: CompositeRegimeService,
-    private readonly slippageCtxSvc: SlippageContextService,
-    private readonly checkpointSvc: CheckpointService,
-    private readonly exitSignalProcessorSvc: ExitSignalProcessorService,
-    private readonly forcedExitSvc: ForcedExitService,
-    private readonly tradeExecutor: TradeExecutorService,
     private readonly metricsAccSvc: MetricsAccumulatorService,
-    private readonly opportunitySellSvc: OpportunitySellService,
-    private readonly barProcessor: BacktestBarProcessor
+    private readonly barProcessor: BacktestBarProcessor,
+    private readonly contextFactory: BacktestContextFactory
   ) {}
 
   /**
@@ -118,7 +65,7 @@ export class BacktestLoopRunner {
     }
 
     // ---- Phase 1: Initialization ----
-    const ctx = await this.initializeContext(backtest, coins, options);
+    const ctx = await this.contextFactory.create(backtest, coins, options);
 
     // ---- Phase 2: Main loop ----
     const startIndex = options.resumeFrom ? options.resumeFrom.lastProcessedIndex + 1 : 0;
@@ -130,300 +77,6 @@ export class BacktestLoopRunner {
 
     // ---- Phase 3: Post-loop cleanup ----
     return this.finalizeResults(ctx);
-  }
-
-  /**
-   * Initialize all context state: config resolution, data loading, portfolio setup.
-   */
-  private async initializeContext(backtest: Backtest, coins: Coin[], options: LoopRunnerOptions): Promise<LoopContext> {
-    const isLiveReplay = options.mode === 'live-replay';
-    const liveReplayOpts = isLiveReplay ? (options as LiveReplayExecuteOptions & { mode: 'live-replay' }) : null;
-
-    const isResuming = !!options.resumeFrom;
-    const checkpointInterval = isLiveReplay
-      ? (options.checkpointInterval ?? DEFAULT_LIVE_REPLAY_CHECKPOINT_INTERVAL)
-      : (options.checkpointInterval ?? DEFAULT_CHECKPOINT_CONFIG.checkpointInterval);
-
-    // Live-replay pacing
-    const replaySpeed = liveReplayOpts?.replaySpeed ?? ReplaySpeed.FAST_5X;
-    const baseIntervalMs = liveReplayOpts?.baseIntervalMs ?? DEFAULT_BASE_INTERVAL_MS;
-    const delayMs = isLiveReplay ? calculateReplayDelay(replaySpeed, baseIntervalMs) : 0;
-
-    const modeLabel = isLiveReplay ? 'live replay' : 'historical';
-    this.logger.log(
-      `Starting ${modeLabel} backtest: ${backtest.name} (dataset=${options.dataset.id}, seed=${options.deterministicSeed}, resuming=${isResuming}` +
-        (isLiveReplay ? `, speed=${ReplaySpeed[replaySpeed]}, delay=${delayMs}ms` : '') +
-        ')'
-    );
-
-    // Initialize or restore RNG
-    let rng: SeededRandom;
-    if (isResuming && options.resumeFrom) {
-      rng = SeededRandom.fromState(options.resumeFrom.rngState);
-      this.logger.log(`Restored RNG state from checkpoint at index ${options.resumeFrom.lastProcessedIndex}`);
-    } else {
-      rng = new SeededRandom(options.deterministicSeed);
-    }
-
-    // Initialize or restore portfolio
-    let portfolio: Portfolio;
-    let peakValue: number;
-    let maxDrawdown: number;
-    if (isResuming && options.resumeFrom) {
-      portfolio = this.portfolioState.deserialize(options.resumeFrom.portfolio);
-      peakValue = options.resumeFrom.peakValue;
-      maxDrawdown = options.resumeFrom.maxDrawdown;
-      this.logger.log(
-        `Restored portfolio: cash=${portfolio.cashBalance.toFixed(2)}, positions=${portfolio.positions.size}, peak=${peakValue.toFixed(2)}`
-      );
-    } else {
-      portfolio = {
-        cashBalance: backtest.initialCapital,
-        positions: new Map(),
-        totalValue: backtest.initialCapital
-      };
-      peakValue = backtest.initialCapital;
-      maxDrawdown = 0;
-    }
-
-    // Cumulative persisted counts
-    const totalPersistedCounts =
-      isResuming && options.resumeFrom
-        ? { ...options.resumeFrom.persistedCounts }
-        : { trades: 0, signals: 0, fills: 0, snapshots: 0, sells: 0, winningSells: 0, grossProfit: 0, grossLoss: 0 };
-
-    // Lightweight metrics accumulators
-    const metricsAcc = this.metricsAccSvc.createMetricsAccumulator(
-      totalPersistedCounts.trades,
-      totalPersistedCounts.sells ?? 0,
-      totalPersistedCounts.winningSells ?? 0,
-      totalPersistedCounts.grossProfit ?? 0,
-      totalPersistedCounts.grossLoss ?? 0
-    );
-
-    const coinMap = new Map<string, Coin>(coins.map((coin) => [coin.id, coin]));
-
-    // Resolve quote currency
-    const preferredQuoteCurrency = (backtest.configSnapshot?.run?.quoteCurrency as string) ?? DEFAULT_QUOTE_CURRENCY;
-    const quoteCoin = await this.quoteCurrencyResolver.resolveQuoteCurrency(preferredQuoteCurrency);
-
-    // Load data from full dataset range for indicator warmup
-    const dataLoadStartDate = options.dataset.startAt ?? backtest.startDate;
-    const dataLoadEndDate = options.dataset.endAt ?? backtest.endDate;
-    const tradingStartDate = backtest.startDate;
-    const tradingEndDate = backtest.endDate;
-
-    let historicalPrices: OHLCCandle[];
-    if (this.marketDataReader.hasStorageLocation(options.dataset)) {
-      this.logger.log(`Reading market data from storage: ${options.dataset.storageLocation}`);
-      const marketDataResult = await this.marketDataReader.readMarketData(
-        options.dataset,
-        dataLoadStartDate,
-        dataLoadEndDate
-      );
-      historicalPrices = this.convertOHLCVToCandles(marketDataResult.data);
-      this.logger.log(
-        `Loaded ${historicalPrices.length} candle records from storage (${marketDataResult.dateRange.start.toISOString()} to ${marketDataResult.dateRange.end.toISOString()})`
-      );
-    } else {
-      historicalPrices = await this.getHistoricalPrices(
-        coins.map((c) => c.id),
-        dataLoadStartDate,
-        dataLoadEndDate
-      );
-    }
-
-    if (historicalPrices.length === 0) {
-      throw new Error('No historical price data available for the specified date range');
-    }
-
-    const pricesByTimestamp = this.priceWindow.groupPricesByTimestamp(historicalPrices);
-    const timestamps = Object.keys(pricesByTimestamp).sort();
-    const priceCtx = this.priceWindow.initPriceTracking(
-      historicalPrices,
-      coins.map((c) => c.id)
-    );
-
-    // Drop reference to the full candles array
-    historicalPrices = [];
-
-    // Pre-load delisting dates for survivorship bias correction
-    const delistingDates =
-      options.enableDelistingExit !== false
-        ? await this.coinListingEventService.getActiveDelistingsAsOf(
-            coins.map((c) => c.id),
-            tradingEndDate
-          )
-        : new Map<string, Date>();
-
-    if (delistingDates.size > 0) {
-      this.logger.log(
-        `Loaded ${delistingDates.size} delisting events for forced-exit simulation` +
-          (isLiveReplay ? ' (live-replay)' : '')
-      );
-    }
-
-    // Calculate warmup vs trading boundaries
-    const tradingStartIndex = timestamps.findIndex((ts) => new Date(ts) >= tradingStartDate);
-    const tradingEndIdx = (() => {
-      let lastIdx = timestamps.length - 1;
-      while (lastIdx >= 0 && new Date(timestamps[lastIdx]) > tradingEndDate) lastIdx--;
-      return lastIdx;
-    })();
-    const effectiveTradingStartIndex = tradingStartIndex >= 0 ? tradingStartIndex : 0;
-    const effectiveTimestampCount = tradingEndIdx + 1;
-    const tradingTimestampCount = effectiveTimestampCount - effectiveTradingStartIndex;
-
-    this.logger.log(
-      `Processing ${timestamps.length} time periods` +
-        (isLiveReplay ? ` with ${delayMs}ms delay` : '') +
-        ` (warmup: ${effectiveTradingStartIndex}, trading: ${tradingTimestampCount})`
-    );
-
-    // Build slippage config from backtest configSnapshot
-    const slippageSnapshot = backtest.configSnapshot?.slippage;
-    const slippageModel = slippageSnapshot
-      ? this.compositeRegimeSvc.mapSlippageModelType(slippageSnapshot.model as string)
-      : SlippageModelType.FIXED;
-    const riskDefaults =
-      slippageModel === SlippageModelType.VOLUME_BASED
-        ? this.slippageCtxSvc.getParticipationDefaults(backtest.configSnapshot?.regime?.riskLevel ?? 3)
-        : undefined;
-    const slippageConfig = slippageSnapshot
-      ? this.slippageService.buildConfig({
-          type: slippageModel,
-          fixedBps: slippageSnapshot.fixedBps ?? 5,
-          baseSlippageBps: slippageSnapshot.baseSlippageBps ?? 5,
-          participationRateLimit: slippageSnapshot.participationRateLimit ?? riskDefaults?.participationRateLimit,
-          rejectParticipationRate: slippageSnapshot.rejectParticipationRate ?? riskDefaults?.rejectParticipationRate,
-          volatilityFactor: slippageSnapshot.volatilityFactor,
-          spreadCalibrationFactor: slippageSnapshot.spreadCalibrationFactor ?? 1.0,
-          minSpreadBps: slippageSnapshot.minSpreadBps ?? 2
-        })
-      : DEFAULT_SLIPPAGE_CONFIG;
-
-    // Minimum hold period
-    const minHoldMs = options.minHoldMs ?? BacktestLoopRunner.DEFAULT_MIN_HOLD_MS;
-
-    // Position sizing
-    const defaultStage = isLiveReplay ? PipelineStage.LIVE_REPLAY : PipelineStage.HISTORICAL;
-    const allocLimits = getAllocationLimits(options.pipelineStage ?? defaultStage, options.riskLevel, {
-      maxAllocation: options.maxAllocation,
-      minAllocation: options.minAllocation
-    });
-
-    // Exit tracker
-    const enableHardStopLoss = options.enableHardStopLoss !== false;
-    const hardStopLossPercent = options.hardStopLossPercent ?? 0.05;
-    const exitTracker = this.exitSignalProcessorSvc.resolveExitTracker({
-      exitConfig: options.exitConfig,
-      enableHardStopLoss,
-      hardStopLossPercent,
-      resumeExitTrackerState: isResuming ? options.resumeFrom?.exitTrackerState : undefined
-    });
-
-    // Opportunity selling config (historical only)
-    const oppSellingEnabled = !isLiveReplay && ((options as ExecuteOptions).enableOpportunitySelling ?? false);
-    const oppSellingConfig = (options as ExecuteOptions).opportunitySellingConfig ?? DEFAULT_OPPORTUNITY_SELLING_CONFIG;
-
-    // Regime config
-    const regimeConfig = this.compositeRegimeSvc.resolveRegimeConfig(options, coins);
-
-    // Signal throttle
-    const throttleConfig = this.signalThrottle.resolveConfig(
-      backtest.configSnapshot?.parameters as Record<string, unknown> | undefined
-    );
-    const throttleState =
-      isResuming && options.resumeFrom?.throttleState
-        ? this.signalThrottle.deserialize(options.resumeFrom.throttleState)
-        : this.signalThrottle.createState();
-
-    // Determine starting index
-    const startIndex = isResuming && options.resumeFrom ? options.resumeFrom.lastProcessedIndex + 1 : 0;
-
-    // Algorithm context metadata
-    const algoMetadata = isLiveReplay
-      ? {
-          datasetId: options.dataset.id,
-          deterministicSeed: options.deterministicSeed,
-          backtestId: backtest.id,
-          isLiveReplay: true,
-          replaySpeed
-        }
-      : {
-          datasetId: options.dataset.id,
-          deterministicSeed: options.deterministicSeed,
-          backtestId: backtest.id
-        };
-
-    // Build context via factory
-    const ctx = LoopContext.create({
-      isLiveReplay,
-      liveReplayOpts,
-      checkpointInterval,
-      delayMs,
-      slippageConfig,
-      minHoldMs,
-      maxAllocation: allocLimits.maxAllocation,
-      minAllocation: allocLimits.minAllocation,
-      oppSellingEnabled,
-      oppSellingConfig,
-      algoMetadata,
-      replaySpeed,
-      enableRegimeScaledSizing: regimeConfig.enableRegimeScaledSizing,
-      riskLevel: regimeConfig.riskLevel,
-      regimeGateEnabled: regimeConfig.regimeGateEnabled,
-      btcCoin: regimeConfig.btcCoin,
-      rng,
-      portfolio,
-      peakValue,
-      maxDrawdown,
-      exitTracker,
-      throttleState,
-      throttleConfig,
-      totalPersistedCounts,
-      metricsAcc,
-      lastCheckpointCounts:
-        isResuming && options.resumeFrom
-          ? { ...options.resumeFrom.persistedCounts }
-          : { trades: 0, signals: 0, fills: 0, snapshots: 0, sells: 0, winningSells: 0, grossProfit: 0, grossLoss: 0 },
-      lastCheckpointIndex: startIndex - 1,
-      watchdog: new AlgorithmWatchdog(BacktestLoopRunner.ALGORITHM_STALL_TIMEOUT_MS),
-      backtest,
-      coins,
-      coinMap,
-      quoteCoin,
-      priceCtx,
-      pricesByTimestamp,
-      timestamps,
-      delistingDates,
-      effectiveTradingStartIndex,
-      effectiveTimestampCount,
-      tradingTimestampCount,
-      options
-    });
-
-    // Initialize incremental SMA for BTC regime detection
-    if (ctx.btcCoin) {
-      ctx.priceCtx.btcRegimeSma = new IncrementalSma(BacktestLoopRunner.REGIME_SMA_PERIOD);
-      ctx.priceCtx.btcCoinId = ctx.btcCoin.id;
-    }
-
-    if (isResuming) {
-      this.logger.log(
-        `Resuming from index ${startIndex} of ${effectiveTimestampCount} (${((startIndex / effectiveTimestampCount) * 100).toFixed(1)}% complete)`
-      );
-
-      // Fast-forward price windows to the resume point
-      if (startIndex > 0) {
-        for (let j = 0; j < startIndex; j++) {
-          this.priceWindow.advancePriceWindows(ctx.priceCtx, coins, new Date(timestamps[j]));
-        }
-        this.logger.log(`Fast-forwarded price windows through ${startIndex} timestamps for resume`);
-      }
-    }
-
-    return ctx;
   }
 
   /**
@@ -507,26 +160,5 @@ export class BacktestLoopRunner {
       snapshots: ctx.snapshots,
       finalMetrics
     };
-  }
-
-  // ---- Private utility methods ----
-
-  private async getHistoricalPrices(coinIds: string[], startDate: Date, endDate: Date): Promise<OHLCCandle[]> {
-    return this.ohlcService.getCandlesByDateRange(coinIds, startDate, endDate);
-  }
-
-  private convertOHLCVToCandles(ohlcvData: OHLCVData[]): OHLCCandle[] {
-    return ohlcvData.map(
-      (data) =>
-        new OHLCCandle({
-          coinId: data.coinId,
-          timestamp: data.timestamp,
-          open: data.open,
-          high: data.high,
-          low: data.low,
-          close: data.close,
-          volume: data.volume
-        })
-    );
   }
 }

--- a/apps/api/src/order/backtest/shared/execution/backtest-signal-trade.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/backtest-signal-trade.service.ts
@@ -54,22 +54,23 @@ export class BacktestSignalTradeService {
     };
     ctx.signals.push(signalRecord);
 
-    const dailyVolume = this.slippageCtxSvc.extractDailyVolume(currentPrices, strategySignal.coinId);
-    const spreadCtx = this.slippageCtxSvc.buildSpreadContext(currentPrices, strategySignal.coinId, ctx.prevCandleMap);
+    const priceMap = new Map(currentPrices.map((c) => [c.coinId, c]));
+    const dailyVolume = this.slippageCtxSvc.extractDailyVolume(priceMap, strategySignal.coinId);
+    const spreadCtx = this.slippageCtxSvc.buildSpreadContext(priceMap, strategySignal.coinId, ctx.prevCandleMap);
 
-    let tradeResult = await this.tradeExecutor.executeTrade(
-      strategySignal,
-      ctx.portfolio,
+    let tradeResult = await this.tradeExecutor.executeTrade({
+      signal: strategySignal,
+      portfolio: ctx.portfolio,
       marketData,
-      ctx.backtest.tradingFee,
-      ctx.slippageConfig,
+      tradingFee: ctx.backtest.tradingFee,
+      slippageConfig: ctx.slippageConfig,
       dailyVolume,
-      ctx.minHoldMs,
-      barMaxAllocation,
-      barMinAllocation,
-      1,
-      spreadCtx
-    );
+      minHoldMs: ctx.minHoldMs,
+      maxAllocation: barMaxAllocation,
+      minAllocation: barMinAllocation,
+      defaultLeverage: 1,
+      spreadContext: spreadCtx
+    });
 
     // Opportunity selling: if BUY failed, attempt to sell positions to fund it
     if (!tradeResult && strategySignal.action === 'BUY' && ctx.oppSellingEnabled) {
@@ -96,19 +97,19 @@ export class BacktestSignalTradeService {
       );
 
       if (oppResult) {
-        tradeResult = await this.tradeExecutor.executeTrade(
-          strategySignal,
-          ctx.portfolio,
+        tradeResult = await this.tradeExecutor.executeTrade({
+          signal: strategySignal,
+          portfolio: ctx.portfolio,
           marketData,
-          ctx.backtest.tradingFee,
-          ctx.slippageConfig,
+          tradingFee: ctx.backtest.tradingFee,
+          slippageConfig: ctx.slippageConfig,
           dailyVolume,
-          ctx.minHoldMs,
-          barMaxAllocation,
-          barMinAllocation,
-          1,
-          spreadCtx
-        );
+          minHoldMs: ctx.minHoldMs,
+          maxAllocation: barMaxAllocation,
+          minAllocation: barMinAllocation,
+          defaultLeverage: 1,
+          spreadContext: spreadCtx
+        });
       }
     }
 

--- a/apps/api/src/order/backtest/shared/execution/forced-exit.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/forced-exit.service.ts
@@ -165,7 +165,7 @@ export class ForcedExitService {
 
     if (positionsToDelete.length > 0) {
       portfolio.totalValue =
-        portfolio.cashBalance + this.portfolioState.calculatePositionsValue(portfolio.positions, new Map());
+        portfolio.cashBalance + this.portfolioState.calculatePositionsValue(portfolio.positions, lastKnownPrices);
     }
 
     return delistingTrades;

--- a/apps/api/src/order/backtest/shared/execution/index.ts
+++ b/apps/api/src/order/backtest/shared/execution/index.ts
@@ -1,4 +1,5 @@
 export * from './backtest-bar-processor.service';
+export * from './backtest-context-factory.service';
 export * from './backtest-loop-context';
 export * from './backtest-loop-runner.service';
 export * from './backtest-signal-trade.service';

--- a/apps/api/src/order/backtest/shared/execution/trade-executor.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/execution/trade-executor.service.spec.ts
@@ -34,26 +34,26 @@ describe('TradeExecutorService', () => {
   describe('signal guards', () => {
     it('returns null for HOLD signal', async () => {
       const portfolio = createPortfolio();
-      const result = await service.executeTrade(
-        { action: 'HOLD', coinId: 'BTC', reason: 'neutral' },
+      const result = await service.executeTrade({
+        signal: { action: 'HOLD', coinId: 'BTC', reason: 'neutral' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
       expect(portfolio.cashBalance).toBe(10000);
     });
 
     it('returns null when no market price for coin', async () => {
       const portfolio = createPortfolio();
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        { timestamp: new Date(), prices: new Map() },
-        0,
-        noSlippage
-      );
+        marketData: { timestamp: new Date(), prices: new Map() },
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
       expect(portfolio.cashBalance).toBe(10000);
     });
@@ -62,13 +62,13 @@ describe('TradeExecutorService', () => {
   describe('BUY execution', () => {
     it('sizes position using confidence-based allocation', async () => {
       const portfolio = createPortfolio({ cashBalance: 1000, totalValue: 1000 });
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', confidence: 1.0, reason: 'strong entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', confidence: 1.0, reason: 'strong entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       // Default HISTORICAL risk-3 limits: max 12% of $1000 = $120 / $100 = 1.2 BTC
@@ -78,13 +78,13 @@ describe('TradeExecutorService', () => {
 
     it('sizes position using signal.percentage', async () => {
       const portfolio = createPortfolio({ cashBalance: 1000, totalValue: 1000 });
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', percentage: 0.1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', percentage: 0.1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result?.trade.quantity).toBeCloseTo(1); // 10% of $1000 / $100
       expect(result?.trade.totalValue).toBeCloseTo(100);
@@ -92,13 +92,13 @@ describe('TradeExecutorService', () => {
 
     it('falls back to minAllocation when no sizing info provided', async () => {
       const portfolio = createPortfolio({ cashBalance: 1000, totalValue: 1000 });
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       // minAllocation default 3% of $1000 = $30 / $100 = 0.3 BTC
@@ -107,13 +107,13 @@ describe('TradeExecutorService', () => {
 
     it('applies slippage to execution price and records metadata', async () => {
       const portfolio = createPortfolio({ cashBalance: 200, totalValue: 200 });
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0.01,
-        { type: SlippageModelType.FIXED, fixedBps: 100 }
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0.01,
+        slippageConfig: { type: SlippageModelType.FIXED, fixedBps: 100 }
+      });
 
       // 100 bps = 1% slippage → price 101 for buy
       expect(result?.trade.price).toBeCloseTo(101);
@@ -125,14 +125,14 @@ describe('TradeExecutorService', () => {
 
     it('handles partial fills with volume-based slippage', async () => {
       const portfolio = createPortfolio({ cashBalance: 10000, totalValue: 10000 });
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
-        50 // very low daily volume
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: { type: SlippageModelType.VOLUME_BASED, baseSlippageBps: 5 },
+        dailyVolume: 50 // very low daily volume
+      });
 
       expect(result).toBeTruthy();
       expect(result?.trade.quantity).toBeGreaterThan(0);
@@ -142,13 +142,13 @@ describe('TradeExecutorService', () => {
   describe('insufficient funds', () => {
     it('rejects BUY when cash cannot cover trade value plus fees', async () => {
       const portfolio = createPortfolio({ cashBalance: 100, totalValue: 100 });
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0.01, // 1% fee → need 101 total
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0.01, // 1% fee → need 101 total
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeNull();
       expect(portfolio.cashBalance).toBe(100);
@@ -156,13 +156,13 @@ describe('TradeExecutorService', () => {
 
     it('allows BUY when cash covers both trade value and fees', async () => {
       const portfolio = createPortfolio({ cashBalance: 101, totalValue: 101 });
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0.01,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0.01,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       expect(portfolio.cashBalance).toBeCloseTo(0);
@@ -180,25 +180,25 @@ describe('TradeExecutorService', () => {
       });
 
     it('returns null when no existing position', async () => {
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', reason: 'exit' },
-        createPortfolio(),
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', reason: 'exit' },
+        portfolio: createPortfolio(),
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
     });
 
     it('calculates realized P&L correctly', async () => {
       const portfolio = createLongPortfolio(10, 10);
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', quantity: 4, reason: 'take-profit', confidence: 1 },
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', quantity: 4, reason: 'take-profit', confidence: 1 },
         portfolio,
-        createMarketData('BTC', 15),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 15),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       expect(result?.trade.realizedPnL).toBeCloseTo(20); // (15 - 10) * 4
@@ -214,13 +214,13 @@ describe('TradeExecutorService', () => {
         positions: new Map([['BTC', { coinId: 'BTC', quantity: 1, averagePrice: 100, totalValue: 100 }]])
       });
 
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', quantity: 1, reason: 'exit' },
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', quantity: 1, reason: 'exit' },
         portfolio,
-        createMarketData('BTC', 200),
-        0.01,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 200),
+        tradingFee: 0.01,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       expect(portfolio.cashBalance).toBeCloseTo(198); // 200 proceeds - 2 fee
@@ -229,26 +229,26 @@ describe('TradeExecutorService', () => {
 
     it('uses signal.percentage for partial sell', async () => {
       const portfolio = createLongPortfolio(10, 100);
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', percentage: 0.5, reason: 'partial exit' },
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', percentage: 0.5, reason: 'partial exit' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result?.trade.quantity).toBeCloseTo(5); // 50% of 10
     });
 
     it('removes position from portfolio when fully sold', async () => {
       const portfolio = createLongPortfolio(5, 100);
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', quantity: 5, reason: 'exit' },
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', quantity: 5, reason: 'exit' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       expect(portfolio.positions.has('BTC')).toBe(false);
@@ -267,15 +267,14 @@ describe('TradeExecutorService', () => {
 
     it('rejects SELL when position held less than minHoldMs', async () => {
       const portfolio = createHeldPortfolio();
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', quantity: 5, reason: 'exit' },
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', quantity: 5, reason: 'exit' },
         portfolio,
-        createMarketData('BTC', 120, new Date('2024-01-01T12:00:00.000Z')), // 12h after entry
-        0,
-        noSlippage,
-        undefined,
-        TWENTY_FOUR_HOURS_MS
-      );
+        marketData: createMarketData('BTC', 120, new Date('2024-01-01T12:00:00.000Z')), // 12h after entry
+        tradingFee: 0,
+        slippageConfig: noSlippage,
+        minHoldMs: TWENTY_FOUR_HOURS_MS
+      });
 
       expect(result).toBeNull();
       expect(portfolio.positions.get('BTC')?.quantity).toBe(10);
@@ -286,15 +285,14 @@ describe('TradeExecutorService', () => {
       { type: SignalType.TAKE_PROFIT, label: 'TAKE_PROFIT' }
     ])('allows $label SELL even within min hold period', async ({ type }) => {
       const portfolio = createHeldPortfolio();
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', quantity: 10, reason: 'risk exit', originalType: type },
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', quantity: 10, reason: 'risk exit', originalType: type },
         portfolio,
-        createMarketData('BTC', 80, new Date('2024-01-01T01:00:00.000Z')), // 1h after entry
-        0,
-        noSlippage,
-        undefined,
-        TWENTY_FOUR_HOURS_MS
-      );
+        marketData: createMarketData('BTC', 80, new Date('2024-01-01T01:00:00.000Z')), // 1h after entry
+        tradingFee: 0,
+        slippageConfig: noSlippage,
+        minHoldMs: TWENTY_FOUR_HOURS_MS
+      });
 
       expect(result).toBeTruthy();
       expect(result?.trade.quantity).toBe(10);
@@ -302,15 +300,14 @@ describe('TradeExecutorService', () => {
 
     it('allows SELL after min hold period has elapsed', async () => {
       const portfolio = createHeldPortfolio();
-      const result = await service.executeTrade(
-        { action: 'SELL', coinId: 'BTC', quantity: 5, reason: 'exit' },
+      const result = await service.executeTrade({
+        signal: { action: 'SELL', coinId: 'BTC', quantity: 5, reason: 'exit' },
         portfolio,
-        createMarketData('BTC', 120, new Date('2024-01-02T01:00:00.000Z')), // 25h after entry
-        0,
-        noSlippage,
-        undefined,
-        TWENTY_FOUR_HOURS_MS
-      );
+        marketData: createMarketData('BTC', 120, new Date('2024-01-02T01:00:00.000Z')), // 25h after entry
+        tradingFee: 0,
+        slippageConfig: noSlippage,
+        minHoldMs: TWENTY_FOUR_HOURS_MS
+      });
 
       expect(result).toBeTruthy();
       expect(result?.trade.quantity).toBe(5);
@@ -323,13 +320,13 @@ describe('TradeExecutorService', () => {
         positions: new Map([['BTC', { coinId: 'BTC', quantity: 1, averagePrice: 100, totalValue: 100 }]])
       });
 
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
     });
 
@@ -338,13 +335,13 @@ describe('TradeExecutorService', () => {
         positions: new Map([['BTC', { coinId: 'BTC', quantity: 1, averagePrice: 100, totalValue: 100, side: 'short' }]])
       });
 
-      const result = await service.executeTrade(
-        { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'BUY', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
     });
 
@@ -353,13 +350,13 @@ describe('TradeExecutorService', () => {
         positions: new Map([['BTC', { coinId: 'BTC', quantity: 1, averagePrice: 100, totalValue: 100 }]])
       });
 
-      const result = await service.executeTrade(
-        { action: 'OPEN_SHORT', coinId: 'BTC', quantity: 1, reason: 'entry' },
+      const result = await service.executeTrade({
+        signal: { action: 'OPEN_SHORT', coinId: 'BTC', quantity: 1, reason: 'entry' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
     });
   });
@@ -367,18 +364,14 @@ describe('TradeExecutorService', () => {
   describe('OPEN_SHORT execution', () => {
     it('opens short position with correct margin, leverage, and liquidation price', async () => {
       const portfolio = createPortfolio({ cashBalance: 5000, totalValue: 5000 });
-      const result = await service.executeTrade(
-        { action: 'OPEN_SHORT', coinId: 'BTC', quantity: 2, reason: 'bearish signal' },
+      const result = await service.executeTrade({
+        signal: { action: 'OPEN_SHORT', coinId: 'BTC', quantity: 2, reason: 'bearish signal' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        2 // 2x leverage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage,
+        defaultLeverage: 2 // 2x leverage
+      });
 
       expect(result).toBeTruthy();
       expect(result?.trade.quantity).toBe(2);
@@ -398,18 +391,14 @@ describe('TradeExecutorService', () => {
 
     it('rejects OPEN_SHORT when cash cannot cover margin plus fees', async () => {
       const portfolio = createPortfolio({ cashBalance: 50, totalValue: 50 });
-      const result = await service.executeTrade(
-        { action: 'OPEN_SHORT', coinId: 'BTC', quantity: 2, reason: 'bearish' },
+      const result = await service.executeTrade({
+        signal: { action: 'OPEN_SHORT', coinId: 'BTC', quantity: 2, reason: 'bearish' },
         portfolio,
-        createMarketData('BTC', 100),
-        0.01, // 1% fee on notional (200) = 2
-        noSlippage,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        1 // 1x leverage → margin = 200
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0.01, // 1% fee on notional (200) = 2
+        slippageConfig: noSlippage,
+        defaultLeverage: 1 // 1x leverage → margin = 200
+      });
 
       expect(result).toBeNull();
       expect(portfolio.cashBalance).toBe(50);
@@ -444,13 +433,13 @@ describe('TradeExecutorService', () => {
     };
 
     it('returns null when no short position exists', async () => {
-      const result = await service.executeTrade(
-        { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 1, reason: 'exit' },
-        createPortfolio(),
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+      const result = await service.executeTrade({
+        signal: { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 1, reason: 'exit' },
+        portfolio: createPortfolio(),
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
     });
 
@@ -458,26 +447,26 @@ describe('TradeExecutorService', () => {
       const portfolio = createPortfolio({
         positions: new Map([['BTC', { coinId: 'BTC', quantity: 1, averagePrice: 100, totalValue: 100 }]])
       });
-      const result = await service.executeTrade(
-        { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 1, reason: 'exit' },
+      const result = await service.executeTrade({
+        signal: { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 1, reason: 'exit' },
         portfolio,
-        createMarketData('BTC', 100),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 100),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
       expect(result).toBeNull();
     });
 
     it('closes profitable short and returns margin with P&L', async () => {
       const portfolio = createShortPortfolio(10, 100, 2);
       // Short at 100, close at 80 → profit = (100-80)*qty
-      const result = await service.executeTrade(
-        { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 10, reason: 'take profit' },
+      const result = await service.executeTrade({
+        signal: { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 10, reason: 'take profit' },
         portfolio,
-        createMarketData('BTC', 80),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 80),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       expect(result?.trade.quantity).toBe(10);
@@ -493,13 +482,13 @@ describe('TradeExecutorService', () => {
 
     it('partially closes short and updates remaining margin', async () => {
       const portfolio = createShortPortfolio(10, 100, 2);
-      const result = await service.executeTrade(
-        { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 4, reason: 'partial exit' },
+      const result = await service.executeTrade({
+        signal: { action: 'CLOSE_SHORT', coinId: 'BTC', quantity: 4, reason: 'partial exit' },
         portfolio,
-        createMarketData('BTC', 90),
-        0,
-        noSlippage
-      );
+        marketData: createMarketData('BTC', 90),
+        tradingFee: 0,
+        slippageConfig: noSlippage
+      });
 
       expect(result).toBeTruthy();
       expect(result?.trade.quantity).toBe(4);

--- a/apps/api/src/order/backtest/shared/execution/trade-executor.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/trade-executor.service.ts
@@ -30,7 +30,7 @@ import { FeeCalculatorService } from '../fees';
 import { Portfolio, PortfolioStateService } from '../portfolio';
 import { Position } from '../positions';
 import { DEFAULT_SLIPPAGE_CONFIG, SlippageConfig, SlippageService, SpreadEstimationContext } from '../slippage';
-import { MarketData, TradingSignal } from '../types';
+import { ExecuteTradeParams, TradingSignal } from '../types';
 
 /**
  * Trade Executor Service
@@ -61,22 +61,23 @@ export class TradeExecutorService {
    * Mutates the portfolio in-place (cash balance, positions, margin tracking).
    * Returns null if the trade cannot be executed (HOLD, no price, insufficient funds, etc.).
    */
-  async executeTrade(
-    signal: TradingSignal,
-    portfolio: Portfolio,
-    marketData: MarketData,
-    tradingFee: number,
-    slippageConfig: SlippageConfig = DEFAULT_SLIPPAGE_CONFIG,
-    dailyVolume?: number,
-    minHoldMs: number = DEFAULT_MIN_HOLD_MS,
-    maxAllocation: number = getAllocationLimits().maxAllocation,
-    minAllocation: number = getAllocationLimits().minAllocation,
-    defaultLeverage = 1,
-    spreadContext?: SpreadEstimationContext
-  ): Promise<ExecuteTradeResult | null> {
+  async executeTrade(params: ExecuteTradeParams): Promise<ExecuteTradeResult | null> {
+    const {
+      signal,
+      portfolio,
+      marketData,
+      tradingFee,
+      slippageConfig = DEFAULT_SLIPPAGE_CONFIG,
+      dailyVolume,
+      minHoldMs = DEFAULT_MIN_HOLD_MS,
+      maxAllocation = getAllocationLimits().maxAllocation,
+      minAllocation = getAllocationLimits().minAllocation,
+      defaultLeverage = 1,
+      spreadContext
+    } = params;
     const marketPrice = marketData.prices.get(signal.coinId);
     if (!marketPrice) {
-      this.logger.warn(`No price data available for coin ${signal.coinId}`);
+      this.logger.debug(`No price data available for coin ${signal.coinId}`);
       return null;
     }
 

--- a/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.ts
+++ b/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import { Decimal } from 'decimal.js';
+
 import { SignalType as AlgoSignalType } from '../../../../algorithm/interfaces';
 import { Coin } from '../../../../coin/coin.entity';
 import { OHLCCandle } from '../../../../ohlc/ohlc-candle.entity';
@@ -107,6 +109,7 @@ export class ExitSignalProcessorService {
 
     if (exitTracker.size === 0) return;
 
+    const priceMap = new Map(currentPrices.map((c) => [c.coinId, c]));
     const lowPrices = new Map(currentPrices.map((c) => [c.coinId, c.low]));
     const highPrices = new Map(currentPrices.map((c) => [c.coinId, c.high]));
     const exitSignals = exitTracker.checkExits(marketData.prices, lowPrices, highPrices);
@@ -139,23 +142,23 @@ export class ExitSignalProcessorService {
         });
       }
 
-      const dailyVolume = fullFidelity ? callbacks.extractDailyVolumeFn(currentPrices, exitSig.coinId) : undefined;
+      const dailyVolume = fullFidelity ? callbacks.extractDailyVolumeFn(priceMap, exitSig.coinId) : undefined;
       const spreadCtx = opts.prevCandleMap
-        ? callbacks.buildSpreadContextFn(currentPrices, exitSig.coinId, opts.prevCandleMap)
+        ? callbacks.buildSpreadContextFn(priceMap, exitSig.coinId, opts.prevCandleMap)
         : undefined;
-      const tradeResult = await callbacks.executeTradeFn(
-        exitTradingSignal,
+      const tradeResult = await callbacks.executeTradeFn({
+        signal: exitTradingSignal,
         portfolio,
         marketData,
         tradingFee,
-        opts.slippageConfig ?? DEFAULT_SLIPPAGE_CONFIG,
+        slippageConfig: opts.slippageConfig ?? DEFAULT_SLIPPAGE_CONFIG,
         dailyVolume,
-        0, // bypass hold period for risk-control exits
-        opts.maxAllocation,
-        opts.minAllocation,
-        1,
-        spreadCtx
-      );
+        minHoldMs: 0, // bypass hold period for risk-control exits
+        maxAllocation: opts.maxAllocation,
+        minAllocation: opts.minAllocation,
+        defaultLeverage: 1,
+        spreadContext: spreadCtx
+      });
 
       if (tradeResult) {
         const { trade, slippageBps, fillStatus } = tradeResult;
@@ -220,7 +223,7 @@ export class ExitSignalProcessorService {
       const price = prices.get(coinId) ?? 0;
       holdings[coinId] = {
         quantity: position.quantity,
-        value: position.quantity * price,
+        value: new Decimal(position.quantity).times(price).toNumber(),
         price
       };
     }

--- a/apps/api/src/order/backtest/shared/index.ts
+++ b/apps/api/src/order/backtest/shared/index.ts
@@ -2,6 +2,7 @@ export * from './checkpoint';
 // Named exports to avoid collision with order/services/ (e.g. OpportunitySellService, TradeExecutorService)
 export {
   BacktestBarProcessor,
+  BacktestContextFactory,
   BacktestLoopRunner,
   BacktestSignalTradeService,
   ExecuteOptions,

--- a/apps/api/src/order/backtest/shared/metrics-accumulator/metrics-accumulator.service.ts
+++ b/apps/api/src/order/backtest/shared/metrics-accumulator/metrics-accumulator.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import * as dayjs from 'dayjs';
+import { Decimal } from 'decimal.js';
 
 import { BacktestPerformanceSnapshot } from '../../backtest-performance-snapshot.entity';
 import { BacktestFinalMetrics } from '../../backtest-result.service';
@@ -135,10 +136,13 @@ export class MetricsAccumulatorService {
     grossLoss: number
   ): BacktestFinalMetrics {
     const finalValue = portfolio.totalValue;
-    const totalReturn = (finalValue - initialCapital) / initialCapital;
+    const totalReturn = new Decimal(finalValue).minus(initialCapital).dividedBy(initialCapital).toNumber();
 
     const durationDays = dayjs(endDate).diff(dayjs(startDate), 'day');
-    const annualizedReturn = durationDays > 0 ? Math.pow(1 + totalReturn, 365 / durationDays) - 1 : totalReturn;
+    const annualizedReturn =
+      durationDays > 0
+        ? new Decimal(1).plus(totalReturn).pow(new Decimal(365).dividedBy(durationDays)).minus(1).toNumber()
+        : totalReturn;
 
     // Calculate Sharpe ratio from lightweight portfolio value array
     const returns: number[] = [];

--- a/apps/api/src/order/backtest/shared/opportunity-selling/opportunity-sell.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/opportunity-selling/opportunity-sell.service.spec.ts
@@ -469,7 +469,8 @@ describe('OpportunitySellService', () => {
       const trades: Partial<BacktestTrade>[] = [];
       const fills: Partial<SimulatedOrderFill>[] = [];
 
-      const mockExecuteTrade = jest.fn().mockImplementation((signal: TradingSignal) => {
+      const mockExecuteTrade = jest.fn().mockImplementation((params: { signal: TradingSignal }) => {
+        const { signal } = params;
         const price = signal.coinId === 'coin-a' ? 300 : signal.coinId === 'coin-b' ? 400 : 500;
         return Promise.resolve({
           trade: { quantity: signal.quantity, price, fee: 0, metadata: {} },

--- a/apps/api/src/order/backtest/shared/opportunity-selling/opportunity-sell.service.ts
+++ b/apps/api/src/order/backtest/shared/opportunity-selling/opportunity-sell.service.ts
@@ -203,6 +203,8 @@ export class OpportunitySellService {
     let totalSellValue = 0;
     let sellExecuted = false;
 
+    const priceMap = currentPrices ? new Map(currentPrices.map((c) => [c.coinId, c])) : undefined;
+
     for (const candidate of candidates) {
       if (remainingShortfall <= 0 || totalSellValue >= maxSellValue) break;
 
@@ -232,24 +234,20 @@ export class OpportunitySellService {
 
       // Use minHoldMs=0 so the sell isn't blocked by hold period (already checked by scoring)
       const spreadCtx =
-        currentPrices && prevCandleMap
-          ? buildSpreadContextFn(currentPrices, candidate.coinId, prevCandleMap)
-          : undefined;
+        priceMap && prevCandleMap ? buildSpreadContextFn(priceMap, candidate.coinId, prevCandleMap) : undefined;
       const candidateDailyVolume =
-        extractDailyVolumeFn && currentPrices ? extractDailyVolumeFn(currentPrices, candidate.coinId) : undefined;
-      const sellResult = await executeTradeFn(
-        sellSignal,
+        extractDailyVolumeFn && priceMap ? extractDailyVolumeFn(priceMap, candidate.coinId) : undefined;
+      const sellResult = await executeTradeFn({
+        signal: sellSignal,
         portfolio,
         marketData,
         tradingFee,
         slippageConfig,
-        candidateDailyVolume,
-        0,
-        undefined,
-        undefined,
-        1,
-        spreadCtx
-      );
+        dailyVolume: candidateDailyVolume,
+        minHoldMs: 0,
+        defaultLeverage: 1,
+        spreadContext: spreadCtx
+      });
       if (sellResult) {
         const { trade, slippageBps, fillStatus } = sellResult;
         if (fillStatus === SimulatedOrderStatus.CANCELLED) {
@@ -286,8 +284,12 @@ export class OpportunitySellService {
             backtest
           });
 
-          totalSellValue += (trade.quantity ?? 0) * (trade.price ?? 0);
-          remainingShortfall -= (trade.quantity ?? 0) * (trade.price ?? 0);
+          if (trade.price == null || trade.quantity == null) {
+            this.logger.warn(`Trade result missing price/quantity for ${candidate.coinId}`);
+            continue;
+          }
+          totalSellValue += trade.quantity * trade.price;
+          remainingShortfall -= trade.quantity * trade.price;
           sellExecuted = true;
         }
       }

--- a/apps/api/src/order/backtest/shared/optimization/optimization-core.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/optimization/optimization-core.service.spec.ts
@@ -260,11 +260,11 @@ describe('OptimizationCoreService', () => {
         executeTradeFn
       });
 
-      // The executeTradeFn should receive the quoteVolume (55000) as the dailyVolume arg (6th position)
+      // The executeTradeFn should receive the quoteVolume (55000) as dailyVolume in the params object
       expect(executeTradeFn).toHaveBeenCalled();
-      const callArgs = executeTradeFn.mock.calls[0];
-      expect(callArgs[0]).toEqual(expect.objectContaining({ coinId: 'coin-1' }));
-      expect(callArgs[5]).toBe(55000); // dailyVolume from volumeMap using quoteVolume
+      const params = executeTradeFn.mock.calls[0][0];
+      expect(params.signal).toEqual(expect.objectContaining({ coinId: 'coin-1' }));
+      expect(params.dailyVolume).toBe(55000); // dailyVolume from volumeMap using quoteVolume
     });
   });
 

--- a/apps/api/src/order/backtest/shared/optimization/optimization-core.service.ts
+++ b/apps/api/src/order/backtest/shared/optimization/optimization-core.service.ts
@@ -327,6 +327,9 @@ export class OptimizationCoreService {
     // Reusable price map to avoid new Map() allocation per iteration
     const currentPriceMap = new Map<string, number>();
 
+    // Reusable candle map to avoid new Map() allocation per iteration
+    const candleMap = new Map<string, OHLCCandle>();
+
     // Track previous candle per coin for spread estimation context
     const prevCandleMap = new Map<string, OHLCCandle>();
 
@@ -342,8 +345,10 @@ export class OptimizationCoreService {
       const currentPrices = pricesByTimestamp[timestamps[i]];
 
       currentPriceMap.clear();
+      candleMap.clear();
       for (const price of currentPrices) {
         currentPriceMap.set(price.coinId, this.priceWindowService.getPriceValue(price));
+        candleMap.set(price.coinId, price);
       }
 
       const marketData: MarketData = {
@@ -446,24 +451,24 @@ export class OptimizationCoreService {
       for (const strategySignal of strategySignals) {
         const dailyVolume = volumeMap.get(`${timestamps[i]}:${strategySignal.coinId}`);
         const spreadCtx = this.slippageContextService.buildSpreadContext(
-          currentPrices,
+          candleMap,
           strategySignal.coinId,
           prevCandleMap
         );
 
-        const tradeResult = await executeTradeFn(
-          strategySignal,
+        const tradeResult = await executeTradeFn({
+          signal: strategySignal,
           portfolio,
           marketData,
           tradingFee,
           slippageConfig,
           dailyVolume,
-          DEFAULT_MIN_HOLD_MS,
-          optMaxAllocation,
-          optMinAllocation,
-          1,
-          spreadCtx
-        );
+          minHoldMs: DEFAULT_MIN_HOLD_MS,
+          maxAllocation: optMaxAllocation,
+          minAllocation: optMinAllocation,
+          defaultLeverage: 1,
+          spreadContext: spreadCtx
+        });
         if (tradeResult && tradeResult.fillStatus !== SimulatedOrderStatus.CANCELLED) {
           trades.push({ ...tradeResult.trade, executedAt: timestamp });
           if (exitTracker && tradeResult.trade.price != null && tradeResult.trade.quantity != null) {

--- a/apps/api/src/order/backtest/shared/price-window/price-window.service.ts
+++ b/apps/api/src/order/backtest/shared/price-window/price-window.service.ts
@@ -41,33 +41,11 @@ export class PriceWindowService {
   }
 
   initPriceTracking(historicalPrices: OHLCCandle[], coinIds: string[]): PriceTrackingContext {
-    const timestampsByCoin = new Map<string, Date[]>();
-    const summariesByCoin = new Map<string, PriceSummary[]>();
+    const { timestampsByCoin, summariesByCoin } = this.groupAndSortByCoins(historicalPrices, coinIds);
     const indexByCoin = new Map<string, number>();
     const windowsByCoin = new Map<string, RingBuffer<PriceSummary>>();
 
-    const pricesByCoin = new Map<string, OHLCCandle[]>();
-    for (const candle of historicalPrices) {
-      let group = pricesByCoin.get(candle.coinId);
-      if (!group) {
-        group = [];
-        pricesByCoin.set(candle.coinId, group);
-      }
-      group.push(candle);
-    }
-
     for (const coinId of coinIds) {
-      const history = (pricesByCoin.get(coinId) ?? []).sort(
-        (a, b) => this.getPriceTimestamp(a).getTime() - this.getPriceTimestamp(b).getTime()
-      );
-      timestampsByCoin.set(
-        coinId,
-        history.map((price) => this.getPriceTimestamp(price))
-      );
-      summariesByCoin.set(
-        coinId,
-        history.map((price) => this.buildPriceSummary(price))
-      );
       indexByCoin.set(coinId, -1);
       windowsByCoin.set(coinId, new RingBuffer<PriceSummary>(MAX_WINDOW_SIZE));
     }
@@ -76,6 +54,13 @@ export class PriceWindowService {
   }
 
   buildImmutablePriceData(historicalPrices: OHLCCandle[], coinIds: string[]): ImmutablePriceTrackingData {
+    return this.groupAndSortByCoins(historicalPrices, coinIds);
+  }
+
+  private groupAndSortByCoins(
+    historicalPrices: OHLCCandle[],
+    coinIds: string[]
+  ): { timestampsByCoin: Map<string, Date[]>; summariesByCoin: Map<string, PriceSummary[]> } {
     const timestampsByCoin = new Map<string, Date[]>();
     const summariesByCoin = new Map<string, PriceSummary[]>();
 

--- a/apps/api/src/order/backtest/shared/regime/composite-regime.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/regime/composite-regime.service.spec.ts
@@ -11,7 +11,6 @@ import { IncrementalSma } from '../../incremental-sma';
 import { RingBuffer } from '../../ring-buffer';
 import { SignalFilterChainService } from '../filters';
 import { type PriceTrackingContext } from '../price-window';
-import { SlippageModelType } from '../slippage';
 import { type MarketData, type TradingSignal } from '../types';
 
 describe('CompositeRegimeService', () => {
@@ -56,26 +55,6 @@ describe('CompositeRegimeService', () => {
     regimeGateService = module.get(RegimeGateService);
     volatilityCalculator = module.get(VolatilityCalculator);
     signalFilterChain = module.get(SignalFilterChainService);
-  });
-
-  describe('mapSlippageModelType', () => {
-    it.each([
-      ['none', SlippageModelType.NONE],
-      ['volume-based', SlippageModelType.VOLUME_BASED],
-      ['historical', SlippageModelType.HISTORICAL],
-      ['spread-adjusted', SlippageModelType.SPREAD_ADJUSTED],
-      ['fixed', SlippageModelType.FIXED]
-    ])('should map "%s" to %s', (input, expected) => {
-      expect(service.mapSlippageModelType(input)).toBe(expected);
-    });
-
-    it('should default to FIXED for undefined', () => {
-      expect(service.mapSlippageModelType(undefined)).toBe(SlippageModelType.FIXED);
-    });
-
-    it('should default to FIXED for unknown string', () => {
-      expect(service.mapSlippageModelType('unknown')).toBe(SlippageModelType.FIXED);
-    });
   });
 
   describe('computeCompositeRegime', () => {

--- a/apps/api/src/order/backtest/shared/regime/composite-regime.service.ts
+++ b/apps/api/src/order/backtest/shared/regime/composite-regime.service.ts
@@ -16,7 +16,6 @@ import { IncrementalSma } from '../../incremental-sma';
 import { SignalFilterChainService, SignalFilterContext } from '../filters';
 import { Portfolio } from '../portfolio';
 import { PriceTrackingContext } from '../price-window';
-import { SlippageModelType } from '../slippage';
 import { MarketData, TradingSignal } from '../types';
 
 /** SMA period used for BTC trend detection in regime classification. */
@@ -37,25 +36,6 @@ export class CompositeRegimeService {
     private readonly volatilityCalculator: VolatilityCalculator,
     private readonly signalFilterChain: SignalFilterChainService
   ) {}
-
-  /**
-   * Map legacy slippage model type string to shared enum
-   */
-  mapSlippageModelType(model?: string): SlippageModelType {
-    switch (model) {
-      case 'none':
-        return SlippageModelType.NONE;
-      case 'volume-based':
-        return SlippageModelType.VOLUME_BASED;
-      case 'historical':
-        return SlippageModelType.HISTORICAL;
-      case 'spread-adjusted':
-        return SlippageModelType.SPREAD_ADJUSTED;
-      case 'fixed':
-      default:
-        return SlippageModelType.FIXED;
-    }
-  }
 
   /**
    * Compute the composite regime (trend + volatility) from BTC price data.

--- a/apps/api/src/order/backtest/shared/slippage-context/slippage-context.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/slippage-context/slippage-context.service.spec.ts
@@ -26,48 +26,50 @@ describe('SlippageContextService', () => {
     } as OHLCCandle;
   };
 
+  const toMap = (candles: OHLCCandle[]): Map<string, OHLCCandle> => new Map(candles.map((c) => [c.coinId, c]));
+
   describe('extractDailyVolume', () => {
     it('should return quoteVolume when available', () => {
-      const candles = [makeCandle({ quoteVolume: 50000 })];
-      expect(service.extractDailyVolume(candles, 'coin-1')).toBe(50000);
+      const priceMap = toMap([makeCandle({ quoteVolume: 50000 })]);
+      expect(service.extractDailyVolume(priceMap, 'coin-1')).toBe(50000);
     });
 
     it('should return volume * close as fallback', () => {
-      const candles = [makeCandle({ quoteVolume: undefined, volume: 1000, close: 105 })];
-      expect(service.extractDailyVolume(candles, 'coin-1')).toBe(105000);
+      const priceMap = toMap([makeCandle({ quoteVolume: undefined, volume: 1000, close: 105 })]);
+      expect(service.extractDailyVolume(priceMap, 'coin-1')).toBe(105000);
     });
 
     it('should return undefined for missing coin', () => {
-      const candles = [makeCandle({ coinId: 'coin-1' })];
-      expect(service.extractDailyVolume(candles, 'coin-999')).toBeUndefined();
+      const priceMap = toMap([makeCandle({ coinId: 'coin-1' })]);
+      expect(service.extractDailyVolume(priceMap, 'coin-999')).toBeUndefined();
     });
   });
 
   describe('buildSpreadContext', () => {
     it('should return undefined when no candle found', () => {
-      const candles = [makeCandle({ coinId: 'coin-1' })];
+      const priceMap = toMap([makeCandle({ coinId: 'coin-1' })]);
       const prevMap = new Map<string, OHLCCandle>();
-      expect(service.buildSpreadContext(candles, 'coin-999', prevMap)).toBeUndefined();
+      expect(service.buildSpreadContext(priceMap, 'coin-999', prevMap)).toBeUndefined();
     });
 
     it('should return undefined for invalid OHLC data (high <= low)', () => {
-      const candles = [makeCandle({ high: 90, low: 90, close: 90 })];
+      const priceMap = toMap([makeCandle({ high: 90, low: 90, close: 90 })]);
       const prevMap = new Map<string, OHLCCandle>();
-      expect(service.buildSpreadContext(candles, 'coin-1', prevMap)).toBeUndefined();
+      expect(service.buildSpreadContext(priceMap, 'coin-1', prevMap)).toBeUndefined();
     });
 
     it('should return undefined when high is zero', () => {
-      const candles = [makeCandle({ high: 0, low: 0, close: 0 })];
+      const priceMap = toMap([makeCandle({ high: 0, low: 0, close: 0 })]);
       const prevMap = new Map<string, OHLCCandle>();
-      expect(service.buildSpreadContext(candles, 'coin-1', prevMap)).toBeUndefined();
+      expect(service.buildSpreadContext(priceMap, 'coin-1', prevMap)).toBeUndefined();
     });
 
     it('should include prevHigh/prevLow from previous candle', () => {
-      const candles = [makeCandle()];
+      const priceMap = toMap([makeCandle()]);
       const prevCandle = makeCandle({ high: 108, low: 88 });
       const prevMap = new Map<string, OHLCCandle>([['coin-1', prevCandle]]);
 
-      const result = service.buildSpreadContext(candles, 'coin-1', prevMap);
+      const result = service.buildSpreadContext(priceMap, 'coin-1', prevMap);
       expect(result).toEqual({
         high: 110,
         low: 90,
@@ -79,10 +81,10 @@ describe('SlippageContextService', () => {
     });
 
     it('should set prevHigh/prevLow to undefined when no previous candle', () => {
-      const candles = [makeCandle()];
+      const priceMap = toMap([makeCandle()]);
       const prevMap = new Map<string, OHLCCandle>();
 
-      const result = service.buildSpreadContext(candles, 'coin-1', prevMap);
+      const result = service.buildSpreadContext(priceMap, 'coin-1', prevMap);
       expect(result).toEqual({
         high: 110,
         low: 90,
@@ -94,21 +96,21 @@ describe('SlippageContextService', () => {
     });
 
     it('should set prevHigh to undefined when previous high is not finite', () => {
-      const candles = [makeCandle()];
+      const priceMap = toMap([makeCandle()]);
       const prevCandle = makeCandle({ high: NaN, low: 88 });
       const prevMap = new Map<string, OHLCCandle>([['coin-1', prevCandle]]);
 
-      const result = service.buildSpreadContext(candles, 'coin-1', prevMap);
+      const result = service.buildSpreadContext(priceMap, 'coin-1', prevMap);
       expect(result?.prevHigh).toBeUndefined();
       expect(result?.prevLow).toBe(88);
     });
 
     it('should set prevLow to undefined when previous low is not finite', () => {
-      const candles = [makeCandle()];
+      const priceMap = toMap([makeCandle()]);
       const prevCandle = makeCandle({ high: 108, low: Infinity });
       const prevMap = new Map<string, OHLCCandle>([['coin-1', prevCandle]]);
 
-      const result = service.buildSpreadContext(candles, 'coin-1', prevMap);
+      const result = service.buildSpreadContext(priceMap, 'coin-1', prevMap);
       expect(result?.prevHigh).toBe(108);
       expect(result?.prevLow).toBeUndefined();
     });

--- a/apps/api/src/order/backtest/shared/slippage-context/slippage-context.service.ts
+++ b/apps/api/src/order/backtest/shared/slippage-context/slippage-context.service.ts
@@ -6,10 +6,11 @@ import { SpreadEstimationContext } from '../slippage';
 @Injectable()
 export class SlippageContextService {
   /**
-   * Extract daily volume from OHLC candles for a specific coin
+   * Extract daily volume from OHLC candles for a specific coin.
+   * Accepts a pre-built Map<coinId, OHLCCandle> for O(1) lookup.
    */
-  extractDailyVolume(currentPrices: OHLCCandle[], coinId: string): number | undefined {
-    const candle = currentPrices.find((c) => c.coinId === coinId);
+  extractDailyVolume(priceMap: Map<string, OHLCCandle>, coinId: string): number | undefined {
+    const candle = priceMap.get(coinId);
     if (!candle) return undefined;
     // Convert base-currency volume to quote-currency (USD) for participation rate math.
     // quoteVolume is preferred but typically NULL (CCXT fetchOHLCV doesn't provide it).
@@ -18,14 +19,15 @@ export class SlippageContextService {
 
   /**
    * Build spread estimation context from current and previous candle data.
+   * Accepts a pre-built Map<coinId, OHLCCandle> for O(1) lookup.
    * Returns undefined if no candle found for the given coinId.
    */
   buildSpreadContext(
-    currentPrices: OHLCCandle[],
+    priceMap: Map<string, OHLCCandle>,
     coinId: string,
     prevCandleMap: Map<string, OHLCCandle>
   ): SpreadEstimationContext | undefined {
-    const candle = currentPrices.find((c) => c.coinId === coinId);
+    const candle = priceMap.get(coinId);
     if (!candle || candle.high <= 0 || candle.low <= 0 || candle.close <= 0 || candle.high <= candle.low)
       return undefined;
 

--- a/apps/api/src/order/backtest/shared/slippage/index.ts
+++ b/apps/api/src/order/backtest/shared/slippage/index.ts
@@ -1,3 +1,4 @@
 export * from './slippage.interface';
+export * from './slippage-model-type.util';
 export * from './slippage.service';
 export * from './spread-estimator';

--- a/apps/api/src/order/backtest/shared/slippage/slippage-model-type.util.spec.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage-model-type.util.spec.ts
@@ -1,0 +1,22 @@
+import { mapSlippageModelType } from './slippage-model-type.util';
+import { SlippageModelType } from './slippage.interface';
+
+describe('mapSlippageModelType', () => {
+  it.each([
+    ['none', SlippageModelType.NONE],
+    ['volume-based', SlippageModelType.VOLUME_BASED],
+    ['historical', SlippageModelType.HISTORICAL],
+    ['spread-adjusted', SlippageModelType.SPREAD_ADJUSTED],
+    ['fixed', SlippageModelType.FIXED]
+  ])('should map "%s" to %s', (input, expected) => {
+    expect(mapSlippageModelType(input)).toBe(expected);
+  });
+
+  it('should default to FIXED for undefined', () => {
+    expect(mapSlippageModelType(undefined)).toBe(SlippageModelType.FIXED);
+  });
+
+  it('should default to FIXED for unknown string', () => {
+    expect(mapSlippageModelType('unknown')).toBe(SlippageModelType.FIXED);
+  });
+});

--- a/apps/api/src/order/backtest/shared/slippage/slippage-model-type.util.ts
+++ b/apps/api/src/order/backtest/shared/slippage/slippage-model-type.util.ts
@@ -1,0 +1,21 @@
+import { SlippageModelType } from './slippage.interface';
+
+/**
+ * Map legacy slippage model type string to shared enum.
+ * Pure function — no dependencies on any service.
+ */
+export function mapSlippageModelType(model?: string): SlippageModelType {
+  switch (model) {
+    case 'none':
+      return SlippageModelType.NONE;
+    case 'volume-based':
+      return SlippageModelType.VOLUME_BASED;
+    case 'historical':
+      return SlippageModelType.HISTORICAL;
+    case 'spread-adjusted':
+      return SlippageModelType.SPREAD_ADJUSTED;
+    case 'fixed':
+    default:
+      return SlippageModelType.FIXED;
+  }
+}

--- a/apps/api/src/order/backtest/shared/types/trade-callback.types.ts
+++ b/apps/api/src/order/backtest/shared/types/trade-callback.types.ts
@@ -6,32 +6,39 @@ import { type Portfolio } from '../portfolio';
 import { type SlippageConfig, type SpreadEstimationContext } from '../slippage';
 
 /**
+ * Parameters for executing a trade on the in-memory portfolio.
+ */
+export interface ExecuteTradeParams {
+  signal: TradingSignal;
+  portfolio: Portfolio;
+  marketData: MarketData;
+  tradingFee: number;
+  slippageConfig: SlippageConfig;
+  dailyVolume?: number;
+  minHoldMs?: number;
+  maxAllocation?: number;
+  minAllocation?: number;
+  defaultLeverage?: number;
+  spreadContext?: SpreadEstimationContext;
+}
+
+/**
  * Callback type for executing a trade on the in-memory portfolio.
  */
-export type ExecuteTradeFn = (
-  signal: TradingSignal,
-  portfolio: Portfolio,
-  marketData: MarketData,
-  tradingFee: number,
-  slippageConfig: SlippageConfig,
-  dailyVolume?: number,
-  minHoldMs?: number,
-  maxAllocation?: number,
-  minAllocation?: number,
-  defaultLeverage?: number,
-  spreadContext?: SpreadEstimationContext
-) => Promise<ExecuteTradeResult | null>;
+export type ExecuteTradeFn = (params: ExecuteTradeParams) => Promise<ExecuteTradeResult | null>;
 
 /**
  * Callback type for extracting daily volume from OHLC candles.
+ * Accepts a pre-built Map<coinId, OHLCCandle> for O(1) lookup.
  */
-export type ExtractDailyVolumeFn = (currentPrices: OHLCCandle[], coinId: string) => number | undefined;
+export type ExtractDailyVolumeFn = (priceMap: Map<string, OHLCCandle>, coinId: string) => number | undefined;
 
 /**
  * Callback type for building spread estimation context.
+ * Accepts a pre-built Map<coinId, OHLCCandle> for O(1) lookup.
  */
 export type BuildSpreadContextFn = (
-  currentPrices: OHLCCandle[],
+  priceMap: Map<string, OHLCCandle>,
   coinId: string,
   prevCandleMap: Map<string, OHLCCandle>
 ) => SpreadEstimationContext | undefined;

--- a/apps/api/src/order/order.module.ts
+++ b/apps/api/src/order/order.module.ts
@@ -30,6 +30,7 @@ import { LiveReplayProcessor } from './backtest/live-replay.processor';
 import { MarketDataReaderService } from './backtest/market-data-reader.service';
 import { MarketDataSet } from './backtest/market-data-set.entity';
 import { QuoteCurrencyResolverService } from './backtest/quote-currency-resolver.service';
+import { BacktestContextFactory } from './backtest/shared/execution/backtest-context-factory.service';
 import { BacktestLoopRunner } from './backtest/shared/execution/backtest-loop-runner.service';
 import { OptimizationCoreService } from './backtest/shared/optimization/optimization-core.service';
 import { OptimizationIndicatorPrecomputeService } from './backtest/shared/optimization/optimization-indicator-precompute.service';
@@ -182,6 +183,7 @@ const BACKTEST_DEFAULTS = backtestConfig();
   ],
   providers: [
     AlgorithmService,
+    BacktestContextFactory,
     BacktestEngine,
     BacktestLoopRunner,
     OptimizationCoreService,


### PR DESCRIPTION
## Summary

- Extract `BacktestContextFactory` from `BacktestLoopRunner`, reducing the runner from 532 to 164 lines (19 → 5 dependencies)
- Fix 3 critical bugs found in code review: shared mutable state on singleton, nullable trade fields, and incorrect portfolio valuation after delisting exits
- Improve code quality with Decimal.js for financial math, options objects for parameter-heavy methods, and O(1) Map lookups replacing linear scans

## Changes

### Factory Extraction
- Create `BacktestContextFactory` service owning all context initialization: config resolution, data loading, portfolio restoration, checkpoint fast-forward
- Decompose `create()` into `loadAndPrepareData`, `resolveTradeConfig`, `resolveSignalConfig` private helpers
- Slim `BacktestLoopRunner` to orchestration only (execute loop + finalizeResults)

### Critical Fixes
- **C1**: Replace shared mutable `reusablePriceMap` on singleton `BacktestBarProcessor` with local variable — prevents data corruption in concurrent backtests
- **C2**: Add null guard on `trade.price`/`trade.quantity` in opportunity sell accumulation — prevents silent zero-value sells
- **C3**: Use `lastKnownPrices` instead of `new Map()` when recalculating portfolio after delisting exits — prevents remaining positions being valued at $0

### Quality Improvements
- Use `Decimal.js` for financial accumulation in checkpoint, metrics, and exit signal services
- Extract `mapSlippageModelType` from `CompositeRegimeService` to standalone pure utility
- Replace 16-param `buildCheckpointState` with `BuildCheckpointStateOptions` object
- Replace 11-param `ExecuteTradeFn` with `ExecuteTradeParams` object
- Change `SlippageContextService` to accept `Map<coinId, OHLCCandle>` for O(1) lookup
- Deduplicate price grouping in `PriceWindowService` via `groupAndSortByCoins`
- Move `validateCheckpoint` from `BacktestEngine` to `CheckpointService`
- Replace fragile dynamic `import()` type with explicit `SignalThrottleConfig`
- Remove unused re-exports from `backtest-engine.service.ts`

## Test Plan

- [x] `npx nx build api` — compiles with no errors
- [x] `npx nx lint api` — passes with no warnings
- [x] `npx nx test api` — all 3,891 tests pass (215 suites)
- [x] Targeted test runs for all modified services pass individually