### PR TITLE
fix(api): mark retry-exhausted paper trading sessions as FAILED, not PAUSED

### DIFF
--- a/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-order-executor.service.ts
@@ -17,7 +17,7 @@ import {
   PaperTradingSession,
   PaperTradingSignal
 } from '../entities';
-import { PaperTradingMarketDataService } from '../paper-trading-market-data.service';
+import { PaperTradingSlippageService } from '../paper-trading-slippage.service';
 
 export interface ExecuteOrderContext {
   session: PaperTradingSession;
@@ -50,7 +50,7 @@ export class PaperTradingOrderExecutorService {
   constructor(
     private readonly dataSource: DataSource,
     private readonly feeCalculator: FeeCalculatorService,
-    private readonly marketDataService: PaperTradingMarketDataService
+    private readonly slippageService: PaperTradingSlippageService
   ) {}
 
   async execute(ctx: ExecuteOrderContext): Promise<ExecuteOrderResult> {
@@ -63,7 +63,7 @@ export class PaperTradingOrderExecutorService {
 
     const isBuy = signal.action === 'BUY';
 
-    const slippageResult = await this.marketDataService.calculateRealisticSlippage(
+    const slippageResult = await this.slippageService.calculateRealisticSlippage(
       exchangeSlug,
       signal.symbol,
       signal.quantity ?? (portfolio.totalValue * 0.1) / basePrice,

--- a/apps/api/src/order/paper-trading/index.ts
+++ b/apps/api/src/order/paper-trading/index.ts
@@ -2,6 +2,7 @@ export * from './dto';
 export * from './entities';
 export * from './paper-trading-engine.service';
 export * from './paper-trading-market-data.service';
+export * from './paper-trading-slippage.service';
 export * from './paper-trading-recovery.service';
 export * from './paper-trading-stream.service';
 export * from './paper-trading.config';

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -133,45 +133,13 @@ describe('PaperTradingMarketDataService', () => {
       }),
       1000
     );
-    // Stale cache write
+    // Stale cache write (30 min TTL)
     expect(cacheManager.set).toHaveBeenCalledWith(
       'paper-trading:price:binance:BTC/USDT:stale',
       expect.objectContaining({ symbol: 'BTC/USDT', price: 45000 }),
-      300000
+      1800000
     );
     expect(result.price).toBe(45000);
-  });
-
-  it('calculates slippage from order book depth', async () => {
-    const { service } = createService();
-
-    jest.spyOn(service, 'getOrderBook').mockResolvedValue({
-      symbol: 'BTC/USD',
-      bids: [],
-      asks: [
-        { price: 100, quantity: 1 },
-        { price: 110, quantity: 1 }
-      ],
-      timestamp: new Date()
-    });
-
-    const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 1.5, 'BUY');
-
-    expect(result.estimatedPrice).toBeCloseTo(103.333, 3);
-    expect(result.slippageBps).toBeCloseTo(337.333, 3);
-    expect(result.marketImpact).toBe(4);
-  });
-
-  it('falls back to fixed slippage when order book lookup fails', async () => {
-    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    const { service } = createService();
-
-    jest.spyOn(service, 'getOrderBook').mockRejectedValue(new Error('boom'));
-
-    const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 1, 'BUY');
-
-    expect(result).toEqual({ estimatedPrice: 0, slippageBps: 10, marketImpact: 0 });
-    loggerSpy.mockRestore();
   });
 
   describe('getHistoricalCandles', () => {
@@ -254,6 +222,42 @@ describe('PaperTradingMarketDataService', () => {
     });
   });
 
+  it('uses ticker.close when ticker.last is null', async () => {
+    const ticker = {
+      last: null,
+      close: 46000,
+      bid: 45950,
+      ask: 46050,
+      timestamp: 1700000000000
+    };
+
+    const client = { fetchTicker: jest.fn().mockResolvedValue(ticker) };
+
+    const cacheManager = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn()
+    };
+
+    const exchangeManager = {
+      formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
+      getPublicClient: jest.fn().mockResolvedValue(client)
+    };
+
+    withExchangeRetrySpy.mockResolvedValue({
+      success: true,
+      result: ticker,
+      attempts: 1,
+      totalDelayMs: 0
+    });
+
+    const { service } = createService({ cacheManager, exchangeManager });
+
+    const result = await service.getCurrentPrice('binance', 'BTC/USDT');
+
+    expect(result.price).toBe(46000);
+    expect(result.source).toBe('binance');
+  });
+
   describe('getCurrentPrice retry + stale-cache fallback', () => {
     it('falls back to stale cache when all retries exhausted', async () => {
       const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
@@ -296,8 +300,18 @@ describe('PaperTradingMarketDataService', () => {
       loggerSpy.mockRestore();
     });
 
-    it('throws when retries exhausted AND no stale cache exists', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    it('falls back to alternative exchange when retries exhausted and no stale cache', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+
+      const fallbackTicker = {
+        last: 43500,
+        bid: 43450,
+        ask: 43550,
+        timestamp: 1700000000000
+      };
+
+      const fallbackClient = { fetchTicker: jest.fn().mockResolvedValue(fallbackTicker) };
 
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
@@ -305,8 +319,120 @@ describe('PaperTradingMarketDataService', () => {
       };
 
       const exchangeManager = {
-        formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
-        getPublicClient: jest.fn().mockResolvedValue({ fetchTicker: jest.fn() })
+        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
+        getPublicClient: jest.fn().mockImplementation((slug: string) => {
+          if (slug === 'gdax') return Promise.resolve(fallbackClient);
+          return Promise.resolve({ fetchTicker: jest.fn() });
+        })
+      };
+
+      withExchangeRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('ETIMEDOUT'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getCurrentPrice('binance', 'BTC/USDT');
+
+      expect(result.price).toBe(43500);
+      expect(result.source).toBe('gdax:fallback');
+      // Should cache the fallback result as stale
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'paper-trading:price:binance:BTC/USDT:stale',
+        expect.objectContaining({ source: 'gdax:fallback' }),
+        1800000
+      );
+      loggerSpy.mockRestore();
+    });
+
+    it('falls back to DB coin price when all exchanges fail', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
+        getPublicClient: jest.fn().mockResolvedValue({
+          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
+        })
+      };
+
+      withExchangeRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('ETIMEDOUT'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const coinService = {
+        getCoinsByRiskLevel: jest.fn(),
+        getCoinBySymbol: jest.fn().mockResolvedValue({ id: 'coin-1', currentPrice: 42000 })
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager, coinService });
+      const result = await service.getCurrentPrice('binance', 'BTC/USDT');
+
+      expect(result.price).toBe(42000);
+      expect(result.source).toBe('db:coin.currentPrice');
+      loggerSpy.mockRestore();
+    });
+
+    it('falls back to DB coin price of 0 without skipping it', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
+        getPublicClient: jest.fn().mockResolvedValue({
+          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
+        })
+      };
+
+      withExchangeRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('ETIMEDOUT'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const coinService = {
+        getCoinsByRiskLevel: jest.fn(),
+        getCoinBySymbol: jest.fn().mockResolvedValue({ id: 'coin-1', currentPrice: 0 })
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager, coinService });
+      const result = await service.getCurrentPrice('binance', 'BTC/USDT');
+
+      expect(result.price).toBe(0);
+      expect(result.source).toBe('db:coin.currentPrice');
+      loggerSpy.mockRestore();
+    });
+
+    it('throws when retries, fallback exchanges, and DB all fail', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
+        getPublicClient: jest.fn().mockResolvedValue({
+          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
+        })
       };
 
       const timeoutError = new Error('ETIMEDOUT');
@@ -317,7 +443,12 @@ describe('PaperTradingMarketDataService', () => {
         totalDelayMs: 14000
       });
 
-      const { service } = createService({ cacheManager, exchangeManager });
+      const coinService = {
+        getCoinsByRiskLevel: jest.fn(),
+        getCoinBySymbol: jest.fn().mockResolvedValue(null)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager, coinService });
 
       await expect(service.getCurrentPrice('binance', 'BTC/USDT')).rejects.toThrow('ETIMEDOUT');
       loggerSpy.mockRestore();
