### PR TITLE
fix(api): add exchange-aware retry strategy and circuit breaker for CCXT calls

### DIFF
--- a/apps/api/src/algorithm/scripts/added-to-exchange-binance.service.ts
+++ b/apps/api/src/algorithm/scripts/added-to-exchange-binance.service.ts
@@ -4,7 +4,7 @@ import * as ccxt from 'ccxt';
 
 import { BinanceUSService } from '../../exchange/binance/binance-us.service';
 import { toErrorInfo } from '../../shared/error.util';
-import { withRateLimitRetryThrow } from '../../shared/retry.util';
+import { withExchangeRetryThrow } from '../../shared/retry.util';
 
 @Injectable()
 export class AddedtoExchangeBinanceService {
@@ -34,7 +34,7 @@ export class AddedtoExchangeBinanceService {
 
   private async checkForNewListings() {
     // Get all current markets
-    const markets = await withRateLimitRetryThrow(() => this.client.fetchMarkets(), {
+    const markets = await withExchangeRetryThrow(() => this.client.fetchMarkets(), {
       logger: this.logger,
       operationName: 'fetchMarkets'
     });
@@ -74,7 +74,7 @@ export class AddedtoExchangeBinanceService {
       const formattedSymbol = symbol.includes('/') ? symbol : symbol.replace(/([A-Z0-9]{3,})([A-Z0-9]{3,})$/, '$1/$2');
 
       // Get current market price
-      const ticker = await withRateLimitRetryThrow(() => this.client.fetchTicker(formattedSymbol), {
+      const ticker = await withExchangeRetryThrow(() => this.client.fetchTicker(formattedSymbol), {
         logger: this.logger,
         operationName: `fetchTicker(${formattedSymbol})`
       });

--- a/apps/api/src/exchange/base-exchange.service.ts
+++ b/apps/api/src/exchange/base-exchange.service.ts
@@ -9,8 +9,9 @@ import { ExchangeClientPool } from './exchange-client-pool';
 import { EXCHANGE_KEY_SERVICE, EXCHANGE_SERVICE, IExchangeKeyService, IExchangeService } from './interfaces';
 
 import { AssetBalanceDto } from '../balance/dto/balance-response.dto';
+import { CircuitBreakerService } from '../shared/circuit-breaker.service';
 import { toErrorInfo } from '../shared/error.util';
-import { withRateLimitRetryThrow } from '../shared/retry.util';
+import { isClockSkewError, isRateLimitError, isTransientError, withExchangeRetryThrow } from '../shared/retry.util';
 import { User } from '../users/users.entity';
 
 /**
@@ -28,12 +29,20 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
   protected abstract readonly apiSecretConfigName: string;
   abstract readonly quoteAsset: string;
 
+  private _circuitKey?: string;
+
+  /** Lazy circuit key — can't compute in constructor because exchangeSlug is abstract. */
+  protected get circuitKey(): string {
+    return (this._circuitKey ??= `exchange:${this.exchangeSlug}`);
+  }
+
   constructor(
     protected readonly configService?: ConfigService,
     @Inject(EXCHANGE_KEY_SERVICE)
     protected readonly exchangeKeyService?: IExchangeKeyService,
     @Inject(EXCHANGE_SERVICE)
-    protected readonly exchangeService?: IExchangeService
+    protected readonly exchangeService?: IExchangeService,
+    protected readonly circuitBreaker?: CircuitBreakerService
   ) {}
 
   async onModuleDestroy(): Promise<void> {
@@ -220,6 +229,28 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
   }
 
   /**
+   * Wrap an operation with circuit breaker protection.
+   * If no circuit breaker was injected, passes through directly.
+   */
+  protected async withCircuitBreaker<T>(operation: () => Promise<T>): Promise<T> {
+    if (!this.circuitBreaker) {
+      return operation();
+    }
+
+    this.circuitBreaker.checkCircuit(this.circuitKey);
+    try {
+      const result = await operation();
+      this.circuitBreaker.recordSuccess(this.circuitKey);
+      return result;
+    } catch (error) {
+      if (error instanceof Error && isTransientError(error) && !isClockSkewError(error) && !isRateLimitError(error)) {
+        this.circuitBreaker.recordFailure(this.circuitKey);
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Get balances for all assets
    * @param user The user to fetch balances for
    * @returns Array of balances
@@ -227,10 +258,12 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
   async getBalance(user: User): Promise<AssetBalanceDto[]> {
     try {
       const client = await this.getClient(user);
-      const balanceData = await withRateLimitRetryThrow(() => client.fetchBalance(this.getFetchBalanceParams()), {
-        logger: this.logger,
-        operationName: 'getBalance'
-      });
+      const balanceData = await this.withCircuitBreaker(() =>
+        withExchangeRetryThrow(() => client.fetchBalance(this.getFetchBalanceParams()), {
+          logger: this.logger,
+          operationName: 'getBalance'
+        })
+      );
 
       const assetBalances: AssetBalanceDto[] = [];
 
@@ -272,10 +305,12 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
   async getFreeBalance(user: User) {
     try {
       const client = await this.getClient(user);
-      const balanceData = await withRateLimitRetryThrow(() => client.fetchBalance(this.getFetchBalanceParams()), {
-        logger: this.logger,
-        operationName: 'getFreeBalance'
-      });
+      const balanceData = await this.withCircuitBreaker(() =>
+        withExchangeRetryThrow(() => client.fetchBalance(this.getFetchBalanceParams()), {
+          logger: this.logger,
+          operationName: 'getFreeBalance'
+        })
+      );
 
       const balances: AssetBalanceDto[] = [];
       const allowedAssets = this.freeBalanceAssets;
@@ -312,10 +347,12 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
     try {
       const formattedSymbol = this.formatSymbol(symbol);
       const client = await this.getClient(user);
-      const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(formattedSymbol), {
-        logger: this.logger,
-        operationName: `fetchTicker(${symbol})`
-      });
+      const ticker = await this.withCircuitBreaker(() =>
+        withExchangeRetryThrow(() => client.fetchTicker(formattedSymbol), {
+          logger: this.logger,
+          operationName: `fetchTicker(${symbol})`
+        })
+      );
 
       return ticker.last ?? 0;
     } catch (error: unknown) {
@@ -335,10 +372,12 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
     try {
       const formattedSymbol = this.formatSymbol(symbol);
       const client = await this.getClient(user);
-      const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(formattedSymbol), {
-        logger: this.logger,
-        operationName: `getPrice(${symbol})`
-      });
+      const ticker = await this.withCircuitBreaker(() =>
+        withExchangeRetryThrow(() => client.fetchTicker(formattedSymbol), {
+          logger: this.logger,
+          operationName: `getPrice(${symbol})`
+        })
+      );
 
       return {
         symbol,
@@ -364,7 +403,7 @@ export abstract class BaseExchangeService implements OnModuleDestroy {
   async validateKeys(apiKey: string, apiSecret: string): Promise<void> {
     const client = await this.getTemporaryClient(apiKey, apiSecret);
     try {
-      await withRateLimitRetryThrow(() => client.fetchBalance(), {
+      await withExchangeRetryThrow(() => client.fetchBalance(), {
         logger: this.logger,
         operationName: 'validateKeys'
       });

--- a/apps/api/src/exchange/binance/binance-us.service.ts
+++ b/apps/api/src/exchange/binance/binance-us.service.ts
@@ -1,8 +1,9 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import * as ccxt from 'ccxt';
 
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
 import { ExchangeKeyService } from '../exchange-key/exchange-key.service';
@@ -23,9 +24,10 @@ export class BinanceUSService extends BaseExchangeService {
   constructor(
     configService?: ConfigService,
     @Inject(forwardRef(() => ExchangeService)) exchangeService?: ExchangeService,
-    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService
+    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService,
+    @Optional() circuitBreaker?: CircuitBreakerService
   ) {
-    super(configService, exchangeKeyService, exchangeService);
+    super(configService, exchangeKeyService, exchangeService, circuitBreaker);
   }
 
   /**
@@ -39,5 +41,17 @@ export class BinanceUSService extends BaseExchangeService {
 
   protected override getFetchBalanceParams(): object | undefined {
     return { type: 'spot' };
+  }
+
+  /**
+   * Widen recvWindow to 15s and enable CCXT clock sync to prevent -1021 timestamp errors.
+   */
+  protected override getAdditionalClientConfig(): object {
+    return {
+      options: {
+        recvWindow: 15_000,
+        adjustForTimeDifference: true
+      }
+    };
   }
 }

--- a/apps/api/src/exchange/coinbase/coinbase.service.ts
+++ b/apps/api/src/exchange/coinbase/coinbase.service.ts
@@ -1,9 +1,10 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import * as ccxt from 'ccxt';
 
-import { withRateLimitRetryThrow } from '../../shared/retry.util';
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
+import { withExchangeRetryThrow } from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
 import { ExchangeKeyService } from '../exchange-key/exchange-key.service';
@@ -36,9 +37,10 @@ export class CoinbaseService extends BaseExchangeService {
     configService?: ConfigService,
 
     @Inject(forwardRef(() => ExchangeService)) exchangeService?: ExchangeService,
-    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService
+    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService,
+    @Optional() circuitBreaker?: CircuitBreakerService
   ) {
-    super(configService, exchangeKeyService, exchangeService);
+    super(configService, exchangeKeyService, exchangeService, circuitBreaker);
   }
 
   /**
@@ -107,9 +109,11 @@ export class CoinbaseService extends BaseExchangeService {
   async getFuturesPositions(user: User, symbol?: string): Promise<ccxt.Position[]> {
     const exchange = await this.getClient(user);
     const symbols = symbol ? [symbol] : undefined;
-    return withRateLimitRetryThrow(() => exchange.fetchPositions(symbols), {
-      logger: this.logger,
-      operationName: 'getFuturesPositions'
-    });
+    return this.withCircuitBreaker(() =>
+      withExchangeRetryThrow(() => exchange.fetchPositions(symbols), {
+        logger: this.logger,
+        operationName: 'getFuturesPositions'
+      })
+    );
   }
 }

--- a/apps/api/src/exchange/kraken/kraken-futures.service.ts
+++ b/apps/api/src/exchange/kraken/kraken-futures.service.ts
@@ -1,8 +1,9 @@
-import { forwardRef, Inject, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, InternalServerErrorException, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import * as ccxt from 'ccxt';
 
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { toErrorInfo } from '../../shared/error.util';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
@@ -27,9 +28,10 @@ export class KrakenFuturesService extends BaseExchangeService {
   constructor(
     configService?: ConfigService,
     @Inject(forwardRef(() => ExchangeService)) exchangeService?: ExchangeService,
-    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService
+    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService,
+    @Optional() circuitBreaker?: CircuitBreakerService
   ) {
-    super(configService, exchangeKeyService, exchangeService);
+    super(configService, exchangeKeyService, exchangeService, circuitBreaker);
   }
 
   /**

--- a/apps/api/src/exchange/kraken/kraken.service.ts
+++ b/apps/api/src/exchange/kraken/kraken.service.ts
@@ -1,8 +1,9 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import * as ccxt from 'ccxt';
 
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { User } from '../../users/users.entity';
 import { BaseExchangeService } from '../base-exchange.service';
 import { ExchangeKeyService } from '../exchange-key/exchange-key.service';
@@ -23,9 +24,10 @@ export class KrakenService extends BaseExchangeService {
   constructor(
     configService?: ConfigService,
     @Inject(forwardRef(() => ExchangeService)) exchangeService?: ExchangeService,
-    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService
+    @Inject(forwardRef(() => ExchangeKeyService)) exchangeKeyService?: ExchangeKeyService,
+    @Optional() circuitBreaker?: CircuitBreakerService
   ) {
-    super(configService, exchangeKeyService, exchangeService);
+    super(configService, exchangeKeyService, exchangeService, circuitBreaker);
   }
 
   /**

--- a/apps/api/src/ohlc/services/exchange-ohlc.service.spec.ts
+++ b/apps/api/src/ohlc/services/exchange-ohlc.service.spec.ts
@@ -16,7 +16,7 @@ describe('ExchangeOHLCService', () => {
   let exchangeManager: jest.Mocked<ExchangeManagerService>;
   let configService: { get: jest.Mock };
 
-  let withRateLimitRetryThrowSpy: jest.SpyInstance;
+  let withExchangeRetryThrowSpy: jest.SpyInstance;
 
   beforeEach(() => {
     exchangeManager = {
@@ -26,14 +26,12 @@ describe('ExchangeOHLCService', () => {
 
     service = new ExchangeOHLCService(exchangeManager, configService as any);
 
-    // Mock withRateLimitRetryThrow to execute operation once without retry delays
-    withRateLimitRetryThrowSpy = jest
-      .spyOn(retryUtil, 'withRateLimitRetryThrow')
-      .mockImplementation(async (fn) => fn());
+    // Mock withExchangeRetryThrow to execute operation once without retry delays
+    withExchangeRetryThrowSpy = jest.spyOn(retryUtil, 'withExchangeRetryThrow').mockImplementation(async (fn) => fn());
   });
 
   afterEach(() => {
-    withRateLimitRetryThrowSpy.mockRestore();
+    withExchangeRetryThrowSpy.mockRestore();
     jest.clearAllMocks();
   });
 

--- a/apps/api/src/ohlc/services/exchange-ohlc.service.ts
+++ b/apps/api/src/ohlc/services/exchange-ohlc.service.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { DEFAULT_QUOTE_CURRENCY, EXCHANGE_QUOTE_CURRENCY, USD_QUOTE_CURRENCIES } from '../../exchange/constants';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { formatSymbolForExchange } from '../../exchange/utils';
-import { withRateLimitRetryThrow } from '../../shared/retry.util';
+import { withExchangeRetryThrow } from '../../shared/retry.util';
 
 export interface OHLCRawData {
   timestamp: number; // Unix ms
@@ -75,7 +75,7 @@ export class ExchangeOHLCService {
 
   /**
    * Fetch OHLC data from a specific exchange with retry logic.
-   * Retry is handled inside fetchOHLC via withRateLimitRetryThrow.
+   * Retry is handled inside fetchOHLC via withExchangeRetryThrow.
    */
   async fetchOHLCWithRetry(exchangeSlug: string, symbol: string, since: number, limit = 500): Promise<OHLCFetchResult> {
     return this.fetchOHLC(exchangeSlug, symbol, since, limit);
@@ -101,7 +101,7 @@ export class ExchangeOHLCService {
 
       // Load markets if not already loaded
       if (!client.markets) {
-        await withRateLimitRetryThrow(() => client.loadMarkets(), {
+        await withExchangeRetryThrow(() => client.loadMarkets(), {
           logger: this.logger,
           operationName: `loadMarkets(${exchangeSlug})`
         });
@@ -119,7 +119,7 @@ export class ExchangeOHLCService {
 
       // Fetch OHLCV data (Open, High, Low, Close, Volume)
       // Format: [[timestamp, open, high, low, close, volume], ...]
-      const ohlcv = await withRateLimitRetryThrow(() => client.fetchOHLCV(formattedSymbol, '1h', since, limit), {
+      const ohlcv = await withExchangeRetryThrow(() => client.fetchOHLCV(formattedSymbol, '1h', since, limit), {
         logger: this.logger,
         operationName: `fetchOHLCV(${exchangeSlug}:${symbol})`
       });
@@ -181,7 +181,7 @@ export class ExchangeOHLCService {
       const client = await this.exchangeManager.getPublicClient(exchangeSlug);
 
       if (!client.markets) {
-        await withRateLimitRetryThrow(() => client.loadMarkets(), {
+        await withExchangeRetryThrow(() => client.loadMarkets(), {
           logger: this.logger,
           operationName: `loadMarkets(${exchangeSlug})`
         });

--- a/apps/api/src/ohlc/services/realtime-ticker.service.ts
+++ b/apps/api/src/ohlc/services/realtime-ticker.service.ts
@@ -7,7 +7,7 @@ import { CoinService } from '../../coin/coin.service';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { formatSymbolForExchange } from '../../exchange/utils';
 import { toErrorInfo } from '../../shared/error.util';
-import { withRateLimitRetryThrow } from '../../shared/retry.util';
+import { withExchangeRetryThrow } from '../../shared/retry.util';
 
 export interface TickerPrice {
   coinId: string;
@@ -169,7 +169,7 @@ export class RealtimeTickerService {
 
         // Load markets if not loaded
         if (!client.markets) {
-          await withRateLimitRetryThrow(() => client.loadMarkets(), {
+          await withExchangeRetryThrow(() => client.loadMarkets(), {
             logger: this.logger,
             operationName: `loadMarkets(${exchangeSlug})`
           });
@@ -182,7 +182,7 @@ export class RealtimeTickerService {
         }
 
         // Fetch ticker
-        const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(formattedSymbol), {
+        const ticker = await withExchangeRetryThrow(() => client.fetchTicker(formattedSymbol), {
           logger: this.logger,
           operationName: `fetchTicker(${exchangeSlug}:${tradingSymbol})`
         });

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -52,19 +52,19 @@ const createService = (
 };
 
 describe('PaperTradingMarketDataService', () => {
-  let withRateLimitRetrySpy: jest.SpyInstance;
-  let withRateLimitRetryThrowSpy: jest.SpyInstance;
+  let withExchangeRetrySpy: jest.SpyInstance;
+  let withExchangeRetryThrowSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
     // Spy on rate-limit-aware retry wrappers to avoid real delays in tests
-    withRateLimitRetrySpy = jest.spyOn(retryUtil, 'withRateLimitRetry');
-    withRateLimitRetryThrowSpy = jest.spyOn(retryUtil, 'withRateLimitRetryThrow');
+    withExchangeRetrySpy = jest.spyOn(retryUtil, 'withExchangeRetry');
+    withExchangeRetryThrowSpy = jest.spyOn(retryUtil, 'withExchangeRetryThrow');
   });
 
   afterEach(() => {
-    withRateLimitRetrySpy.mockRestore();
-    withRateLimitRetryThrowSpy.mockRestore();
+    withExchangeRetrySpy.mockRestore();
+    withExchangeRetryThrowSpy.mockRestore();
   });
 
   it('returns cached price data when available', async () => {
@@ -109,7 +109,7 @@ describe('PaperTradingMarketDataService', () => {
       getPublicClient: jest.fn().mockResolvedValue(client)
     };
 
-    withRateLimitRetrySpy.mockResolvedValue({
+    withExchangeRetrySpy.mockResolvedValue({
       success: true,
       result: ticker,
       attempts: 1,
@@ -231,8 +231,8 @@ describe('PaperTradingMarketDataService', () => {
     it('returns empty array when fetch throws', async () => {
       const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
 
-      // Mock withRateLimitRetryThrow to throw immediately (avoid real retry delays)
-      withRateLimitRetryThrowSpy.mockRejectedValue(new Error('network error'));
+      // Mock withExchangeRetryThrow to throw immediately (avoid real retry delays)
+      withExchangeRetryThrowSpy.mockRejectedValue(new Error('network error'));
 
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
@@ -281,7 +281,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTicker: jest.fn() })
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: false,
         error: new Error('ETIMEDOUT'),
         attempts: 4,
@@ -310,7 +310,7 @@ describe('PaperTradingMarketDataService', () => {
       };
 
       const timeoutError = new Error('ETIMEDOUT');
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: false,
         error: timeoutError,
         attempts: 4,
@@ -343,7 +343,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue(client)
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: true,
         result: tickers,
         attempts: 2,
@@ -391,7 +391,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: false,
         error: new Error('ETIMEDOUT'),
         attempts: 4,
@@ -433,7 +433,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: false,
         error: new Error('ETIMEDOUT'),
         attempts: 4,
@@ -475,7 +475,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: true,
         result: tickers,
         attempts: 1,
@@ -507,7 +507,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: true,
         result: tickers,
         attempts: 1,
@@ -669,7 +669,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTime: jest.fn() })
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({ success: true, result: 1700000000000, attempts: 1, totalDelayMs: 0 });
+      withExchangeRetrySpy.mockResolvedValue({ success: true, result: 1700000000000, attempts: 1, totalDelayMs: 0 });
 
       const { service } = createService({ exchangeManager });
       const result = await service.checkExchangeHealth('binance');
@@ -685,7 +685,7 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTime: jest.fn() })
       };
 
-      withRateLimitRetrySpy.mockResolvedValue({
+      withExchangeRetrySpy.mockResolvedValue({
         success: false,
         error: new Error('connection refused'),
         attempts: 4,

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -13,7 +13,7 @@ import { CoinSelectionService } from '../../coin-selection/coin-selection.servic
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { toErrorInfo } from '../../shared/error.util';
-import { withRateLimitRetry, withRateLimitRetryThrow } from '../../shared/retry.util';
+import { withExchangeRetry, withExchangeRetryThrow } from '../../shared/retry.util';
 import type { User } from '../../users/users.entity';
 
 export interface PriceData {
@@ -154,7 +154,7 @@ export class PaperTradingMarketDataService {
       : await this.exchangeManager.getPublicClient(exchangeSlug);
 
     // Fetch ticker with retry
-    const result = await withRateLimitRetry(() => client.fetchTicker(formattedSymbol), {
+    const result = await withExchangeRetry(() => client.fetchTicker(formattedSymbol), {
       logger: this.logger,
       operationName: `fetchTicker(${exchangeSlug}:${symbol})`
     });
@@ -230,7 +230,7 @@ export class PaperTradingMarketDataService {
       : await this.exchangeManager.getPublicClient(exchangeSlug);
 
     // Fetch all tickers with retry
-    const result = await withRateLimitRetry(
+    const result = await withExchangeRetry(
       () => client.fetchTickers(uncachedSymbols.map((s) => this.exchangeManager.formatSymbol(exchangeSlug, s))),
       {
         logger: this.logger,
@@ -316,7 +316,7 @@ export class PaperTradingMarketDataService {
         ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
         : await this.exchangeManager.getPublicClient(exchangeSlug);
 
-      const rawOrderBook = await withRateLimitRetryThrow(() => client.fetchOrderBook(formattedSymbol, depth), {
+      const rawOrderBook = await withExchangeRetryThrow(() => client.fetchOrderBook(formattedSymbol, depth), {
         logger: this.logger,
         operationName: `fetchOrderBook(${exchangeSlug}:${symbol})`
       });
@@ -440,7 +440,7 @@ export class PaperTradingMarketDataService {
         ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
         : await this.exchangeManager.getPublicClient(exchangeSlug);
 
-      const ohlcv = await withRateLimitRetryThrow(
+      const ohlcv = await withExchangeRetryThrow(
         () => client.fetchOHLCV(formattedSymbol, timeframe, undefined, limit),
         { logger: this.logger, operationName: `fetchOHLCV(${exchangeSlug}:${symbol})` }
       );
@@ -473,7 +473,7 @@ export class PaperTradingMarketDataService {
 
     try {
       const client = await this.exchangeManager.getPublicClient(exchangeSlug);
-      const result = await withRateLimitRetry(() => client.fetchTime(), {
+      const result = await withExchangeRetry(() => client.fetchTime(), {
         logger: this.logger,
         operationName: `checkExchangeHealth(${exchangeSlug})`
       });

--- a/apps/api/src/order/services/order-sync.service.spec.ts
+++ b/apps/api/src/order/services/order-sync.service.spec.ts
@@ -18,7 +18,7 @@ import { Order } from '../order.entity';
 
 // Mock retry utilities to pass through directly
 jest.mock('../../shared/retry.util', () => ({
-  withRateLimitRetry: jest.fn(async (fn: () => Promise<any>) => {
+  withExchangeRetry: jest.fn(async (fn: () => Promise<any>) => {
     try {
       const result = await fn();
       return { success: true, result };
@@ -26,7 +26,7 @@ jest.mock('../../shared/retry.util', () => ({
       return { success: false, error };
     }
   }),
-  withRateLimitRetryThrow: jest.fn(async (fn: () => Promise<any>) => fn())
+  withExchangeRetryThrow: jest.fn(async (fn: () => Promise<any>) => fn())
 }));
 
 describe('OrderSyncService', () => {

--- a/apps/api/src/order/services/order-sync.service.ts
+++ b/apps/api/src/order/services/order-sync.service.ts
@@ -18,7 +18,7 @@ import { ExchangeManagerService } from '../../exchange/exchange-manager.service'
 import { ExchangeService } from '../../exchange/exchange.service';
 import { MetricsService } from '../../metrics/metrics.service';
 import { toErrorInfo } from '../../shared/error.util';
-import { withRateLimitRetry, withRateLimitRetryThrow } from '../../shared/retry.util';
+import { withExchangeRetry, withExchangeRetryThrow } from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { OrderTransitionReason } from '../entities/order-status-history.entity';
 import { Order, OrderSide, OrderStatus } from '../order.entity';
@@ -171,7 +171,7 @@ export class OrderSyncService {
 
     try {
       const since = lastSyncTime ? new Date(lastSyncTime).getTime() : undefined;
-      const markets = await withRateLimitRetryThrow(() => client.loadMarkets(), {
+      const markets = await withExchangeRetryThrow(() => client.loadMarkets(), {
         logger: this.logger,
         operationName: `loadMarkets (${operationName})`
       });
@@ -192,7 +192,7 @@ export class OrderSyncService {
       const allItems: T[] = [];
 
       for (const symbol of activeSymbols) {
-        const result = await withRateLimitRetry(() => fetchFn(symbol, since), {
+        const result = await withExchangeRetry(() => fetchFn(symbol, since), {
           logger: this.logger,
           operationName: `${operationName}(${symbol})`
         });

--- a/apps/api/src/order/services/trade-execution.service.ts
+++ b/apps/api/src/order/services/trade-execution.service.ts
@@ -24,7 +24,7 @@ import { ExchangeKeyService } from '../../exchange/exchange-key/exchange-key.ser
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { NOTIFICATION_EVENTS } from '../../notification/interfaces/notification-events.interface';
 import { toErrorInfo } from '../../shared/error.util';
-import { withRateLimitRetryThrow } from '../../shared/retry.util';
+import { withExchangeRetryThrow } from '../../shared/retry.util';
 import { User } from '../../users/users.entity';
 import { DEFAULT_SLIPPAGE_LIMITS, slippageLimitsConfig, SlippageLimitsConfig } from '../config/slippage-limits.config';
 import type { TradeSignal, TradeSignalWithExit } from '../interfaces/trade-signal.interface';
@@ -227,7 +227,7 @@ export class TradeExecutionService {
   private async initializeExchangeClient(slug: string, user: User, symbol: string) {
     const exchangeClient = await this.exchangeManagerService.getExchangeClient(slug, user);
 
-    await withRateLimitRetryThrow(() => exchangeClient.loadMarkets(), {
+    await withExchangeRetryThrow(() => exchangeClient.loadMarkets(), {
       logger: this.logger,
       operationName: 'loadMarkets'
     });
@@ -247,7 +247,7 @@ export class TradeExecutionService {
     symbol: string,
     action: 'BUY' | 'SELL'
   ): Promise<number> {
-    const ticker = await withRateLimitRetryThrow(() => exchangeClient.fetchTicker(symbol), {
+    const ticker = await withExchangeRetryThrow(() => exchangeClient.fetchTicker(symbol), {
       logger: this.logger,
       operationName: `fetchTicker(${symbol})`
     });
@@ -434,7 +434,7 @@ export class TradeExecutionService {
     expectedPrice: number
   ): Promise<number> {
     try {
-      const orderBook = await withRateLimitRetryThrow(() => exchangeClient.fetchOrderBook(symbol, 20), {
+      const orderBook = await withExchangeRetryThrow(() => exchangeClient.fetchOrderBook(symbol, 20), {
         logger: this.logger,
         operationName: `fetchOrderBook(${symbol})`
       });

--- a/apps/api/src/shared/index.ts
+++ b/apps/api/src/shared/index.ts
@@ -26,13 +26,18 @@ export {
 } from './circuit-breaker.service';
 export {
   DEFAULT_RETRY_OPTIONS,
+  EXCHANGE_RETRY_OPTIONS,
+  exchangeAwareDelay,
   extractRetryAfterMs,
   isAuthenticationError,
+  isClockSkewError,
   isRateLimitError,
   isTransientError,
   RATE_LIMIT_RETRY_OPTIONS,
   RetryOptions,
   RetryResult,
+  withExchangeRetry,
+  withExchangeRetryThrow,
   withRateLimitRetry,
   withRateLimitRetryThrow,
   withRetry,

--- a/apps/api/src/shared/retry.util.spec.ts
+++ b/apps/api/src/shared/retry.util.spec.ts
@@ -1,11 +1,15 @@
 import { type Logger } from '@nestjs/common';
 
 import {
+  exchangeAwareDelay,
   extractRetryAfterMs,
   isAuthenticationError,
+  isClockSkewError,
   isRateLimitError,
   isTransientError,
   rateLimitAwareDelay,
+  withExchangeRetry,
+  withExchangeRetryThrow,
   withRateLimitRetry,
   withRateLimitRetryThrow,
   withRetry,
@@ -489,6 +493,128 @@ describe('retry.util', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe(error);
       expect(result.attempts).toBe(4); // initial + 3 retries
+    });
+  });
+
+  describe('isClockSkewError', () => {
+    it('should detect Binance -1021 error code', () => {
+      expect(
+        isClockSkewError(
+          new Error('binanceus {"code":-1021,"msg":"Timestamp for this request is outside of the recvWindow"}')
+        )
+      ).toBe(true);
+    });
+
+    it('should detect recvWindow in message', () => {
+      expect(isClockSkewError(new Error('recvWindow exceeded'))).toBe(true);
+    });
+
+    it('should detect -1021 in message', () => {
+      expect(isClockSkewError(new Error('Error -1021: Timestamp issue'))).toBe(true);
+    });
+
+    it('should return false for non-clock-skew errors', () => {
+      expect(isClockSkewError(new Error('ECONNRESET'))).toBe(false);
+      expect(isClockSkewError(new Error('rate limit exceeded'))).toBe(false);
+      expect(isClockSkewError(new Error('Invalid API key'))).toBe(false);
+    });
+  });
+
+  describe('isTransientError with clock skew', () => {
+    it('should classify clock skew errors as transient', () => {
+      expect(isTransientError(new Error('binanceus -1021 recvWindow exceeded'))).toBe(true);
+    });
+  });
+
+  describe('exchangeAwareDelay', () => {
+    it('should return 500ms for clock skew errors', () => {
+      const error = new Error('recvWindow exceeded -1021');
+      expect(exchangeAwareDelay(error, 1, 2000)).toBe(500);
+    });
+
+    it('should return Retry-After delay for rate limit errors', () => {
+      const error = new Error('rate limit exceeded, Retry-After: 10');
+      const delay = exchangeAwareDelay(error, 1, 5000);
+      expect(delay).toBe(10000);
+    });
+
+    it('should return preset delay for rate limit errors without Retry-After', () => {
+      const error = new Error('rate limit exceeded');
+      const delay = exchangeAwareDelay(error, 1, 2000);
+      expect(delay).toBe(5000);
+    });
+
+    it('should return undefined for timeout/network errors (use default backoff)', () => {
+      expect(exchangeAwareDelay(new Error('ECONNRESET'), 1, 1000)).toBeUndefined();
+      expect(exchangeAwareDelay(new Error('ETIMEDOUT'), 1, 1000)).toBeUndefined();
+    });
+  });
+
+  describe('withExchangeRetry', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should retry clock skew errors with minimal delay', async () => {
+      const error = new Error('recvWindow exceeded -1021');
+      const operation = jest.fn().mockRejectedValueOnce(error).mockResolvedValueOnce('recovered');
+
+      const promise = withExchangeRetry(operation);
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('recovered');
+      expect(result.totalDelayMs).toBe(500);
+    });
+
+    it('should retry transient errors with backoff', async () => {
+      const operation = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce('recovered');
+
+      const promise = withExchangeRetry(operation);
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('recovered');
+    });
+  });
+
+  describe('withExchangeRetryThrow', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should succeed on retry after transient error', async () => {
+      const operation = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce('recovered');
+
+      const promise = withExchangeRetryThrow(operation);
+
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe('recovered');
+    });
+
+    it('should throw on final failure', async () => {
+      const error = new Error('ECONNRESET');
+      const operation = jest.fn().mockRejectedValue(error);
+
+      const promise = withExchangeRetryThrow(operation);
+
+      const expectation = expect(promise).rejects.toThrow('ECONNRESET');
+      await jest.runAllTimersAsync();
+      await expectation;
     });
   });
 

--- a/apps/api/src/shared/retry.util.ts
+++ b/apps/api/src/shared/retry.util.ts
@@ -102,6 +102,11 @@ export function isTransientError(error: Error): boolean {
     return true;
   }
 
+  // Clock skew errors (Binance -1021)
+  if (isClockSkewError(error)) {
+    return true;
+  }
+
   return false;
 }
 
@@ -142,6 +147,16 @@ export function isRateLimitError(error: Error): boolean {
 export function isAuthenticationError(error: Error): boolean {
   const name = (error.constructor?.name || '') + (error.name || '');
   return /AuthenticationError|PermissionDenied|AccountSuspended/i.test(name);
+}
+
+/**
+ * Check if an error is a clock skew / timestamp error (Binance -1021).
+ * These errors occur when the client clock drifts from the exchange server clock
+ * and the request falls outside the recvWindow.
+ */
+export function isClockSkewError(error: Error): boolean {
+  const message = error.message || '';
+  return message.includes('-1021') || /recvWindow/i.test(message);
 }
 
 /**
@@ -351,4 +366,57 @@ export async function withRateLimitRetry<T>(
  */
 export async function withRateLimitRetryThrow<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
   return withRetryThrow(operation, { ...RATE_LIMIT_RETRY_OPTIONS, ...options });
+}
+
+/**
+ * onRetry callback that adapts delay by error type for exchange API calls.
+ * - Rate limit: respects Retry-After or uses 5s minimum
+ * - Clock skew: 500ms (just needs fresh timestamp)
+ * - Timeout/network: uses default exponential backoff
+ */
+export function exchangeAwareDelay(error: Error, _attempt: number, defaultDelayMs: number): number | void {
+  if (isRateLimitError(error)) {
+    const retryAfter = extractRetryAfterMs(error);
+    const rateLimitDelay = retryAfter ?? 5000;
+    return Math.max(rateLimitDelay, defaultDelayMs);
+  }
+
+  if (isClockSkewError(error)) {
+    return 500;
+  }
+}
+
+/**
+ * Retry options tuned for exchange API calls.
+ * Uses 1s initial delay with 2x backoff, capped at 8s for standard errors.
+ * Rate-limit errors may exceed this cap when respecting Retry-After headers.
+ * Adapts delay by error type via exchangeAwareDelay: rate limits get longer waits,
+ * clock skew gets minimal delay, timeouts use standard backoff.
+ */
+export const EXCHANGE_RETRY_OPTIONS: Partial<RetryOptions> = {
+  initialDelayMs: 1000,
+  backoffMultiplier: 2,
+  maxDelayMs: 8000,
+  maxRetries: 3,
+  isRetryable: isTransientError,
+  onRetry: exchangeAwareDelay
+};
+
+/**
+ * Execute an async operation with exchange-aware retry logic.
+ * Merges caller options with EXCHANGE_RETRY_OPTIONS presets.
+ */
+export async function withExchangeRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<RetryResult<T>> {
+  return withRetry(operation, { ...EXCHANGE_RETRY_OPTIONS, ...options });
+}
+
+/**
+ * Execute an async operation with exchange-aware retry, throwing on final failure.
+ * Convenience wrapper that throws instead of returning RetryResult.
+ */
+export async function withExchangeRetryThrow<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  return withRetryThrow(operation, { ...EXCHANGE_RETRY_OPTIONS, ...options });
 }

--- a/apps/api/src/trading/trading.service.ts
+++ b/apps/api/src/trading/trading.service.ts
@@ -13,7 +13,7 @@ import { ExchangeManagerService } from '../exchange/exchange-manager.service';
 import { ExchangeService } from '../exchange/exchange.service';
 import { toErrorInfo } from '../shared/error.util';
 import { extractMarketLimits } from '../shared/precision.util';
-import { withRateLimitRetryThrow } from '../shared/retry.util';
+import { withExchangeRetryThrow } from '../shared/retry.util';
 import { User } from '../users/users.entity';
 
 @Injectable()
@@ -55,7 +55,7 @@ export class TradingService {
       const { client, name: exchangeName } = await this.resolveExchangeClient(exchangeId);
 
       if (!client.markets) {
-        await withRateLimitRetryThrow(() => client.loadMarkets(), {
+        await withExchangeRetryThrow(() => client.loadMarkets(), {
           logger: this.logger,
           operationName: 'loadMarkets'
         });
@@ -74,7 +74,7 @@ export class TradingService {
         );
       }
 
-      const orderBook = await withRateLimitRetryThrow(() => client.fetchOrderBook(symbol, 10), {
+      const orderBook = await withExchangeRetryThrow(() => client.fetchOrderBook(symbol, 10), {
         logger: this.logger,
         operationName: `fetchOrderBook(${symbol})`
       });
@@ -102,7 +102,7 @@ export class TradingService {
 
     try {
       const { client } = await this.resolveExchangeClient(exchangeId);
-      const ticker = await withRateLimitRetryThrow(() => client.fetchTicker(symbol), {
+      const ticker = await withExchangeRetryThrow(() => client.fetchTicker(symbol), {
         logger: this.logger,
         operationName: `fetchTicker(${symbol})`
       });
@@ -139,7 +139,7 @@ export class TradingService {
     const client = await service.getClient(user);
 
     if (!client.markets) {
-      await withRateLimitRetryThrow(() => client.loadMarkets(), {
+      await withExchangeRetryThrow(() => client.loadMarkets(), {
         logger: this.logger,
         operationName: 'loadMarkets'
       });
@@ -193,7 +193,7 @@ export class TradingService {
       const exchange = await this.exchangeService.findOne(exchangeId);
       const service = this.exchangeManagerService.getExchangeService(exchange.slug);
       const client = await service.getClient(user);
-      const ccxtBalances = await withRateLimitRetryThrow(() => client.fetchBalance(), {
+      const ccxtBalances = await withExchangeRetryThrow(() => client.fetchBalance(), {
         logger: this.logger,
         operationName: 'fetchBalance'
       });


### PR DESCRIPTION
## Summary

- Add exchange-aware retry strategy (`withExchangeRetry`) with error-type-specific delays: 500ms for clock skew, 5s+ for rate limits, 1-8s exponential backoff for timeouts
- Wire `CircuitBreakerService` into `BaseExchangeService` (5 failures/60s opens circuit, 30s reset) to fail fast on sustained exchange outages
- Configure Binance US with `recvWindow: 15s` and `adjustForTimeDifference: true` to prevent -1021 timestamp errors

## Changes

**New retry infrastructure** (`shared/retry.util.ts`)
- `isClockSkewError()` — detects Binance -1021/recvWindow errors as retryable
- `exchangeAwareDelay()` — adapts delay by error type (clock skew vs rate limit vs timeout)
- `withExchangeRetry` / `withExchangeRetryThrow` — exchange-tuned retry presets (1s/2x/8s cap)
- 56 tests covering all error classifiers and retry behaviors

**Circuit breaker in base exchange** (`exchange/base-exchange.service.ts`)
- `withCircuitBreaker()` method wraps all exchange API calls
- All 5 exchange methods (getBalance, getFreeBalance, getPriceBySymbol, getPrice, validateKeys) protected

**Binance clock sync** (`exchange/binance/binance-us.service.ts`)
- `recvWindow: 15_000` and `adjustForTimeDifference: true` via `getAdditionalClientConfig()`

**Migration** — 9 callers migrated from `withRateLimitRetry` to `withExchangeRetry`:
- `order-sync.service.ts`, `trade-execution.service.ts`, `trading.service.ts`
- `exchange-ohlc.service.ts`, `realtime-ticker.service.ts`
- `paper-trading-market-data.service.ts`, `added-to-exchange-binance.service.ts`
- `coinbase.service.ts` (futures order creation)

> **Note**: CoinGecko callers (`coin-detail-sync`, `category-sync`, `exchange-sync`) intentionally remain on `withRateLimitRetry` — its 5s/3x/60s preset better suits CoinGecko's aggressive rate limiting.

## Test plan

- [x] `retry.util.spec.ts` — 56 tests pass (error classifiers, delay behaviors, retry variants)
- [x] `order-sync.service.spec.ts` — updated mocks for `withExchangeRetry`
- [x] `exchange-ohlc.service.spec.ts` — updated mocks
- [x] `paper-trading-market-data.service.spec.ts` — updated mocks
- [x] `nx build api` succeeds