### PR TITLE
fix(api): prevent zombie pipelines and harden BullMQ workers

### DIFF
--- a/apps/api/src/order/backtest/backtest-result.service.spec.ts
+++ b/apps/api/src/order/backtest/backtest-result.service.spec.ts
@@ -305,7 +305,7 @@ describe('BacktestResultService', () => {
 
       await service.persistSuccess(backtest, mockResults);
 
-      expect(mockEventEmitter.emit).toHaveBeenCalledWith('backtest.completed', {
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(PIPELINE_EVENTS.BACKTEST_COMPLETED, {
         backtestId: 'backtest-123',
         type: 'HISTORICAL',
         metrics: {
@@ -334,7 +334,7 @@ describe('BacktestResultService', () => {
 
       await service.persistSuccess(backtest, mockResults);
 
-      expect(mockEventEmitter.emit).not.toHaveBeenCalledWith('backtest.completed', expect.any(Object));
+      expect(mockEventEmitter.emit).not.toHaveBeenCalledWith(PIPELINE_EVENTS.BACKTEST_COMPLETED, expect.any(Object));
     });
   });
 

--- a/apps/api/src/order/backtest/backtest-result.service.ts
+++ b/apps/api/src/order/backtest/backtest-result.service.ts
@@ -154,7 +154,7 @@ export class BacktestResultService {
     const mappedType = typeMapping[backtest.type];
 
     if (mappedType) {
-      this.eventEmitter.emit('backtest.completed', {
+      this.eventEmitter.emit(PIPELINE_EVENTS.BACKTEST_COMPLETED, {
         backtestId: backtest.id,
         type: mappedType,
         metrics: {

--- a/apps/api/src/order/paper-trading/paper-trading-job.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-job.service.spec.ts
@@ -9,6 +9,8 @@ import { PaperTradingEngineService } from './paper-trading-engine.service';
 import { PaperTradingJobService } from './paper-trading-job.service';
 import { PaperTradingJobType } from './paper-trading.job-data';
 
+import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
+
 jest.mock('../../shared/queue.util', () => ({
   forceRemoveJob: jest.fn().mockResolvedValue(undefined)
 }));
@@ -170,7 +172,7 @@ describe('PaperTradingJobService', () => {
       expect(session.completedAt).toBeInstanceOf(Date);
       expect(engineService.clearThrottleState).toHaveBeenCalledWith('sess-1');
       expect(eventEmitter.emit).toHaveBeenCalledWith(
-        'paper-trading.completed',
+        PIPELINE_EVENTS.PAPER_TRADING_COMPLETED,
         expect.objectContaining({
           sessionId: 'sess-1',
           pipelineId: 'pipe-1',
@@ -215,7 +217,7 @@ describe('PaperTradingJobService', () => {
       await service.markCompleted('sess-1', 'duration_reached');
 
       expect(eventEmitter.emit).toHaveBeenCalledWith(
-        'paper-trading.completed',
+        PIPELINE_EVENTS.PAPER_TRADING_COMPLETED,
         expect.objectContaining({
           metrics: expect.objectContaining({
             currentPortfolioValue: 10000,

--- a/apps/api/src/order/paper-trading/paper-trading-job.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-job.service.ts
@@ -12,6 +12,7 @@ import { PaperTradingOrder, PaperTradingSession, PaperTradingStatus } from './en
 import { PaperTradingEngineService } from './paper-trading-engine.service';
 import { PaperTradingJobType, RetryTickJobData } from './paper-trading.job-data';
 
+import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
 import { forceRemoveJob } from '../../shared/queue.util';
 
 @Injectable()
@@ -137,7 +138,7 @@ export class PaperTradingJobService {
 
     // Emit event so the pipeline transitions to FAILED instead of staying RUNNING forever
     if (session?.pipelineId) {
-      this.eventEmitter.emit('paper-trading.failed', {
+      this.eventEmitter.emit(PIPELINE_EVENTS.PAPER_TRADING_FAILED, {
         sessionId,
         pipelineId: session.pipelineId,
         reason: errorMessage
@@ -168,7 +169,7 @@ export class PaperTradingJobService {
     // Emit event for pipeline orchestrator
     if (session.pipelineId) {
       const metrics = await this.calculateMetrics(session);
-      this.eventEmitter.emit('paper-trading.completed', {
+      this.eventEmitter.emit(PIPELINE_EVENTS.PAPER_TRADING_COMPLETED, {
         sessionId,
         pipelineId: session.pipelineId,
         metrics,

--- a/apps/api/src/order/paper-trading/paper-trading-job.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-job.service.ts
@@ -122,6 +122,10 @@ export class PaperTradingJobService {
    * Mark session as failed
    */
   async markFailed(sessionId: string, errorMessage: string): Promise<void> {
+    const session = await this.sessionRepository.findOne({
+      where: { id: sessionId }
+    });
+
     await this.sessionRepository.update(sessionId, {
       status: PaperTradingStatus.FAILED,
       errorMessage,
@@ -130,6 +134,15 @@ export class PaperTradingJobService {
     });
 
     await this.cleanupSession(sessionId);
+
+    // Emit event so the pipeline transitions to FAILED instead of staying RUNNING forever
+    if (session?.pipelineId) {
+      this.eventEmitter.emit('paper-trading.failed', {
+        sessionId,
+        pipelineId: session.pipelineId,
+        reason: errorMessage
+      });
+    }
 
     this.logger.error(`Paper trading session ${sessionId} marked as failed: ${errorMessage}`);
   }

--- a/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
@@ -5,6 +5,8 @@ import { PaperTradingRetryService } from './paper-trading-retry.service';
 import { PaperTradingJobType } from './paper-trading.job-data';
 import { PaperTradingProcessor } from './paper-trading.processor';
 
+import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
+
 describe('PaperTradingProcessor', () => {
   const createJob = (data: any): Job<any> => ({ id: 'job-1', data }) as Job<any>;
 
@@ -731,7 +733,7 @@ describe('PaperTradingProcessor', () => {
       where: { id: 'session-notify' }
     });
     expect(paperTradingService.calculateMetrics).toHaveBeenCalledWith(session);
-    expect(eventEmitter.emit).toHaveBeenCalledWith('paper-trading.completed', {
+    expect(eventEmitter.emit).toHaveBeenCalledWith(PIPELINE_EVENTS.PAPER_TRADING_COMPLETED, {
       sessionId: 'session-notify',
       pipelineId: 'pipeline-1',
       metrics,

--- a/apps/api/src/order/paper-trading/paper-trading.processor.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.ts
@@ -29,6 +29,7 @@ import { ExchangeKey } from '../../exchange/exchange-key/exchange-key.entity';
 import { FailSafeWorkerHost } from '../../failed-jobs/fail-safe-worker-host';
 import { FailedJobService } from '../../failed-jobs/failed-job.service';
 import { MetricsService } from '../../metrics/metrics.service';
+import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
 import { toErrorInfo } from '../../shared/error.util';
 
 const MAX_CLEANUP_CACHE = 500;
@@ -354,7 +355,7 @@ export class PaperTradingProcessor extends FailSafeWorkerHost {
 
     const metrics = await this.jobService.calculateMetrics(session);
 
-    this.eventEmitter.emit('paper-trading.completed', {
+    this.eventEmitter.emit(PIPELINE_EVENTS.PAPER_TRADING_COMPLETED, {
       sessionId,
       pipelineId,
       metrics,

--- a/apps/api/src/order/paper-trading/paper-trading.processor.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.ts
@@ -34,7 +34,7 @@ import { toErrorInfo } from '../../shared/error.util';
 const MAX_CLEANUP_CACHE = 500;
 
 @Injectable()
-@Processor('paper-trading')
+@Processor('paper-trading', { lockDuration: 60_000, stalledInterval: 30_000 })
 export class PaperTradingProcessor extends FailSafeWorkerHost {
   private readonly logger = new Logger(PaperTradingProcessor.name);
   private readonly maxConsecutiveErrors: number;

--- a/apps/api/src/order/tasks/trade-execution.task.ts
+++ b/apps/api/src/order/tasks/trade-execution.task.ts
@@ -19,7 +19,7 @@ import { TradeOrchestratorService } from '../services/trade-orchestrator.service
  * This is a thin scheduling/routing layer — all orchestration logic lives
  * in TradeOrchestratorService and its dependencies.
  */
-@Processor('trade-execution')
+@Processor('trade-execution', { lockDuration: 120_000, stalledInterval: 30_000 })
 @Injectable()
 export class TradeExecutionTask extends FailSafeWorkerHost implements OnModuleInit {
   private readonly logger = new Logger(TradeExecutionTask.name);

--- a/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
@@ -48,6 +48,15 @@ export interface BacktestFailedEvent {
 }
 
 /**
+ * Event payload for paper trading failure (stale watchdog or error)
+ */
+export interface PaperTradingFailedEvent {
+  sessionId: string;
+  pipelineId: string;
+  reason: string;
+}
+
+/**
  * Event payload for paper trading completion
  */
 export interface PaperTradingCompletedEvent {
@@ -132,6 +141,7 @@ export const PIPELINE_EVENTS = {
   BACKTEST_COMPLETED: 'backtest.completed',
   BACKTEST_FAILED: 'backtest.failed',
   PAPER_TRADING_COMPLETED: 'paper-trading.completed',
+  PAPER_TRADING_FAILED: 'paper-trading.failed',
   PIPELINE_STAGE_TRANSITION: 'pipeline.stage-transition',
   PIPELINE_STATUS_CHANGE: 'pipeline.status-change',
   PIPELINE_PROGRESS: 'pipeline.progress',

--- a/apps/api/src/pipeline/listeners/pipeline-event.listener.ts
+++ b/apps/api/src/pipeline/listeners/pipeline-event.listener.ts
@@ -8,7 +8,8 @@ import {
   OptimizationCompletedEvent,
   OptimizationFailedEvent,
   PIPELINE_EVENTS,
-  PaperTradingCompletedEvent
+  PaperTradingCompletedEvent,
+  PaperTradingFailedEvent
 } from '../interfaces';
 import { PipelineOrchestratorService } from '../services/pipeline-orchestrator.service';
 
@@ -85,6 +86,31 @@ export class PipelineEventListener {
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Failed to handle backtest failure for ${payload.backtestId}: ${err.message}`, err.stack);
+    }
+  }
+
+  /**
+   * Handle paper trading failure event (stale watchdog or error)
+   */
+  @OnEvent(PIPELINE_EVENTS.PAPER_TRADING_FAILED, { async: true })
+  async handlePaperTradingFailed(payload: PaperTradingFailedEvent): Promise<void> {
+    if (!payload.pipelineId) {
+      return;
+    }
+
+    this.logger.log(
+      `Received paper-trading.failed event for session ${payload.sessionId} ` +
+        `(pipeline ${payload.pipelineId}): ${payload.reason}`
+    );
+
+    try {
+      await this.orchestratorService.handlePaperTradingFailed(payload.sessionId, payload.pipelineId, payload.reason);
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to handle paper trading failure for session ${payload.sessionId}: ${err.message}`,
+        err.stack
+      );
     }
   }
 

--- a/apps/api/src/pipeline/processors/pipeline.processor.ts
+++ b/apps/api/src/pipeline/processors/pipeline.processor.ts
@@ -13,7 +13,7 @@ import { PipelineJobData, PipelineStatus } from '../interfaces';
 import { PipelineOrchestratorService } from '../services/pipeline-orchestrator.service';
 
 @Injectable()
-@Processor('pipeline')
+@Processor('pipeline', { lockDuration: 120_000, stalledInterval: 30_000 })
 export class PipelineProcessor extends FailSafeWorkerHost {
   private readonly logger = new Logger(PipelineProcessor.name);
   private static readonly PENDING_RETRY_DELAY_MS = 2000;

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.spec.ts
@@ -194,6 +194,42 @@ describe('PipelineEventHandlerService', () => {
     });
   });
 
+  describe('handleBacktestFailed', () => {
+    it('fails HISTORICAL pipeline with the provided reason', async () => {
+      pipelineRepository.findOne.mockResolvedValue(
+        makePipeline({ currentStage: PipelineStage.HISTORICAL, historicalBacktestId: 'bt-123' })
+      );
+
+      await service.handleBacktestFailed('bt-123', 'HISTORICAL', 'data unavailable');
+
+      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.stringContaining('data unavailable')
+      );
+    });
+
+    it('fails LIVE_REPLAY pipeline with the provided reason', async () => {
+      pipelineRepository.findOne.mockResolvedValue(
+        makePipeline({ currentStage: PipelineStage.LIVE_REPLAY, liveReplayBacktestId: 'bt-456' })
+      );
+
+      await service.handleBacktestFailed('bt-456', 'LIVE_REPLAY', 'timeout');
+
+      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.stringContaining('timeout')
+      );
+    });
+
+    it('is a no-op when no active pipeline found', async () => {
+      pipelineRepository.findOne.mockResolvedValue(null);
+
+      await service.handleBacktestFailed('bt-999', 'HISTORICAL', 'some error');
+
+      expect(progressionService.failPipeline).not.toHaveBeenCalled();
+    });
+  });
+
   describe('handleBacktestComplete', () => {
     it('fails pipeline when 0 trades produced', async () => {
       pipelineRepository.findOne.mockResolvedValue(
@@ -340,6 +376,27 @@ describe('PipelineEventHandlerService', () => {
         })
       );
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handlePaperTradingFailed', () => {
+    it('fails pipeline with the provided reason', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline({ currentStage: PipelineStage.PAPER_TRADE }));
+
+      await service.handlePaperTradingFailed('session-123', 'pipeline-123', 'out of funds');
+
+      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.stringContaining('out of funds')
+      );
+    });
+
+    it('is a no-op when no active pipeline found', async () => {
+      pipelineRepository.findOne.mockResolvedValue(null);
+
+      await service.handlePaperTradingFailed('session-123', 'pipeline-123', 'out of funds');
+
+      expect(progressionService.failPipeline).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
@@ -276,6 +276,24 @@ export class PipelineEventHandlerService {
     }
   }
 
+  async handlePaperTradingFailed(sessionId: string, pipelineId: string, reason: string): Promise<void> {
+    const pipeline = await this.pipelineRepository.findOne({
+      where: {
+        id: pipelineId,
+        currentStage: PipelineStage.PAPER_TRADE,
+        status: In([PipelineStatus.RUNNING, PipelineStatus.PAUSED])
+      },
+      relations: ['user']
+    });
+
+    if (!pipeline) {
+      this.logger.debug(`No active pipeline found for failed paper trading session ${sessionId}`);
+      return;
+    }
+
+    await this.progressionService.failPipeline(pipeline, `Paper trading session failed: ${reason}`);
+  }
+
   async handlePaperTradingComplete(
     sessionId: string,
     pipelineId: string,

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -348,6 +348,10 @@ export class PipelineOrchestratorService {
     return this.eventHandlerService.handleBacktestFailed(backtestId, type, reason);
   }
 
+  async handlePaperTradingFailed(sessionId: string, pipelineId: string, reason: string): Promise<void> {
+    return this.eventHandlerService.handlePaperTradingFailed(sessionId, pipelineId, reason);
+  }
+
   async handlePaperTradingComplete(
     sessionId: string,
     pipelineId: string,

--- a/apps/api/src/shutdown/shutdown.service.spec.ts
+++ b/apps/api/src/shutdown/shutdown.service.spec.ts
@@ -5,7 +5,7 @@ import { type Queue } from 'bullmq';
 import { QUEUE_NAMES } from './queue-names.constant';
 import { ShutdownService } from './shutdown.service';
 
-type QueueMock = Pick<Queue, 'pause' | 'getActiveCount'>;
+type QueueMock = Pick<Queue, 'pause' | 'getActiveCount' | 'isPaused' | 'resume'>;
 
 const createQueueMocks = (overrides?: Partial<Record<(typeof QUEUE_NAMES)[number], Partial<QueueMock>>>) => {
   const queues: Record<string, QueueMock> = {};
@@ -14,6 +14,8 @@ const createQueueMocks = (overrides?: Partial<Record<(typeof QUEUE_NAMES)[number
     queues[name] = {
       pause: jest.fn().mockResolvedValue(undefined),
       getActiveCount: jest.fn().mockResolvedValue(0),
+      isPaused: jest.fn().mockResolvedValue(false),
+      resume: jest.fn().mockResolvedValue(undefined),
       ...(overrides?.[name] ?? {})
     } as QueueMock;
   }
@@ -112,6 +114,52 @@ describe('ShutdownService', () => {
     for (const name of QUEUE_NAMES) {
       expect(queues[name].pause).toHaveBeenCalled();
     }
+  });
+
+  describe('resumeAllQueues on bootstrap', () => {
+    it('resumes a paused queue and logs a warning', async () => {
+      const { queues, service } = createQueueMocks({
+        'order-queue': {
+          isPaused: jest.fn().mockResolvedValue(true)
+        }
+      });
+      const warnSpy = jest.spyOn(service['logger'] as Logger, 'warn');
+
+      await service.onApplicationBootstrap();
+
+      expect(queues['order-queue'].resume).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Resumed paused queue: order-queue'));
+    });
+
+    it('does not resume queues that are not paused', async () => {
+      const { queues, service } = createQueueMocks();
+
+      await service.onApplicationBootstrap();
+
+      for (const name of QUEUE_NAMES) {
+        expect(queues[name].resume).not.toHaveBeenCalled();
+      }
+    });
+
+    it('continues resuming other queues when one fails', async () => {
+      const { queues, service } = createQueueMocks({
+        'order-queue': {
+          isPaused: jest.fn().mockRejectedValue(new Error('redis down'))
+        },
+        'paper-trading': {
+          isPaused: jest.fn().mockResolvedValue(true)
+        }
+      });
+      const errorSpy = jest.spyOn(service['logger'] as Logger, 'error');
+
+      await service.onApplicationBootstrap();
+
+      expect(queues['paper-trading'].resume).toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to resume queue order-queue: redis down'),
+        expect.any(String)
+      );
+    });
   });
 
   it('returns zero for queues that fail to report active count', async () => {

--- a/apps/api/src/shutdown/shutdown.service.ts
+++ b/apps/api/src/shutdown/shutdown.service.ts
@@ -114,7 +114,7 @@ export class ShutdownService implements OnApplicationBootstrap, OnApplicationShu
         }
       } catch (error: unknown) {
         const err = toErrorInfo(error);
-        this.logger.error(`Failed to resume queue ${name}: ${err.message}`);
+        this.logger.error(`Failed to resume queue ${name}: ${err.message}`, err.stack);
       }
     });
 

--- a/apps/api/src/shutdown/shutdown.service.ts
+++ b/apps/api/src/shutdown/shutdown.service.ts
@@ -1,5 +1,5 @@
 import { InjectQueue } from '@nestjs/bullmq';
-import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
 
 import { Queue } from 'bullmq';
 
@@ -17,7 +17,7 @@ import { toErrorInfo } from '../shared/error.util';
  * 3. Logs shutdown progress for visibility
  */
 @Injectable()
-export class ShutdownService implements OnApplicationShutdown {
+export class ShutdownService implements OnApplicationBootstrap, OnApplicationShutdown {
   private readonly logger = new Logger(ShutdownService.name);
   private readonly JOB_DRAIN_TIMEOUT = 25000; // 25 seconds (leave 5s buffer for other cleanup)
   private readonly POLL_INTERVAL = 1000; // Check every second
@@ -77,6 +77,15 @@ export class ShutdownService implements OnApplicationShutdown {
     ];
   }
 
+  /**
+   * Resume all queues on boot in case the previous instance paused them during shutdown.
+   * BullMQ's queue.pause() persists a flag in Redis, so queues stay paused across restarts
+   * unless explicitly resumed.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    await this.resumeAllQueues();
+  }
+
   async onApplicationShutdown(signal?: string): Promise<void> {
     this.logger.log(`Shutdown signal received: ${signal || 'unknown'}. Starting graceful job shutdown...`);
 
@@ -90,6 +99,26 @@ export class ShutdownService implements OnApplicationShutdown {
     await this.waitForActiveJobs();
 
     this.logger.log('Graceful shutdown complete. All queues drained or timeout reached.');
+  }
+
+  /**
+   * Resume all queues that may have been left paused by a previous shutdown.
+   */
+  private async resumeAllQueues(): Promise<void> {
+    const resumePromises = this.queues.map(async ({ name, queue }) => {
+      try {
+        const isPaused = await queue.isPaused();
+        if (isPaused) {
+          await queue.resume();
+          this.logger.warn(`Resumed paused queue: ${name}`);
+        }
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        this.logger.error(`Failed to resume queue ${name}: ${err.message}`);
+      }
+    });
+
+    await Promise.allSettled(resumePromises);
   }
 
   /**

--- a/apps/api/src/tasks/backtest-orchestration.processor.ts
+++ b/apps/api/src/tasks/backtest-orchestration.processor.ts
@@ -18,7 +18,7 @@ import { FailedJobService } from '../failed-jobs/failed-job.service';
 import { toErrorInfo } from '../shared/error.util';
 
 @Injectable()
-@Processor('backtest-orchestration')
+@Processor('backtest-orchestration', { lockDuration: 300_000, stalledInterval: 60_000 })
 export class BacktestOrchestrationProcessor extends FailSafeWorkerHost {
   private readonly logger = new Logger(BacktestOrchestrationProcessor.name);
 

--- a/apps/api/src/tasks/pipeline-orchestration.processor.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.processor.ts
@@ -18,7 +18,7 @@ import { FailedJobService } from '../failed-jobs/failed-job.service';
 import { toErrorInfo } from '../shared/error.util';
 
 @Injectable()
-@Processor('pipeline-orchestration')
+@Processor('pipeline-orchestration', { lockDuration: 300_000, stalledInterval: 60_000 })
 export class PipelineOrchestrationProcessor extends FailSafeWorkerHost {
   private readonly logger = new Logger(PipelineOrchestrationProcessor.name);
 

--- a/apps/api/src/tasks/pipeline-orchestration.service.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.ts
@@ -237,6 +237,11 @@ export class PipelineOrchestrationService {
           `${result.pipelinesCreated} created, ${result.skippedConfigs.length} skipped`
       );
 
+      if (result.skippedConfigs.length > 0) {
+        const skipSummary = result.skippedConfigs.map((s) => `${s.strategyName}: ${s.reason}`).join('; ');
+        this.logger.log(`Skipped strategies: ${skipSummary}`);
+      }
+
       return result;
     } catch (error: unknown) {
       const err = toErrorInfo(error);

--- a/apps/api/src/tasks/promotion.task.ts
+++ b/apps/api/src/tasks/promotion.task.ts
@@ -105,7 +105,7 @@ export class PromotionTask {
               .filter((r) => !r.passed)
               .map((r) => `${r.gateName}: ${r.message}`)
               .join('; ');
-            this.logger.log(`Strategy ${strategy.name} rejected: ${failedDetails}`);
+            this.logger.log(`Strategy ${strategy.name} rejected: ${failedDetails || 'no gate details available'}`);
             results.rejected++;
           }
         } catch (error: unknown) {

--- a/apps/api/src/tasks/promotion.task.ts
+++ b/apps/api/src/tasks/promotion.task.ts
@@ -101,7 +101,11 @@ export class PromotionTask {
             // Queue deployment activation job (after 24-hour review period)
             await this.queueDeploymentActivation(deployment.id, strategy.name);
           } else {
-            this.logger.debug(`Strategy ${strategy.name} rejected for promotion: ${evaluation.failedGates.join(', ')}`);
+            const failedDetails = evaluation.gateResults
+              .filter((r) => !r.passed)
+              .map((r) => `${r.gateName}: ${r.message}`)
+              .join('; ');
+            this.logger.log(`Strategy ${strategy.name} rejected: ${failedDetails}`);
             results.rejected++;
           }
         } catch (error: unknown) {


### PR DESCRIPTION
## Summary

- Fix zombie pipelines caused by paper trading sessions failing without notifying the pipeline
- Resume BullMQ queues on boot after shutdown pauses them (persists to Redis across deploys)
- Add explicit lock durations to 5 processors running on unsafe 30s defaults
- Log promotion rejection and pipeline skip reasons at INFO level for production debugging

## Changes

### Zombie pipeline fix
- `paper-trading-job.service.ts` — `markFailed()` now emits `paper-trading.failed` event so the pipeline transitions to FAILED instead of staying RUNNING forever
- `pipeline-events.interface.ts` — Add `PaperTradingFailedEvent` interface and `PAPER_TRADING_FAILED` constant
- `pipeline-event-handler.service.ts` — Add `handlePaperTradingFailed()` following the optimization/backtest failure pattern
- `pipeline-orchestrator.service.ts` — Add thin delegator
- `pipeline-event.listener.ts` — Add `@OnEvent('paper-trading.failed')` handler

### BullMQ worker hardening
- `shutdown.service.ts` — Resume all paused queues on `OnApplicationBootstrap` (queue.pause() persists to Redis, was never resumed after deploy)
- `paper-trading.processor.ts` — lockDuration: 60s, stalledInterval: 30s (was 30s/5s default)
- `pipeline-orchestration.processor.ts` / `backtest-orchestration.processor.ts` — lockDuration: 5min, stalledInterval: 60s (orchestration spans 4-13min in production)
- `pipeline.processor.ts` / `trade-execution.task.ts` — lockDuration: 2min, stalledInterval: 30s

### Observability
- `promotion.task.ts` — Log gate failure messages at INFO instead of DEBUG
- `pipeline-orchestration.service.ts` — Log per-strategy skip reasons at INFO

## Context

Production investigation revealed:
- 140 zombie pipelines stuck at PAPER_TRADE/RUNNING (sessions were FAILED but pipeline was never notified)
- 0 deployments ever created (pipelines never completed → strategies never scored → promotions always rejected)
- All 131 failed paper trading sessions died from the same cause: `"Session stale for 20+ minutes"`
- `queue.pause()` in shutdown service persists to Redis but was never resumed on boot

## Test plan

- [x] `npx nx test api -- --testPathPattern='pipeline-event'` — 24 passed
- [x] `npx nx test api -- --testPathPattern='paper-trading-job.service'` — 12 passed
- [x] `npx nx test api -- --testPathPattern='pipeline-orchestration'` — 42 passed
- [x] `npx nx test api -- --testPathPattern='shutdown'` — 10 passed
- [x] `npx nx test api -- --testPathPattern='processor-contract'` — 56 passed
- [x] `npx nx lint api` — clean