### PR TITLE
fix(api): prevent overlapping paper-trading sessions

### DIFF
--- a/apps/api/src/order/paper-trading/paper-trading-cleanup.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-cleanup.service.spec.ts
@@ -1,0 +1,213 @@
+import { Logger } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { PaperTradingSession, PaperTradingStatus } from './entities';
+import { PaperTradingCleanupService } from './paper-trading-cleanup.service';
+import { PaperTradingService } from './paper-trading.service';
+
+import { Pipeline } from '../../pipeline/entities/pipeline.entity';
+import { PipelineStatus } from '../../pipeline/interfaces';
+
+describe('PaperTradingCleanupService', () => {
+  let service: PaperTradingCleanupService;
+  let sessionRepository: any;
+  let pipelineRepository: any;
+  let paperTradingService: any;
+
+  /**
+   * Build a fake session row with the relations the service expects.
+   */
+  const makeSession = (overrides: Partial<any>) => ({
+    id: overrides.id ?? `s-${Math.random()}`,
+    status: PaperTradingStatus.ACTIVE,
+    createdAt: overrides.createdAt ?? new Date(),
+    pipelineId: overrides.pipelineId,
+    user: { id: overrides.userId ?? 'user-1' },
+    algorithm: { id: overrides.algorithmId ?? 'algo-1' }
+  });
+
+  /**
+   * The cleanup query loads ACTIVE/PAUSED sessions ordered by user/algorithm/createdAt.
+   * Use this helper to seed the query builder result.
+   */
+  const mockCleanupQuery = (rows: any[]) => {
+    const qb = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(rows)
+    };
+    sessionRepository.createQueryBuilder.mockReturnValue(qb);
+    return qb;
+  };
+
+  beforeEach(async () => {
+    sessionRepository = {
+      createQueryBuilder: jest.fn()
+    };
+
+    pipelineRepository = {
+      update: jest.fn().mockResolvedValue(undefined)
+    };
+
+    paperTradingService = {
+      stop: jest.fn().mockResolvedValue({})
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaperTradingCleanupService,
+        { provide: getRepositoryToken(PaperTradingSession), useValue: sessionRepository },
+        { provide: getRepositoryToken(Pipeline), useValue: pipelineRepository },
+        { provide: PaperTradingService, useValue: paperTradingService }
+      ]
+    }).compile();
+
+    service = module.get<PaperTradingCleanupService>(PaperTradingCleanupService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('cleanupDuplicateSessions', () => {
+    it('keeps the oldest session per (user, algorithm) group and stops the rest', async () => {
+      // All three share user-1 + algo-1, so they form one group of three
+      const oldest = makeSession({
+        id: 'old',
+        userId: 'user-1',
+        algorithmId: 'algo-1',
+        createdAt: new Date('2026-01-01'),
+        pipelineId: 'p-old'
+      });
+      const middle = makeSession({
+        id: 'mid',
+        userId: 'user-1',
+        algorithmId: 'algo-1',
+        createdAt: new Date('2026-02-01'),
+        pipelineId: 'p-mid'
+      });
+      const newest = makeSession({
+        id: 'new',
+        userId: 'user-1',
+        algorithmId: 'algo-1',
+        createdAt: new Date('2026-03-01'),
+        pipelineId: 'p-new'
+      });
+      mockCleanupQuery([oldest, middle, newest]);
+
+      const result = await service.cleanupDuplicateSessions(false);
+
+      expect(result).toEqual({
+        scanned: 3,
+        kept: 1,
+        stopped: [
+          { sessionId: 'mid', pipelineId: 'p-mid' },
+          { sessionId: 'new', pipelineId: 'p-new' }
+        ],
+        dryRun: false
+      });
+      expect(paperTradingService.stop).toHaveBeenCalledTimes(2);
+      expect(paperTradingService.stop).toHaveBeenCalledWith(
+        'mid',
+        expect.objectContaining({ id: 'user-1' }),
+        'duplicate-cleanup'
+      );
+      expect(paperTradingService.stop).toHaveBeenCalledWith(
+        'new',
+        expect.objectContaining({ id: 'user-1' }),
+        'duplicate-cleanup'
+      );
+
+      // Linked pipelines cancelled — oldest is preserved, only duplicates touched
+      expect(pipelineRepository.update).toHaveBeenCalledTimes(2);
+      expect(pipelineRepository.update).toHaveBeenCalledWith(
+        { id: 'p-mid' },
+        expect.objectContaining({ status: PipelineStatus.CANCELLED, failureReason: expect.any(String) })
+      );
+      expect(pipelineRepository.update).toHaveBeenCalledWith(
+        { id: 'p-new' },
+        expect.objectContaining({ status: PipelineStatus.CANCELLED })
+      );
+      expect(pipelineRepository.update).not.toHaveBeenCalledWith({ id: 'p-old' }, expect.anything());
+    });
+
+    it('stops duplicate without a pipelineId without touching pipelineRepository for it', async () => {
+      const oldest = makeSession({ id: 'old', createdAt: new Date('2026-01-01'), pipelineId: 'p-old' });
+      const orphan = makeSession({ id: 'orphan', createdAt: new Date('2026-02-01') }); // no pipelineId
+      mockCleanupQuery([oldest, orphan]);
+
+      const result = await service.cleanupDuplicateSessions(false);
+
+      expect(result.stopped).toEqual([{ sessionId: 'orphan', pipelineId: undefined }]);
+      expect(paperTradingService.stop).toHaveBeenCalledWith('orphan', expect.anything(), 'duplicate-cleanup');
+      // Only the duplicate's pipeline would ever be updated, and it has none, so update() must not fire
+      expect(pipelineRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('logs and skips a duplicate when stop() throws, continuing with the rest of the group', async () => {
+      const loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+      const oldest = makeSession({ id: 'old', createdAt: new Date('2026-01-01'), pipelineId: 'p-old' });
+      const failing = makeSession({ id: 'fail', createdAt: new Date('2026-02-01'), pipelineId: 'p-fail' });
+      const surviving = makeSession({ id: 'ok', createdAt: new Date('2026-03-01'), pipelineId: 'p-ok' });
+      mockCleanupQuery([oldest, failing, surviving]);
+
+      paperTradingService.stop.mockImplementation(async (sessionId: string) => {
+        if (sessionId === 'fail') throw new Error('boom');
+        return {};
+      });
+
+      const result = await service.cleanupDuplicateSessions(false);
+
+      // Failed duplicate is NOT recorded as stopped, but the next duplicate still proceeds
+      expect(result.scanned).toBe(3);
+      expect(result.kept).toBe(1);
+      expect(result.stopped).toEqual([{ sessionId: 'ok', pipelineId: 'p-ok' }]);
+      expect(paperTradingService.stop).toHaveBeenCalledTimes(2);
+      // Failed duplicate's pipeline never gets cancelled
+      expect(pipelineRepository.update).toHaveBeenCalledTimes(1);
+      expect(pipelineRepository.update).toHaveBeenCalledWith({ id: 'p-ok' }, expect.anything());
+      expect(loggerErrorSpy).toHaveBeenCalledWith(expect.stringContaining('fail'));
+
+      loggerErrorSpy.mockRestore();
+    });
+
+    it('does not call stop() or pipeline update in dryRun mode', async () => {
+      const oldest = makeSession({ id: 'old', createdAt: new Date('2026-01-01') });
+      const newest = makeSession({ id: 'new', createdAt: new Date('2026-02-01'), pipelineId: 'p-new' });
+      mockCleanupQuery([oldest, newest]);
+
+      const result = await service.cleanupDuplicateSessions(true);
+
+      expect(result.scanned).toBe(2);
+      expect(result.kept).toBe(1);
+      expect(result.stopped).toEqual([{ sessionId: 'new', pipelineId: 'p-new' }]);
+      expect(paperTradingService.stop).not.toHaveBeenCalled();
+      expect(pipelineRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('does not stop sessions in groups of size 1', async () => {
+      const lonelyA = makeSession({ id: 'A', userId: 'user-1', algorithmId: 'algo-1' });
+      const lonelyB = makeSession({ id: 'B', userId: 'user-2', algorithmId: 'algo-1' });
+      const lonelyC = makeSession({ id: 'C', userId: 'user-1', algorithmId: 'algo-2' });
+      mockCleanupQuery([lonelyA, lonelyB, lonelyC]);
+
+      const result = await service.cleanupDuplicateSessions(false);
+
+      expect(result.scanned).toBe(3);
+      expect(result.kept).toBe(3);
+      expect(result.stopped).toHaveLength(0);
+      expect(paperTradingService.stop).not.toHaveBeenCalled();
+    });
+
+    it('returns empty result when no active/paused sessions exist', async () => {
+      mockCleanupQuery([]);
+
+      const result = await service.cleanupDuplicateSessions(false);
+
+      expect(result).toEqual({ scanned: 0, kept: 0, stopped: [], dryRun: false });
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/paper-trading-cleanup.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-cleanup.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { PaperTradingSession, PaperTradingStatus } from './entities';
+import { PaperTradingService } from './paper-trading.service';
+
+import { Pipeline } from '../../pipeline/entities/pipeline.entity';
+import { PipelineStatus } from '../../pipeline/interfaces';
+
+/**
+ * One-shot cleanup utility for overlapping paper-trading sessions.
+ *
+ * TODO: delete this service (and its bootstrap call from `PaperTradingRecoveryService`)
+ * once the legacy duplicate sessions are cleared in production. The orchestration-level
+ * guard (`PipelineOrchestrationService.checkDuplicate`) and the `startFromPipeline`
+ * defense-in-depth check are the intended long-term protection. Keeping a silent
+ * boot-time fix would hide regressions that should fail loudly instead.
+ */
+@Injectable()
+export class PaperTradingCleanupService {
+  private readonly logger = new Logger(PaperTradingCleanupService.name);
+
+  constructor(
+    @InjectRepository(PaperTradingSession)
+    private readonly sessionRepository: Repository<PaperTradingSession>,
+    @InjectRepository(Pipeline)
+    private readonly pipelineRepository: Repository<Pipeline>,
+    private readonly paperTradingService: PaperTradingService
+  ) {}
+
+  /**
+   * Cleanup overlapping paper-trading sessions.
+   *
+   * Finds all ACTIVE/PAUSED sessions, groups them by `(userId, algorithmId)`, and stops
+   * every duplicate beyond the oldest one in each group. Linked pipelines are cancelled.
+   *
+   * Going through `stop()` is the only safe path — it removes the per-session
+   * `paper-trading-tick-{sessionId}` BullMQ scheduler and clears in-memory throttle/exit
+   * tracker state. A direct DB update would leave orphan schedulers ticking against dead rows.
+   *
+   * Set `dryRun` to preview the action without writing.
+   */
+  async cleanupDuplicateSessions(dryRun: boolean): Promise<{
+    scanned: number;
+    kept: number;
+    stopped: Array<{ sessionId: string; pipelineId?: string }>;
+    dryRun: boolean;
+  }> {
+    // Eager-load user + algorithm so we can group on their IDs and call stop() with a User shape
+    const sessions = await this.sessionRepository
+      .createQueryBuilder('s')
+      .leftJoinAndSelect('s.user', 'user')
+      .leftJoinAndSelect('s.algorithm', 'algorithm')
+      .where('s.status IN (:...active)', {
+        active: [PaperTradingStatus.ACTIVE, PaperTradingStatus.PAUSED]
+      })
+      .orderBy('user.id', 'ASC')
+      .addOrderBy('algorithm.id', 'ASC')
+      .addOrderBy('s.createdAt', 'ASC')
+      .getMany();
+
+    const groups = new Map<string, PaperTradingSession[]>();
+    for (const session of sessions) {
+      const userId = session.user?.id;
+      const algorithmId = session.algorithm?.id;
+      if (!userId || !algorithmId) continue;
+      const key = `${userId}::${algorithmId}`;
+      const list = groups.get(key) ?? [];
+      list.push(session);
+      groups.set(key, list);
+    }
+
+    let kept = 0;
+    const stopped: Array<{ sessionId: string; pipelineId?: string }> = [];
+
+    for (const [, group] of groups) {
+      if (group.length <= 1) {
+        kept += group.length;
+        continue;
+      }
+
+      // Keep the oldest (closest to legitimate completion, most ticks accrued)
+      kept += 1;
+      const duplicates = group.slice(1);
+
+      for (const duplicate of duplicates) {
+        if (!dryRun) {
+          try {
+            await this.paperTradingService.stop(duplicate.id, duplicate.user, 'duplicate-cleanup');
+
+            if (duplicate.pipelineId) {
+              await this.pipelineRepository.update(
+                { id: duplicate.pipelineId },
+                {
+                  status: PipelineStatus.CANCELLED,
+                  failureReason: 'Duplicate paper-trading session cleanup'
+                }
+              );
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            this.logger.error(`Failed to stop duplicate session ${duplicate.id}: ${message}`);
+            continue;
+          }
+        }
+
+        stopped.push({ sessionId: duplicate.id, pipelineId: duplicate.pipelineId });
+      }
+    }
+
+    if (stopped.length > 0) {
+      this.logger.log(
+        `cleanupDuplicateSessions: scanned=${sessions.length}, kept=${kept}, stopped=${stopped.length}, dryRun=${dryRun}`
+      );
+    } else {
+      this.logger.debug(`cleanupDuplicateSessions: scanned=${sessions.length}, no duplicates found`);
+    }
+
+    return { scanned: sessions.length, kept, stopped, dryRun };
+  }
+}

--- a/apps/api/src/order/paper-trading/paper-trading-query.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-query.service.spec.ts
@@ -1,0 +1,269 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import {
+  PaperTradingAccount,
+  PaperTradingOrder,
+  PaperTradingSession,
+  PaperTradingSignal,
+  PaperTradingSnapshot
+} from './entities';
+import { PaperTradingJobService } from './paper-trading-job.service';
+import { PaperTradingQueryService } from './paper-trading-query.service';
+
+import type { User } from '../../users/users.entity';
+
+describe('PaperTradingQueryService', () => {
+  let service: PaperTradingQueryService;
+  let sessionRepository: any;
+  let accountRepository: any;
+  let orderRepository: any;
+  let signalRepository: any;
+  let snapshotRepository: any;
+  let jobService: any;
+
+  const mockUser = { id: 'user-1' } as User;
+
+  const createQueryBuilderMock = (result: unknown[] = []) => ({
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue(result)
+  });
+
+  beforeEach(async () => {
+    sessionRepository = {
+      findOne: jest.fn(),
+      findAndCount: jest.fn()
+    };
+
+    accountRepository = {
+      find: jest.fn()
+    };
+
+    orderRepository = {
+      findAndCount: jest.fn()
+    };
+
+    signalRepository = {
+      findAndCount: jest.fn()
+    };
+
+    snapshotRepository = {
+      createQueryBuilder: jest.fn()
+    };
+
+    jobService = {
+      calculateMetrics: jest.fn()
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaperTradingQueryService,
+        { provide: getRepositoryToken(PaperTradingSession), useValue: sessionRepository },
+        { provide: getRepositoryToken(PaperTradingAccount), useValue: accountRepository },
+        { provide: getRepositoryToken(PaperTradingOrder), useValue: orderRepository },
+        { provide: getRepositoryToken(PaperTradingSignal), useValue: signalRepository },
+        { provide: getRepositoryToken(PaperTradingSnapshot), useValue: snapshotRepository },
+        { provide: PaperTradingJobService, useValue: jobService }
+      ]
+    }).compile();
+
+    service = module.get<PaperTradingQueryService>(PaperTradingQueryService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findOne', () => {
+    it('returns the session scoped to the requesting user', async () => {
+      const session = { id: 'session-1', user: mockUser } as any;
+      sessionRepository.findOne.mockResolvedValue(session);
+
+      const result = await service.findOne('session-1', mockUser);
+
+      expect(sessionRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'session-1', user: { id: mockUser.id } },
+        relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange', 'accounts']
+      });
+      expect(result).toBe(session);
+    });
+
+    it('throws NotFoundException when the session is missing', async () => {
+      sessionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('missing', mockUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('applies optional filters and pagination', async () => {
+      sessionRepository.findAndCount.mockResolvedValue([[{ id: 'session-1' }], 1]);
+
+      const result = await service.findAll(mockUser, {
+        status: 'RUNNING',
+        algorithmId: 'algo-1',
+        pipelineId: 'pipeline-1',
+        limit: 25,
+        offset: 10
+      } as any);
+
+      expect(sessionRepository.findAndCount).toHaveBeenCalledWith({
+        where: {
+          user: { id: mockUser.id },
+          status: 'RUNNING',
+          algorithm: { id: 'algo-1' },
+          pipelineId: 'pipeline-1'
+        },
+        relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange'],
+        order: { createdAt: 'DESC' },
+        take: 25,
+        skip: 10
+      });
+      expect(result).toEqual({ data: [{ id: 'session-1' }], total: 1 });
+    });
+
+    it('falls back to default pagination when filters are empty', async () => {
+      sessionRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll(mockUser, {} as any);
+
+      const [options] = sessionRepository.findAndCount.mock.calls[0];
+      expect(options.where).toEqual({ user: { id: mockUser.id } });
+      expect(options.take).toBe(50);
+      expect(options.skip).toBe(0);
+    });
+  });
+
+  describe('getOrders', () => {
+    it('propagates NotFoundException from the access check and skips the order query', async () => {
+      jest.spyOn(service, 'findOne').mockRejectedValue(new NotFoundException());
+
+      await expect(service.getOrders('session-1', mockUser, {} as any)).rejects.toThrow(NotFoundException);
+      expect(orderRepository.findAndCount).not.toHaveBeenCalled();
+    });
+
+    it('forwards status, side, and symbol filters to the repository', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1' } as any);
+      orderRepository.findAndCount.mockResolvedValue([[{ id: 'order-1' }], 1]);
+
+      const result = await service.getOrders('session-1', mockUser, {
+        status: 'FILLED',
+        side: 'BUY',
+        symbol: 'BTC/USD'
+      } as any);
+
+      expect(orderRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            session: { id: 'session-1' },
+            status: 'FILLED',
+            side: 'BUY',
+            symbol: 'BTC/USD'
+          },
+          relations: ['signal'],
+          take: 100,
+          skip: 0
+        })
+      );
+      expect(result).toEqual({ data: [{ id: 'order-1' }], total: 1 });
+    });
+  });
+
+  describe('getSignals', () => {
+    it('includes processed=false in the where clause (regression: falsy guard)', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1' } as any);
+      signalRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.getSignals('session-1', mockUser, { processed: false } as any);
+
+      expect(signalRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { session: { id: 'session-1' }, processed: false }
+        })
+      );
+    });
+  });
+
+  describe('getSnapshots', () => {
+    it('wires after/before conditions and the caller-supplied limit onto the query builder', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1' } as any);
+      const qb = createQueryBuilderMock([{ id: 'snap-1' }]);
+      snapshotRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getSnapshots('session-1', mockUser, {
+        after: '2026-01-01T00:00:00Z',
+        before: '2026-02-01T00:00:00Z',
+        limit: 50
+      } as any);
+
+      expect(qb.where).toHaveBeenCalledWith('snapshot.sessionId = :sessionId', { sessionId: 'session-1' });
+      expect(qb.orderBy).toHaveBeenCalledWith('snapshot.timestamp', 'ASC');
+      expect(qb.take).toHaveBeenCalledWith(50);
+      expect(qb.andWhere).toHaveBeenCalledWith('snapshot.timestamp > :after', {
+        after: new Date('2026-01-01T00:00:00Z')
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith('snapshot.timestamp < :before', {
+        before: new Date('2026-02-01T00:00:00Z')
+      });
+      expect(result).toEqual([{ id: 'snap-1' }]);
+    });
+
+    it('uses the default limit of 200 and omits andWhere when no date bounds are given', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1' } as any);
+      const qb = createQueryBuilderMock();
+      snapshotRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getSnapshots('session-1', mockUser, {} as any);
+
+      expect(qb.take).toHaveBeenCalledWith(200);
+      expect(qb.andWhere).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPositions', () => {
+    it('excludes the quote currency and zero-balance holdings', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1' } as any);
+      accountRepository.find.mockResolvedValue([
+        { currency: 'USD', total: 50000, averageCost: 0 },
+        { currency: 'BTC', total: 0.5, averageCost: 30000 },
+        { currency: 'ETH', total: 0, averageCost: 2000 }
+      ]);
+
+      const positions = await service.getPositions('session-1', mockUser);
+
+      expect(positions).toEqual([{ symbol: 'BTC/USD', quantity: 0.5, averageCost: 30000 }]);
+    });
+
+    it('defaults averageCost to 0 when the account value is null', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1' } as any);
+      accountRepository.find.mockResolvedValue([
+        { currency: 'USD', total: 1000, averageCost: 0 },
+        { currency: 'BTC', total: 0.1, averageCost: null }
+      ]);
+
+      const positions = await service.getPositions('session-1', mockUser);
+
+      expect(positions).toEqual([{ symbol: 'BTC/USD', quantity: 0.1, averageCost: 0 }]);
+    });
+  });
+
+  describe('getPerformance', () => {
+    it('fetches the session and delegates to jobService.calculateMetrics', async () => {
+      const session = { id: 'session-10', user: mockUser } as any;
+      const metrics = { totalReturn: 2000, totalReturnPercent: 20 } as any;
+
+      const findOneSpy = jest.spyOn(service, 'findOne').mockResolvedValue(session);
+      jobService.calculateMetrics.mockResolvedValue(metrics);
+
+      const result = await service.getPerformance('session-10', mockUser);
+
+      expect(findOneSpy).toHaveBeenCalledWith('session-10', mockUser);
+      expect(jobService.calculateMetrics).toHaveBeenCalledWith(session);
+      expect(result).toBe(metrics);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/paper-trading-query.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-query.service.ts
@@ -1,0 +1,246 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { FindOptionsWhere, Repository } from 'typeorm';
+
+import { SessionStatusResponse } from '@chansey/api-interfaces';
+
+import {
+  PaperTradingOrderFiltersDto,
+  PaperTradingSessionFiltersDto,
+  PaperTradingSignalFiltersDto,
+  PaperTradingSnapshotFiltersDto
+} from './dto';
+import {
+  PaperTradingAccount,
+  PaperTradingOrder,
+  PaperTradingSession,
+  PaperTradingSignal,
+  PaperTradingSnapshot
+} from './entities';
+import { PaperTradingJobService } from './paper-trading-job.service';
+
+import { getQuoteCurrency } from '../../exchange/constants';
+import { User } from '../../users/users.entity';
+
+/**
+ * Read-only queries for paper trading sessions and their associated data.
+ *
+ * Split out from {@link PaperTradingService} to keep that service focused on
+ * lifecycle / write operations. All methods here are pure reads (plus access
+ * validation via session lookup).
+ */
+@Injectable()
+export class PaperTradingQueryService {
+  constructor(
+    @InjectRepository(PaperTradingSession)
+    private readonly sessionRepository: Repository<PaperTradingSession>,
+    @InjectRepository(PaperTradingAccount)
+    private readonly accountRepository: Repository<PaperTradingAccount>,
+    @InjectRepository(PaperTradingOrder)
+    private readonly orderRepository: Repository<PaperTradingOrder>,
+    @InjectRepository(PaperTradingSignal)
+    private readonly signalRepository: Repository<PaperTradingSignal>,
+    @InjectRepository(PaperTradingSnapshot)
+    private readonly snapshotRepository: Repository<PaperTradingSnapshot>,
+    private readonly jobService: PaperTradingJobService
+  ) {}
+
+  /**
+   * Find all sessions for a user with optional filters
+   */
+  async findAll(
+    user: User,
+    filters: PaperTradingSessionFiltersDto
+  ): Promise<{ data: PaperTradingSession[]; total: number }> {
+    const where: FindOptionsWhere<PaperTradingSession> = { user: { id: user.id } };
+
+    if (filters.status) {
+      where.status = filters.status;
+    }
+    if (filters.algorithmId) {
+      where.algorithm = { id: filters.algorithmId };
+    }
+    if (filters.pipelineId) {
+      where.pipelineId = filters.pipelineId;
+    }
+
+    const [data, total] = await this.sessionRepository.findAndCount({
+      where,
+      relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange'],
+      order: { createdAt: 'DESC' },
+      take: filters.limit ?? 50,
+      skip: filters.offset ?? 0
+    });
+
+    return { data, total };
+  }
+
+  /**
+   * Find a single session by ID
+   */
+  async findOne(id: string, user: User): Promise<PaperTradingSession> {
+    const session = await this.sessionRepository.findOne({
+      where: { id, user: { id: user.id } },
+      relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange', 'accounts']
+    });
+
+    if (!session) {
+      throw new NotFoundException(`Paper trading session ${id} not found`);
+    }
+
+    return session;
+  }
+
+  /**
+   * Get orders for a session
+   */
+  async getOrders(
+    sessionId: string,
+    user: User,
+    filters: PaperTradingOrderFiltersDto
+  ): Promise<{ data: PaperTradingOrder[]; total: number }> {
+    await this.findOne(sessionId, user); // Validates access
+
+    const where: FindOptionsWhere<PaperTradingOrder> = { session: { id: sessionId } };
+
+    if (filters.status) {
+      where.status = filters.status;
+    }
+    if (filters.side) {
+      where.side = filters.side;
+    }
+    if (filters.symbol) {
+      where.symbol = filters.symbol;
+    }
+
+    const [data, total] = await this.orderRepository.findAndCount({
+      where,
+      relations: ['signal'],
+      order: { createdAt: 'DESC' },
+      take: filters.limit ?? 100,
+      skip: filters.offset ?? 0
+    });
+
+    return { data, total };
+  }
+
+  /**
+   * Get signals for a session
+   */
+  async getSignals(
+    sessionId: string,
+    user: User,
+    filters: PaperTradingSignalFiltersDto
+  ): Promise<{ data: PaperTradingSignal[]; total: number }> {
+    await this.findOne(sessionId, user); // Validates access
+
+    const where: FindOptionsWhere<PaperTradingSignal> = { session: { id: sessionId } };
+
+    if (filters.signalType) {
+      where.signalType = filters.signalType;
+    }
+    if (filters.direction) {
+      where.direction = filters.direction;
+    }
+    if (filters.instrument) {
+      where.instrument = filters.instrument;
+    }
+    if (filters.processed !== undefined) {
+      where.processed = filters.processed;
+    }
+
+    const [data, total] = await this.signalRepository.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      take: filters.limit ?? 100,
+      skip: filters.offset ?? 0
+    });
+
+    return { data, total };
+  }
+
+  /**
+   * Get virtual balances for a session
+   */
+  async getBalances(sessionId: string, user: User): Promise<PaperTradingAccount[]> {
+    await this.findOne(sessionId, user); // Validates access
+
+    return this.accountRepository.find({
+      where: { session: { id: sessionId } },
+      order: { currency: 'ASC' }
+    });
+  }
+
+  /**
+   * Get snapshots for a session (for charting)
+   */
+  async getSnapshots(
+    sessionId: string,
+    user: User,
+    filters: PaperTradingSnapshotFiltersDto
+  ): Promise<PaperTradingSnapshot[]> {
+    await this.findOne(sessionId, user); // Validates access
+
+    const qb = this.snapshotRepository
+      .createQueryBuilder('snapshot')
+      .where('snapshot.sessionId = :sessionId', { sessionId })
+      .orderBy('snapshot.timestamp', 'ASC')
+      .take(filters.limit ?? 200);
+
+    if (filters.after) {
+      qb.andWhere('snapshot.timestamp > :after', { after: new Date(filters.after) });
+    }
+    if (filters.before) {
+      qb.andWhere('snapshot.timestamp < :before', { before: new Date(filters.before) });
+    }
+
+    return qb.getMany();
+  }
+
+  /**
+   * Get current positions for a session
+   */
+  async getPositions(
+    sessionId: string,
+    user: User
+  ): Promise<
+    Array<{
+      symbol: string;
+      quantity: number;
+      averageCost: number;
+      currentPrice?: number;
+      marketValue?: number;
+      unrealizedPnL?: number;
+      unrealizedPnLPercent?: number;
+    }>
+  > {
+    // Verify session exists and belongs to user
+    await this.findOne(sessionId, user);
+
+    // Get accounts that have holdings (not quote currency)
+    const accounts = await this.accountRepository.find({
+      where: { session: { id: sessionId } }
+    });
+
+    const quoteCurrency = getQuoteCurrency(accounts.map((a) => a.currency));
+
+    // Filter to only holding accounts with positive balances
+    const holdingAccounts = accounts.filter((a) => a.currency !== quoteCurrency && a.total > 0);
+
+    return holdingAccounts.map((account) => ({
+      symbol: `${account.currency}/${quoteCurrency}`,
+      quantity: account.total,
+      averageCost: account.averageCost ?? 0
+      // currentPrice, marketValue, unrealizedPnL populated by market data service
+    }));
+  }
+
+  /**
+   * Get performance metrics for a session
+   */
+  async getPerformance(sessionId: string, user: User): Promise<SessionStatusResponse['metrics']> {
+    const session = await this.findOne(sessionId, user);
+    return this.jobService.calculateMetrics(session);
+  }
+}

--- a/apps/api/src/order/paper-trading/paper-trading-recovery.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-recovery.service.spec.ts
@@ -36,6 +36,9 @@ describe('PaperTradingRecoveryService', () => {
     const service = new PaperTradingRecoveryService(
       paperTradingService as any,
       { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+      {
+        cleanupDuplicateSessions: jest.fn().mockResolvedValue({ scanned: 0, kept: 0, stopped: [], dryRun: false })
+      } as any,
       queue as any
     );
 
@@ -63,6 +66,9 @@ describe('PaperTradingRecoveryService', () => {
     const service = new PaperTradingRecoveryService(
       paperTradingService as any,
       { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+      {
+        cleanupDuplicateSessions: jest.fn().mockResolvedValue({ scanned: 0, kept: 0, stopped: [], dryRun: false })
+      } as any,
       queue as any
     );
 
@@ -97,6 +103,9 @@ describe('PaperTradingRecoveryService', () => {
       const service = new PaperTradingRecoveryService(
         paperTradingService as any,
         { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+        {
+          cleanupDuplicateSessions: jest.fn().mockResolvedValue({ scanned: 0, kept: 0, stopped: [], dryRun: false })
+        } as any,
         queue as any
       );
 
@@ -128,6 +137,9 @@ describe('PaperTradingRecoveryService', () => {
       const service = new PaperTradingRecoveryService(
         paperTradingService as any,
         { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+        {
+          cleanupDuplicateSessions: jest.fn().mockResolvedValue({ scanned: 0, kept: 0, stopped: [], dryRun: false })
+        } as any,
         queue as any
       );
 
@@ -153,6 +165,9 @@ describe('PaperTradingRecoveryService', () => {
       const service = new PaperTradingRecoveryService(
         paperTradingService as any,
         { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+        {
+          cleanupDuplicateSessions: jest.fn().mockResolvedValue({ scanned: 0, kept: 0, stopped: [], dryRun: false })
+        } as any,
         queue as any
       );
 
@@ -175,12 +190,84 @@ describe('PaperTradingRecoveryService', () => {
       const service = new PaperTradingRecoveryService(
         paperTradingService as any,
         { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+        {
+          cleanupDuplicateSessions: jest.fn().mockResolvedValue({ scanned: 0, kept: 0, stopped: [], dryRun: false })
+        } as any,
         queue as any
       );
 
       await service.onApplicationBootstrap();
 
       expect(queue.removeRepeatableByKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanupDuplicateActiveSessions on bootstrap', () => {
+    it('invokes PaperTradingService.cleanupDuplicateSessions before recovering active sessions', async () => {
+      const callOrder: string[] = [];
+
+      const jobService = {
+        findActiveSessions: jest.fn().mockImplementation(async () => {
+          callOrder.push('findActiveSessions');
+          return [];
+        }),
+        removeTickJobs: jest.fn(),
+        scheduleTickJob: jest.fn(),
+        markFailed: jest.fn(),
+        getSessionStatus: jest.fn()
+      };
+
+      const paperTradingService = {
+        cleanupDuplicateSessions: jest.fn().mockImplementation(async () => {
+          callOrder.push('cleanupDuplicateSessions');
+          return {
+            scanned: 5,
+            kept: 2,
+            stopped: [{ sessionId: 'a' }, { sessionId: 'b' }, { sessionId: 'c' }],
+            dryRun: false
+          };
+        })
+      };
+
+      const queue = createMockQueue();
+      const service = new PaperTradingRecoveryService(
+        jobService as any,
+        { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+        paperTradingService as any,
+        queue as any
+      );
+
+      await service.onApplicationBootstrap();
+
+      expect(paperTradingService.cleanupDuplicateSessions).toHaveBeenCalledWith(false);
+      // cleanup must run before recovery so duplicates are stopped before tick jobs are re-scheduled
+      expect(callOrder.indexOf('cleanupDuplicateSessions')).toBeLessThan(callOrder.indexOf('findActiveSessions'));
+    });
+
+    it('does not abort bootstrap when cleanup throws', async () => {
+      const jobService = {
+        findActiveSessions: jest.fn().mockResolvedValue([]),
+        removeTickJobs: jest.fn(),
+        scheduleTickJob: jest.fn(),
+        markFailed: jest.fn(),
+        getSessionStatus: jest.fn()
+      };
+
+      const paperTradingService = {
+        cleanupDuplicateSessions: jest.fn().mockRejectedValue(new Error('boom'))
+      };
+
+      const queue = createMockQueue();
+      const service = new PaperTradingRecoveryService(
+        jobService as any,
+        { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+        paperTradingService as any,
+        queue as any
+      );
+
+      await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+      // Recovery still ran despite cleanup failure
+      expect(jobService.findActiveSessions).toHaveBeenCalled();
     });
   });
 
@@ -192,6 +279,9 @@ describe('PaperTradingRecoveryService', () => {
       const service = new PaperTradingRecoveryService(
         paperTradingService as any,
         { sweepOrphanedState: jest.fn().mockReturnValue(0) } as any,
+        {
+          cleanupDuplicateSessions: jest.fn().mockResolvedValue({ scanned: 0, kept: 0, stopped: [], dryRun: false })
+        } as any,
         queue as any
       );
       // Override bootedAt to simulate time since boot

--- a/apps/api/src/order/paper-trading/paper-trading-recovery.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-recovery.service.ts
@@ -5,6 +5,7 @@ import { Cron } from '@nestjs/schedule';
 import { Queue } from 'bullmq';
 
 import { PaperTradingStatus } from './entities';
+import { PaperTradingCleanupService } from './paper-trading-cleanup.service';
 import { PaperTradingEngineService } from './paper-trading-engine.service';
 import { PaperTradingJobService } from './paper-trading-job.service';
 
@@ -28,14 +29,55 @@ export class PaperTradingRecoveryService implements OnApplicationBootstrap {
   constructor(
     private readonly jobService: PaperTradingJobService,
     private readonly engineService: PaperTradingEngineService,
+    private readonly cleanupService: PaperTradingCleanupService,
     @InjectQueue('paper-trading') private readonly paperTradingQueue: Queue
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
     // OnApplicationBootstrap is called after all modules are initialized
-    // This is the proper lifecycle hook for recovery operations
+    // This is the proper lifecycle hook for recovery operations.
+    //
+    // Order matters:
+    //   1. cleanupOrphanedSchedulers — removes legacy schedulers for terminal sessions
+    //   2. cleanupDuplicateActiveSessions — stops duplicates so step 3 doesn't re-schedule them
+    //   3. recoverActiveSessions — re-schedules tick jobs for the survivors
     await this.cleanupOrphanedSchedulers();
+    // TODO: remove cleanupDuplicateActiveSessions once the 31 legacy duplicate sessions are
+    // cleared. Leaving this in long-term is risky — it would silently mask any future bug
+    // that re-introduces overlapping sessions instead of letting it surface loudly.
+    await this.cleanupDuplicateActiveSessions();
     await this.recoverActiveSessions();
+  }
+
+  /**
+   * One-shot self-healing pass for overlapping paper-trading sessions.
+   *
+   * Delegates to {@link PaperTradingCleanupService.cleanupDuplicateSessions}, which keeps the
+   * oldest session per `(userId, algorithmId)` group and stops the rest via the normal `stop()`
+   * flow (so per-session BullMQ tick schedulers and in-memory throttle/exit state are cleaned up).
+   * Linked pipelines are cancelled.
+   *
+   * TODO: delete this method (and its bootstrap call) — along with `PaperTradingCleanupService`
+   * itself — after the legacy duplicate sessions are cleared in production. The orchestration-level
+   * guard (`PipelineOrchestrationService.checkDuplicate`) and the `startFromPipeline` defense-in-depth
+   * check are the intended long-term protection. Keeping a silent boot-time fix would hide
+   * regressions that should fail loudly instead.
+   *
+   * Idempotent — a no-op when no duplicates exist, so it's safe to run on every boot until removed.
+   * Errors are logged but never rethrown so they don't block the rest of the boot sequence.
+   */
+  private async cleanupDuplicateActiveSessions(): Promise<void> {
+    try {
+      const result = await this.cleanupService.cleanupDuplicateSessions(false);
+      if (result.stopped.length > 0) {
+        this.logger.warn(
+          `Duplicate session cleanup: scanned=${result.scanned}, kept=${result.kept}, stopped=${result.stopped.length}`
+        );
+      }
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Duplicate session cleanup failed: ${err.message}`, err.stack);
+    }
   }
 
   /**

--- a/apps/api/src/order/paper-trading/paper-trading.controller.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.controller.ts
@@ -31,6 +31,7 @@ import {
   PaperTradingSnapshotFiltersDto,
   UpdatePaperTradingSessionDto
 } from './dto';
+import { PaperTradingQueryService } from './paper-trading-query.service';
 import { PaperTradingService } from './paper-trading.service';
 
 import GetUser from '../../authentication/decorator/get-user.decorator';
@@ -42,7 +43,10 @@ import { User } from '../../users/users.entity';
 @UseGuards(JwtAuthenticationGuard)
 @ApiBearerAuth('token')
 export class PaperTradingController {
-  constructor(private readonly paperTradingService: PaperTradingService) {}
+  constructor(
+    private readonly paperTradingService: PaperTradingService,
+    private readonly queryService: PaperTradingQueryService
+  ) {}
 
   @Post('sessions')
   @ApiOperation({ summary: 'Create a new paper trading session' })
@@ -64,7 +68,7 @@ export class PaperTradingController {
     @Query() filters: PaperTradingSessionFiltersDto,
     @GetUser() user: User
   ): Promise<PaperTradingListResponseDto> {
-    const { data, total } = await this.paperTradingService.findAll(user, filters);
+    const { data, total } = await this.queryService.findAll(user, filters);
     return {
       data: data.map((s) => this.toSummaryDto(s)),
       total,
@@ -79,7 +83,7 @@ export class PaperTradingController {
   @ApiResponse({ status: 200, description: 'Session retrieved successfully', type: PaperTradingSessionDetailDto })
   @ApiResponse({ status: 404, description: 'Session not found' })
   async findOne(@Param('id', ParseUUIDPipe) id: string, @GetUser() user: User): Promise<PaperTradingSessionDetailDto> {
-    const session = await this.paperTradingService.findOne(id, user);
+    const session = await this.queryService.findOne(id, user);
     return this.toDetailDto(session);
   }
 
@@ -163,7 +167,7 @@ export class PaperTradingController {
     @Query() filters: PaperTradingOrderFiltersDto,
     @GetUser() user: User
   ): Promise<{ data: PaperTradingOrderDto[]; total: number }> {
-    const { data, total } = await this.paperTradingService.getOrders(id, user, filters);
+    const { data, total } = await this.queryService.getOrders(id, user, filters);
     return {
       data: data.map((o) => ({
         id: o.id,
@@ -199,7 +203,7 @@ export class PaperTradingController {
     @Query() filters: PaperTradingSignalFiltersDto,
     @GetUser() user: User
   ): Promise<{ data: PaperTradingSignalDto[]; total: number }> {
-    const { data, total } = await this.paperTradingService.getSignals(id, user, filters);
+    const { data, total } = await this.queryService.getSignals(id, user, filters);
     return {
       data: data.map((s) => ({
         id: s.id,
@@ -224,7 +228,7 @@ export class PaperTradingController {
   @ApiResponse({ status: 200, description: 'Balances retrieved successfully', type: [PaperTradingBalanceDto] })
   @ApiResponse({ status: 404, description: 'Session not found' })
   async getBalance(@Param('id', ParseUUIDPipe) id: string, @GetUser() user: User): Promise<PaperTradingBalanceDto[]> {
-    const accounts = await this.paperTradingService.getBalances(id, user);
+    const accounts = await this.queryService.getBalances(id, user);
     return accounts.map((a) => ({
       currency: a.currency,
       available: a.available,
@@ -243,7 +247,7 @@ export class PaperTradingController {
     @Param('id', ParseUUIDPipe) id: string,
     @GetUser() user: User
   ): Promise<PaperTradingPositionDto[]> {
-    const positions = await this.paperTradingService.getPositions(id, user);
+    const positions = await this.queryService.getPositions(id, user);
     return positions.map((p) => ({
       symbol: p.symbol,
       quantity: p.quantity,
@@ -261,7 +265,7 @@ export class PaperTradingController {
   @ApiResponse({ status: 200, description: 'Metrics retrieved successfully', type: PaperTradingMetricsDto })
   @ApiResponse({ status: 404, description: 'Session not found' })
   async getPerformance(@Param('id', ParseUUIDPipe) id: string, @GetUser() user: User): Promise<PaperTradingMetricsDto> {
-    const metrics = await this.paperTradingService.getPerformance(id, user);
+    const metrics = await this.queryService.getPerformance(id, user);
     return {
       ...metrics,
       totalReturnPercent: metrics.totalReturnPercent ?? (metrics.totalReturn / metrics.initialCapital) * 100
@@ -278,7 +282,7 @@ export class PaperTradingController {
     @Query() filters: PaperTradingSnapshotFiltersDto,
     @GetUser() user: User
   ): Promise<PaperTradingSnapshotDto[]> {
-    const snapshots = await this.paperTradingService.getSnapshots(id, user, filters);
+    const snapshots = await this.queryService.getSnapshots(id, user, filters);
     return snapshots.map((s) => ({
       id: s.id,
       portfolioValue: s.portfolioValue,

--- a/apps/api/src/order/paper-trading/paper-trading.module.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.module.ts
@@ -18,9 +18,11 @@ import {
   PaperTradingSignal,
   PaperTradingSnapshot
 } from './entities';
+import { PaperTradingCleanupService } from './paper-trading-cleanup.service';
 import { PaperTradingEngineService } from './paper-trading-engine.service';
 import { PaperTradingJobService } from './paper-trading-job.service';
 import { PaperTradingMarketDataService } from './paper-trading-market-data.service';
+import { PaperTradingQueryService } from './paper-trading-query.service';
 import { PaperTradingRecoveryService } from './paper-trading-recovery.service';
 import { PaperTradingStreamService } from './paper-trading-stream.service';
 import { paperTradingConfig } from './paper-trading.config';
@@ -40,6 +42,7 @@ import { ExchangeModule } from '../../exchange/exchange.module';
 import { MarketRegimeModule } from '../../market-regime/market-regime.module';
 import { MetricsModule } from '../../metrics/metrics.module';
 import { OHLCModule } from '../../ohlc/ohlc.module';
+import { Pipeline } from '../../pipeline/entities/pipeline.entity';
 import { SharedCacheModule } from '../../shared-cache.module';
 import { UsersModule } from '../../users/users.module';
 import { BacktestSharedModule } from '../backtest/shared/shared.module';
@@ -56,7 +59,8 @@ const PAPER_TRADING_CONFIG = paperTradingConfig();
       PaperTradingSignal,
       PaperTradingSnapshot,
       Algorithm,
-      ExchangeKey
+      ExchangeKey,
+      Pipeline
     ]),
     BullModule.registerQueue({ name: PAPER_TRADING_CONFIG.queue }),
     EventEmitterModule.forRoot(),
@@ -76,6 +80,8 @@ const PAPER_TRADING_CONFIG = paperTradingConfig();
   controllers: [PaperTradingController],
   providers: [
     PaperTradingService,
+    PaperTradingQueryService,
+    PaperTradingCleanupService,
     PaperTradingJobService,
     PaperTradingEngineService,
     PaperTradingPortfolioService,
@@ -91,6 +97,13 @@ const PAPER_TRADING_CONFIG = paperTradingConfig();
     PaperTradingGateway,
     PaperTradingRecoveryService
   ],
-  exports: [PaperTradingService, PaperTradingJobService, PaperTradingEngineService, PaperTradingMarketDataService]
+  exports: [
+    PaperTradingService,
+    PaperTradingQueryService,
+    PaperTradingCleanupService,
+    PaperTradingJobService,
+    PaperTradingEngineService,
+    PaperTradingMarketDataService
+  ]
 })
 export class PaperTradingModule {}

--- a/apps/api/src/order/paper-trading/paper-trading.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.service.spec.ts
@@ -5,14 +5,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { DataSource } from 'typeorm';
 
-import {
-  PaperTradingAccount,
-  PaperTradingOrder,
-  PaperTradingSession,
-  PaperTradingSignal,
-  PaperTradingSnapshot,
-  PaperTradingStatus
-} from './entities';
+import { PaperTradingAccount, PaperTradingSession, PaperTradingStatus } from './entities';
 import { PaperTradingJobService } from './paper-trading-job.service';
 import { PaperTradingJobType } from './paper-trading.job-data';
 import { PaperTradingService } from './paper-trading.service';
@@ -25,7 +18,6 @@ describe('PaperTradingService', () => {
   let service: PaperTradingService;
   let sessionRepository: any;
   let accountRepository: any;
-  let orderRepository: any;
   let algorithmRepository: any;
   let exchangeKeyRepository: any;
   let paperTradingQueue: any;
@@ -40,29 +32,25 @@ describe('PaperTradingService', () => {
     initialCapital: 1000
   } as any;
 
+  /**
+   * Spy on the private `findOne` lookup the lifecycle methods use to validate ownership.
+   * Cast through `any` because the method is intentionally private on the lifecycle service.
+   */
+  const spyFindOne = () => jest.spyOn(service as any, 'findOne');
+
   beforeEach(async () => {
     sessionRepository = {
       create: jest.fn(),
       save: jest.fn(),
       findOne: jest.fn(),
-      findAndCount: jest.fn(),
       remove: jest.fn(),
-      update: jest.fn()
+      createQueryBuilder: jest.fn()
     };
 
     accountRepository = {
       create: jest.fn(),
-      save: jest.fn(),
-      find: jest.fn()
+      save: jest.fn()
     };
-
-    orderRepository = {
-      findAndCount: jest.fn(),
-      createQueryBuilder: jest.fn()
-    };
-
-    const signalRepository = { findAndCount: jest.fn() };
-    const snapshotRepository = { createQueryBuilder: jest.fn() };
 
     algorithmRepository = { findOne: jest.fn() };
     exchangeKeyRepository = { findOne: jest.fn() };
@@ -80,27 +68,9 @@ describe('PaperTradingService', () => {
 
     jobService = {
       scheduleTickJob: jest.fn().mockResolvedValue(undefined),
-      scheduleRetryTick: jest.fn().mockResolvedValue(undefined),
       removeTickJobs: jest.fn().mockResolvedValue(undefined),
-      updateSessionMetrics: jest.fn().mockResolvedValue(undefined),
       markFailed: jest.fn().mockResolvedValue(undefined),
-      markCompleted: jest.fn().mockResolvedValue(undefined),
-      findActiveSessions: jest.fn().mockResolvedValue([]),
-      getSessionStatus: jest.fn().mockResolvedValue({}),
-      calculateMetrics: jest.fn().mockResolvedValue({
-        initialCapital: 10000,
-        currentPortfolioValue: 12000,
-        totalReturn: 2000,
-        totalReturnPercent: 20,
-        maxDrawdown: 0,
-        sharpeRatio: null,
-        winRate: 0,
-        totalTrades: 0,
-        winningTrades: 0,
-        losingTrades: 0,
-        totalFees: 0,
-        durationHours: 0
-      })
+      markCompleted: jest.fn().mockResolvedValue(undefined)
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -108,9 +78,6 @@ describe('PaperTradingService', () => {
         PaperTradingService,
         { provide: getRepositoryToken(PaperTradingSession), useValue: sessionRepository },
         { provide: getRepositoryToken(PaperTradingAccount), useValue: accountRepository },
-        { provide: getRepositoryToken(PaperTradingOrder), useValue: orderRepository },
-        { provide: getRepositoryToken(PaperTradingSignal), useValue: signalRepository },
-        { provide: getRepositoryToken(PaperTradingSnapshot), useValue: snapshotRepository },
         { provide: getRepositoryToken(Algorithm), useValue: algorithmRepository },
         { provide: getRepositoryToken(ExchangeKey), useValue: exchangeKeyRepository },
         { provide: getQueueToken('paper-trading'), useValue: paperTradingQueue },
@@ -157,7 +124,7 @@ describe('PaperTradingService', () => {
       accountRepository.create.mockReturnValue({});
       accountRepository.save.mockResolvedValue({});
 
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1' } as any);
+      spyFindOne().mockResolvedValue({ id: 'session-1' } as any);
 
       const result = await service.create({ ...baseCreateDto, quoteCurrency: 'USD' } as any, mockUser);
 
@@ -167,11 +134,27 @@ describe('PaperTradingService', () => {
       );
       expect(result).toEqual({ id: 'session-1' });
     });
+
+    it('falls back to DEFAULT_QUOTE_CURRENCY when quoteCurrency omitted', async () => {
+      algorithmRepository.findOne.mockResolvedValue({ id: 'algo-1' });
+      exchangeKeyRepository.findOne.mockResolvedValue({ id: 'key-1', user: { id: mockUser.id }, exchange: {} });
+
+      sessionRepository.create.mockReturnValue({ id: 'session-1' });
+      sessionRepository.save.mockResolvedValue({ id: 'session-1' });
+      accountRepository.create.mockReturnValue({});
+      accountRepository.save.mockResolvedValue({});
+      spyFindOne().mockResolvedValue({ id: 'session-1' } as any);
+
+      await service.create(baseCreateDto, mockUser);
+
+      // DEFAULT_QUOTE_CURRENCY from exchange constants is 'USDT'
+      expect(accountRepository.create).toHaveBeenCalledWith(expect.objectContaining({ currency: 'USDT' }));
+    });
   });
 
   describe('update', () => {
     it('throws BadRequestException when session is active', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'session-1', status: PaperTradingStatus.ACTIVE } as any);
+      spyFindOne().mockResolvedValue({ id: 'session-1', status: PaperTradingStatus.ACTIVE } as any);
 
       await expect(service.update('session-1', { name: 'new' } as any, mockUser)).rejects.toBeInstanceOf(
         BadRequestException
@@ -180,8 +163,7 @@ describe('PaperTradingService', () => {
 
     it('applies dto changes and returns updated session', async () => {
       const session = { id: 'session-1', status: PaperTradingStatus.PAUSED, name: 'old' } as any;
-      jest
-        .spyOn(service, 'findOne')
+      spyFindOne()
         .mockResolvedValueOnce(session)
         .mockResolvedValueOnce({ ...session, name: 'new' });
       sessionRepository.save.mockResolvedValue(session);
@@ -196,8 +178,7 @@ describe('PaperTradingService', () => {
   describe('start', () => {
     it('transitions to ACTIVE and enqueues start job', async () => {
       const session = { id: 'session-2', status: PaperTradingStatus.PAUSED } as any;
-      jest
-        .spyOn(service, 'findOne')
+      spyFindOne()
         .mockResolvedValueOnce(session)
         .mockResolvedValueOnce({ id: 'session-2', status: PaperTradingStatus.ACTIVE } as any);
 
@@ -214,17 +195,13 @@ describe('PaperTradingService', () => {
       expect(result.status).toBe(PaperTradingStatus.ACTIVE);
     });
 
-    it('rejects when already active', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.ACTIVE } as any);
+    it.each([
+      ['ACTIVE', PaperTradingStatus.ACTIVE],
+      ['COMPLETED', PaperTradingStatus.COMPLETED],
+      ['FAILED', PaperTradingStatus.FAILED]
+    ])('rejects start when session is %s', async (_label, status) => {
+      spyFindOne().mockResolvedValue({ id: 's', status } as any);
 
-      await expect(service.start('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
-    });
-
-    it('rejects when completed or failed', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.COMPLETED } as any);
-      await expect(service.start('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
-
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.FAILED } as any);
       await expect(service.start('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
     });
   });
@@ -232,7 +209,7 @@ describe('PaperTradingService', () => {
   describe('stop', () => {
     it('stops session, removes tick jobs, and notifies pipeline when pipelineId exists', async () => {
       const session = { id: 'session-5', status: PaperTradingStatus.ACTIVE, pipelineId: 'pipe-1' } as any;
-      jest.spyOn(service, 'findOne').mockResolvedValue(session);
+      spyFindOne().mockResolvedValue(session);
 
       await service.stop('session-5', mockUser, 'user_cancelled');
 
@@ -253,7 +230,7 @@ describe('PaperTradingService', () => {
 
     it('skips pipeline notification when no pipelineId', async () => {
       const session = { id: 'session-np', status: PaperTradingStatus.ACTIVE, pipelineId: undefined } as any;
-      jest.spyOn(service, 'findOne').mockResolvedValue(session);
+      spyFindOne().mockResolvedValue(session);
 
       await service.stop('session-np', mockUser);
 
@@ -261,12 +238,27 @@ describe('PaperTradingService', () => {
       expect(paperTradingQueue.add).toHaveBeenCalledWith('stop-session', expect.anything(), expect.anything());
     });
 
-    it('rejects when already stopped or completed', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.STOPPED } as any);
-      await expect(service.stop('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
+    it.each([
+      ['STOPPED', PaperTradingStatus.STOPPED],
+      ['COMPLETED', PaperTradingStatus.COMPLETED]
+    ])('rejects stop when session is %s', async (_label, status) => {
+      spyFindOne().mockResolvedValue({ id: 's', status } as any);
 
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.COMPLETED } as any);
       await expect(service.stop('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('defaults reason to "user_cancelled" when omitted', async () => {
+      const session = { id: 'session-dr', status: PaperTradingStatus.ACTIVE, pipelineId: undefined } as any;
+      spyFindOne().mockResolvedValue(session);
+
+      await service.stop('session-dr', mockUser);
+
+      expect(session.stoppedReason).toBe('user_cancelled');
+      expect(paperTradingQueue.add).toHaveBeenCalledWith(
+        'stop-session',
+        expect.objectContaining({ reason: 'user_cancelled' }),
+        expect.anything()
+      );
     });
   });
 
@@ -276,8 +268,7 @@ describe('PaperTradingService', () => {
       dataSource.transaction.mockImplementation((callback: any) => callback(transactionalEntityManager));
 
       const session = { id: 'session-6', status: PaperTradingStatus.ACTIVE, tickIntervalMs: 30000 } as any;
-      jest
-        .spyOn(service, 'findOne')
+      spyFindOne()
         .mockResolvedValueOnce(session)
         .mockResolvedValueOnce({ ...session, status: PaperTradingStatus.PAUSED });
 
@@ -292,7 +283,7 @@ describe('PaperTradingService', () => {
     });
 
     it('rejects when session is not active', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.PAUSED } as any);
+      spyFindOne().mockResolvedValue({ id: 's', status: PaperTradingStatus.PAUSED } as any);
 
       await expect(service.pause('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
     });
@@ -304,8 +295,7 @@ describe('PaperTradingService', () => {
       dataSource.transaction.mockImplementation((callback: any) => callback(transactionalEntityManager));
 
       const session = { id: 'session-7', status: PaperTradingStatus.PAUSED, tickIntervalMs: 30000 } as any;
-      jest
-        .spyOn(service, 'findOne')
+      spyFindOne()
         .mockResolvedValueOnce(session)
         .mockResolvedValueOnce({ ...session, status: PaperTradingStatus.ACTIVE });
 
@@ -320,7 +310,7 @@ describe('PaperTradingService', () => {
     });
 
     it('rejects when session is not paused', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.ACTIVE } as any);
+      spyFindOne().mockResolvedValue({ id: 's', status: PaperTradingStatus.ACTIVE } as any);
 
       await expect(service.resume('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
     });
@@ -329,7 +319,7 @@ describe('PaperTradingService', () => {
   describe('delete', () => {
     it('removes tick jobs and deletes session', async () => {
       const session = { id: 'session-del', status: PaperTradingStatus.PAUSED } as any;
-      jest.spyOn(service, 'findOne').mockResolvedValue(session);
+      spyFindOne().mockResolvedValue(session);
 
       await service.delete('session-del', mockUser);
 
@@ -338,51 +328,41 @@ describe('PaperTradingService', () => {
     });
 
     it('rejects when session is active', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue({ id: 's', status: PaperTradingStatus.ACTIVE } as any);
+      spyFindOne().mockResolvedValue({ id: 's', status: PaperTradingStatus.ACTIVE } as any);
 
       await expect(service.delete('s', mockUser)).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 
-  describe('getPerformance', () => {
-    it('delegates to jobService.calculateMetrics', async () => {
-      const session = {
-        id: 'session-10',
-        initialCapital: 10000,
-        currentPortfolioValue: 12000,
-        user: mockUser
-      };
-
-      jest.spyOn(service, 'findOne').mockResolvedValue(session as any);
-      jobService.calculateMetrics.mockResolvedValue({
-        initialCapital: 10000,
-        currentPortfolioValue: 12000,
-        totalReturn: 2000,
-        totalReturnPercent: 20,
-        maxDrawdown: 0.05,
-        sharpeRatio: 1.2,
-        winRate: 0.6,
-        totalTrades: 50,
-        winningTrades: 30,
-        losingTrades: 20,
-        totalFees: 100,
-        durationHours: 168
-      });
-
-      const result = await service.getPerformance('session-10', mockUser);
-
-      expect(jobService.calculateMetrics).toHaveBeenCalledWith(session);
-      expect(result.initialCapital).toBe(10000);
-      expect(result.currentPortfolioValue).toBe(12000);
-      expect(result.totalReturn).toBe(2000);
-      expect(result.totalReturnPercent).toBe(20);
-      expect(result.totalFees).toBe(100);
-      expect(result.durationHours).toBeCloseTo(168, 0);
-    });
-  });
-
   describe('startFromPipeline', () => {
+    /**
+     * The duplicate guard runs a query builder. Use this helper to seed its result —
+     * pass `null` for "no existing active session" or a session row to trigger the guard.
+     */
+    const mockDuplicateGuardResult = (existing: any | null) => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(existing)
+      };
+      sessionRepository.createQueryBuilder.mockReturnValue(qb);
+      return qb;
+    };
+
+    const baseStartParams = {
+      userId: 'user-1',
+      pipelineId: 'pipe-1',
+      algorithmId: 'algo-1',
+      exchangeKeyId: 'key-1',
+      initialCapital: 10000,
+      riskLevel: 3,
+      exitConfig: { stopLoss: 0.05 },
+      minTrades: 20
+    } as any;
+
     it('creates session, sets pipeline fields, and auto-starts', async () => {
+      mockDuplicateGuardResult(null);
+
       const pipelineSession = {
         id: 'pipe-session',
         status: PaperTradingStatus.PAUSED,
@@ -398,16 +378,7 @@ describe('PaperTradingService', () => {
       sessionRepository.save.mockResolvedValue(pipelineSession);
       jest.spyOn(service, 'start').mockResolvedValue(startedSession);
 
-      const result = await service.startFromPipeline({
-        userId: mockUser.id,
-        pipelineId: 'pipe-1',
-        algorithmId: 'algo-1',
-        exchangeKeyId: 'key-1',
-        initialCapital: 10000,
-        riskLevel: 3,
-        exitConfig: { stopLoss: 0.05 },
-        minTrades: 20
-      } as any);
+      const result = await service.startFromPipeline(baseStartParams);
 
       expect(service.create).toHaveBeenCalled();
       expect(pipelineSession.pipelineId).toBe('pipe-1');
@@ -415,8 +386,42 @@ describe('PaperTradingService', () => {
       expect(pipelineSession.exitConfig).toEqual({ stopLoss: 0.05 });
       expect(pipelineSession.minTrades).toBe(20);
       expect(sessionRepository.save).toHaveBeenCalledWith(pipelineSession);
-      expect(service.start).toHaveBeenCalledWith('pipe-session', expect.objectContaining({ id: mockUser.id }));
+      expect(service.start).toHaveBeenCalledWith('pipe-session', expect.objectContaining({ id: 'user-1' }));
       expect(result.status).toBe(PaperTradingStatus.ACTIVE);
+    });
+
+    it.each([
+      ['ACTIVE', PaperTradingStatus.ACTIVE],
+      ['PAUSED', PaperTradingStatus.PAUSED]
+    ])(
+      'throws BadRequestException when an %s session already exists for same (user, algorithm)',
+      async (_l, status) => {
+        mockDuplicateGuardResult({ id: 'existing-session', status });
+
+        const createSpy = jest.spyOn(service, 'create');
+
+        await expect(service.startFromPipeline(baseStartParams)).rejects.toBeInstanceOf(BadRequestException);
+        expect(createSpy).not.toHaveBeenCalled();
+      }
+    );
+
+    it('passes the active-status filter and pipelineId exclusion to the query builder', async () => {
+      const qb = mockDuplicateGuardResult(null);
+
+      jest.spyOn(service, 'create').mockResolvedValue({ id: 'pipe-session' } as any);
+      sessionRepository.save.mockResolvedValue({});
+      jest.spyOn(service, 'start').mockResolvedValue({ id: 'pipe-session' } as any);
+
+      await service.startFromPipeline(baseStartParams);
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('s.status IN'),
+        expect.objectContaining({ active: [PaperTradingStatus.ACTIVE, PaperTradingStatus.PAUSED] })
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('s.pipelineId'),
+        expect.objectContaining({ pipelineId: 'pipe-1' })
+      );
     });
   });
 });

--- a/apps/api/src/order/paper-trading/paper-trading.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.service.ts
@@ -3,26 +3,12 @@ import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundEx
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Queue } from 'bullmq';
-import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 
-import { PipelineStartParams, SessionStatusResponse } from '@chansey/api-interfaces';
+import { PipelineStartParams } from '@chansey/api-interfaces';
 
-import {
-  CreatePaperTradingSessionDto,
-  PaperTradingOrderFiltersDto,
-  PaperTradingSessionFiltersDto,
-  PaperTradingSignalFiltersDto,
-  PaperTradingSnapshotFiltersDto,
-  UpdatePaperTradingSessionDto
-} from './dto';
-import {
-  PaperTradingAccount,
-  PaperTradingOrder,
-  PaperTradingSession,
-  PaperTradingSignal,
-  PaperTradingSnapshot,
-  PaperTradingStatus
-} from './entities';
+import { CreatePaperTradingSessionDto, UpdatePaperTradingSessionDto } from './dto';
+import { PaperTradingAccount, PaperTradingSession, PaperTradingStatus } from './entities';
 import { PaperTradingJobService } from './paper-trading-job.service';
 import {
   NotifyPipelineJobData,
@@ -32,12 +18,18 @@ import {
 } from './paper-trading.job-data';
 
 import { Algorithm } from '../../algorithm/algorithm.entity';
-import { DEFAULT_QUOTE_CURRENCY, getQuoteCurrency } from '../../exchange/constants';
+import { DEFAULT_QUOTE_CURRENCY } from '../../exchange/constants';
 import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { forceRemoveJob } from '../../shared/queue.util';
 import { User } from '../../users/users.entity';
 import { ExitConfig } from '../interfaces/exit-config.interface';
 
+/**
+ * Lifecycle / write operations for paper trading sessions.
+ *
+ * Read-only queries live in {@link PaperTradingQueryService}; the legacy duplicate
+ * cleanup utility lives in {@link PaperTradingCleanupService}.
+ */
 @Injectable()
 export class PaperTradingService {
   private readonly logger = new Logger(PaperTradingService.name);
@@ -47,12 +39,6 @@ export class PaperTradingService {
     private readonly sessionRepository: Repository<PaperTradingSession>,
     @InjectRepository(PaperTradingAccount)
     private readonly accountRepository: Repository<PaperTradingAccount>,
-    @InjectRepository(PaperTradingOrder)
-    private readonly orderRepository: Repository<PaperTradingOrder>,
-    @InjectRepository(PaperTradingSignal)
-    private readonly signalRepository: Repository<PaperTradingSignal>,
-    @InjectRepository(PaperTradingSnapshot)
-    private readonly snapshotRepository: Repository<PaperTradingSnapshot>,
     @InjectRepository(Algorithm)
     private readonly algorithmRepository: Repository<Algorithm>,
     @InjectRepository(ExchangeKey)
@@ -119,39 +105,13 @@ export class PaperTradingService {
   }
 
   /**
-   * Find all sessions for a user with optional filters
+   * Find a session by ID + user ownership.
+   *
+   * Kept private here so the lifecycle methods can validate ownership without
+   * a cross-service dependency on `PaperTradingQueryService`. The public copy
+   * lives on `PaperTradingQueryService.findOne` for the controller to consume.
    */
-  async findAll(
-    user: User,
-    filters: PaperTradingSessionFiltersDto
-  ): Promise<{ data: PaperTradingSession[]; total: number }> {
-    const where: FindOptionsWhere<PaperTradingSession> = { user: { id: user.id } };
-
-    if (filters.status) {
-      where.status = filters.status;
-    }
-    if (filters.algorithmId) {
-      where.algorithm = { id: filters.algorithmId };
-    }
-    if (filters.pipelineId) {
-      where.pipelineId = filters.pipelineId;
-    }
-
-    const [data, total] = await this.sessionRepository.findAndCount({
-      where,
-      relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange'],
-      order: { createdAt: 'DESC' },
-      take: filters.limit ?? 50,
-      skip: filters.offset ?? 0
-    });
-
-    return { data, total };
-  }
-
-  /**
-   * Find a single session by ID
-   */
-  async findOne(id: string, user: User): Promise<PaperTradingSession> {
+  private async findOne(id: string, user: User): Promise<PaperTradingSession> {
     const session = await this.sessionRepository.findOne({
       where: { id, user: { id: user.id } },
       relations: ['algorithm', 'exchangeKey', 'exchangeKey.exchange', 'accounts']
@@ -351,163 +311,35 @@ export class PaperTradingService {
   }
 
   /**
-   * Get orders for a session
-   */
-  async getOrders(
-    sessionId: string,
-    user: User,
-    filters: PaperTradingOrderFiltersDto
-  ): Promise<{ data: PaperTradingOrder[]; total: number }> {
-    await this.findOne(sessionId, user); // Validates access
-
-    const where: FindOptionsWhere<PaperTradingOrder> = { session: { id: sessionId } };
-
-    if (filters.status) {
-      where.status = filters.status;
-    }
-    if (filters.side) {
-      where.side = filters.side;
-    }
-    if (filters.symbol) {
-      where.symbol = filters.symbol;
-    }
-
-    const [data, total] = await this.orderRepository.findAndCount({
-      where,
-      relations: ['signal'],
-      order: { createdAt: 'DESC' },
-      take: filters.limit ?? 100,
-      skip: filters.offset ?? 0
-    });
-
-    return { data, total };
-  }
-
-  /**
-   * Get signals for a session
-   */
-  async getSignals(
-    sessionId: string,
-    user: User,
-    filters: PaperTradingSignalFiltersDto
-  ): Promise<{ data: PaperTradingSignal[]; total: number }> {
-    await this.findOne(sessionId, user); // Validates access
-
-    const where: FindOptionsWhere<PaperTradingSignal> = { session: { id: sessionId } };
-
-    if (filters.signalType) {
-      where.signalType = filters.signalType;
-    }
-    if (filters.direction) {
-      where.direction = filters.direction;
-    }
-    if (filters.instrument) {
-      where.instrument = filters.instrument;
-    }
-    if (filters.processed !== undefined) {
-      where.processed = filters.processed;
-    }
-
-    const [data, total] = await this.signalRepository.findAndCount({
-      where,
-      order: { createdAt: 'DESC' },
-      take: filters.limit ?? 100,
-      skip: filters.offset ?? 0
-    });
-
-    return { data, total };
-  }
-
-  /**
-   * Get virtual balances for a session
-   */
-  async getBalances(sessionId: string, user: User): Promise<PaperTradingAccount[]> {
-    await this.findOne(sessionId, user); // Validates access
-
-    return this.accountRepository.find({
-      where: { session: { id: sessionId } },
-      order: { currency: 'ASC' }
-    });
-  }
-
-  /**
-   * Get snapshots for a session (for charting)
-   */
-  async getSnapshots(
-    sessionId: string,
-    user: User,
-    filters: PaperTradingSnapshotFiltersDto
-  ): Promise<PaperTradingSnapshot[]> {
-    await this.findOne(sessionId, user); // Validates access
-
-    const qb = this.snapshotRepository
-      .createQueryBuilder('snapshot')
-      .where('snapshot.sessionId = :sessionId', { sessionId })
-      .orderBy('snapshot.timestamp', 'ASC')
-      .take(filters.limit ?? 200);
-
-    if (filters.after) {
-      qb.andWhere('snapshot.timestamp > :after', { after: new Date(filters.after) });
-    }
-    if (filters.before) {
-      qb.andWhere('snapshot.timestamp < :before', { before: new Date(filters.before) });
-    }
-
-    return qb.getMany();
-  }
-
-  /**
-   * Get current positions for a session
-   */
-  async getPositions(
-    sessionId: string,
-    user: User
-  ): Promise<
-    Array<{
-      symbol: string;
-      quantity: number;
-      averageCost: number;
-      currentPrice?: number;
-      marketValue?: number;
-      unrealizedPnL?: number;
-      unrealizedPnLPercent?: number;
-    }>
-  > {
-    // Verify session exists and belongs to user
-    await this.findOne(sessionId, user);
-
-    // Get accounts that have holdings (not quote currency)
-    const accounts = await this.accountRepository.find({
-      where: { session: { id: sessionId } }
-    });
-
-    const quoteCurrency = getQuoteCurrency(accounts.map((a) => a.currency));
-
-    // Filter to only holding accounts with positive balances
-    const holdingAccounts = accounts.filter((a) => a.currency !== quoteCurrency && a.total > 0);
-
-    return holdingAccounts.map((account) => ({
-      symbol: `${account.currency}/${quoteCurrency}`,
-      quantity: account.total,
-      averageCost: account.averageCost ?? 0
-      // currentPrice, marketValue, unrealizedPnL populated by market data service
-    }));
-  }
-
-  /**
-   * Get performance metrics for a session
-   */
-  async getPerformance(sessionId: string, user: User): Promise<SessionStatusResponse['metrics']> {
-    const session = await this.findOne(sessionId, user);
-    return this.jobService.calculateMetrics(session);
-  }
-
-  /**
    * Start a paper trading session from pipeline orchestrator
    * Called by PipelineOrchestratorService
    */
   async startFromPipeline(params: PipelineStartParams): Promise<PaperTradingSession> {
     const user = { id: params.userId } as User;
+
+    // Defense-in-depth: block if an active session already exists for this
+    // (user, algorithm). Excludes the current pipeline's own session in case
+    // of retry. The orchestration-level checkDuplicate is the primary guard;
+    // this prevents silent duplicates if orchestration is bypassed.
+    const existing = await this.sessionRepository
+      .createQueryBuilder('s')
+      .where('s.userId = :userId', { userId: params.userId })
+      .andWhere('s.algorithmId = :algorithmId', { algorithmId: params.algorithmId })
+      .andWhere('s.status IN (:...active)', {
+        active: [PaperTradingStatus.ACTIVE, PaperTradingStatus.PAUSED]
+      })
+      .andWhere('(s.pipelineId IS NULL OR s.pipelineId != :pipelineId)', {
+        pipelineId: params.pipelineId
+      })
+      .getOne();
+
+    if (existing) {
+      throw new BadRequestException(
+        `Cannot start paper-trading from pipeline ${params.pipelineId}: ` +
+          `an active session (${existing.id}, status=${existing.status}) already exists ` +
+          `for user ${params.userId} and algorithm ${params.algorithmId}.`
+      );
+    }
 
     // Create session with pipeline context
     const dto: CreatePaperTradingSessionDto = {

--- a/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
@@ -214,20 +214,71 @@ describe('PipelineOrchestrationService', () => {
   });
 
   describe('checkDuplicate', () => {
-    it('should return false when no duplicate exists', async () => {
-      expect(await service.checkDuplicate('strategy-123', 'user-123')).toBe(false);
-    });
-
-    it('should return true when duplicate exists', async () => {
-      const mockQB = {
+    /**
+     * Helper that mocks the pipeline repository's query builder. The query builder used in
+     * checkDuplicate filters by strategyConfigId, userId, and status IN (PENDING, RUNNING, PAUSED).
+     * Pass `existing` to seed the row that getOne() will return.
+     */
+    const mockQueryBuilderWithResult = (existing: Partial<Pipeline> | null) => {
+      const qb = {
         innerJoin: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue({ id: 'existing-pipeline' })
+        getOne: jest.fn().mockResolvedValue(existing)
       };
-      pipelineRepository.createQueryBuilder = jest.fn().mockReturnValue(mockQB);
+      pipelineRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      return qb;
+    };
 
+    it('returns false when no active pipeline exists', async () => {
+      mockQueryBuilderWithResult(null);
+      expect(await service.checkDuplicate('strategy-123', 'user-123')).toBe(false);
+    });
+
+    it.each([
+      ['PENDING', PipelineStatus.PENDING],
+      ['RUNNING', PipelineStatus.RUNNING],
+      ['PAUSED', PipelineStatus.PAUSED]
+    ])('blocks when an active pipeline with status %s exists', async (_label, status) => {
+      mockQueryBuilderWithResult({ id: 'existing-pipeline', status });
       expect(await service.checkDuplicate('strategy-123', 'user-123')).toBe(true);
+    });
+
+    it.each([
+      ['COMPLETED', PipelineStatus.COMPLETED],
+      ['FAILED', PipelineStatus.FAILED],
+      ['CANCELLED', PipelineStatus.CANCELLED]
+    ])('does NOT block when only %s pipelines exist', async (_label, _status) => {
+      // The query filters by status IN (active), so terminal-status rows are excluded by SQL,
+      // not by the service. We simulate this by returning null from getOne().
+      mockQueryBuilderWithResult(null);
+      expect(await service.checkDuplicate('strategy-123', 'user-123')).toBe(false);
+    });
+
+    it('parameterizes the query with the active statuses (PENDING/RUNNING/PAUSED)', async () => {
+      const qb = mockQueryBuilderWithResult(null);
+      await service.checkDuplicate('strategy-123', 'user-123');
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('pipeline.status IN'),
+        expect.objectContaining({
+          activeStatuses: [PipelineStatus.PENDING, PipelineStatus.RUNNING, PipelineStatus.PAUSED]
+        })
+      );
+    });
+
+    it('scopes the query to the requested strategyConfigId and userId', async () => {
+      const qb = mockQueryBuilderWithResult(null);
+      await service.checkDuplicate('strategy-XYZ', 'user-ABC');
+
+      expect(qb.where).toHaveBeenCalledWith(
+        expect.stringContaining('pipeline.strategyConfigId'),
+        expect.objectContaining({ strategyConfigId: 'strategy-XYZ' })
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('user.id'),
+        expect.objectContaining({ userId: 'user-ABC' })
+      );
     });
   });
 
@@ -282,12 +333,12 @@ describe('PipelineOrchestrationService', () => {
       expect(result.skippedConfigs).toHaveLength(0);
     });
 
-    it('should skip duplicate pipelines', async () => {
+    it('should skip when an active pipeline already exists', async () => {
       const mockQB = {
         innerJoin: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue({ id: 'existing-pipeline' })
+        getOne: jest.fn().mockResolvedValue({ id: 'existing-pipeline', status: PipelineStatus.RUNNING })
       };
       pipelineRepository.createQueryBuilder = jest.fn().mockReturnValue(mockQB);
 
@@ -295,7 +346,7 @@ describe('PipelineOrchestrationService', () => {
 
       expect(result.pipelinesCreated).toBe(0);
       expect(result.skippedConfigs).toHaveLength(1);
-      expect(result.skippedConfigs[0].reason).toContain('Duplicate');
+      expect(result.skippedConfigs[0].reason).toBe('Active pipeline already exists (PENDING/RUNNING/PAUSED)');
     });
 
     it('should use initialStage=HISTORICAL and record skip when no optimizable strategy', async () => {

--- a/apps/api/src/tasks/pipeline-orchestration.service.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.ts
@@ -130,20 +130,22 @@ export class PipelineOrchestrationService {
   }
 
   /**
-   * Check if a duplicate pipeline exists for this strategy config
-   * within the last 24 hours (excluding failed/cancelled).
+   * Returns true if an active pipeline already exists for this strategy config / user.
+   * "Active" = PENDING | RUNNING | PAUSED. Completed/failed/cancelled pipelines do NOT block.
+   *
+   * An in-flight pipeline is the natural rate-limit for re-runs: as long as the previous
+   * pipeline is still PENDING, RUNNING, or PAUSED, this guard prevents the daily 2 AM cron
+   * from spawning a duplicate. No cooldown is applied after COMPLETED/FAILED so legitimate
+   * retries (e.g. transient exchange-key error) are not delayed.
    */
   async checkDuplicate(strategyConfigId: string, userId: string): Promise<boolean> {
-    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
     const existing = await this.pipelineRepository
       .createQueryBuilder('pipeline')
       .innerJoin('pipeline.user', 'user')
       .where('pipeline.strategyConfigId = :strategyConfigId', { strategyConfigId })
       .andWhere('user.id = :userId', { userId })
-      .andWhere('pipeline.createdAt >= :since', { since: twentyFourHoursAgo })
-      .andWhere('pipeline.status NOT IN (:...failedStatuses)', {
-        failedStatuses: [PipelineStatus.FAILED, PipelineStatus.CANCELLED]
+      .andWhere('pipeline.status IN (:...activeStatuses)', {
+        activeStatuses: [PipelineStatus.PENDING, PipelineStatus.RUNNING, PipelineStatus.PAUSED]
       })
       .getOne();
 
@@ -335,13 +337,14 @@ export class PipelineOrchestrationService {
     const strategyConfigId = strategyConfig.id;
     const strategyName = strategyConfig.name ?? 'Unknown';
 
-    // Check for duplicate pipeline in the last 24 hours
+    // Skip if an active pipeline already exists for this (user, strategyConfig) pair.
+    // The configured paper-trade duration naturally rate-limits re-runs while the pipeline is in flight.
     if (await this.checkDuplicate(strategyConfigId, user.id)) {
-      this.logger.debug(`Skipping duplicate pipeline for user ${user.id}, strategy ${strategyConfigId}`);
+      this.logger.debug(`Active pipeline already exists for user ${user.id}, strategy ${strategyConfigId}`);
       result.skippedConfigs.push({
         strategyConfigId,
         strategyName,
-        reason: 'Duplicate pipeline exists within 24 hours'
+        reason: 'Active pipeline already exists (PENDING/RUNNING/PAUSED)'
       });
       return;
     }


### PR DESCRIPTION
## Summary

- Prevent the daily 2 AM pipeline cron from spawning duplicate paper-trading sessions for strategies that still have one in flight
- Add defense-in-depth guard in `PaperTradingService.startFromPipeline` so an active session for the same `(user, algorithm)` cannot be created even if the upstream check is bypassed
- Decompose `paper-trading.service.ts` (656 lines, over the 500 soft limit) into three focused services, following the recent backtest decomposition pattern

## Changes

**Duplicate prevention**
- `PipelineOrchestrationService.checkDuplicate` now blocks on active pipeline status (`PENDING`/`RUNNING`/`PAUSED`) instead of a 24h window
- `PaperTradingService.startFromPipeline` throws when an active session already exists for the same `(user, algorithm)`, excluding the current pipeline's own session
- One-shot boot-time cleanup in `PaperTradingRecoveryService` stops legacy duplicate sessions through the safe `stop()` path (clears tick schedulers, cancels linked pipelines). Marked TODO for removal once legacy sessions are cleared

**Service decomposition** (`paper-trading.service.ts` → 3 focused services)
- `PaperTradingService` — lifecycle only
- `PaperTradingQueryService` — read-only queries (new)
- `PaperTradingCleanupService` — duplicate cleanup (new)
- `PaperTradingController` routes read endpoints through the query service
- `PaperTradingRecoveryService` depends on the cleanup service instead of the main service
- `PaperTradingModule` registers `Pipeline` entity and both new services

**Tests**
- Co-located spec files for the two new services
- Relocated query and cleanup tests
- Updated recovery spec for the new constructor signature
- Updated `pipeline-orchestration.service.spec.ts` for the new duplicate-check behavior

## Test Plan

- [ ] `nx test api` passes
- [ ] `nx lint api` passes
- [ ] Manually verify the 2 AM pipeline cron does not create a second pipeline when one is `RUNNING`
- [ ] Verify legacy duplicate sessions are cleaned up on boot (check logs from `PaperTradingRecoveryService`)
- [ ] Verify read endpoints on `PaperTradingController` still return the same shape