@@ -408,14 +539,22 @@ describe('PaperTradingMarketDataService', () => {
       loggerSpy.mockRestore();
     });
 
-    it('throws when retries exhausted AND some symbols have no stale cache', async () => {
+    it('uses fallback exchange for symbols missing stale cache', async () => {
       const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
 
       const stalebtc = {
         symbol: 'BTC/USDT',
         price: 44000,
         timestamp: new Date(),
         source: 'binance'
+      };
+
+      const fallbackTicker = {
+        last: 2400,
+        bid: 2390,
+        ask: 2410,
+        timestamp: 1700000000000
       };
 
       const cacheManager = {
@@ -430,7 +569,12 @@ describe('PaperTradingMarketDataService', () => {
 
       const exchangeManager = {
         formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+        getPublicClient: jest.fn().mockImplementation((slug: string) => {
+          if (slug === 'gdax') {
+            return Promise.resolve({ fetchTicker: jest.fn().mockResolvedValue(fallbackTicker) });
+          }
+          return Promise.resolve({ fetchTickers: jest.fn() });
+        })
       };
 
       withExchangeRetrySpy.mockResolvedValue({
@@ -441,9 +585,47 @@ describe('PaperTradingMarketDataService', () => {
       });
 
       const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(result.get('BTC/USDT')?.source).toBe('binance:stale');
+      expect(result.get('ETH/USDT')?.price).toBe(2400);
+      expect(result.get('ETH/USDT')?.source).toBe('gdax:fallback');
+      loggerSpy.mockRestore();
+    });
+
+    it('throws when retries, fallback exchanges, and DB all fail for some symbols', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({
+          fetchTickers: jest.fn(),
+          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
+        })
+      };
+
+      withExchangeRetrySpy.mockResolvedValue({
+        success: false,
+        error: new Error('ETIMEDOUT'),
+        attempts: 4,
+        totalDelayMs: 14000
+      });
+
+      const coinService = {
+        getCoinsByRiskLevel: jest.fn(),
+        getCoinBySymbol: jest.fn().mockResolvedValue(null)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager, coinService });
 
       await expect(service.getPrices('binance', ['BTC/USDT', 'ETH/USDT'])).rejects.toThrow(
-        /1 symbol\(s\) have no stale cache fallback/
+        /2 symbol\(s\) have no stale cache, fallback exchange, or DB fallback/
       );
       loggerSpy.mockRestore();
     });
@@ -519,146 +701,6 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result.get('BTC/USDT')?.price).toBe(45000);
       expect(result.has('ETH/USDT')).toBe(false);
-    });
-  });
-
-  describe('getOrderBook', () => {
-    it('returns cached order book when available', async () => {
-      const cached = {
-        symbol: 'BTC/USD',
-        bids: [{ price: 100, quantity: 1 }],
-        asks: [{ price: 101, quantity: 1 }],
-        timestamp: new Date()
-      };
-
-      const { service, exchangeManager } = createService({
-        cacheManager: {
-          get: jest.fn().mockResolvedValue(cached),
-          set: jest.fn()
-        }
-      });
-
-      const result = await service.getOrderBook('binance', 'BTC/USD');
-
-      expect(result).toBe(cached);
-      expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
-    });
-
-    it('fetches, maps, and caches order book on cache miss', async () => {
-      const rawOrderBook = {
-        bids: [
-          [100, 5],
-          [99, 10]
-        ],
-        asks: [
-          [101, 3],
-          [102, 7]
-        ],
-        timestamp: 1700000000000
-      };
-
-      const client = { fetchOrderBook: jest.fn().mockResolvedValue(rawOrderBook) };
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
-        getPublicClient: jest.fn().mockResolvedValue(client)
-      };
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      const result = await service.getOrderBook('binance', 'BTC/USD', 10);
-
-      expect(client.fetchOrderBook).toHaveBeenCalledWith('BTC/USD', 10);
-      expect(result.bids).toEqual([
-        { price: 100, quantity: 5 },
-        { price: 99, quantity: 10 }
-      ]);
-      expect(result.asks).toEqual([
-        { price: 101, quantity: 3 },
-        { price: 102, quantity: 7 }
-      ]);
-      // Cache TTL capped at min(cacheTtlMs, 2000)
-      expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:orderbook:binance:BTC/USD', result, 1000);
-    });
-
-    it('throws and logs on fetch failure', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
-
-      const client = { fetchOrderBook: jest.fn().mockRejectedValue(new Error('exchange down')) };
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
-        getPublicClient: jest.fn().mockResolvedValue(client)
-      };
-
-      const { service } = createService({ cacheManager, exchangeManager });
-
-      await expect(service.getOrderBook('binance', 'BTC/USD')).rejects.toThrow('exchange down');
-      expect(loggerSpy).toHaveBeenCalled();
-      loggerSpy.mockRestore();
-    });
-  });
-
-  describe('calculateRealisticSlippage edge cases', () => {
-    it('returns fixed slippage when order book has empty levels', async () => {
-      const { service } = createService();
-
-      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
-        symbol: 'BTC/USD',
-        bids: [],
-        asks: [],
-        timestamp: new Date()
-      });
-
-      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 1, 'BUY');
-
-      expect(result).toEqual({ estimatedPrice: 0, slippageBps: 10, marketImpact: 0 });
-    });
-
-    it('returns high slippage when quantity exceeds available liquidity', async () => {
-      const { service } = createService();
-
-      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
-        symbol: 'BTC/USD',
-        bids: [{ price: 100, quantity: 0 }],
-        asks: [{ price: 101, quantity: 0 }],
-        timestamp: new Date()
-      });
-
-      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 10, 'BUY');
-
-      expect(result.slippageBps).toBe(50);
-      expect(result.estimatedPrice).toBe(101);
-    });
-
-    it('uses bids for SELL side slippage', async () => {
-      const { service } = createService();
-
-      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
-        symbol: 'BTC/USD',
-        bids: [
-          { price: 100, quantity: 2 },
-          { price: 90, quantity: 2 }
-        ],
-        asks: [],
-        timestamp: new Date()
-      });
-
-      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 3, 'SELL');
-
-      // VWAP = (2*100 + 1*90) / 3 = 96.667
-      expect(result.estimatedPrice).toBeCloseTo(96.667, 2);
-      // Slippage from best bid (100): |96.667 - 100| / 100 * 10000 = 333.33 bps + 4 impact
-      expect(result.slippageBps).toBeCloseTo(337.333, 0);
     });
   });
 

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -5,43 +5,23 @@ import { ConfigType } from '@nestjs/config';
 import { Cache } from 'cache-manager';
 
 import { PaperTradingSession } from './entities';
