### PR TITLE
fix(api): make exchange health indicator informational, never fatal

### DIFF
--- a/apps/api/src/health/indicators/exchange.health.spec.ts
+++ b/apps/api/src/health/indicators/exchange.health.spec.ts
@@ -1,0 +1,122 @@
+import { Logger } from '@nestjs/common';
+import { HealthIndicatorService } from '@nestjs/terminus';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { ExchangeHealthIndicator } from './exchange.health';
+
+import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+
+describe('ExchangeHealthIndicator', () => {
+  let indicator: ExchangeHealthIndicator;
+  let exchangeManager: { getPublicClient: jest.Mock };
+  let mockIndicator: { up: jest.Mock; down: jest.Mock };
+  let loggerWarnSpy: jest.SpyInstance;
+
+  const healthyClient = () => ({
+    fetchTicker: jest.fn().mockResolvedValue({ last: 50000 })
+  });
+
+  beforeEach(async () => {
+    exchangeManager = { getPublicClient: jest.fn() };
+    mockIndicator = {
+      up: jest.fn((data) => ({ exchanges: { status: 'up', ...data } })),
+      down: jest.fn((data) => ({ exchanges: { status: 'down', ...data } }))
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExchangeHealthIndicator,
+        { provide: ExchangeManagerService, useValue: exchangeManager },
+        {
+          provide: HealthIndicatorService,
+          useValue: { check: jest.fn().mockReturnValue(mockIndicator) }
+        }
+      ]
+    }).compile();
+
+    indicator = module.get<ExchangeHealthIndicator>(ExchangeHealthIndicator);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should report all_healthy when every exchange responds', async () => {
+    exchangeManager.getPublicClient.mockResolvedValue(healthyClient());
+
+    const result = await indicator.isHealthy('exchanges');
+
+    expect(mockIndicator.up).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overallStatus: 'all_healthy',
+        healthyCount: 3,
+        totalExchanges: 3,
+        binance_us: expect.objectContaining({ status: 'healthy', latencyMs: expect.any(Number) }),
+        coinbase: expect.objectContaining({ status: 'healthy', latencyMs: expect.any(Number) }),
+        kraken: expect.objectContaining({ status: 'healthy', latencyMs: expect.any(Number) })
+      })
+    );
+    expect(mockIndicator.down).not.toHaveBeenCalled();
+    expect(result).toEqual({ exchanges: expect.objectContaining({ status: 'up', overallStatus: 'all_healthy' }) });
+  });
+
+  it('should report degraded when one exchange fetchTicker rejects', async () => {
+    const failingClient = { fetchTicker: jest.fn().mockRejectedValue(new Error('503 Service Unavailable')) };
+
+    exchangeManager.getPublicClient
+      .mockResolvedValueOnce(failingClient) // binance_us fails at fetchTicker
+      .mockResolvedValueOnce(healthyClient()) // coinbase ok
+      .mockResolvedValueOnce(healthyClient()); // kraken ok
+
+    const result = await indicator.isHealthy('exchanges');
+
+    expect(mockIndicator.up).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overallStatus: 'degraded',
+        healthyCount: 2,
+        totalExchanges: 3,
+        binance_us: expect.objectContaining({ status: 'unhealthy', error: '503 Service Unavailable' })
+      })
+    );
+    expect(mockIndicator.down).not.toHaveBeenCalled();
+    expect(result).toEqual({ exchanges: expect.objectContaining({ status: 'up', overallStatus: 'degraded' }) });
+  });
+
+  it('should report degraded when one exchange getPublicClient rejects', async () => {
+    exchangeManager.getPublicClient
+      .mockRejectedValueOnce(new Error('Connection refused'))
+      .mockResolvedValueOnce(healthyClient())
+      .mockResolvedValueOnce(healthyClient());
+
+    const result = await indicator.isHealthy('exchanges');
+
+    expect(mockIndicator.up).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overallStatus: 'degraded',
+        healthyCount: 2,
+        totalExchanges: 3
+      })
+    );
+    expect(mockIndicator.down).not.toHaveBeenCalled();
+    expect(result).toEqual({ exchanges: expect.objectContaining({ status: 'up', overallStatus: 'degraded' }) });
+  });
+
+  it('should report all_unavailable, log warning, and still return up when every exchange is down', async () => {
+    exchangeManager.getPublicClient.mockRejectedValue(new Error('Service Unavailable'));
+
+    const result = await indicator.isHealthy('exchanges');
+
+    expect(mockIndicator.up).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overallStatus: 'all_unavailable',
+        healthyCount: 0,
+        totalExchanges: 3
+      })
+    );
+    expect(mockIndicator.down).not.toHaveBeenCalled();
+    expect(loggerWarnSpy).toHaveBeenCalledWith('All monitored exchanges are unavailable');
+    expect(result).toEqual({ exchanges: expect.objectContaining({ status: 'up', overallStatus: 'all_unavailable' }) });
+  });
+});

