### PR TITLE
fix(api): reduce CoinGecko API throughput to stay under 30 req/min demo limit

### DIFF
--- a/apps/api/src/coin/coin-market-data.service.spec.ts
+++ b/apps/api/src/coin/coin-market-data.service.spec.ts
@@ -212,10 +212,48 @@ describe('CoinMarketDataService', () => {
       await expect(service.getCoinHistoricalData('coin-123')).rejects.toThrow(CoinNotFoundException);
     });
 
-    it('re-throws non-404 errors', async () => {
-      geckoMock.marketChartGet.mockRejectedValueOnce(new Error('Network error'));
+    it('returns empty array and skips API call when circuit breaker is open', async () => {
+      circuitBreaker.isOpen.mockReturnValue(true);
+
+      const result = await service.getCoinHistoricalData('coin-123');
+
+      expect(result).toEqual([]);
+      expect(geckoMock.marketChartGet).not.toHaveBeenCalled();
+    });
+
+    it('does not record circuit breaker failure on 404 (NotFoundError)', async () => {
+      geckoMock.marketChartGet.mockRejectedValueOnce(makeCoinGeckoError(404, 'Not Found'));
+
+      await expect(service.getCoinHistoricalData('coin-123')).rejects.toThrow(CoinNotFoundException);
+      expect(circuitBreaker.recordFailure).not.toHaveBeenCalled();
+    });
+
+    it('records circuit breaker failure on non-404 errors', async () => {
+      geckoMock.marketChartGet.mockRejectedValue(new Error('Network error'));
+
+      setTimeoutSpy.mockImplementation(((fn: (...args: any[]) => void) => {
+        fn();
+        return 0 as any;
+      }) as any);
 
       await expect(service.getCoinHistoricalData('coin-123')).rejects.toThrow('Network error');
+      expect(circuitBreaker.recordFailure).toHaveBeenCalledWith('coingecko-chart');
+
+      geckoMock.marketChartGet.mockReset();
+    });
+
+    it('re-throws non-404 errors after retries are exhausted', async () => {
+      geckoMock.marketChartGet.mockRejectedValue(new Error('Network error'));
+
+      // Bypass retry delays so the test doesn't time out
+      setTimeoutSpy.mockImplementation(((fn: (...args: any[]) => void) => {
+        fn();
+        return 0 as any;
+      }) as any);
+
+      await expect(service.getCoinHistoricalData('coin-123')).rejects.toThrow('Network error');
+
+      geckoMock.marketChartGet.mockReset();
     });
   });
 

--- a/apps/api/src/coin/coin-market-data.service.ts
+++ b/apps/api/src/coin/coin-market-data.service.ts
@@ -16,6 +16,8 @@ import { CoinService } from './coin.service';
 import { CoinNotFoundException } from '../common/exceptions/resource';
 import { CircuitBreakerService, CircuitOpenError } from '../shared';
 import { CoinGeckoClientService } from '../shared/coingecko-client.service';