+import type { PriceData } from './paper-trading-market-data.types';
 import { paperTradingConfig } from './paper-trading.config';
 
 import { CoinService } from '../../coin/coin.service';
 import { CoinSelectionRelations } from '../../coin-selection/coin-selection.entity';
 import { CoinSelectionService } from '../../coin-selection/coin-selection.service';
+import { EXCHANGE_QUOTE_CURRENCY } from '../../exchange/constants';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { toErrorInfo } from '../../shared/error.util';
 import { withExchangeRetry, withExchangeRetryThrow } from '../../shared/retry.util';
 import type { User } from '../../users/users.entity';
 
-export interface PriceData {
-  symbol: string;
-  price: number;
-  bid?: number;
-  ask?: number;
-  timestamp: Date;
-  source: string;
-}
+export type { PriceData, OrderBook, OrderBookLevel, RealisticSlippageResult } from './paper-trading-market-data.types';
 
-export interface OrderBookLevel {
-  price: number;
-  quantity: number;
-}
-
-export interface OrderBook {
-  symbol: string;
-  bids: OrderBookLevel[];
-  asks: OrderBookLevel[];
-  timestamp: Date;
-}
-
-export interface RealisticSlippageResult {
-  estimatedPrice: number;
-  slippageBps: number;
-  marketImpact: number;
-}
+const STALE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const FALLBACK_EXCHANGE_SLUGS = ['gdax', 'kraken'] as const;
 
 @Injectable()
 export class PaperTradingMarketDataService {
@@ -175,7 +155,7 @@ export class PaperTradingMarketDataService {
 
       // Write stale fallback cache with longer TTL
       const staleKey = `${cacheKey}:stale`;
-      await this.cacheManager.set(staleKey, priceData, 5 * 60 * 1000);
+      await this.cacheManager.set(staleKey, priceData, STALE_CACHE_TTL_MS);
 
       return priceData;
     }
@@ -190,8 +170,22 @@ export class PaperTradingMarketDataService {
       return { ...stale, source: `${stale.source}:stale` };
     }
 
+    // Try fallback exchanges
+    const fallbackPrice = await this.tryFallbackExchanges(symbol, exchangeSlug);
+    if (fallbackPrice) {
+      const staleKey2 = `${cacheKey}:stale`;
+      await this.cacheManager.set(staleKey2, fallbackPrice, STALE_CACHE_TTL_MS);
+      return fallbackPrice;
+    }
+
+    // Try database price as last resort
+    const dbPrice = await this.tryDatabasePrice(symbol);
+    if (dbPrice) {
+      return dbPrice;
+    }
+
     this.logger.error(
-      `Failed to fetch price for ${symbol} from ${exchangeSlug} after retries, and no stale cache fallback`
+      `Failed to fetch price for ${symbol} from ${exchangeSlug} after retries, fallback exchanges, and DB lookup`
     );
     throw result.error;
   }
@@ -263,7 +257,7 @@ export class PaperTradingMarketDataService {
 
           // Write stale fallback cache with longer TTL
           const staleKey = `${cacheKey}:stale`;
-          await this.cacheManager.set(staleKey, priceData, 5 * 60 * 1000);
+          await this.cacheManager.set(staleKey, priceData, STALE_CACHE_TTL_MS);
         }
       }
 
@@ -276,144 +270,43 @@ export class PaperTradingMarketDataService {
         `Falling back to stale cached prices for ${uncachedSymbols.length} symbol(s).`
     );
 
-    let staleMisses = 0;
+    const stillMissing: string[] = [];
     for (const symbol of uncachedSymbols) {
       const staleKey = `paper-trading:price:${exchangeSlug}:${symbol}:stale`;
       const stale = await this.cacheManager.get<PriceData>(staleKey);
       if (stale) {
         results.set(symbol, { ...stale, source: `${stale.source}:stale` });
       } else {
-        staleMisses++;
+        stillMissing.push(symbol);
       }
     }
 
