### PR TITLE
fix(api): clear orphaned parent pipelines when backtests fail

### DIFF
--- a/apps/api/src/order/backtest/backtest-result.service.spec.ts
+++ b/apps/api/src/order/backtest/backtest-result.service.spec.ts
@@ -9,17 +9,19 @@ import { type BacktestFinalMetrics, BacktestResultService } from './backtest-res
 import { BacktestSignal } from './backtest-signal.entity';
 import { BacktestStreamService } from './backtest-stream.service';
 import { BacktestTrade } from './backtest-trade.entity';
-import { Backtest, BacktestStatus } from './backtest.entity';
+import { Backtest, BacktestStatus, BacktestType } from './backtest.entity';
 import { SimulatedOrderFill } from './simulated-order-fill.entity';
 
 import { MetricsService } from '../../metrics/metrics.service';
+import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
 
 describe('BacktestResultService', () => {
   let service: BacktestResultService;
 
   const mockBacktestRepository = {
     save: jest.fn(),
-    update: jest.fn()
+    update: jest.fn(),
+    findOne: jest.fn()
   };
 
   const mockBacktestStreamService = {
@@ -340,6 +342,11 @@ describe('BacktestResultService', () => {
     it('should update backtest status and publish failed state', async () => {
       const backtestId = 'backtest-456';
       const errorMessage = 'Strategy execution error';
+      mockBacktestRepository.findOne.mockResolvedValue({
+        id: backtestId,
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.RUNNING
+      });
 
       await service.markFailed(backtestId, errorMessage);
 
@@ -348,6 +355,80 @@ describe('BacktestResultService', () => {
         errorMessage
       });
       expect(mockBacktestStreamService.publishStatus).toHaveBeenCalledWith(backtestId, 'failed', errorMessage);
+    });
+
+    it('emits BACKTEST_FAILED for HISTORICAL backtest', async () => {
+      const backtestId = 'backtest-hist-1';
+      const errorMessage = 'Strategy crashed';
+      mockBacktestRepository.findOne.mockResolvedValue({
+        id: backtestId,
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.RUNNING
+      });
+
+      await service.markFailed(backtestId, errorMessage);
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(PIPELINE_EVENTS.BACKTEST_FAILED, {
+        backtestId,
+        type: 'HISTORICAL',
+        reason: errorMessage
+      });
+    });
+
+    it('emits BACKTEST_FAILED for LIVE_REPLAY backtest', async () => {
+      const backtestId = 'backtest-lr-1';
+      const errorMessage = 'OOM';
+      mockBacktestRepository.findOne.mockResolvedValue({
+        id: backtestId,
+        type: BacktestType.LIVE_REPLAY,
+        status: BacktestStatus.RUNNING
+      });
+
+      await service.markFailed(backtestId, errorMessage);
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(PIPELINE_EVENTS.BACKTEST_FAILED, {
+        backtestId,
+        type: 'LIVE_REPLAY',
+        reason: errorMessage
+      });
+    });
+
+    it('does not emit BACKTEST_FAILED for PAPER_TRADING backtest', async () => {
+      const backtestId = 'backtest-pt-1';
+      mockBacktestRepository.findOne.mockResolvedValue({
+        id: backtestId,
+        type: BacktestType.PAPER_TRADING,
+        status: BacktestStatus.RUNNING
+      });
+
+      await service.markFailed(backtestId, 'some error');
+
+      expect(mockEventEmitter.emit).not.toHaveBeenCalledWith(PIPELINE_EVENTS.BACKTEST_FAILED, expect.any(Object));
+    });
+
+    it('is idempotent — skips update and emit when backtest is already FAILED', async () => {
+      const backtestId = 'backtest-already-failed';
+      mockBacktestRepository.findOne.mockResolvedValue({
+        id: backtestId,
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.FAILED
+      });
+
+      await service.markFailed(backtestId, 'duplicate failure');
+
+      expect(mockBacktestRepository.update).not.toHaveBeenCalled();
+      expect(mockBacktestStreamService.publishStatus).not.toHaveBeenCalled();
+      expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when backtest does not exist', async () => {
+      mockBacktestRepository.findOne.mockResolvedValue(null);
+
+      await service.markFailed('missing-id', 'err');
+
+      expect(mockBacktestRepository.update).not.toHaveBeenCalled();
+      expect(mockBacktestStreamService.publishStatus).not.toHaveBeenCalled();
+      expect(mockEventEmitter.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/order/backtest/backtest-result.service.ts
+++ b/apps/api/src/order/backtest/backtest-result.service.ts
@@ -9,10 +9,11 @@ import { BacktestPerformanceSnapshot } from './backtest-performance-snapshot.ent
 import { BacktestSignal } from './backtest-signal.entity';
 import { BacktestStreamService } from './backtest-stream.service';
 import { BacktestTrade } from './backtest-trade.entity';
-import { Backtest, BacktestStatus } from './backtest.entity';
+import { Backtest, BacktestStatus, BacktestType } from './backtest.entity';
 import { SimulatedOrderFill } from './simulated-order-fill.entity';
 
 import { MetricsService } from '../../metrics/metrics.service';
+import { BacktestFailedEvent, PIPELINE_EVENTS } from '../../pipeline/interfaces';
 import { toErrorInfo } from '../../shared/error.util';
 import { sanitizeNumericValue } from '../../utils/validators/numeric-sanitizer';
 
@@ -195,12 +196,40 @@ export class BacktestResultService {
   }
 
   async markFailed(backtestId: string, errorMessage: string): Promise<void> {
+    // Read first so we have the type for the event payload and can skip double-emit
+    // when multiple call sites (watchdog + processor catch block) race to fail the same backtest.
+    const backtest = await this.backtestRepository.findOne({
+      where: { id: backtestId },
+      select: ['id', 'type', 'status']
+    });
+
+    if (!backtest || backtest.status === BacktestStatus.FAILED) {
+      return;
+    }
+
     await this.backtestRepository.update(backtestId, {
       status: BacktestStatus.FAILED,
       errorMessage
     });
 
     await this.backtestStream.publishStatus(backtestId, 'failed', errorMessage);
+
+    // Emit failure event for pipeline orchestrator so parent pipelines can transition to FAILED.
+    // Mirrors the typeMapping pattern in persistSuccess — filters out PAPER_TRADING and
+    // STRATEGY_OPTIMIZATION, which have no corresponding pipeline stage.
+    const typeMapping: Record<string, 'HISTORICAL' | 'LIVE_REPLAY' | undefined> = {
+      [BacktestType.HISTORICAL]: 'HISTORICAL',
+      [BacktestType.LIVE_REPLAY]: 'LIVE_REPLAY'
+    };
+    const mappedType = typeMapping[backtest.type];
+
+    if (mappedType) {
+      this.eventEmitter.emit(PIPELINE_EVENTS.BACKTEST_FAILED, {
+        backtestId,
+        type: mappedType,
+        reason: errorMessage
+      } satisfies BacktestFailedEvent);
+    }
   }
 
   async markCancelled(backtest: Backtest, reason?: string): Promise<void> {

--- a/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
@@ -39,6 +39,15 @@ export interface BacktestCompletedEvent {
 }
 
 /**
+ * Event payload for backtest failure (stale watchdog or error)
+ */
+export interface BacktestFailedEvent {
+  backtestId: string;
+  type: 'HISTORICAL' | 'LIVE_REPLAY';
+  reason: string;
+}
+
+/**
  * Event payload for paper trading completion
  */
 export interface PaperTradingCompletedEvent {
@@ -121,6 +130,7 @@ export const PIPELINE_EVENTS = {
   OPTIMIZATION_COMPLETED: 'optimization.completed',
   OPTIMIZATION_FAILED: 'optimization.failed',
   BACKTEST_COMPLETED: 'backtest.completed',
+  BACKTEST_FAILED: 'backtest.failed',
   PAPER_TRADING_COMPLETED: 'paper-trading.completed',
   PIPELINE_STAGE_TRANSITION: 'pipeline.stage-transition',
   PIPELINE_STATUS_CHANGE: 'pipeline.status-change',

--- a/apps/api/src/pipeline/listeners/pipeline-event.listener.ts
+++ b/apps/api/src/pipeline/listeners/pipeline-event.listener.ts
@@ -4,6 +4,7 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { toErrorInfo } from '../../shared/error.util';
 import {
   BacktestCompletedEvent,
+  BacktestFailedEvent,
   OptimizationCompletedEvent,
   OptimizationFailedEvent,
   PIPELINE_EVENTS,
@@ -67,6 +68,23 @@ export class PipelineEventListener {
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Failed to handle backtest completion for ${payload.backtestId}: ${err.message}`, err.stack);
+    }
+  }
+
+  /**
+   * Handle backtest failure event (stale watchdog or error)
+   */
+  @OnEvent(PIPELINE_EVENTS.BACKTEST_FAILED, { async: true })
+  async handleBacktestFailed(payload: BacktestFailedEvent): Promise<void> {
+    this.logger.log(
+      `Received backtest.failed event for backtest ${payload.backtestId} (type: ${payload.type}): ${payload.reason}`
+    );
+
+    try {
+      await this.orchestratorService.handleBacktestFailed(payload.backtestId, payload.type, payload.reason);
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Failed to handle backtest failure for ${payload.backtestId}: ${err.message}`, err.stack);
     }
   }
 

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
@@ -108,6 +108,27 @@ export class PipelineEventHandlerService {
     await this.progressionService.failPipeline(pipeline, `Optimization failed: ${reason}`);
   }
 
+  async handleBacktestFailed(backtestId: string, type: 'HISTORICAL' | 'LIVE_REPLAY', reason: string): Promise<void> {
+    const whereClause =
+      type === 'HISTORICAL' ? { historicalBacktestId: backtestId } : { liveReplayBacktestId: backtestId };
+
+    const pipeline = await this.pipelineRepository.findOne({
+      where: {
+        ...whereClause,
+        status: In([PipelineStatus.RUNNING, PipelineStatus.PAUSED])
+      },
+      relations: ['user']
+    });
+
+    if (!pipeline) {
+      // Standalone backtest (not part of a pipeline) — nothing to do.
+      this.logger.debug(`No active pipeline found for failed ${type} backtest ${backtestId}`);
+      return;
+    }
+
+    await this.progressionService.failPipeline(pipeline, `${type} backtest ${backtestId} failed: ${reason}`);
+  }
+
   async handleBacktestComplete(
     backtestId: string,
     type: 'HISTORICAL' | 'LIVE_REPLAY',

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
@@ -111,10 +111,12 @@ export class PipelineEventHandlerService {
   async handleBacktestFailed(backtestId: string, type: 'HISTORICAL' | 'LIVE_REPLAY', reason: string): Promise<void> {
     const whereClause =
       type === 'HISTORICAL' ? { historicalBacktestId: backtestId } : { liveReplayBacktestId: backtestId };
+    const stage = type === 'HISTORICAL' ? PipelineStage.HISTORICAL : PipelineStage.LIVE_REPLAY;
 
     const pipeline = await this.pipelineRepository.findOne({
       where: {
         ...whereClause,
+        currentStage: stage,
         status: In([PipelineStatus.RUNNING, PipelineStatus.PAUSED])
       },
       relations: ['user']

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -334,6 +334,10 @@ export class PipelineOrchestratorService {
     return this.eventHandlerService.handleBacktestComplete(backtestId, type, metrics);
   }
 
+  async handleBacktestFailed(backtestId: string, type: 'HISTORICAL' | 'LIVE_REPLAY', reason: string): Promise<void> {
+    return this.eventHandlerService.handleBacktestFailed(backtestId, type, reason);
+  }
+
   async handlePaperTradingComplete(
     sessionId: string,
     pipelineId: string,

--- a/apps/api/src/tasks/backtest-orchestration.task.spec.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.spec.ts
@@ -36,7 +36,8 @@ describe('BacktestOrchestrationTask', () => {
     detectStaleBacktests: jest.fn().mockResolvedValue(undefined),
     detectStaleOptimizationRuns: jest.fn().mockResolvedValue(undefined),
     detectOrphanedOptimizePipelines: jest.fn().mockResolvedValue(undefined),
-    detectFailedOptimizationPipelines: jest.fn().mockResolvedValue(undefined)
+    detectFailedOptimizationPipelines: jest.fn().mockResolvedValue(undefined),
+    detectFailedBacktestPipelines: jest.fn().mockResolvedValue(undefined)
   };
 
   beforeEach(async () => {
@@ -168,6 +169,7 @@ describe('BacktestOrchestrationTask', () => {
       expect(mockWatchdog.detectStaleOptimizationRuns).toHaveBeenCalledTimes(1);
       expect(mockWatchdog.detectOrphanedOptimizePipelines).toHaveBeenCalledTimes(1);
       expect(mockWatchdog.detectFailedOptimizationPipelines).toHaveBeenCalledTimes(1);
+      expect(mockWatchdog.detectFailedBacktestPipelines).toHaveBeenCalledTimes(1);
     });
 
     it('should not run concurrently (re-entrant guard)', async () => {

--- a/apps/api/src/tasks/backtest-orchestration.task.ts
+++ b/apps/api/src/tasks/backtest-orchestration.task.ts
@@ -150,6 +150,7 @@ export class BacktestOrchestrationTask {
       await this.watchdog.detectStaleOptimizationRuns();
       await this.watchdog.detectOrphanedOptimizePipelines();
       await this.watchdog.detectFailedOptimizationPipelines();
+      await this.watchdog.detectFailedBacktestPipelines();
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Watchdog checks failed: ${err.message}`, err.stack);

--- a/apps/api/src/tasks/backtest-watchdog.service.spec.ts
+++ b/apps/api/src/tasks/backtest-watchdog.service.spec.ts
@@ -120,33 +120,6 @@ describe('BacktestWatchdogService', () => {
       );
     });
 
-    it('should emit BACKTEST_FAILED event so parent pipelines can transition to FAILED', async () => {
-      const staleBacktest = {
-        id: 'stale-bt-event',
-        type: BacktestType.HISTORICAL,
-        status: BacktestStatus.RUNNING,
-        lastCheckpointAt: new Date(Date.now() - 100 * 60 * 1000),
-        processedTimestampCount: 500,
-        totalTimestampCount: 2000,
-        checkpointState: { lastProcessedIndex: 499 }
-      };
-      mockBacktestRepository.find
-        .mockResolvedValueOnce([staleBacktest])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
-
-      await service.detectStaleBacktests();
-
-      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
-        PIPELINE_EVENTS.BACKTEST_FAILED,
-        expect.objectContaining({
-          backtestId: 'stale-bt-event',
-          type: 'HISTORICAL',
-          reason: expect.stringContaining('Stale: no heartbeat progress for 90 min')
-        })
-      );
-    });
-
     it('should mark stale LIVE_REPLAY backtests as failed with 120-min threshold', async () => {
       const staleReplay = {
         id: 'stale-replay-1',
@@ -167,33 +140,6 @@ describe('BacktestWatchdogService', () => {
       expect(mockBacktestResultService.markFailed).toHaveBeenCalledWith(
         'stale-replay-1',
         expect.stringContaining('Stale: no heartbeat progress for 120 min')
-      );
-    });
-
-    it('should emit BACKTEST_FAILED with type LIVE_REPLAY for stale replay backtests', async () => {
-      const staleReplay = {
-        id: 'stale-replay-event',
-        type: BacktestType.LIVE_REPLAY,
-        status: BacktestStatus.RUNNING,
-        lastCheckpointAt: new Date(Date.now() - 130 * 60 * 1000),
-        processedTimestampCount: 300,
-        totalTimestampCount: 1000,
-        checkpointState: { lastProcessedIndex: 299 }
-      };
-      mockBacktestRepository.find
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([staleReplay])
-        .mockResolvedValueOnce([]);
-
-      await service.detectStaleBacktests();
-
-      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
-        PIPELINE_EVENTS.BACKTEST_FAILED,
-        expect.objectContaining({
-          backtestId: 'stale-replay-event',
-          type: 'LIVE_REPLAY',
-          reason: expect.stringContaining('Stale: no heartbeat progress for 120 min')
-        })
       );
     });
 
@@ -558,6 +504,148 @@ describe('BacktestWatchdogService', () => {
       await service.detectFailedOptimizationPipelines();
 
       expect(mockPipelineRepository.find).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('detectFailedBacktestPipelines', () => {
+    it('should do nothing when no candidates exist', async () => {
+      mockPipelineRepository.find.mockResolvedValue([]);
+
+      await service.detectFailedBacktestPipelines();
+
+      expect(mockBacktestRepository.find).not.toHaveBeenCalled();
+      expect(mockPipelineRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should mark HISTORICAL-stage pipeline as FAILED when backtest is FAILED', async () => {
+      const pipeline = {
+        id: 'pipeline-h-1',
+        status: PipelineStatus.RUNNING,
+        currentStage: PipelineStage.HISTORICAL,
+        historicalBacktestId: 'bt-h-1',
+        liveReplayBacktestId: null
+      };
+      const failedBacktest = {
+        id: 'bt-h-1',
+        status: BacktestStatus.FAILED,
+        errorMessage: 'Strategy crashed'
+      };
+      mockPipelineRepository.find.mockResolvedValue([pipeline]);
+      mockBacktestRepository.find.mockResolvedValue([failedBacktest]);
+      mockPipelineRepository.update.mockResolvedValue({ affected: 1 });
+
+      await service.detectFailedBacktestPipelines();
+
+      expect(mockPipelineRepository.update).toHaveBeenCalledWith(
+        { id: 'pipeline-h-1', status: PipelineStatus.RUNNING, currentStage: PipelineStage.HISTORICAL },
+        expect.objectContaining({
+          status: PipelineStatus.FAILED,
+          failureReason: expect.stringContaining('Strategy crashed')
+        })
+      );
+    });
+
+    it('should mark LIVE_REPLAY-stage pipeline as FAILED when backtest is FAILED', async () => {
+      const pipeline = {
+        id: 'pipeline-lr-1',
+        status: PipelineStatus.RUNNING,
+        currentStage: PipelineStage.LIVE_REPLAY,
+        historicalBacktestId: null,
+        liveReplayBacktestId: 'bt-lr-1'
+      };
+      const failedBacktest = {
+        id: 'bt-lr-1',
+        status: BacktestStatus.FAILED,
+        errorMessage: 'OOM'
+      };
+      mockPipelineRepository.find.mockResolvedValue([pipeline]);
+      mockBacktestRepository.find.mockResolvedValue([failedBacktest]);
+      mockPipelineRepository.update.mockResolvedValue({ affected: 1 });
+
+      await service.detectFailedBacktestPipelines();
+
+      expect(mockPipelineRepository.update).toHaveBeenCalledWith(
+        { id: 'pipeline-lr-1', status: PipelineStatus.RUNNING, currentStage: PipelineStage.LIVE_REPLAY },
+        expect.objectContaining({
+          status: PipelineStatus.FAILED,
+          failureReason: expect.stringContaining('OOM')
+        })
+      );
+    });
+
+    it('should mark pipeline as FAILED when linked backtest no longer exists', async () => {
+      const pipeline = {
+        id: 'pipeline-h-2',
+        status: PipelineStatus.RUNNING,
+        currentStage: PipelineStage.HISTORICAL,
+        historicalBacktestId: 'bt-deleted',
+        liveReplayBacktestId: null
+      };
+      mockPipelineRepository.find.mockResolvedValue([pipeline]);
+      mockBacktestRepository.find.mockResolvedValue([]); // backtest deleted
+      mockPipelineRepository.update.mockResolvedValue({ affected: 1 });
+
+      await service.detectFailedBacktestPipelines();
+
+      expect(mockPipelineRepository.update).toHaveBeenCalledWith(
+        { id: 'pipeline-h-2', status: PipelineStatus.RUNNING, currentStage: PipelineStage.HISTORICAL },
+        expect.objectContaining({
+          status: PipelineStatus.FAILED,
+          failureReason: expect.stringContaining('no longer exists')
+        })
+      );
+    });
+
+    it('should skip pipeline when backtest is still RUNNING', async () => {
+      const pipeline = {
+        id: 'pipeline-h-3',
+        status: PipelineStatus.RUNNING,
+        currentStage: PipelineStage.HISTORICAL,
+        historicalBacktestId: 'bt-running',
+        liveReplayBacktestId: null
+      };
+      const runningBacktest = {
+        id: 'bt-running',
+        status: BacktestStatus.RUNNING,
+        errorMessage: null
+      };
+      mockPipelineRepository.find.mockResolvedValue([pipeline]);
+      mockBacktestRepository.find.mockResolvedValue([runningBacktest]);
+
+      await service.detectFailedBacktestPipelines();
+
+      expect(mockPipelineRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should skip pipeline when atomic update reports affected === 0', async () => {
+      const pipeline = {
+        id: 'pipeline-h-4',
+        status: PipelineStatus.RUNNING,
+        currentStage: PipelineStage.HISTORICAL,
+        historicalBacktestId: 'bt-h-4',
+        liveReplayBacktestId: null
+      };
+      const failedBacktest = {
+        id: 'bt-h-4',
+        status: BacktestStatus.FAILED,
+        errorMessage: 'err'
+      };
+      mockPipelineRepository.find.mockResolvedValue([pipeline]);
+      mockBacktestRepository.find.mockResolvedValue([failedBacktest]);
+      mockPipelineRepository.update.mockResolvedValue({ affected: 0 });
+
+      await expect(service.detectFailedBacktestPipelines()).resolves.toBeUndefined();
+
+      expect(mockPipelineRepository.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip during boot grace period', async () => {
+      (service as any).bootedAt = Date.now();
+
+      await service.detectFailedBacktestPipelines();
+
+      expect(mockPipelineRepository.find).not.toHaveBeenCalled();
+      expect(mockBacktestRepository.find).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/tasks/backtest-watchdog.service.spec.ts
+++ b/apps/api/src/tasks/backtest-watchdog.service.spec.ts
@@ -120,6 +120,33 @@ describe('BacktestWatchdogService', () => {
       );
     });
 
+    it('should emit BACKTEST_FAILED event so parent pipelines can transition to FAILED', async () => {
+      const staleBacktest = {
+        id: 'stale-bt-event',
+        type: BacktestType.HISTORICAL,
+        status: BacktestStatus.RUNNING,
+        lastCheckpointAt: new Date(Date.now() - 100 * 60 * 1000),
+        processedTimestampCount: 500,
+        totalTimestampCount: 2000,
+        checkpointState: { lastProcessedIndex: 499 }
+      };
+      mockBacktestRepository.find
+        .mockResolvedValueOnce([staleBacktest])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      await service.detectStaleBacktests();
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        PIPELINE_EVENTS.BACKTEST_FAILED,
+        expect.objectContaining({
+          backtestId: 'stale-bt-event',
+          type: 'HISTORICAL',
+          reason: expect.stringContaining('Stale: no heartbeat progress for 90 min')
+        })
+      );
+    });
+
     it('should mark stale LIVE_REPLAY backtests as failed with 120-min threshold', async () => {
       const staleReplay = {
         id: 'stale-replay-1',
@@ -140,6 +167,33 @@ describe('BacktestWatchdogService', () => {
       expect(mockBacktestResultService.markFailed).toHaveBeenCalledWith(
         'stale-replay-1',
         expect.stringContaining('Stale: no heartbeat progress for 120 min')
+      );
+    });
+
+    it('should emit BACKTEST_FAILED with type LIVE_REPLAY for stale replay backtests', async () => {
+      const staleReplay = {
+        id: 'stale-replay-event',
+        type: BacktestType.LIVE_REPLAY,
+        status: BacktestStatus.RUNNING,
+        lastCheckpointAt: new Date(Date.now() - 130 * 60 * 1000),
+        processedTimestampCount: 300,
+        totalTimestampCount: 1000,
+        checkpointState: { lastProcessedIndex: 299 }
+      };
+      mockBacktestRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([staleReplay])
+        .mockResolvedValueOnce([]);
+
+      await service.detectStaleBacktests();
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        PIPELINE_EVENTS.BACKTEST_FAILED,
+        expect.objectContaining({
+          backtestId: 'stale-replay-event',
+          type: 'LIVE_REPLAY',
+          reason: expect.stringContaining('Stale: no heartbeat progress for 120 min')
+        })
       );
     });
 

--- a/apps/api/src/tasks/backtest-watchdog.service.ts
+++ b/apps/api/src/tasks/backtest-watchdog.service.ts
@@ -18,7 +18,7 @@ import { BacktestResultService } from '../order/backtest/backtest-result.service
 import { backtestConfig } from '../order/backtest/backtest.config';
 import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
 import { Pipeline } from '../pipeline/entities/pipeline.entity';
-import { PIPELINE_EVENTS, PipelineStage, PipelineStatus } from '../pipeline/interfaces';
+import { BacktestFailedEvent, PIPELINE_EVENTS, PipelineStage, PipelineStatus } from '../pipeline/interfaces';
 import { toErrorInfo } from '../shared/error.util';
 
 const BACKTEST_QUEUE_NAMES = backtestConfig();
@@ -141,6 +141,15 @@ export class BacktestWatchdogService {
                 `progress: ${backtest.processedTimestampCount}/${backtest.totalTimestampCount})`)
         );
         await this.backtestResultService.markFailed(backtest.id, reason);
+
+        // Notify any parent pipeline so it can transition to FAILED instead of orphaning.
+        // markFailed() does not emit events, so this is the sole source for backtest.failed.
+        this.eventEmitter.emit(PIPELINE_EVENTS.BACKTEST_FAILED, {
+          backtestId: backtest.id,
+          type: this.toFailedEventType(backtest.type),
+          reason
+        } satisfies BacktestFailedEvent);
+
         marked++;
       } catch (error: unknown) {
         const err = toErrorInfo(error);
@@ -347,6 +356,24 @@ export class BacktestWatchdogService {
     } catch (error: unknown) {
       this.logger.warn(`Failed to check queue status for job ${jobId}: ${toErrorInfo(error).message}`);
       return false;
+    }
+  }
+
+  /**
+   * Map a backtest type to its BacktestFailedEvent `type` string.
+   * Exhaustive switch — TypeScript enforces handling every BacktestType member.
+   * Throws for types the watchdog should never see so misrouted rows fail loudly
+   * in logs (via the caller's try/catch) instead of emitting a bogus event.
+   */
+  private toFailedEventType(type: BacktestType): 'HISTORICAL' | 'LIVE_REPLAY' {
+    switch (type) {
+      case BacktestType.HISTORICAL:
+        return 'HISTORICAL';
+      case BacktestType.LIVE_REPLAY:
+        return 'LIVE_REPLAY';
+      case BacktestType.PAPER_TRADING:
+      case BacktestType.STRATEGY_OPTIMIZATION:
+        throw new Error(`BacktestWatchdog should never process ${type} — check stale detection query filters`);
     }
   }
 

--- a/apps/api/src/tasks/backtest-watchdog.service.ts
+++ b/apps/api/src/tasks/backtest-watchdog.service.ts
@@ -18,7 +18,7 @@ import { BacktestResultService } from '../order/backtest/backtest-result.service
 import { backtestConfig } from '../order/backtest/backtest.config';
 import { Backtest, BacktestStatus, BacktestType } from '../order/backtest/backtest.entity';
 import { Pipeline } from '../pipeline/entities/pipeline.entity';
-import { BacktestFailedEvent, PIPELINE_EVENTS, PipelineStage, PipelineStatus } from '../pipeline/interfaces';
+import { PIPELINE_EVENTS, PipelineStage, PipelineStatus } from '../pipeline/interfaces';
 import { toErrorInfo } from '../shared/error.util';
 
 const BACKTEST_QUEUE_NAMES = backtestConfig();
@@ -140,15 +140,9 @@ export class BacktestWatchdogService {
               : `(last heartbeat: ${backtest.lastCheckpointAt?.toISOString()}, ` +
                 `progress: ${backtest.processedTimestampCount}/${backtest.totalTimestampCount})`)
         );
+        // markFailed() now emits PIPELINE_EVENTS.BACKTEST_FAILED internally so the parent
+        // pipeline can transition to FAILED instead of orphaning.
         await this.backtestResultService.markFailed(backtest.id, reason);
-
-        // Notify any parent pipeline so it can transition to FAILED instead of orphaning.
-        // markFailed() does not emit events, so this is the sole source for backtest.failed.
-        this.eventEmitter.emit(PIPELINE_EVENTS.BACKTEST_FAILED, {
-          backtestId: backtest.id,
-          type: this.toFailedEventType(backtest.type),
-          reason
-        } satisfies BacktestFailedEvent);
 
         marked++;
       } catch (error: unknown) {
@@ -344,6 +338,93 @@ export class BacktestWatchdogService {
   }
 
   /**
+   * Detects RUNNING pipelines in HISTORICAL or LIVE_REPLAY stage whose linked backtest
+   * has already FAILED (or been deleted). This is the reconciliation safety net for cases
+   * where the BACKTEST_FAILED event was never delivered (process kill between DB commit
+   * and emit, listener exception, etc.) — mirrors detectFailedOptimizationPipelines.
+   */
+  async detectFailedBacktestPipelines(): Promise<void> {
+    if (this.isWithinBootGrace()) return;
+
+    const candidates = await this.pipelineRepository.find({
+      select: ['id', 'status', 'currentStage', 'historicalBacktestId', 'liveReplayBacktestId'],
+      where: [
+        {
+          status: PipelineStatus.RUNNING,
+          currentStage: PipelineStage.HISTORICAL,
+          historicalBacktestId: Not(IsNull())
+        },
+        {
+          status: PipelineStatus.RUNNING,
+          currentStage: PipelineStage.LIVE_REPLAY,
+          liveReplayBacktestId: Not(IsNull())
+        }
+      ]
+    });
+
+    // Batch-fetch the linked backtests for all candidates
+    const backtestIds = candidates
+      .map((p) => (p.currentStage === PipelineStage.HISTORICAL ? p.historicalBacktestId : p.liveReplayBacktestId))
+      .filter((id): id is string => id != null);
+    const backtests =
+      backtestIds.length > 0
+        ? await this.backtestRepository.find({
+            select: ['id', 'status', 'errorMessage'],
+            where: { id: In(backtestIds) }
+          })
+        : [];
+    const backtestsById = new Map(backtests.map((b) => [b.id, b]));
+
+    let marked = 0;
+    for (const pipeline of candidates) {
+      try {
+        const stage = pipeline.currentStage;
+        const linkedId =
+          stage === PipelineStage.HISTORICAL ? pipeline.historicalBacktestId : pipeline.liveReplayBacktestId;
+        if (!linkedId) continue;
+
+        const backtest = backtestsById.get(linkedId);
+
+        // Pipeline is invalid if its backtest is FAILED or missing entirely
+        if (backtest && backtest.status !== BacktestStatus.FAILED) {
+          continue;
+        }
+
+        const reason = backtest
+          ? `${stage} backtest ${backtest.id} FAILED: ${backtest.errorMessage || 'unknown error'}`
+          : `${stage} backtest ${linkedId} no longer exists`;
+
+        this.logger.warn(`Marking pipeline ${pipeline.id} as FAILED — ${reason}`);
+
+        // Include currentStage in the predicate so we don't fail a pipeline that advanced
+        // to a different stage between our find() and update().
+        const result = await this.pipelineRepository.update(
+          { id: pipeline.id, status: PipelineStatus.RUNNING, currentStage: stage },
+          {
+            status: PipelineStatus.FAILED,
+            failureReason: reason,
+            completedAt: new Date()
+          }
+        );
+
+        if (result.affected === 0) {
+          this.logger.log(`Pipeline ${pipeline.id} already transitioned — skipping`);
+          continue;
+        }
+
+        marked++;
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        this.logger.error(`Failed to mark pipeline ${pipeline.id} with failed backtest as FAILED: ${err.message}`);
+      }
+    }
+
+    if (marked > 0) {
+      this.logger.log(`Failed-backtest pipeline watchdog marked ${marked} pipeline(s) as FAILED`);
+    }
+  }
+
+  /**
    * Check if a BullMQ job is legitimately queued (waiting or delayed).
    * Returns false on missing job or any error (lets watchdog proceed on failure).
    */
@@ -356,24 +437,6 @@ export class BacktestWatchdogService {
     } catch (error: unknown) {
       this.logger.warn(`Failed to check queue status for job ${jobId}: ${toErrorInfo(error).message}`);
       return false;
-    }
-  }
-
-  /**
-   * Map a backtest type to its BacktestFailedEvent `type` string.
-   * Exhaustive switch — TypeScript enforces handling every BacktestType member.
-   * Throws for types the watchdog should never see so misrouted rows fail loudly
-   * in logs (via the caller's try/catch) instead of emitting a bogus event.
-   */
-  private toFailedEventType(type: BacktestType): 'HISTORICAL' | 'LIVE_REPLAY' {
-    switch (type) {
-      case BacktestType.HISTORICAL:
-        return 'HISTORICAL';
-      case BacktestType.LIVE_REPLAY:
-        return 'LIVE_REPLAY';
-      case BacktestType.PAPER_TRADING:
-      case BacktestType.STRATEGY_OPTIMIZATION:
-        throw new Error(`BacktestWatchdog should never process ${type} — check stale detection query filters`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Route `BACKTEST_FAILED` events through `BacktestResultService.markFailed()` so every failure path — watchdog, processor catch blocks, wrong-type routing, strategy-evaluation — notifies the parent pipeline
- Add `detectFailedBacktestPipelines()` reconciliation sweep as the eventual-consistency safety net for HISTORICAL/LIVE_REPLAY stages, mirroring the existing `detectFailedOptimizationPipelines` pattern
- Auto-cleans the 12 pre-existing orphaned pipelines on the first post-deploy watchdog run (replaces the manual SQL cleanup)

## Background

`BacktestWatchdogService.detectStaleBacktests()` marked stale backtests as FAILED but never notified the parent pipeline, leaving HISTORICAL-stage pipelines stuck in RUNNING forever (12 orphans observed in production). The parallel watchdog method for optimization runs already emits `PIPELINE_EVENTS.OPTIMIZATION_FAILED` — this PR adds and generalizes the equivalent for backtests.

During review it became clear that emitting only from the watchdog covered just 1 of 6 `markFailed()` call sites. The common case (processor catch block after a crash/OOM/unhandled error) bypassed the watchdog's `status: RUNNING` query entirely, so the parent pipeline orphaned exactly as before. Events are also fragile — a process kill between DB commit and emit, a listener exception, or a DI boot issue silently drops the signal.

## Changes

### Commit 1: `76aaa1ef` — initial watchdog → pipeline wiring

- Added `PIPELINE_EVENTS.BACKTEST_FAILED` constant and `BacktestFailedEvent` interface
- Added `handleBacktestFailed()` to `PipelineOrchestratorService` + `PipelineEventHandlerService`
- Wired `PipelineEventListener.onBacktestFailed()` to find the parent pipeline by `historicalBacktestId`/`liveReplayBacktestId` and transition it to FAILED via the existing `failPipeline()` helper
- Watchdog emitted `BACKTEST_FAILED` directly after calling `markFailed()`

### Commit 2: `3b1c33da` — emit relocation + reconciliation sweep

**Fix #1: Move the emit into `markFailed()` itself**
- `BacktestResultService.markFailed()` now reads the backtest first (idempotency guard — no-op if missing or already FAILED), runs the update/publish, then emits `BACKTEST_FAILED` using the same `typeMapping` pattern as `persistSuccess` (filters out `PAPER_TRADING`/`STRATEGY_OPTIMIZATION`)
- Removed the now-redundant direct emit + `toFailedEventType` helper from the watchdog
- All 6 `markFailed()` call sites now fire the event atomically through one code path

**Fix #2: Add `detectFailedBacktestPipelines()` reconciliation sweep**
- New watchdog method modeled on `detectFailedOptimizationPipelines`: finds RUNNING pipelines in HISTORICAL/LIVE_REPLAY stage whose linked backtest is FAILED or deleted, transitions them atomically
- Atomic update predicate includes `currentStage` to guard against stage-drift races
- Wired into `BacktestOrchestrationTask.runWatchdogChecks()`
- Safely handles races: processor vs watchdog (idempotency guard), listener vs reconciliation (affected === 0 check)

## Test Plan

### Automated
- [x] `npx nx lint api` — 0 errors, 0 new warnings in touched files
- [x] `npx nx build api` — clean compile
- [x] `npx nx test api -- --testPathPattern='backtest-result.service'` — 24/24 (5 new `markFailed` tests: HISTORICAL emit, LIVE_REPLAY emit, PAPER_TRADING skip, idempotent on already-FAILED, no-op on missing)
- [x] `npx nx test api -- --testPathPattern='backtest-watchdog.service'` — 33/33 (7 new `detectFailedBacktestPipelines` tests)

### Manual smoke test (dev)
- [ ] Force a small test backtest to fail (admin abort OR artificially set `lastCheckpointAt` to 2 hours ago)
- [ ] Wait ≤15 min for the watchdog cron OR manually invoke `watchdog.detectFailedBacktestPipelines()`
- [ ] Confirm the parent pipeline transitions to `FAILED` with populated `failureReason` and `completedAt`

### Post-deploy verification (prod)
Wait ~25 min after deploy (10 min boot grace + next `*/15` boundary), then:
```sql
-- Should return 0 rows
SELECT COUNT(*) FROM pipelines p
JOIN backtests b ON b.id = p."historicalBacktestId"
WHERE p."currentStage" = 'HISTORICAL' AND p.status = 'RUNNING' AND b.status = 'FAILED';

-- Should show the 12 orphans now FAILED
SELECT id, "currentStage", status, "failureReason", "completedAt"
FROM pipelines
WHERE "failureReason" LIKE 'HISTORICAL backtest % FAILED%'
ORDER BY "completedAt" DESC LIMIT 15;
```

Also check API logs for `Failed-backtest pipeline watchdog marked N pipeline(s) as FAILED`.

## Coverage

| Failure mode | Covered by |
|---|---|
| Stale-heartbeat watchdog kills a backtest | `markFailed` emits → listener fails pipeline |
| Processor catch block (OOM, crash, unhandled error) | `markFailed` emits → listener fails pipeline |
| Event dispatch lost (process kill, listener exception, DI failure) | `detectFailedBacktestPipelines` sweep on next cron |
| 12 pre-existing orphans in prod | Reconciliation sweep on first post-deploy run |

## Notes

- Deploy runbook: the manual SQL cleanup step for the 12 orphans can be removed — the reconciliation sweep replaces it.