### PR TITLE
fix(api): reject impossible Confluence minConfluence optimizer combos

### DIFF
--- a/apps/api/src/algorithm/strategies/confluence-config.spec.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.spec.ts
@@ -1,0 +1,104 @@
+import { getConfluenceParameterConstraints } from './confluence-config';
+
+import { GridSearchService } from '../../optimization/services/grid-search.service';
+
+describe('getConfluenceParameterConstraints — minConfluence guard', () => {
+  const gridSearch = new GridSearchService();
+  const constraints = getConfluenceParameterConstraints();
+
+  // Sensible defaults that satisfy the existing period-ordering constraints so
+  // each test only exercises the new minConfluence guard in isolation.
+  const baseParams = {
+    emaFastPeriod: 12,
+    emaSlowPeriod: 26,
+    macdFastPeriod: 12,
+    macdSlowPeriod: 26,
+    rsiBuyThreshold: 55,
+    rsiSellThreshold: 45,
+    bbBuyThreshold: 0.55,
+    bbSellThreshold: 0.45
+  };
+
+  it('rejects minConfluence > number of enabled directional indicators', () => {
+    const params = {
+      ...baseParams,
+      emaEnabled: false,
+      rsiEnabled: false,
+      macdEnabled: false,
+      bbEnabled: true,
+      atrEnabled: true,
+      minConfluence: 4
+    };
+
+    expect(gridSearch.validateConstraints(params, constraints)).toBe(false);
+  });
+
+  it('rejects minSellConfluence > number of enabled directional indicators', () => {
+    const params = {
+      ...baseParams,
+      emaEnabled: true,
+      rsiEnabled: true,
+      macdEnabled: false,
+      bbEnabled: false,
+      minConfluence: 2,
+      minSellConfluence: 3
+    };
+
+    expect(gridSearch.validateConstraints(params, constraints)).toBe(false);
+  });
+
+  it('does not count ATR toward the directional pool', () => {
+    // 3 directional indicators enabled (EMA, RSI, MACD), ATR is filter-only.
+    // minConfluence: 4 should fail even though 4 indicators total are enabled.
+    const params = {
+      ...baseParams,
+      emaEnabled: true,
+      rsiEnabled: true,
+      macdEnabled: true,
+      bbEnabled: false,
+      atrEnabled: true,
+      minConfluence: 4
+    };
+
+    expect(gridSearch.validateConstraints(params, constraints)).toBe(false);
+  });
+
+  it('accepts a combination where minConfluence equals enabled directional count', () => {
+    const params = {
+      ...baseParams,
+      emaEnabled: true,
+      rsiEnabled: true,
+      macdEnabled: true,
+      bbEnabled: true,
+      atrEnabled: false,
+      minConfluence: 4,
+      minSellConfluence: 4
+    };
+
+    expect(gridSearch.validateConstraints(params, constraints)).toBe(true);
+  });
+
+  it('treats undefined indicator flags as enabled (matches getConfluenceIndicatorRequirements)', () => {
+    // No *Enabled flags set explicitly — all four directional indicators count as enabled.
+    const params = {
+      ...baseParams,
+      minConfluence: 3
+    };
+
+    expect(gridSearch.validateConstraints(params, constraints)).toBe(true);
+  });
+
+  it('defaults minSellConfluence to minConfluence when not provided', () => {
+    const params = {
+      ...baseParams,
+      emaEnabled: true,
+      rsiEnabled: false,
+      macdEnabled: false,
+      bbEnabled: false,
+      minConfluence: 1
+      // minSellConfluence omitted — should default to minConfluence (1) and pass
+    };
+
+    expect(gridSearch.validateConstraints(params, constraints)).toBe(true);
+  });
+});

--- a/apps/api/src/algorithm/strategies/confluence-config.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.ts
@@ -237,8 +237,8 @@ export function getConfluenceParameterConstraints(): ParameterConstraint[] {
           params.macdEnabled !== false,
           params.bbEnabled !== false
         ].filter(Boolean).length;
-        const minBuy = (params.minConfluence as number) ?? 2;
-        const minSell = (params.minSellConfluence as number) ?? minBuy;
+        const minBuy = typeof params.minConfluence === 'number' ? params.minConfluence : 2;
+        const minSell = typeof params.minSellConfluence === 'number' ? params.minSellConfluence : minBuy;
         return minBuy <= enabledDirectional && minSell <= enabledDirectional;
       },
       message:

--- a/apps/api/src/algorithm/strategies/confluence-config.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.ts
@@ -221,6 +221,28 @@ export function getConfluenceParameterConstraints(): ParameterConstraint[] {
       param1: 'bbSellThreshold',
       param2: 'bbBuyThreshold',
       message: 'bbSellThreshold must be less than bbBuyThreshold'
+    },
+    {
+      // Reject combinations whose minConfluence requirement exceeds the
+      // number of enabled directional indicators — these would never
+      // produce a buy signal and waste optimizer iterations on guaranteed
+      // zero-trade results. ATR is volatility-only and intentionally
+      // excluded from the count.
+      type: 'custom',
+      param1: 'minConfluence',
+      customValidator: (params) => {
+        const enabledDirectional = [
+          params.emaEnabled !== false,
+          params.rsiEnabled !== false,
+          params.macdEnabled !== false,
+          params.bbEnabled !== false
+        ].filter(Boolean).length;
+        const minBuy = (params.minConfluence as number) ?? 2;
+        const minSell = (params.minSellConfluence as number) ?? minBuy;
+        return minBuy <= enabledDirectional && minSell <= enabledDirectional;
+      },
+      message:
+        'minConfluence/minSellConfluence must not exceed the number of enabled directional indicators (EMA/RSI/MACD/BB; ATR is filter-only)'
     }
   ];
 }


### PR DESCRIPTION
## Summary

- Reject optimizer parameter combinations where `minConfluence` or `minSellConfluence` exceeds the number of enabled directional indicators (EMA, RSI, MACD, BB)
- Prevents zero-signal strategies from wasting pipeline resources (21 zero-trade pipelines observed in production)
- ATR is intentionally excluded from the count as it is volatility-only

## Changes

- `apps/api/src/algorithm/strategies/confluence-config.ts` — Add custom-validator constraint to `getConfluenceParameterConstraints()` that enforces `minConfluence ≤ enabledDirectionalCount`
- `apps/api/src/algorithm/strategies/confluence-config.spec.ts` — Add test coverage for the new constraint

## Test Plan

- [x] Unit tests cover valid/invalid combinations
- [ ] Verify optimizer no longer produces impossible Confluence configs