### PR TITLE
fix(api): filter delisted markets and improve order sync reliability

### DIFF
--- a/apps/api/src/coin/coin-daily-snapshot.service.spec.ts
+++ b/apps/api/src/coin/coin-daily-snapshot.service.spec.ts
@@ -257,6 +257,23 @@ describe('CoinDailySnapshotService', () => {
       expect(result.qualifiedIds).toEqual(['coin-large', 'coin-medium', 'coin-small']);
     });
 
+    it('qualifies coin with null currentPrice when marketCap and volume are valid', async () => {
+      const snapshots = [
+        {
+          coinId: 'coin-akt',
+          marketCap: 116_000_000,
+          totalVolume: 4_500_000,
+          currentPrice: null
+        }
+      ] as unknown as CoinDailySnapshot[];
+
+      mockQb.getMany.mockResolvedValueOnce(snapshots);
+
+      const result = await service.getQualifiedCoinIdsAtDate(['coin-akt'], new Date('2025-06-15'));
+
+      expect(result).toEqual({ qualifiedIds: ['coin-akt'], hasSnapshots: true });
+    });
+
     it('returns empty for empty coinIds', async () => {
       const result = await service.getQualifiedCoinIdsAtDate([], new Date());
 

--- a/apps/api/src/coin/coin-daily-snapshot.service.ts
+++ b/apps/api/src/coin/coin-daily-snapshot.service.ts
@@ -94,8 +94,7 @@ export class CoinDailySnapshotService {
           s.marketCap != null &&
           Number(s.marketCap) >= minMarketCap &&
           s.totalVolume != null &&
-          Number(s.totalVolume) >= minDailyVolume &&
-          s.currentPrice != null
+          Number(s.totalVolume) >= minDailyVolume
       )
       .sort((a, b) => Number(b.marketCap ?? 0) - Number(a.marketCap ?? 0))
       .map((s) => s.coinId);

--- a/apps/api/src/order/backtest/coin-resolver.service.spec.ts
+++ b/apps/api/src/order/backtest/coin-resolver.service.spec.ts
@@ -235,6 +235,31 @@ describe('CoinResolverService', () => {
     expect(result.warnings).toContain('instrument_universe_truncated');
   });
 
+  it('logs coins dropped by quality filtering as "filtered by quality" not "unresolved"', async () => {
+    const coinService = {
+      getMultipleCoinsBySymbol: jest.fn(async (symbols: string[]) => symbols.map((s) => createCoin(s.toUpperCase()))),
+      getCoinsByIdsFilteredAtDate: jest.fn(async () => ({
+        coins: [createCoin('BTC')],
+        usedHistoricalData: true
+      }))
+    };
+    const ohlcService = {
+      getCoinsWithCandleDataInRange: jest.fn(async () => ['BTC', 'ETH', 'AKT'])
+    };
+    const service = createService(coinService, ohlcService);
+    const loggerSpy = jest.spyOn(service['logger'], 'warn');
+    const dataset = createDataset({ instrumentUniverse: ['BTC', 'ETH', 'AKT'] });
+
+    const result = await service.resolveCoins(dataset, {
+      startDate: new Date('2022-01-01'),
+      endDate: new Date('2022-12-31')
+    });
+
+    expect(result.coins.map((c) => c.symbol)).toEqual(['BTC']);
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('filtered by quality: [ETH, AKT]'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.not.stringContaining('unresolved'));
+  });
+
   it('resolves partial universe without throwing', async () => {
     const coinService = {
       getMultipleCoinsBySymbol: jest.fn(async (symbols: string[]) =>

--- a/apps/api/src/order/backtest/coin-resolver.service.ts
+++ b/apps/api/src/order/backtest/coin-resolver.service.ts
@@ -199,18 +199,9 @@ export class CoinResolverService {
     // Compute instruments that resolved in DB but were dropped by quality/date filtering
     const filteredByQuality = instruments.filter((instrument) => {
       const symbol = instrument.toUpperCase();
-      const inDb =
-        dbResolvedSymbols.has(symbol) ||
-        (() => {
-          const base = this.extractBaseSymbol(symbol);
-          return base != null && dbResolvedSymbols.has(base);
-        })();
-      const inFinal =
-        resolvedSymbols.has(symbol) ||
-        (() => {
-          const base = this.extractBaseSymbol(symbol);
-          return base != null && resolvedSymbols.has(base);
-        })();
+      const base = this.extractBaseSymbol(symbol);
+      const inDb = dbResolvedSymbols.has(symbol) || (base != null && dbResolvedSymbols.has(base));
+      const inFinal = resolvedSymbols.has(symbol) || (base != null && resolvedSymbols.has(base));
       return inDb && !inFinal;
     });
 

--- a/apps/api/src/order/backtest/coin-resolver.service.ts
+++ b/apps/api/src/order/backtest/coin-resolver.service.ts
@@ -164,6 +164,9 @@ export class CoinResolverService {
       resolved = filtered;
     }
 
+    // Capture DB-resolved symbols before quality filtering for accurate logging
+    const dbResolvedSymbols = new Set(resolved.map((c) => c.symbol.toUpperCase()));
+
     // Date-aware filtering: only keep coins that were tradeable and met quality thresholds during the backtest period
     if (options.startDate && options.endDate) {
       const tradeableCoinIds = await this.ohlcService.getCoinsWithCandleDataInRange(
@@ -184,13 +187,31 @@ export class CoinResolverService {
       resolved = tradeableCoins.filter((c) => qualifiedIdSet.has(c.id));
     }
 
-    // Compute unresolved instruments
+    // Compute truly unresolved instruments (not found in DB at all)
     const resolvedSymbols = new Set(resolved.map((c) => c.symbol.toUpperCase()));
     const unresolved = instruments.filter((instrument) => {
       const symbol = instrument.toUpperCase();
-      if (resolvedSymbols.has(symbol)) return false;
+      if (dbResolvedSymbols.has(symbol)) return false;
       const base = this.extractBaseSymbol(symbol);
-      return !base || !resolvedSymbols.has(base);
+      return !base || !dbResolvedSymbols.has(base);
+    });
+
+    // Compute instruments that resolved in DB but were dropped by quality/date filtering
+    const filteredByQuality = instruments.filter((instrument) => {
+      const symbol = instrument.toUpperCase();
+      const inDb =
+        dbResolvedSymbols.has(symbol) ||
+        (() => {
+          const base = this.extractBaseSymbol(symbol);
+          return base != null && dbResolvedSymbols.has(base);
+        })();
+      const inFinal =
+        resolvedSymbols.has(symbol) ||
+        (() => {
+          const base = this.extractBaseSymbol(symbol);
+          return base != null && resolvedSymbols.has(base);
+        })();
+      return inDb && !inFinal;
     });
 
     if (!resolved.length) {
@@ -199,13 +220,17 @@ export class CoinResolverService {
       throw new InstrumentUniverseUnresolvedException(dataset.id, instruments, unresolved);
     }
 
-    if (unresolved.length > 0) {
+    if (unresolved.length > 0 || filteredByQuality.length > 0) {
       // Record partial resolution
       this.metricsService?.recordCoinResolution('partial');
-      this.logger.warn(
-        `Partial instrument resolution for dataset ${dataset.id}: ` +
-          `resolved ${resolved.length}/${instruments.length}, unresolved: [${unresolved.join(', ')}]`
-      );
+      const parts = [`resolved ${resolved.length}/${instruments.length}`];
+      if (unresolved.length > 0) {
+        parts.push(`unresolved: [${unresolved.join(', ')}]`);
+      }
+      if (filteredByQuality.length > 0) {
+        parts.push(`filtered by quality: [${filteredByQuality.join(', ')}]`);
+      }
+      this.logger.warn(`Partial instrument resolution for dataset ${dataset.id}: ${parts.join(', ')}`);
     } else {
       // Record successful resolution (all instruments resolved)
       this.metricsService?.recordCoinResolution('success');

--- a/apps/api/src/order/services/order-sync.service.spec.ts
+++ b/apps/api/src/order/services/order-sync.service.spec.ts
@@ -88,8 +88,8 @@ describe('OrderSyncService', () => {
       expect(client.fetchOrders).toHaveBeenCalledTimes(2);
       expect(client.fetchOrders).toHaveBeenCalledWith('BTC/USD', undefined);
       expect(client.fetchOrders).toHaveBeenCalledWith('ETH/USD', undefined);
-      expect(client.fetchOrders).not.toHaveBeenCalledWith('RLC/USD', expect.anything());
-      expect(client.fetchOrders).not.toHaveBeenCalledWith('VOXEL/USD', expect.anything());
+      expect((client.fetchOrders as jest.Mock).mock.calls).not.toContainEqual(['RLC/USD', undefined]);
+      expect((client.fetchOrders as jest.Mock).mock.calls).not.toContainEqual(['VOXEL/USD', undefined]);
     });
 
     it('should treat markets with active === undefined as active (safe fallback)', async () => {

--- a/apps/api/src/order/services/order-sync.service.spec.ts
+++ b/apps/api/src/order/services/order-sync.service.spec.ts
@@ -1,0 +1,194 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import type * as ccxt from 'ccxt';
+
+import { OrderCalculationService } from './order-calculation.service';
+import { OrderStateMachineService } from './order-state-machine.service';
+import { OrderSyncService } from './order-sync.service';
+import { PositionManagementService } from './position-management.service';
+
+import { CoinService } from '../../coin/coin.service';
+import { TickerPairService } from '../../coin/ticker-pairs/ticker-pairs.service';
+import { ExchangeKeyService } from '../../exchange/exchange-key/exchange-key.service';
+import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import { ExchangeService } from '../../exchange/exchange.service';
+import { MetricsService } from '../../metrics/metrics.service';
+import { Order } from '../order.entity';
+
+// Mock retry utilities to pass through directly
+jest.mock('../../shared/retry.util', () => ({
+  withRateLimitRetry: jest.fn(async (fn: () => Promise<any>) => {
+    try {
+      const result = await fn();
+      return { success: true, result };
+    } catch (error) {
+      return { success: false, error };
+    }
+  }),
+  withRateLimitRetryThrow: jest.fn(async (fn: () => Promise<any>) => fn())
+}));
+
+describe('OrderSyncService', () => {
+  let service: OrderSyncService;
+
+  const mockOrderRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn()
+  };
+
+  const createMockClient = (
+    markets: Record<string, { active?: boolean }>,
+    overrides: Partial<Record<string, jest.Mock>> = {}
+  ) =>
+    ({
+      id: 'binance_us',
+      has: { fetchOrders: true, fetchMyTrades: true },
+      loadMarkets: jest.fn().mockResolvedValue(markets),
+      fetchOrders: jest.fn().mockResolvedValue([]),
+      fetchMyTrades: jest.fn().mockResolvedValue([]),
+      ...overrides
+    }) as unknown as ccxt.Exchange;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrderSyncService,
+        { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
+        { provide: OrderCalculationService, useValue: {} },
+        { provide: CoinService, useValue: {} },
+        { provide: ExchangeService, useValue: {} },
+        { provide: TickerPairService, useValue: {} },
+        { provide: ExchangeKeyService, useValue: {} },
+        { provide: ExchangeManagerService, useValue: {} },
+        { provide: MetricsService, useValue: {} },
+        { provide: OrderStateMachineService, useValue: {} },
+        { provide: PositionManagementService, useValue: {} }
+      ]
+    }).compile();
+
+    service = module.get<OrderSyncService>(OrderSyncService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('fetchFromExchange (via fetchHistoricalOrders)', () => {
+    it('should only fetch from active markets, skipping delisted ones', async () => {
+      const client = createMockClient({
+        'BTC/USD': { active: true },
+        'RLC/USD': { active: false },
+        'ETH/USD': { active: true },
+        'VOXEL/USD': { active: false }
+      });
+
+      await service.fetchHistoricalOrders(client);
+
+      expect(client.fetchOrders).toHaveBeenCalledTimes(2);
+      expect(client.fetchOrders).toHaveBeenCalledWith('BTC/USD', undefined);
+      expect(client.fetchOrders).toHaveBeenCalledWith('ETH/USD', undefined);
+      expect(client.fetchOrders).not.toHaveBeenCalledWith('RLC/USD', expect.anything());
+      expect(client.fetchOrders).not.toHaveBeenCalledWith('VOXEL/USD', expect.anything());
+    });
+
+    it('should treat markets with active === undefined as active (safe fallback)', async () => {
+      const client = createMockClient({
+        'BTC/USD': { active: true },
+        'SOL/USD': { active: undefined },
+        'DOGE/USD': {}
+      });
+
+      await service.fetchHistoricalOrders(client);
+
+      expect(client.fetchOrders).toHaveBeenCalledTimes(3);
+      expect(client.fetchOrders).toHaveBeenCalledWith('SOL/USD', undefined);
+      expect(client.fetchOrders).toHaveBeenCalledWith('DOGE/USD', undefined);
+    });
+
+    it('should not call fetchFn when all markets are inactive', async () => {
+      const client = createMockClient({
+        'RLC/USD': { active: false },
+        'VOXEL/USD': { active: false }
+      });
+
+      const result = await service.fetchHistoricalOrders(client);
+
+      expect(client.fetchOrders).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when exchange does not support capability', async () => {
+      const client = { id: 'test', has: { fetchOrders: false } } as unknown as ccxt.Exchange;
+
+      const result = await service.fetchHistoricalOrders(client);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array and not throw when loadMarkets fails', async () => {
+      const client = createMockClient(
+        {},
+        { loadMarkets: jest.fn().mockRejectedValue(new Error('Exchange unavailable')) }
+      );
+
+      const result = await service.fetchHistoricalOrders(client);
+
+      expect(result).toEqual([]);
+      expect(client.fetchOrders).not.toHaveBeenCalled();
+    });
+
+    it('should continue fetching remaining symbols when one fails', async () => {
+      const mockOrder = { id: '1', symbol: 'ETH/USD' } as ccxt.Order;
+      const client = createMockClient({
+        'BTC/USD': { active: true },
+        'ETH/USD': { active: true }
+      });
+      (client.fetchOrders as jest.Mock)
+        .mockRejectedValueOnce(new Error('Rate limited'))
+        .mockResolvedValueOnce([mockOrder]);
+
+      const result = await service.fetchHistoricalOrders(client);
+
+      expect(client.fetchOrders).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('1');
+    });
+
+    it('should deduplicate results by order id across symbols', async () => {
+      const mockOrder = { id: '123', symbol: 'BTC/USD' } as ccxt.Order;
+      const client = createMockClient({
+        'BTC/USD': { active: true },
+        'ETH/USD': { active: true }
+      });
+      (client.fetchOrders as jest.Mock).mockResolvedValueOnce([mockOrder]).mockResolvedValueOnce([mockOrder]);
+
+      const result = await service.fetchHistoricalOrders(client);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('should pass lastSyncTime as unix timestamp to fetchFn', async () => {
+      const syncTime = new Date('2025-06-01T00:00:00Z');
+      const client = createMockClient({ 'BTC/USD': { active: true } });
+
+      await service.fetchHistoricalOrders(client, syncTime);
+
+      expect(client.fetchOrders).toHaveBeenCalledWith('BTC/USD', syncTime.getTime());
+    });
+  });
+
+  describe('fetchMyTrades', () => {
+    it('should filter inactive markets the same as fetchHistoricalOrders', async () => {
+      const client = createMockClient({
+        'BTC/USD': { active: true },
+        'DELISTED/USD': { active: false }
+      });
+
+      await service.fetchMyTrades(client);
+
+      expect(client.fetchMyTrades).toHaveBeenCalledTimes(1);
+      expect(client.fetchMyTrades).toHaveBeenCalledWith('BTC/USD', undefined);
+    });
+  });
+});

--- a/apps/api/src/order/services/order-sync.service.ts
+++ b/apps/api/src/order/services/order-sync.service.ts
@@ -180,11 +180,12 @@ export class OrderSyncService {
       const skippedCount = allSymbols.length - activeSymbols.length;
 
       this.logger.log(`Fetching historical ${operationName} since: ${since}`);
-      this.logger.log(`Active markets (${activeSymbols.length}/${allSymbols.length}): ${activeSymbols.join(', ')}`);
+      this.logger.log(`Active markets: ${activeSymbols.length}/${allSymbols.length}`);
+      this.logger.debug(`Active symbols: ${activeSymbols.join(', ')}`);
 
       if (skippedCount > 0) {
         this.logger.debug(
-          `Skipped ${skippedCount} inactive/delisted market(s): ${allSymbols.filter((s) => !markets[s]?.active).join(', ')}`
+          `Skipped ${skippedCount} inactive/delisted market(s): ${allSymbols.filter((s) => markets[s]?.active === false).join(', ')}`
         );
       }
 

--- a/apps/api/src/order/services/order-sync.service.ts
+++ b/apps/api/src/order/services/order-sync.service.ts
@@ -175,11 +175,22 @@ export class OrderSyncService {
         logger: this.logger,
         operationName: `loadMarkets (${operationName})`
       });
+      const allSymbols = Object.keys(markets);
+      const activeSymbols = allSymbols.filter((s) => markets[s]?.active !== false);
+      const skippedCount = allSymbols.length - activeSymbols.length;
+
       this.logger.log(`Fetching historical ${operationName} since: ${since}`);
-      this.logger.log(`Available markets: ${Object.keys(markets).join(', ')}`);
+      this.logger.log(`Active markets (${activeSymbols.length}/${allSymbols.length}): ${activeSymbols.join(', ')}`);
+
+      if (skippedCount > 0) {
+        this.logger.debug(
+          `Skipped ${skippedCount} inactive/delisted market(s): ${allSymbols.filter((s) => !markets[s]?.active).join(', ')}`
+        );
+      }
+
       const allItems: T[] = [];
 
-      for (const symbol of Object.keys(markets)) {
+      for (const symbol of activeSymbols) {
         const result = await withRateLimitRetry(() => fetchFn(symbol, since), {
           logger: this.logger,
           operationName: `${operationName}(${symbol})`


### PR DESCRIPTION
## Summary

- Filter inactive/delisted markets in `OrderSyncService` before fetching, preventing wasted API calls and errors on dead trading pairs
- Remove incorrect `currentPrice != null` quality filter that was dropping valid coins (e.g. AKT) from backtest snapshots
- Improve resolver logging to distinguish unresolved coins from quality-filtered coins

## Changes

- **`order-sync.service.ts`** — Skip markets where `active === false` in `fetchFromExchange`, log skipped markets at debug level
- **`coin-resolver.service.ts`** — Drop `currentPrice` from quality check in `getQualifiedCoinIdsAtDate`; separate "unresolved" vs "filtered by quality" log messages; simplify IIFE pattern in filter callback
- **`order-sync.service.spec.ts`** — 9 new tests for active market filtering, undefined fallback, loadMarkets failure, partial symbol failure, dedup, and lastSyncTime
- **`coin-resolver.service.spec.ts`** — Tests for quality-filtered logging and partial universe resolution

## Test Plan

- [x] `npx nx test api -- --testPathPattern='order-sync.service.spec'` — 9 passed
- [x] `npx nx test api -- --testPathPattern='coin-resolver.service.spec'` — 14 passed
- [x] `npx nx lint api` — clean