--- a/apps/api/src/health/indicators/exchange.health.ts
+++ b/apps/api/src/health/indicators/exchange.health.ts
@@ -5,6 +5,7 @@ import { ExchangeManagerService } from '../../exchange/exchange-manager.service'
 import { toErrorInfo } from '../../shared/error.util';
 
 type ExchangeStatus = 'healthy' | 'slow' | 'unhealthy';
+type OverallExchangeStatus = 'all_healthy' | 'degraded' | 'all_unavailable';
 
 interface ExchangeHealthResult {
   latencyMs: number;
@@ -36,9 +37,9 @@ export class ExchangeHealthIndicator {
   ) {}
 
   /**
-   * Check exchange connectivity and latency
-   * Fails if all exchanges are unhealthy
-   * Runs all exchange checks in parallel to avoid sequential timeout accumulation
+   * Check exchange connectivity and latency.
+   * Always reports UP — exchange availability is informational, not application health.
+   * Includes overallStatus for dashboard observability.
    */
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
     const indicator = this.healthIndicatorService.check(key);
@@ -68,12 +69,18 @@ export class ExchangeHealthIndicator {
       }
     }
 
-    // Fail only if ALL exchanges are unhealthy
-    if (healthyCount === 0) {
-      return indicator.down({ ...results, message: 'All monitored exchanges are unavailable' });
+    const totalExchanges = this.exchanges.length;
+    let overallStatus: OverallExchangeStatus;
+    if (healthyCount === totalExchanges) {
+      overallStatus = 'all_healthy';
+    } else if (healthyCount > 0) {
+      overallStatus = 'degraded';
+    } else {
+      overallStatus = 'all_unavailable';
+      this.logger.warn('All monitored exchanges are unavailable');
     }
 
-    return indicator.up(results);
+    return indicator.up({ ...results, overallStatus, healthyCount, totalExchanges });
   }
 
   private async checkExchange(slug: string, pair: string): Promise<ExchangeHealthResult> {


### PR DESCRIPTION
## Summary
- Exchange unavailability no longer returns 503 from `/health` or triggers container restarts
- Replace `indicator.down()` with `indicator.up()` so exchange status is informational metadata, not a liveness signal
- Add `overallStatus`, `healthyCount`, and `totalExchanges` metadata for dashboard observability

## Changes
- `apps/api/src/health/indicators/exchange.health.ts` — Always report UP with rich status metadata instead of failing when all exchanges are down
- `apps/api/src/health/indicators/exchange.health.spec.ts` — New unit tests covering `all_healthy`, `degraded`, and `all_unavailable` paths

## Test Plan
- [x] Unit tests pass (4 tests covering all states)
- [x] Build passes
- [ ] Verify `/health` returns 200 even when exchanges are unreachable
- [ ] Confirm `overallStatus` field appears in health check response