### PR TITLE
fix(api): resolve pipeline enqueue race orphaning OPTIMIZE stage

### DIFF
--- a/apps/api/src/pipeline/processors/pipeline.processor.spec.ts
+++ b/apps/api/src/pipeline/processors/pipeline.processor.spec.ts
@@ -1,0 +1,145 @@
+import { type Job } from 'bullmq';
+import { type Repository } from 'typeorm';
+
+import { PipelineProcessor } from './pipeline.processor';
+
+import { type Pipeline } from '../entities/pipeline.entity';
+import { PipelineStage, PipelineStatus, type PipelineJobData } from '../interfaces';
+import { type PipelineOrchestratorService } from '../services/pipeline-orchestrator.service';
+
+describe('PipelineProcessor', () => {
+  let processor: PipelineProcessor;
+  let orchestratorService: jest.Mocked<PipelineOrchestratorService>;
+  let pipelineRepository: jest.Mocked<Repository<Pipeline>>;
+
+  const PIPELINE_ID = 'pipeline-123';
+  const STAGE = PipelineStage.OPTIMIZE;
+  const RETRY_DELAY = PipelineProcessor['PENDING_RETRY_DELAY_MS'];
+
+  const makeJob = (): Job<PipelineJobData> =>
+    ({
+      id: 'job-1',
+      data: { pipelineId: PIPELINE_ID, stage: STAGE, userId: 'user-1' }
+    }) as unknown as Job<PipelineJobData>;
+
+  const makePipeline = (status: PipelineStatus): Pipeline =>
+    ({ id: PIPELINE_ID, status, currentStage: STAGE }) as Pipeline;
+
+  beforeEach(() => {
+    orchestratorService = {
+      executeStage: jest.fn().mockResolvedValue(undefined)
+    } as unknown as jest.Mocked<PipelineOrchestratorService>;
+
+    pipelineRepository = {
+      findOne: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined)
+    } as unknown as jest.Mocked<Repository<Pipeline>>;
+
+    processor = new PipelineProcessor(orchestratorService, pipelineRepository);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns silently and skips execution when pipeline is not found', async () => {
+    pipelineRepository.findOne.mockResolvedValueOnce(null);
+
+    await processor.process(makeJob());
+
+    expect(orchestratorService.executeStage).not.toHaveBeenCalled();
+    expect(pipelineRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('executes the stage on the happy path when status is RUNNING', async () => {
+    pipelineRepository.findOne.mockResolvedValueOnce(makePipeline(PipelineStatus.RUNNING));
+
+    await processor.process(makeJob());
+
+    expect(orchestratorService.executeStage).toHaveBeenCalledWith(PIPELINE_ID, STAGE);
+    expect(pipelineRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('retries on PENDING then executes when pipeline transitions to RUNNING', async () => {
+    jest.useFakeTimers();
+    pipelineRepository.findOne
+      .mockResolvedValueOnce(makePipeline(PipelineStatus.PENDING))
+      .mockResolvedValueOnce(makePipeline(PipelineStatus.RUNNING));
+
+    const promise = processor.process(makeJob());
+    await jest.advanceTimersByTimeAsync(RETRY_DELAY);
+    await promise;
+
+    expect(pipelineRepository.findOne).toHaveBeenCalledTimes(2);
+    expect(orchestratorService.executeStage).toHaveBeenCalledWith(PIPELINE_ID, STAGE);
+    expect(pipelineRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('marks pipeline FAILED and rethrows when status is still PENDING after retry', async () => {
+    jest.useFakeTimers();
+    pipelineRepository.findOne
+      .mockResolvedValueOnce(makePipeline(PipelineStatus.PENDING))
+      .mockResolvedValueOnce(makePipeline(PipelineStatus.PENDING));
+
+    const promise = processor.process(makeJob());
+    // Attach the rejection assertion before advancing timers so the rejection
+    // does not fire as an unhandled promise during timer flush.
+    const assertion = expect(promise).rejects.toThrow(/still PENDING after \d+ms retry/);
+    await jest.advanceTimersByTimeAsync(RETRY_DELAY);
+    await assertion;
+
+    expect(orchestratorService.executeStage).not.toHaveBeenCalled();
+    expect(pipelineRepository.update).toHaveBeenCalledWith(
+      PIPELINE_ID,
+      expect.objectContaining({
+        status: PipelineStatus.FAILED,
+        failureReason: expect.stringMatching(/still PENDING after \d+ms retry/),
+        completedAt: expect.any(Date)
+      })
+    );
+  });
+
+  it('marks pipeline FAILED and rethrows when pipeline disappears during retry', async () => {
+    jest.useFakeTimers();
+    pipelineRepository.findOne.mockResolvedValueOnce(makePipeline(PipelineStatus.PENDING)).mockResolvedValueOnce(null);
+
+    const promise = processor.process(makeJob());
+    const assertion = expect(promise).rejects.toThrow(/orchestrator transaction may not have committed/);
+    await jest.advanceTimersByTimeAsync(RETRY_DELAY);
+    await assertion;
+
+    expect(orchestratorService.executeStage).not.toHaveBeenCalled();
+    expect(pipelineRepository.update).toHaveBeenCalledWith(
+      PIPELINE_ID,
+      expect.objectContaining({ status: PipelineStatus.FAILED })
+    );
+  });
+
+  it.each([[PipelineStatus.CANCELLED], [PipelineStatus.COMPLETED], [PipelineStatus.PAUSED]])(
+    'returns silently without marking FAILED when pipeline is in terminal state %s',
+    async (status) => {
+      pipelineRepository.findOne.mockResolvedValueOnce(makePipeline(status));
+
+      await processor.process(makeJob());
+
+      expect(orchestratorService.executeStage).not.toHaveBeenCalled();
+      expect(pipelineRepository.update).not.toHaveBeenCalled();
+    }
+  );
+
+  it('marks pipeline FAILED with the orchestrator error when executeStage throws', async () => {
+    pipelineRepository.findOne.mockResolvedValueOnce(makePipeline(PipelineStatus.RUNNING));
+    orchestratorService.executeStage.mockRejectedValueOnce(new Error('stage exploded'));
+
+    await expect(processor.process(makeJob())).rejects.toThrow('stage exploded');
+
+    expect(pipelineRepository.update).toHaveBeenCalledWith(
+      PIPELINE_ID,
+      expect.objectContaining({
+        status: PipelineStatus.FAILED,
+        failureReason: 'stage exploded',
+        completedAt: expect.any(Date)
+      })
+    );
+  });
+});

--- a/apps/api/src/pipeline/processors/pipeline.processor.ts
+++ b/apps/api/src/pipeline/processors/pipeline.processor.ts
@@ -14,6 +14,7 @@ import { PipelineOrchestratorService } from '../services/pipeline-orchestrator.s
 @Processor('pipeline')
 export class PipelineProcessor extends WorkerHost {
   private readonly logger = new Logger(PipelineProcessor.name);
+  private static readonly PENDING_RETRY_DELAY_MS = 2000;
 
   constructor(
     private readonly orchestratorService: PipelineOrchestratorService,
@@ -30,7 +31,7 @@ export class PipelineProcessor extends WorkerHost {
 
     try {
       // Get pipeline and verify state
-      const pipeline = await this.pipelineRepository.findOne({
+      let pipeline = await this.pipelineRepository.findOne({
         where: { id: pipelineId }
       });
 
@@ -39,8 +40,27 @@ export class PipelineProcessor extends WorkerHost {
         return;
       }
 
-      // Only process if pipeline is still running
-      if (pipeline.status !== PipelineStatus.RUNNING) {
+      // Defense-in-depth against PG/Redis race: if the worker picks up the job
+      // before the orchestrator's transaction commits, we'll see PENDING. Wait
+      // briefly and re-read before giving up.
+      if (pipeline.status === PipelineStatus.PENDING) {
+        this.logger.warn(
+          `Pipeline ${pipelineId} is PENDING — possible race condition, retrying in ${PipelineProcessor.PENDING_RETRY_DELAY_MS}ms`
+        );
+        await new Promise((resolve) => setTimeout(resolve, PipelineProcessor.PENDING_RETRY_DELAY_MS));
+        const retried = await this.pipelineRepository.findOne({ where: { id: pipelineId } });
+        if (!retried || retried.status !== PipelineStatus.RUNNING) {
+          // Throw so the catch handler marks the pipeline FAILED — silently
+          // returning here would orphan the pipeline (no worker job, status
+          // never advances), recreating a narrower version of the original race.
+          throw new Error(
+            `Pipeline ${pipelineId} still PENDING after ${PipelineProcessor.PENDING_RETRY_DELAY_MS}ms retry (status: ${retried?.status}) — orchestrator transaction may not have committed`
+          );
+        }
+        pipeline = retried;
+      } else if (pipeline.status !== PipelineStatus.RUNNING) {
+        // Only process if pipeline is still running. CANCELLED/COMPLETED/PAUSED
+        // are intentional terminal states — silently skipping is correct here.
         this.logger.warn(`Pipeline ${pipelineId} is not running (status: ${pipeline.status}). Skipping stage ${stage}`);
         return;
       }

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
@@ -58,7 +58,8 @@ describe('PipelineOrchestratorService', () => {
             save: jest.fn(),
             findOne: jest.fn(),
             findAndCount: jest.fn(),
-            remove: jest.fn()
+            remove: jest.fn(),
+            update: jest.fn()
           }
         },
         {
@@ -147,6 +148,9 @@ describe('PipelineOrchestratorService', () => {
     it('queues first stage when starting a pending pipeline', async () => {
       pipelineRepository.findOne.mockResolvedValue(makePipeline());
       await service.startPipeline('pipeline-123', mockUser);
+      expect(pipelineRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'pipeline-123', status: PipelineStatus.RUNNING })
+      );
       expect(stageExecutionService.enqueueStageJob).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'pipeline-123' }),
         PipelineStage.OPTIMIZE,
@@ -162,6 +166,22 @@ describe('PipelineOrchestratorService', () => {
         expect(stageExecutionService.enqueueStageJob).not.toHaveBeenCalled();
       }
     );
+
+    it('marks pipeline FAILED and rethrows when enqueueStageJob fails', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline());
+      stageExecutionService.enqueueStageJob.mockRejectedValueOnce(new Error('queue down'));
+
+      await expect(service.startPipeline('pipeline-123', mockUser)).rejects.toThrow('queue down');
+
+      expect(pipelineRepository.update).toHaveBeenCalledWith(
+        'pipeline-123',
+        expect.objectContaining({
+          status: PipelineStatus.FAILED,
+          failureReason: expect.stringMatching(/Failed to enqueue stage job: queue down/),
+          completedAt: expect.any(Date)
+        })
+      );
+    });
   });
 
   describe('pausePipeline', () => {

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -180,13 +180,23 @@ export class PipelineOrchestratorService {
       throw new BadRequestException('Pipeline has been cancelled');
     }
 
-    await this.dataSource.transaction(async (manager) => {
-      pipeline.status = PipelineStatus.RUNNING;
-      pipeline.startedAt = pipeline.startedAt ?? new Date();
-      await manager.save(pipeline);
+    pipeline.status = PipelineStatus.RUNNING;
+    pipeline.startedAt = pipeline.startedAt ?? new Date();
+    await this.pipelineRepository.save(pipeline);
 
+    try {
       await this.stageExecutionService.enqueueStageJob(pipeline, pipeline.currentStage, user.id);
-    });
+    } catch (error) {
+      // Enqueue failed after commit — mark pipeline FAILED so it doesn't sit RUNNING forever
+      const err = toErrorInfo(error);
+      this.logger.error(`Failed to enqueue stage job for pipeline ${id}: ${err.message}`);
+      await this.pipelineRepository.update(id, {
+        status: PipelineStatus.FAILED,
+        failureReason: `Failed to enqueue stage job: ${err.message}`,
+        completedAt: new Date()
+      });
+      throw error;
+    }
 
     this.logger.log(`Started pipeline ${id} at stage ${pipeline.currentStage}`);
     return this.findOne(id, user);


### PR DESCRIPTION
## Summary

- Fix race where the BullMQ enqueue could fire before the `RUNNING` status commit was visible, causing the processor to read `PENDING` and orphan the pipeline at the OPTIMIZE stage
- Add defense-in-depth retry in `PipelineProcessor` and ensure failed enqueues mark the pipeline `FAILED` instead of leaving it stuck `RUNNING`
- Cover the new retry/terminal-state and enqueue-failure paths with unit tests

## Changes

**`pipeline-orchestrator.service.ts`**
- Move `enqueueStageJob` outside the PG transaction in `startPipeline` so workers cannot observe `PENDING` before the `RUNNING` commit is visible
- If the post-commit enqueue throws, mark the pipeline `FAILED` with `failureReason` instead of leaving it stuck `RUNNING`
- Drop the now-redundant single-save transaction wrapper

**`pipeline.processor.ts`**
- When status is `PENDING`, wait `PENDING_RETRY_DELAY_MS` (2s) and re-fetch before giving up — handles any residual replication/visibility lag
- Throw (instead of silently returning) when the pipeline is still `PENDING` after the retry, so BullMQ's failure handler marks it `FAILED` rather than orphaning it
- Extract `PENDING_RETRY_DELAY_MS` constant

**Tests**
- `pipeline.processor.spec.ts`: cover retry path, terminal-state short-circuit, and post-retry failure
- `pipeline-orchestrator.service.spec.ts`: cover enqueue-failure → `FAILED` transition

## Test Plan

- [ ] `npx nx test api -- --testPathPattern='pipeline.processor.spec'`
- [ ] `npx nx test api -- --testPathPattern='pipeline-orchestrator.service.spec'`
- [ ] Manually trigger a pipeline and confirm OPTIMIZE stage starts cleanly
- [ ] Verify a forced enqueue failure surfaces as `FAILED` (with `failureReason`) rather than stuck `RUNNING`