-    if (staleMisses > 0) {
+    // Try fallback exchanges and DB for symbols with no stale cache
+    for (const symbol of stillMissing) {
+      const fallbackPrice = await this.tryFallbackExchanges(symbol, exchangeSlug);
+      if (fallbackPrice) {
+        results.set(symbol, fallbackPrice);
+        const cacheKey = `paper-trading:price:${exchangeSlug}:${symbol}:stale`;
+        await this.cacheManager.set(cacheKey, fallbackPrice, STALE_CACHE_TTL_MS);
+        continue;
+      }
+
+      const dbPrice = await this.tryDatabasePrice(symbol);
+      if (dbPrice) {
+        results.set(symbol, dbPrice);
+        continue;
+      }
+    }
+
+    const finalMisses = stillMissing.filter((s) => !results.has(s));
+    if (finalMisses.length > 0) {
       throw new Error(
         `Failed to fetch prices from ${exchangeSlug} after retries, ` +
-          `and ${staleMisses} symbol(s) have no stale cache fallback`
+          `and ${finalMisses.length} symbol(s) have no stale cache, fallback exchange, or DB fallback`
       );
     }
 
     return results;
-  }
-
-  /**
-   * Get order book for realistic slippage calculation
-   */
-  async getOrderBook(exchangeSlug: string, symbol: string, depth = 20, user?: User): Promise<OrderBook> {
-    const cacheKey = `paper-trading:orderbook:${exchangeSlug}:${symbol}`;
-
-    // Try cache first (shorter TTL for order books)
-    const cached = await this.cacheManager.get<OrderBook>(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    try {
-      const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
-
-      const client = user
-        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-        : await this.exchangeManager.getPublicClient(exchangeSlug);
-
-      const rawOrderBook = await withExchangeRetryThrow(() => client.fetchOrderBook(formattedSymbol, depth), {
-        logger: this.logger,
-        operationName: `fetchOrderBook(${exchangeSlug}:${symbol})`
-      });
-
-      const orderBook: OrderBook = {
-        symbol,
-        bids: rawOrderBook.bids.map(([price, quantity]) => ({
-          price: Number(price ?? 0),
-          quantity: Number(quantity ?? 0)
-        })),
-        asks: rawOrderBook.asks.map(([price, quantity]) => ({
-          price: Number(price ?? 0),
-          quantity: Number(quantity ?? 0)
-        })),
-        timestamp: new Date(rawOrderBook.timestamp ?? Date.now())
-      };
-
-      // Cache with short TTL (order books change quickly)
-      await this.cacheManager.set(cacheKey, orderBook, Math.min(this.cacheTtlMs, 2000));
-
-      return orderBook;
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.error(`Failed to fetch order book for ${symbol} from ${exchangeSlug}: ${err.message}`);
-      throw error;
-    }
-  }
-
-  /**
-   * Calculate realistic slippage based on order book depth
-   */
-  async calculateRealisticSlippage(
-    exchangeSlug: string,
-    symbol: string,
-    quantity: number,
-    side: 'BUY' | 'SELL',
-    user?: User
-  ): Promise<RealisticSlippageResult> {
-    try {
-      const orderBook = await this.getOrderBook(exchangeSlug, symbol, 50, user);
-      const levels = side === 'BUY' ? orderBook.asks : orderBook.bids;
-
-      if (levels.length === 0) {
-        // Fallback to fixed slippage if no order book
-        return {
-          estimatedPrice: 0,
-          slippageBps: 10, // Default 10 bps
-          marketImpact: 0
-        };
-      }
-
-      // Calculate volume-weighted average price for the quantity
-      let remainingQuantity = quantity;
-      let totalCost = 0;
-      let levelsFilled = 0;
-
-      for (const level of levels) {
-        if (remainingQuantity <= 0) break;
-
-        const fillQuantity = Math.min(remainingQuantity, level.quantity);
-        totalCost += fillQuantity * level.price;
-        remainingQuantity -= fillQuantity;
-        levelsFilled++;
-      }
-
-      const filledQuantity = quantity - remainingQuantity;
-      if (filledQuantity === 0) {
-        return {
-          estimatedPrice: levels[0].price,
-          slippageBps: 50, // High slippage for no fill
-          marketImpact: 0
-        };
-      }
-
-      const avgPrice = totalCost / filledQuantity;
-      const bestPrice = levels[0].price;
-      const slippageBps = Math.abs(((avgPrice - bestPrice) / bestPrice) * 10000);
-
-      // Market impact is based on how many levels were consumed
-      const marketImpact = Math.min(levelsFilled * 2, 50); // Cap at 50 bps
-
-      return {
-        estimatedPrice: avgPrice,
-        slippageBps: slippageBps + marketImpact,
-        marketImpact
-      };
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.warn(`Failed to calculate slippage for ${symbol}: ${err.message}. Using fixed slippage.`);
-
-      // Fallback to fixed slippage
-      return {
-        estimatedPrice: 0,
-        slippageBps: 10,
-        marketImpact: 0
-      };
-    }
   }
 
   /**
@@ -496,6 +389,69 @@ export class PaperTradingMarketDataService {
         error: err.message
       };
     }
+  }
+
+  /**
+   * Try alternative exchanges when the primary exchange fails.
+   * Handles quote currency mismatch (e.g. USDT on Binance → USD on Coinbase/Kraken).
+   */
+  private async tryFallbackExchanges(symbol: string, primarySlug: string): Promise<PriceData | null> {
+    const [base] = symbol.split('/');
+
+    for (const slug of FALLBACK_EXCHANGE_SLUGS) {
+      if (slug === primarySlug) continue;
+
+      try {
+        const quoteAsset = EXCHANGE_QUOTE_CURRENCY[slug] ?? 'USD';
+        const fallbackSymbol = `${base}/${quoteAsset}`;
+        const formattedSymbol = this.exchangeManager.formatSymbol(slug, fallbackSymbol);
+        const client = await this.exchangeManager.getPublicClient(slug);
+        const ticker = await client.fetchTicker(formattedSymbol);
+
+        if (ticker?.last != null || ticker?.close != null) {
+          this.logger.warn(`Fetched price for ${symbol} from fallback exchange ${slug}`);
+          return {
+            symbol,
+            price: ticker.last ?? ticker.close ?? 0,
+            bid: ticker.bid,
+            ask: ticker.ask,
+            timestamp: new Date(ticker.timestamp ?? Date.now()),
+            source: `${slug}:fallback`
+          };
+        }
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        this.logger.debug(`Fallback exchange ${slug} failed for ${symbol}: ${err.message}`);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Last-resort fallback using the coin's stored price from the database.
+   * May be hours stale but prevents hard failure.
+   */
+  private async tryDatabasePrice(symbol: string): Promise<PriceData | null> {
+    const [base] = symbol.split('/');
+
+    try {
+      const coin = await this.coinService.getCoinBySymbol(base, undefined, false);
+      if (coin?.currentPrice != null) {
+        this.logger.warn(`Using DB coin.currentPrice for ${symbol} (coinId: ${coin.id})`);
+        return {
+          symbol,
+          price: coin.currentPrice,
+          timestamp: new Date(),
+          source: 'db:coin.currentPrice'
+        };
+      }
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.debug(`DB price fallback failed for ${symbol}: ${err.message}`);
+    }
+
+    return null;
   }
 
   /**

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.types.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.types.ts
@@ -1,0 +1,26 @@
+export interface PriceData {
+  symbol: string;
+  price: number;
+  bid?: number;
+  ask?: number;
+  timestamp: Date;
+  source: string;
+}
+
+export interface OrderBookLevel {
+  price: number;
+  quantity: number;
+}
+
+export interface OrderBook {
+  symbol: string;
+  bids: OrderBookLevel[];
+  asks: OrderBookLevel[];
+  timestamp: Date;
+}
+
+export interface RealisticSlippageResult {
+  estimatedPrice: number;
+  slippageBps: number;
+  marketImpact: number;
+}

--- a/apps/api/src/order/paper-trading/paper-trading-retry.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-retry.service.ts
@@ -96,7 +96,7 @@ export class PaperTradingRetryService {
         }
       } else {
         // Tick processed but failed — trigger next retry or permanent pause
-        await this.pauseSessionDueToErrors(session, result.errors.join('; '));
+        await this.handleConsecutiveErrors(session, result.errors.join('; '));
       }
     } catch (error: unknown) {
       const err = toErrorInfo(error);
@@ -115,7 +115,7 @@ export class PaperTradingRetryService {
         return;
       }
 
-      await this.pauseSessionDueToErrors(session, classifiedError.message);
+      await this.handleConsecutiveErrors(session, classifiedError.message);
     } finally {
       endTimer();
     }
@@ -124,7 +124,7 @@ export class PaperTradingRetryService {
   /**
    * Pause session due to consecutive errors, with exponential backoff retry.
    */
-  async pauseSessionDueToErrors(session: PaperTradingSession, errorMessage: string): Promise<void> {
+  async handleConsecutiveErrors(session: PaperTradingSession, errorMessage: string): Promise<void> {
     if (session.retryAttempts < this.maxRetryAttempts) {
       // Schedule retry with exponential backoff
       const delay = Math.min(this.retryBackoffMs * Math.pow(2, session.retryAttempts), MAX_RETRY_DELAY_MS);
@@ -154,25 +154,20 @@ export class PaperTradingRetryService {
       return;
     }
 
-    // Exhausted retries — permanent pause
-    session.status = PaperTradingStatus.PAUSED;
-    session.pausedAt = new Date();
-    session.retryAttempts = 0;
-    session.errorMessage = `Auto-paused after ${this.maxRetryAttempts} retry attempts: ${errorMessage}`;
-    await this.sessionRepository.save(session);
+    // Exhausted retries — mark as failed (not paused) so it won't block future pipelines
+    const failMessage = `Retries exhausted (${this.maxRetryAttempts} attempts): ${errorMessage}`;
+    await this.jobService.markFailed(session.id, failMessage);
 
-    await this.jobService.removeTickJobs(session.id);
-
-    // Clear throttle and exit tracker state so resumed sessions start fresh
+    // Clear in-memory throttle and exit tracker state
     this.engineService.clearThrottleState(session.id);
     this.engineService.clearExitTracker(session.id);
 
-    await this.streamService.publishStatus(session.id, 'paused', 'consecutive_errors', {
+    await this.streamService.publishStatus(session.id, 'failed', 'consecutive_errors', {
       errorMessage,
       consecutiveErrors: session.consecutiveErrors,
       retriesExhausted: true
     });
 
-    this.logger.warn(`Session ${session.id} auto-paused after exhausting ${this.maxRetryAttempts} retry attempts`);
+    this.logger.warn(`Session ${session.id} failed after exhausting ${this.maxRetryAttempts} retry attempts`);
   }
 }

--- a/apps/api/src/order/paper-trading/paper-trading-retry.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-retry.service.ts
@@ -95,7 +95,7 @@ export class PaperTradingRetryService {
           this.logger.log(`Session ${sessionId} recovered after retry ${retryAttempt}, normal ticks resumed`);
         }
       } else {
-        // Tick processed but failed — trigger next retry or permanent pause
+        // Tick processed but failed — trigger next retry or mark as FAILED when retries are exhausted
         await this.handleConsecutiveErrors(session, result.errors.join('; '));
       }
     } catch (error: unknown) {
@@ -122,7 +122,7 @@ export class PaperTradingRetryService {
   }
 
   /**
-   * Pause session due to consecutive errors, with exponential backoff retry.
+   * Handle consecutive errors with exponential backoff retry, or fail if exhausted.
    */
   async handleConsecutiveErrors(session: PaperTradingSession, errorMessage: string): Promise<void> {
     if (session.retryAttempts < this.maxRetryAttempts) {

--- a/apps/api/src/order/paper-trading/paper-trading-slippage.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-slippage.service.spec.ts
@@ -1,0 +1,295 @@
+import { Logger } from '@nestjs/common';
+
+import { PaperTradingSlippageService } from './paper-trading-slippage.service';
+
+import type { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+
+const createService = (
+  overrides: Partial<{
+    cacheManager: any;
+    exchangeManager: any;
+    config: any;
+  }> = {}
+) => {
+  const cacheManager = overrides.cacheManager ?? {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn()
+  };
+
+  const exchangeManager = overrides.exchangeManager ?? {
+    formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
+    getExchangeClient: jest.fn(),
+    getPublicClient: jest.fn()
+  };
+
+  const config = overrides.config ?? { priceCacheTtlMs: 1000 };
+
+  return {
+    service: new PaperTradingSlippageService(config as any, cacheManager, exchangeManager as ExchangeManagerService),
+    cacheManager,
+    exchangeManager
+  };
+};
+
+describe('PaperTradingSlippageService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calculates slippage from order book depth', async () => {
+    const { service } = createService();
+
+    jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+      symbol: 'BTC/USD',
+      bids: [],
+      asks: [
+        { price: 100, quantity: 1 },
+        { price: 110, quantity: 1 }
+      ],
+      timestamp: new Date()
+    });
+
+    const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 1.5, 'BUY');
+
+    expect(result.estimatedPrice).toBeCloseTo(103.333, 3);
+    expect(result.slippageBps).toBeCloseTo(337.333, 3);
+    expect(result.marketImpact).toBe(4);
+  });
+
+  it('falls back to fixed slippage when order book lookup fails', async () => {
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const { service } = createService();
+
+    jest.spyOn(service, 'getOrderBook').mockRejectedValue(new Error('boom'));
+
+    const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 1, 'BUY');
+
+    expect(result).toEqual({ estimatedPrice: 0, slippageBps: 10, marketImpact: 0 });
+    loggerSpy.mockRestore();
+  });
+
+  describe('getOrderBook', () => {
+    it('returns cached order book when available', async () => {
+      const cached = {
+        symbol: 'BTC/USD',
+        bids: [{ price: 100, quantity: 1 }],
+        asks: [{ price: 101, quantity: 1 }],
+        timestamp: new Date()
+      };
+
+      const { service, exchangeManager } = createService({
+        cacheManager: {
+          get: jest.fn().mockResolvedValue(cached),
+          set: jest.fn()
+        }
+      });
+
+      const result = await service.getOrderBook('binance', 'BTC/USD');
+
+      expect(result).toBe(cached);
+      expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+    });
+
+    it('fetches, maps, and caches order book on cache miss', async () => {
+      const rawOrderBook = {
+        bids: [
+          [100, 5],
+          [99, 10]
+        ],
+        asks: [
+          [101, 3],
+          [102, 7]
+        ],
+        timestamp: 1700000000000
+      };
+
+      const client = { fetchOrderBook: jest.fn().mockResolvedValue(rawOrderBook) };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getOrderBook('binance', 'BTC/USD', 10);
+
+      expect(client.fetchOrderBook).toHaveBeenCalledWith('BTC/USD', 10);
+      expect(result.bids).toEqual([
+        { price: 100, quantity: 5 },
+        { price: 99, quantity: 10 }
+      ]);
+      expect(result.asks).toEqual([
+        { price: 101, quantity: 3 },
+        { price: 102, quantity: 7 }
+      ]);
+      // Cache TTL capped at min(cacheTtlMs, 2000)
+      expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:orderbook:binance:BTC/USD', result, 1000);
+    });
+
+    it('uses authenticated client when user is provided', async () => {
+      const rawOrderBook = {
+        bids: [[100, 5]],
+        asks: [[101, 3]],
+        timestamp: 1700000000000
+      };
+
+      const client = { fetchOrderBook: jest.fn().mockResolvedValue(rawOrderBook) };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getExchangeClient: jest.fn().mockResolvedValue(client),
+        getPublicClient: jest.fn()
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const user = { id: 'user-1' } as any;
+
+      await service.getOrderBook('binance', 'BTC/USD', 10, user);
+
+      expect(exchangeManager.getExchangeClient).toHaveBeenCalledWith('binance', user);
+      expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+    });
+
+    it('throws and logs on fetch failure', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+      const client = { fetchOrderBook: jest.fn().mockRejectedValue(new Error('exchange down')) };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager });
+
+      await expect(service.getOrderBook('binance', 'BTC/USD')).rejects.toThrow('exchange down');
+      expect(loggerSpy).toHaveBeenCalled();
+      loggerSpy.mockRestore();
+    });
+  });
+
+  describe('calculateRealisticSlippage edge cases', () => {
+    it('returns fixed slippage when order book has empty levels', async () => {
+      const { service } = createService();
+
+      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+        symbol: 'BTC/USD',
+        bids: [],
+        asks: [],
+        timestamp: new Date()
+      });
+
+      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 1, 'BUY');
+
+      expect(result).toEqual({ estimatedPrice: 0, slippageBps: 10, marketImpact: 0 });
+    });
+
+    it('returns high slippage when quantity exceeds available liquidity', async () => {
+      const { service } = createService();
+
+      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+        symbol: 'BTC/USD',
+        bids: [{ price: 100, quantity: 0 }],
+        asks: [{ price: 101, quantity: 0 }],
+        timestamp: new Date()
+      });
+
+      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 10, 'BUY');
+
+      expect(result.slippageBps).toBe(50);
+      expect(result.estimatedPrice).toBe(101);
+    });
+
+    it('handles partial fill when quantity exceeds total liquidity', async () => {
+      const { service } = createService();
+
+      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+        symbol: 'BTC/USD',
+        bids: [],
+        asks: [
+          { price: 100, quantity: 1 },
+          { price: 105, quantity: 1 }
+        ],
+        timestamp: new Date()
+      });
+
+      // Request 5 but only 2 available — partial fill
+      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 5, 'BUY');
+
+      // VWAP = (1*100 + 1*105) / 2 = 102.5
+      expect(result.estimatedPrice).toBeCloseTo(102.5, 1);
+      expect(result.marketImpact).toBe(4); // 2 levels * 2
+    });
+
+    it('filters out zero-price and zero-quantity levels from order book', async () => {
+      const rawOrderBook = {
+        bids: [
+          [0, 5],
+          [99, 10]
+        ],
+        asks: [
+          [101, 0],
+          [102, 7],
+          [0, 3]
+        ],
+        timestamp: 1700000000000
+      };
+
+      const client = { fetchOrderBook: jest.fn().mockResolvedValue(rawOrderBook) };
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue(client)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getOrderBook('binance', 'BTC/USD', 10);
+
+      // Zero-price bid and zero-quantity/zero-price asks should be filtered out
+      expect(result.bids).toEqual([{ price: 99, quantity: 10 }]);
+      expect(result.asks).toEqual([{ price: 102, quantity: 7 }]);
+    });
+
+    it('uses bids for SELL side slippage', async () => {
+      const { service } = createService();
+
+      jest.spyOn(service, 'getOrderBook').mockResolvedValue({
+        symbol: 'BTC/USD',
+        bids: [
+          { price: 100, quantity: 2 },
+          { price: 90, quantity: 2 }
+        ],
+        asks: [],
+        timestamp: new Date()
+      });
+
+      const result = await service.calculateRealisticSlippage('binance', 'BTC/USD', 3, 'SELL');
+
+      // VWAP = (2*100 + 1*90) / 3 = 96.667
+      expect(result.estimatedPrice).toBeCloseTo(96.667, 2);
+      // Slippage from best bid (100): |96.667 - 100| / 100 * 10000 = 333.33 bps + 4 impact
+      expect(result.slippageBps).toBeCloseTo(337.333, 0);
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/paper-trading-slippage.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-slippage.service.ts
@@ -1,0 +1,153 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+
+import { Cache } from 'cache-manager';
+
+import { OrderBook, RealisticSlippageResult } from './paper-trading-market-data.types';
+import { paperTradingConfig } from './paper-trading.config';
+
+import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import { toErrorInfo } from '../../shared/error.util';
+import { withExchangeRetryThrow } from '../../shared/retry.util';
+import type { User } from '../../users/users.entity';
+
+@Injectable()
+export class PaperTradingSlippageService {
+  private readonly logger = new Logger(PaperTradingSlippageService.name);
+  private readonly cacheTtlMs: number;
+
+  constructor(
+    @Inject(paperTradingConfig.KEY) private readonly config: ConfigType<typeof paperTradingConfig>,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly exchangeManager: ExchangeManagerService
+  ) {
+    this.cacheTtlMs = config.priceCacheTtlMs;
+  }
+
+  /**
+   * Get order book for realistic slippage calculation
+   */
+  async getOrderBook(exchangeSlug: string, symbol: string, depth = 20, user?: User): Promise<OrderBook> {
+    const cacheKey = `paper-trading:orderbook:${exchangeSlug}:${symbol}`;
+
+    // Try cache first (shorter TTL for order books)
+    const cached = await this.cacheManager.get<OrderBook>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
+
+      const client = user
+        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
+        : await this.exchangeManager.getPublicClient(exchangeSlug);
+
+      const rawOrderBook = await withExchangeRetryThrow(() => client.fetchOrderBook(formattedSymbol, depth), {
+        logger: this.logger,
+        operationName: `fetchOrderBook(${exchangeSlug}:${symbol})`
+      });
+
+      const orderBook: OrderBook = {
+        symbol,
+        bids: rawOrderBook.bids
+          .map(([price, quantity]) => ({
+            price: Number(price ?? 0),
+            quantity: Number(quantity ?? 0)
+          }))
+          .filter((l) => l.price > 0 && l.quantity > 0),
+        asks: rawOrderBook.asks
+          .map(([price, quantity]) => ({
+            price: Number(price ?? 0),
+            quantity: Number(quantity ?? 0)
+          }))
+          .filter((l) => l.price > 0 && l.quantity > 0),
+        timestamp: new Date(rawOrderBook.timestamp ?? Date.now())
+      };
+
+      // Cache with short TTL (order books change quickly)
+      await this.cacheManager.set(cacheKey, orderBook, Math.min(this.cacheTtlMs, 2000));
+
+      return orderBook;
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.error(`Failed to fetch order book for ${symbol} from ${exchangeSlug}: ${err.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Calculate realistic slippage based on order book depth
+   */
+  async calculateRealisticSlippage(
+    exchangeSlug: string,
+    symbol: string,
+    quantity: number,
+    side: 'BUY' | 'SELL',
+    user?: User
+  ): Promise<RealisticSlippageResult> {
+    try {
+      const orderBook = await this.getOrderBook(exchangeSlug, symbol, 50, user);
+      const levels = side === 'BUY' ? orderBook.asks : orderBook.bids;
+
+      if (levels.length === 0) {
+        // Fallback to fixed slippage if no order book
+        return {
+          estimatedPrice: 0,
+          slippageBps: 10, // Default 10 bps
+          marketImpact: 0
+        };
+      }
+
+      // Calculate volume-weighted average price for the quantity
+      let remainingQuantity = quantity;
+      let totalCost = 0;
+      let levelsFilled = 0;
+
+      for (const level of levels) {
+        if (remainingQuantity <= 0) break;
+
+        const fillQuantity = Math.min(remainingQuantity, level.quantity);
+        totalCost += fillQuantity * level.price;
+        remainingQuantity -= fillQuantity;
+        levelsFilled++;
+      }
+
+      const filledQuantity = quantity - remainingQuantity;
+      if (filledQuantity === 0) {
+        return {
+          estimatedPrice: levels[0].price,
+          slippageBps: 50, // High slippage for no fill
+          marketImpact: 0
+        };
+      }
+
+      const avgPrice = totalCost / filledQuantity;
+      const bestPrice = levels[0].price;
+      if (bestPrice <= 0) {
+        return { estimatedPrice: avgPrice, slippageBps: 10, marketImpact: 0 };
+      }
+      const slippageBps = Math.abs(((avgPrice - bestPrice) / bestPrice) * 10000);
+
+      // Market impact is based on how many levels were consumed
+      const marketImpact = Math.min(levelsFilled * 2, 50); // Cap at 50 bps
+
+      return {
+        estimatedPrice: avgPrice,
+        slippageBps: slippageBps + marketImpact,
+        marketImpact
+      };
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Failed to calculate slippage for ${symbol}: ${err.message}. Using fixed slippage.`);
+
+      // Fallback to fixed slippage
+      return {
+        estimatedPrice: 0,
+        slippageBps: 10,
+        marketImpact: 0
+      };
+    }
+  }
+}

--- a/apps/api/src/order/paper-trading/paper-trading.module.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.module.ts
@@ -24,6 +24,7 @@ import { PaperTradingMarketDataService } from './paper-trading-market-data.servi
 import { PaperTradingQueryService } from './paper-trading-query.service';
 import { PaperTradingRecoveryService } from './paper-trading-recovery.service';
 import { PaperTradingRetryService } from './paper-trading-retry.service';
+import { PaperTradingSlippageService } from './paper-trading-slippage.service';
 import { PaperTradingStreamService } from './paper-trading-stream.service';
 import { paperTradingConfig } from './paper-trading.config';
 import { PaperTradingController } from './paper-trading.controller';
@@ -89,6 +90,7 @@ const PAPER_TRADING_CONFIG = paperTradingConfig();
     PaperTradingExitExecutorService,
     PaperTradingOpportunitySellingService,
     PaperTradingMarketDataService,
+    PaperTradingSlippageService,
     PaperTradingStreamService,
     PaperTradingProcessor,
     PaperTradingGateway,

--- a/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.spec.ts
@@ -188,7 +188,7 @@ describe('PaperTradingProcessor', () => {
     expect(endTimer).toHaveBeenCalled();
   });
 
-  it('permanently pauses after exhausting retry attempts', async () => {
+  it('marks session failed after exhausting retry attempts', async () => {
     const session = {
       id: 'session-2b',
       status: PaperTradingStatus.ACTIVE,
@@ -221,12 +221,13 @@ describe('PaperTradingProcessor', () => {
 
     await processor.process(job);
 
-    expect(session.status).toBe(PaperTradingStatus.PAUSED);
-    expect(session.retryAttempts).toBe(0); // Reset after exhaustion
-    expect(paperTradingService.removeTickJobs).toHaveBeenCalledWith('session-2b');
+    expect(paperTradingService.markFailed).toHaveBeenCalledWith(
+      'session-2b',
+      expect.stringContaining('Retries exhausted (3 attempts)')
+    );
     expect(streamService.publishStatus).toHaveBeenCalledWith(
       'session-2b',
-      'paused',
+      'failed',
       'consecutive_errors',
       expect.objectContaining({ retriesExhausted: true })
     );

--- a/apps/api/src/order/paper-trading/paper-trading.processor.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.ts
@@ -181,7 +181,7 @@ export class PaperTradingProcessor extends FailSafeWorkerHost {
         await this.sessionRepository.save(session);
 
         if (session.consecutiveErrors >= this.maxConsecutiveErrors) {
-          this.logger.warn(`Session ${sessionId} reached max consecutive errors, pausing`);
+          this.logger.warn(`Session ${sessionId} reached max consecutive errors, handling retry/failure flow`);
           await this.retryService.handleConsecutiveErrors(session, result.errors.join('; '));
           return;
         }

--- a/apps/api/src/order/paper-trading/paper-trading.processor.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.processor.ts
@@ -182,7 +182,7 @@ export class PaperTradingProcessor extends FailSafeWorkerHost {
 
         if (session.consecutiveErrors >= this.maxConsecutiveErrors) {
           this.logger.warn(`Session ${sessionId} reached max consecutive errors, pausing`);
-          await this.retryService.pauseSessionDueToErrors(session, result.errors.join('; '));
+          await this.retryService.handleConsecutiveErrors(session, result.errors.join('; '));
           return;
         }
 
@@ -255,7 +255,7 @@ export class PaperTradingProcessor extends FailSafeWorkerHost {
       await this.sessionRepository.save(session);
 
       if (session.consecutiveErrors >= this.maxConsecutiveErrors) {
-        await this.retryService.pauseSessionDueToErrors(session, classifiedError.message);
+        await this.retryService.handleConsecutiveErrors(session, classifiedError.message);
       } else {
         await this.streamService.publishLog(
           sessionId,

--- a/apps/api/src/order/paper-trading/paper-trading.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.service.spec.ts
@@ -240,7 +240,8 @@ describe('PaperTradingService', () => {
 
     it.each([
       ['STOPPED', PaperTradingStatus.STOPPED],
-      ['COMPLETED', PaperTradingStatus.COMPLETED]
+      ['COMPLETED', PaperTradingStatus.COMPLETED],
+      ['FAILED', PaperTradingStatus.FAILED]
     ])('rejects stop when session is %s', async (_label, status) => {
       spyFindOne().mockResolvedValue({ id: 's', status } as any);
 
@@ -404,6 +405,27 @@ describe('PaperTradingService', () => {
         expect(createSpy).not.toHaveBeenCalled();
       }
     );
+
+    it('allows starting when only FAILED sessions exist for same (user, algorithm)', async () => {
+      // FAILED sessions from retry exhaustion should not block new pipelines
+      mockDuplicateGuardResult(null); // FAILED sessions are excluded from the IN(:...active) filter
+
+      const pipelineSession = {
+        id: 'pipe-session-new',
+        status: PaperTradingStatus.PAUSED,
+        pipelineId: undefined,
+        riskLevel: undefined,
+        exitConfig: undefined,
+        minTrades: undefined
+      } as any;
+
+      jest.spyOn(service, 'create').mockResolvedValue(pipelineSession);
+      sessionRepository.save.mockResolvedValue(pipelineSession);
+      jest.spyOn(service, 'start').mockResolvedValue({ ...pipelineSession, status: PaperTradingStatus.ACTIVE });
+
+      await expect(service.startFromPipeline(baseStartParams)).resolves.toBeDefined();
+      expect(service.create).toHaveBeenCalled();
+    });
 
     it('passes the active-status filter and pipelineId exclusion to the query builder', async () => {
       const qb = mockDuplicateGuardResult(null);

--- a/apps/api/src/order/paper-trading/paper-trading.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.service.ts
@@ -258,8 +258,12 @@ export class PaperTradingService {
   async stop(id: string, user: User, reason = 'user_cancelled'): Promise<PaperTradingSession> {
     const session = await this.findOne(id, user);
 
-    if (session.status === PaperTradingStatus.STOPPED || session.status === PaperTradingStatus.COMPLETED) {
-      throw new BadRequestException('Session is already stopped or completed');
+    if (
+      session.status === PaperTradingStatus.STOPPED ||
+      session.status === PaperTradingStatus.COMPLETED ||
+      session.status === PaperTradingStatus.FAILED
+    ) {
+      throw new BadRequestException('Session is already stopped, completed, or failed');
     }
 
     // Use transaction to ensure session state, job removal, and stop job are atomic


### PR DESCRIPTION
## Summary
- Retry-exhausted paper trading sessions were marked `PAUSED`, which the `startFromPipeline` duplicate guard treats as active — blocking all future pipelines for the same user+algorithm combination
- Changed to `FAILED` status via `markFailed()`, which also emits `PAPER_TRADING_FAILED` so the parent pipeline transitions correctly
- Renamed `pauseSessionDueToErrors` → `handleConsecutiveErrors` since the method now fails (not pauses) on exhaustion

## Changes
- **paper-trading-retry.service.ts** — Replace manual PAUSED field-setting with `markFailed()` call; rename method
- **paper-trading.processor.ts** — Update call sites to renamed method
- **paper-trading.service.ts** — Add `FAILED` to `stop()` terminal-state guard
- **paper-trading.processor.spec.ts** — Expect `markFailed()` and `'failed'` stream status
- **paper-trading.service.spec.ts** — Add test verifying FAILED sessions don't block `startFromPipeline`; add FAILED to stop rejection parameterized test

## Test Plan
- [x] `paper-trading.processor.spec` — 33 tests pass
- [x] `paper-trading.service.spec` — 28 tests pass
- [ ] Verify in staging: exhaust retries on a paper session, confirm status is FAILED
- [ ] Verify a new pipeline can start for the same user+algorithm after the FAILED session