### PR TITLE
fix(api): allow null currentPrice in backtest coin filter fallback

### DIFF
--- a/apps/api/src/coin/coin.service.spec.ts
+++ b/apps/api/src/coin/coin.service.spec.ts
@@ -236,6 +236,21 @@ describe('CoinService', () => {
       const delistedCalls = qb.andWhere.mock.calls.filter((call: unknown[]) => call[0] === 'coin.delistedAt IS NULL');
       expect(delistedCalls).toHaveLength(0);
     });
+
+    it('omits currentPrice IS NOT NULL clause when skipCurrentPriceCheck is true', async () => {
+      const qb = mockQueryBuilder();
+      coinRepository.createQueryBuilder.mockReturnValue(qb as any);
+
+      await service.getCoinsByIdsFiltered(['id1'], 100_000_000, 1_000_000, { skipCurrentPriceCheck: true });
+
+      const currentPriceCalls = qb.andWhere.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'coin.currentPrice IS NOT NULL'
+      );
+      expect(currentPriceCalls).toHaveLength(0);
+      // Quality filters still applied
+      expect(qb.andWhere).toHaveBeenCalledWith('coin.marketCap >= :minMarketCap', { minMarketCap: 100_000_000 });
+      expect(qb.andWhere).toHaveBeenCalledWith('coin.totalVolume >= :minDailyVolume', { minDailyVolume: 1_000_000 });
+    });
   });
 
   // ===========================================================================

--- a/apps/api/src/coin/coin.service.ts
+++ b/apps/api/src/coin/coin.service.ts
@@ -89,7 +89,7 @@ export class CoinService {
     coinIds: string[],
     minMarketCap = 100_000_000,
     minDailyVolume = 1_000_000,
-    options?: { includeDelisted?: boolean }
+    options?: { includeDelisted?: boolean; skipCurrentPriceCheck?: boolean }
   ): Promise<Coin[]> {
     if (coinIds.length === 0) return [];
 
@@ -100,8 +100,11 @@ export class CoinService {
       .createQueryBuilder('coin')
       .where('coin.id IN (:...ids)', { ids: uniqueIds })
       .andWhere('coin.marketCap >= :minMarketCap', { minMarketCap })
-      .andWhere('coin.totalVolume >= :minDailyVolume', { minDailyVolume })
-      .andWhere('coin.currentPrice IS NOT NULL');
+      .andWhere('coin.totalVolume >= :minDailyVolume', { minDailyVolume });
+
+    if (!options?.skipCurrentPriceCheck) {
+      qb.andWhere('coin.currentPrice IS NOT NULL');
+    }
 
     if (!options?.includeDelisted) {
       qb.andWhere('coin.delistedAt IS NULL');
@@ -149,9 +152,15 @@ export class CoinService {
       return { coins: [], usedHistoricalData: true };
     }
 
-    // No snapshot data at all — fall back to current market data
+    // No snapshot data at all — fall back to current market data.
+    // Skip the currentPrice check: this path is only reached from backtest contexts where
+    // tradeability is already confirmed via OHLC candle data, and a stale/null currentPrice
+    // on the coin row should not exclude an otherwise qualifying coin.
     this.logger.warn(`No snapshot data exists near ${dateStr} — falling back to current market data`);
-    const coins = await this.getCoinsByIdsFiltered(coinIds, minMarketCap, minDailyVolume, { includeDelisted: true });
+    const coins = await this.getCoinsByIdsFiltered(coinIds, minMarketCap, minDailyVolume, {
+      includeDelisted: true,
+      skipCurrentPriceCheck: true
+    });
     return { coins, usedHistoricalData: false };
   }
 


### PR DESCRIPTION
## Summary
- Fix AKT (and similar coins) being silently dropped from backtest coin resolution when their `currentPrice` is null in the `coin` table
- The `getCoinsByIdsFilteredAtDate` fallback path was inheriting an overly strict `currentPrice IS NOT NULL` filter intended for live trading

## Background
AKT failed backtest resolution with `Partial resolution: 39/40, unresolved: [akt]`. Root cause: AKT had `currentPrice: null` (likely added to selections before coin-detail sync ran). It passed the market cap (\$123M) and volume (\$4.4M) thresholds but was excluded by the hard `coin.currentPrice IS NOT NULL` clause in `getCoinsByIdsFiltered`.

The currentPrice check makes sense for live trading (need a tradeable price), but is unnecessary in backtest contexts where OHLC candle data already confirms tradeability.

## Changes
- `apps/api/src/coin/coin.service.ts` — Added `skipCurrentPriceCheck?: boolean` option to `getCoinsByIdsFiltered`. The `currentPrice IS NOT NULL` clause is now conditional (default: still required, preserving live trading behavior).
- `apps/api/src/coin/coin.service.ts` — `getCoinsByIdsFilteredAtDate` passes `skipCurrentPriceCheck: true` in its fallback call, since it's only reached from backtest contexts.
- `apps/api/src/coin/coin.service.spec.ts` — Added unit test verifying the new option omits the clause while still applying market cap and volume filters.

## Test Plan
- [x] `npx nx test api -- --testPathPattern='coin.service.spec'` — 69 tests pass
- [x] `npx nx test api -- --testPathPattern='coin-resolver.service.spec'` — 13 tests pass
- [ ] Verify AKT resolves successfully in next backtest pipeline run