+import { toErrorInfo } from '../shared/error.util';
+import { withRateLimitRetry } from '../shared/retry.util';
 import { stripHtml } from '../utils/strip-html.util';
 
 interface HistoricalDataPoint {
@@ -47,32 +49,51 @@ export class CoinMarketDataService {
   async getCoinHistoricalData(coinId: string): Promise<HistoricalDataPoint[]> {
     const coin = await this.coinService.getCoinById(coinId);
 
-    try {
-      const geckoData = await this.gecko.client.coins.marketChart.get(coin.slug, {
-        vs_currency: 'usd',
-        days: '365', // !NOTE: Max value w/o paying money
-        interval: 'daily'
-      });
-
-      if (geckoData?.prices && geckoData.prices.length > 0) {
-        return geckoData.prices.map((point, index) => ({
-          timestamp: point[0],
-          price: point[1],
-          volume: geckoData.total_volumes?.[index]?.[1] ?? 0,
-          marketCap: geckoData.market_caps?.[index]?.[1] ?? 0
-        }));
-      }
-
+    if (this.circuitBreaker.isOpen(CoinMarketDataService.CIRCUIT_KEY)) {
+      this.logger.warn(
+        `Circuit breaker OPEN for ${CoinMarketDataService.CIRCUIT_KEY}, skipping historical fetch for ${coinId}`
+      );
       return [];
-    } catch (error: unknown) {
-      if (error instanceof NotFoundError) {
+    }
+
+    const retryResult = await withRateLimitRetry(
+      () =>
+        this.gecko.client.coins.marketChart.get(coin.slug, {
+          vs_currency: 'usd',
+          days: '365', // !NOTE: Max value w/o paying money
+          interval: 'daily'
+        }),
+      {
+        maxRetries: 2,
+        logger: this.logger,
+        operationName: `historicalData(${coin.slug})`
+      }
+    );
+
+    if (retryResult.success) {
+      this.circuitBreaker.recordSuccess(CoinMarketDataService.CIRCUIT_KEY);
+    } else {
+      // 404s are per-coin errors, not service degradation — don't trip the breaker
+      if (retryResult.error instanceof NotFoundError) {
         throw new CoinNotFoundException(coinId);
       }
-      this.logger.error(
-        `Failed to fetch historical data for ${coinId}: ${error instanceof Error ? error.message : error}`
-      );
-      throw error;
+      this.circuitBreaker.recordFailure(CoinMarketDataService.CIRCUIT_KEY);
+      const { message } = toErrorInfo(retryResult.error);
+      this.logger.error(`Failed to fetch historical data for ${coinId}: ${message}`);
+      throw retryResult.error ?? new Error(message);
     }
+
+    const geckoData = retryResult.result;
+    if (geckoData?.prices && geckoData.prices.length > 0) {
+      return geckoData.prices.map((point, index) => ({
+        timestamp: point[0],
+        price: point[1],
+        volume: geckoData.total_volumes?.[index]?.[1] ?? 0,
+        marketCap: geckoData.market_caps?.[index]?.[1] ?? 0
+      }));
+    }
+
+    return [];
   }
 
   /**

--- a/apps/api/src/coin/tasks/coin-detail-sync.service.spec.ts
+++ b/apps/api/src/coin/tasks/coin-detail-sync.service.spec.ts
@@ -358,10 +358,10 @@ describe('CoinDetailSyncService', () => {
       .map(([, ms]) => ms)
       .filter((ms): ms is number => typeof ms === 'number' && ms > 1000);
 
-    // First timeout is the circuit pause (45s), then elevated delays (5s) until normalization
+    // First timeout is the circuit pause (45s), then elevated delays (6s) until normalization
     expect(delays[0]).toBe(45_000); // circuit backoff
-    // After circuit pause, first inter-batch delays should be elevated (5000ms)
-    expect(delays.filter((t) => t === 5000).length).toBeGreaterThanOrEqual(1);
+    // After circuit pause, first inter-batch delays should be elevated (6000ms)
+    expect(delays.filter((t) => t === 6000).length).toBeGreaterThanOrEqual(1);
 
     setTimeoutSpy.mockRestore();
   });

--- a/apps/api/src/coin/tasks/coin-detail-sync.service.ts
+++ b/apps/api/src/coin/tasks/coin-detail-sync.service.ts
@@ -15,8 +15,8 @@ export class CoinDetailSyncService {
   private static readonly CIRCUIT_RESET_MS = 45_000;
   private static readonly MAX_BACKOFF_MS = 5 * 60_000;
   private static readonly BACKOFF_MULTIPLIER = 2;
-  private static readonly NORMAL_BATCH_DELAY_MS = 2500;
-  private static readonly ELEVATED_BATCH_DELAY_MS = 5000;
+  private static readonly NORMAL_BATCH_DELAY_MS = 3000;
+  private static readonly ELEVATED_BATCH_DELAY_MS = 6000;
   private static readonly SUCCESS_BATCHES_TO_NORMALIZE = 3;
   private readonly logger = new Logger(CoinDetailSyncService.name);
 
@@ -52,7 +52,7 @@ export class CoinDetailSyncService {
 
     let updatedCount = 0;
     let errorCount = 0;
-    const batchSize = 3;
+    const batchSize = 1;
     const startedAt = Date.now();
     let batchIndex = 0;
     let consecutivePauses = 0;
@@ -163,7 +163,7 @@ export class CoinDetailSyncService {
                 tickers: false
               }),
             {
-              maxRetries: 2,
+              maxRetries: 3,
               logger: this.logger,
               operationName: `coinId(${symbol})`
             }

--- a/apps/api/src/coin/tasks/coin-sync.task.spec.ts
+++ b/apps/api/src/coin/tasks/coin-sync.task.spec.ts
@@ -99,6 +99,7 @@ describe('CoinSyncTask', () => {
       coinMarketData as any,
       geckoService,
       { acquire: jest.fn().mockResolvedValue({ acquired: true, lockId: 'test' }), release: jest.fn() } as any,
+      { isOpen: jest.fn().mockReturnValue(false), recordSuccess: jest.fn(), recordFailure: jest.fn() } as any,
       { recordFailure: jest.fn() } as any
     );
   });

--- a/apps/api/src/coin/tasks/coin-sync.task.ts
+++ b/apps/api/src/coin/tasks/coin-sync.task.ts
@@ -9,10 +9,12 @@ import { CoinDetailSyncService } from './coin-detail-sync.service';
 import { ExchangeService } from '../../exchange/exchange.service';
 import { FailSafeWorkerHost } from '../../failed-jobs/fail-safe-worker-host';
 import { FailedJobService } from '../../failed-jobs/failed-job.service';
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { CoinGeckoClientService } from '../../shared/coingecko-client.service';
 import { LOCK_DEFAULTS, LOCK_KEYS } from '../../shared/distributed-lock.constants';
 import { DistributedLockService } from '../../shared/distributed-lock.service';
 import { toErrorInfo } from '../../shared/error.util';
+import { withRateLimitRetry } from '../../shared/retry.util';
 import { withTimeout } from '../../shared/with-timeout.util';
 import { CoinDailySnapshotService } from '../coin-daily-snapshot.service';
 import { CoinListingEventService } from '../coin-listing-event.service';
@@ -29,7 +31,9 @@ import { CoinService } from '../coin.service';
 export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
   private readonly logger = new Logger(CoinSyncTask.name);
   private jobScheduled = false;
-  private readonly API_RATE_LIMIT_DELAY = 2500;
+  private readonly API_RATE_LIMIT_DELAY = 3000;
+  private static readonly COINGECKO_CHART_CIRCUIT_KEY = 'coingecko-chart';
+  private static readonly POST_DETAIL_COOLDOWN_MS = 30_000;
 
   constructor(
     @InjectQueue('coin-queue') private readonly coinQueue: Queue,
@@ -41,6 +45,7 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
     private readonly coinMarketData: CoinMarketDataService,
     private readonly gecko: CoinGeckoClientService,
     private readonly lockService: DistributedLockService,
+    private readonly circuitBreaker: CircuitBreakerService,
     failedJobService: FailedJobService
   ) {
     super(failedJobService);
@@ -142,40 +147,43 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
 
         // eslint-disable-next-line no-constant-condition
         while (true) {
-          let tickers = [];
+          const id = exchange.slug === 'coinbase' ? 'gdax' : exchange.slug.toLowerCase();
+          const retryResult = await withRateLimitRetry(() => this.gecko.client.exchanges.tickers.get(id, { page }), {
+            maxRetries: 2,
+            logger: this.logger,
+            operationName: `tickers(${id}, page=${page})`
+          });
 
-          try {
-            const id = exchange.slug === 'coinbase' ? 'gdax' : exchange.slug.toLowerCase();
-            const response = await this.gecko.client.exchanges.tickers.get(id, { page });
-
-            tickers = response.tickers || [];
-
-            if (tickers.length === 0) {
-              this.logger.log(
-                `Completed loading ticker data for ${exchange.name}, total processed: ${totalProcessedTickers}`
-              );
-              break;
-            }
-
-            totalProcessedTickers += tickers.length;
-
-            for (const ticker of tickers) {
-              const baseId = ticker.coin_id?.toLowerCase();
-              const quoteId = ticker.target_coin_id?.toLowerCase();
-
-              if (baseId) usedCoinSlugs.add(baseId);
-              if (quoteId) usedCoinSlugs.add(quoteId);
-            }
-
-            await new Promise((r) => setTimeout(r, this.API_RATE_LIMIT_DELAY));
-            page++;
-          } catch (tickerError: unknown) {
-            const err = toErrorInfo(tickerError);
+          if (!retryResult.success) {
+            const err = toErrorInfo(retryResult.error);
             this.logger.error(`Failed to fetch page ${page} tickers for ${exchange.name}: ${err.message}`);
             if (page === 1) break;
+            await new Promise((r) => setTimeout(r, this.API_RATE_LIMIT_DELAY));
             page++;
             continue;
           }
+
+          const tickers = retryResult.result?.tickers || [];
+
+          if (tickers.length === 0) {
+            this.logger.log(
+              `Completed loading ticker data for ${exchange.name}, total processed: ${totalProcessedTickers}`
+            );
+            break;
+          }
+
+          totalProcessedTickers += tickers.length;
+
+          for (const ticker of tickers) {
+            const baseId = ticker.coin_id?.toLowerCase();
+            const quoteId = ticker.target_coin_id?.toLowerCase();
+
+            if (baseId) usedCoinSlugs.add(baseId);
+            if (quoteId) usedCoinSlugs.add(quoteId);
+          }
+
+          await new Promise((r) => setTimeout(r, this.API_RATE_LIMIT_DELAY));
+          page++;
         }
       } catch (error: unknown) {
         const err = toErrorInfo(error);
@@ -337,6 +345,10 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
     try {
       const detailResult = await this.coinDetailSync.syncCoinDetails((percent) => job.updateProgress(percent));
 
+      // Cooldown after detail sync to let CoinGecko rate limits recover before snapshot/backfill
+      this.logger.log(`Cooling down ${CoinSyncTask.POST_DETAIL_COOLDOWN_MS / 1000}s before snapshot/backfill`);
+      await new Promise((resolve) => setTimeout(resolve, CoinSyncTask.POST_DETAIL_COOLDOWN_MS));
+
       const freshCoins = await this.coin.getCoins();
 
       // Capture daily market data snapshots for all active coins
@@ -351,31 +363,40 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
 
       // Backfill historical snapshots for coins with insufficient data
       try {
-        const allCoinIds = freshCoins.map((c) => c.id);
-        const coinsNeedingBackfill = await this.snapshotService.getCoinsNeedingBackfill(allCoinIds, 30);
+        if (this.circuitBreaker.isOpen(CoinSyncTask.COINGECKO_CHART_CIRCUIT_KEY)) {
+          this.logger.warn('Circuit breaker OPEN for coingecko-chart, skipping backfill entirely');
+        } else {
+          const allCoinIds = freshCoins.map((c) => c.id);
+          const coinsNeedingBackfill = await this.snapshotService.getCoinsNeedingBackfill(allCoinIds, 30);
 
-        if (coinsNeedingBackfill.length > 0) {
-          this.logger.log(`Backfilling historical snapshots for ${coinsNeedingBackfill.length} coins`);
-          const batchSize = 3;
+          if (coinsNeedingBackfill.length > 0) {
+            this.logger.log(`Backfilling historical snapshots for ${coinsNeedingBackfill.length} coins`);
+            const batchSize = 1;
 
-          for (let i = 0; i < coinsNeedingBackfill.length; i += batchSize) {
-            const batch = coinsNeedingBackfill.slice(i, i + batchSize);
+            for (let i = 0; i < coinsNeedingBackfill.length; i += batchSize) {
+              if (this.circuitBreaker.isOpen(CoinSyncTask.COINGECKO_CHART_CIRCUIT_KEY)) {
+                this.logger.warn('Circuit breaker opened mid-backfill, stopping');
+                break;
+              }
 
-            await Promise.allSettled(
-              batch.map(async (coinId) => {
-                try {
-                  const historicalData = await this.coinMarketData.getCoinHistoricalData(coinId);
-                  const inserted = await this.snapshotService.backfillFromHistoricalData(coinId, historicalData);
-                  this.logger.debug(`Backfilled ${inserted} snapshots for coin ${coinId}`);
-                } catch (err: unknown) {
-                  const { message } = toErrorInfo(err);
-                  this.logger.warn(`Failed to backfill snapshots for coin ${coinId}: ${message}`);
-                }
-              })
-            );
+              const batch = coinsNeedingBackfill.slice(i, i + batchSize);
 
-            if (i + batchSize < coinsNeedingBackfill.length) {
-              await new Promise((resolve) => setTimeout(resolve, this.API_RATE_LIMIT_DELAY));
+              await Promise.allSettled(
+                batch.map(async (coinId) => {
+                  try {
+                    const historicalData = await this.coinMarketData.getCoinHistoricalData(coinId);
+                    const inserted = await this.snapshotService.backfillFromHistoricalData(coinId, historicalData);
+                    this.logger.debug(`Backfilled ${inserted} snapshots for coin ${coinId}`);
+                  } catch (err: unknown) {
+                    const { message } = toErrorInfo(err);
+                    this.logger.warn(`Failed to backfill snapshots for coin ${coinId}: ${message}`);
+                  }
+                })
+              );
+
+              if (i + batchSize < coinsNeedingBackfill.length) {
+                await new Promise((resolve) => setTimeout(resolve, this.API_RATE_LIMIT_DELAY));
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- Throttle all CoinGecko API paths to stay within the 30 req/min demo plan limit
- Add retry-with-backoff and circuit breaker protection to previously unguarded endpoints
- Add inter-phase cooldowns so detail sync, snapshots, and backfill don't compete for quota

## Changes

**Batch size & delay tuning**
- Coin detail batch size 3 → 1, inter-batch delay 2.5s → 3s (normal) / 5s → 6s (elevated)
- Backfill batch size 3 → 1 with per-iteration circuit breaker check
- Increase detail fetch `maxRetries` from 2 → 3

**New resilience wrappers**
- `getCoinHistoricalData()` — add `withRateLimitRetry` + circuit breaker (`coingecko-chart` key)
- `getUsedCoinSlugs()` ticker pagination — wrap in `withRateLimitRetry`
- 30s cooldown between detail sync and snapshot/backfill phases

**Cleanup**
- Remove redundant outer try/catch in `getCoinHistoricalData()` (inner retry result handling already covers all error paths)

## Test Plan

- [x] `coin-market-data.service.spec` — 23/23 passing
- [x] `coin-detail-sync.service.spec` — tests updated for new delay values
- [x] `coin-sync.task.spec` — circuit breaker mock added to constructor
- [x] `nx build api` succeeds