### PR TITLE
refactor(api): reduce optimization coin filtering log noise

### DIFF
--- a/apps/api/src/optimization/services/optimization-evaluation.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-evaluation.service.spec.ts
@@ -64,7 +64,7 @@ describe('OptimizationEvaluationService', () => {
       filteredCandles: [],
       timestamps: [],
       pricesByTimestamp: {},
-      immutablePriceData: {},
+      immutablePriceData: { summariesByCoin: new Map() },
       volumeMap: new Map(),
       tradingStartIndex: 0
     }) as unknown as PrecomputedWindowData;

--- a/apps/api/src/optimization/services/optimization-evaluation.service.ts
+++ b/apps/api/src/optimization/services/optimization-evaluation.service.ts
@@ -261,7 +261,8 @@ export class OptimizationEvaluationService {
     candlesByCoin: Map<string, OHLCCandle[]>,
     warmupDays: number,
     extendedMinDate: Date,
-    runId: string
+    runId: string,
+    minBars?: number
   ): Map<string, PrecomputedWindowData> {
     const precomputedWindows = new Map<string, PrecomputedWindowData>();
     const warmupMs = warmupDays * 24 * 60 * 60 * 1000;
@@ -288,6 +289,23 @@ export class OptimizationEvaluationService {
             }
           }
           precomputed.tradingStartIndex = tradingStartIdx;
+
+          // Log once per window which coins have insufficient data
+          if (minBars && minBars > 0) {
+            const lowDataCoins: string[] = [];
+            for (const coin of coins) {
+              const barCount = precomputed.immutablePriceData.summariesByCoin.get(coin.id)?.length ?? 0;
+              if (barCount < minBars) {
+                lowDataCoins.push(`${coin.symbol}(${barCount}/${minBars})`);
+              }
+            }
+            if (lowDataCoins.length > 0) {
+              this.logger.warn(
+                `Window ${start.toISOString().split('T')[0]}→${end.toISOString().split('T')[0]}: ` +
+                  `${lowDataCoins.length} coin(s) with insufficient data: ${lowDataCoins.join(', ')}`
+              );
+            }
+          }
 
           precomputedWindows.set(key, precomputed);
         }
@@ -428,7 +446,8 @@ export class OptimizationEvaluationService {
       candlesByCoin,
       warmupDays,
       extendedMinDate,
-      runId
+      runId,
+      warmupDays
     );
 
     return { windows, candlesByCoin, precomputedWindows, warmupDays };

--- a/apps/api/src/order/backtest/shared/optimization/optimization-core.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/optimization/optimization-core.service.spec.ts
@@ -59,7 +59,9 @@ describe('OptimizationCoreService', () => {
       advancePriceWindows: jest.fn().mockReturnValue(new Map()),
       getPriceValue: jest.fn().mockImplementation((c: OHLCCandle) => c.close),
       precomputeWindowData: jest.fn(),
-      filterCoinsWithSufficientData: jest.fn().mockResolvedValue({ filtered: [], excludedCount: 0 })
+      filterCoinsWithSufficientData: jest
+        .fn()
+        .mockResolvedValue({ filtered: [], excludedCount: 0, excludedDetails: [] })
     };
     portfolioState = {
       updateValues: jest.fn().mockImplementation((p) => p)
@@ -345,7 +347,8 @@ describe('OptimizationCoreService', () => {
 
       priceWindowService.filterCoinsWithSufficientData.mockResolvedValue({
         filtered: coins,
-        excludedCount: 0
+        excludedCount: 0,
+        excludedDetails: []
       });
 
       const result = await service.runOptimizationBacktestWithPrecomputed(baseConfig, coins, precomputed);
@@ -433,7 +436,8 @@ describe('OptimizationCoreService', () => {
 
       priceWindowService.filterCoinsWithSufficientData.mockResolvedValue({
         filtered: coins,
-        excludedCount: 0
+        excludedCount: 0,
+        excludedDetails: []
       });
 
       await service.runOptimizationBacktestWithPrecomputed(baseConfig, coins, precomputed);

--- a/apps/api/src/order/backtest/shared/optimization/optimization-core.service.ts
+++ b/apps/api/src/order/backtest/shared/optimization/optimization-core.service.ts
@@ -166,7 +166,11 @@ export class OptimizationCoreService {
     const priceCtx = this.priceWindowService.initPriceTrackingFromPrecomputed(immutablePriceData);
 
     // Pre-filter coins whose total bar count is below the strategy's minimum requirement
-    const { filtered: loopCoins, excludedCount } = await this.priceWindowService.filterCoinsWithSufficientData(
+    const {
+      filtered: loopCoins,
+      excludedCount,
+      excludedDetails
+    } = await this.priceWindowService.filterCoinsWithSufficientData(
       config.algorithmId,
       coins,
       config.parameters,
@@ -174,7 +178,7 @@ export class OptimizationCoreService {
       this.algorithmRegistry
     );
     if (excludedCount > 0) {
-      this.logger.warn(`Excluded ${excludedCount} coin(s) with insufficient data for optimization`);
+      this.logger.debug(`Excluded ${excludedCount} coin(s) with insufficient data: ${excludedDetails.join(', ')}`);
     }
 
     // Precompute indicators only for coins that passed the filter

--- a/apps/api/src/order/backtest/shared/price-window/price-window.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/price-window/price-window.service.spec.ts
@@ -178,7 +178,7 @@ describe('PriceWindowService', () => {
       mockRegistry.getStrategyForAlgorithm.mockResolvedValue({});
       const coins = makeCoins('btc');
       const result = await service.filterCoinsWithSufficientData('alg1', coins, {}, new Map(), mockRegistry);
-      expect(result).toEqual({ filtered: coins, excludedCount: 0 });
+      expect(result).toEqual({ filtered: coins, excludedCount: 0, excludedDetails: [] });
     });
 
     it('returns all coins when minRequired is 0', async () => {
@@ -187,7 +187,7 @@ describe('PriceWindowService', () => {
       });
       const coins = makeCoins('btc');
       const result = await service.filterCoinsWithSufficientData('alg1', coins, {}, new Map(), mockRegistry);
-      expect(result).toEqual({ filtered: coins, excludedCount: 0 });
+      expect(result).toEqual({ filtered: coins, excludedCount: 0, excludedDetails: [] });
     });
 
     it('filters coins with insufficient data points', async () => {
@@ -203,6 +203,7 @@ describe('PriceWindowService', () => {
       expect(result.filtered).toHaveLength(1);
       expect(result.filtered[0].id).toBe('btc');
       expect(result.excludedCount).toBe(1);
+      expect(result.excludedDetails).toEqual(['ETH(50/100)']);
     });
   });
 });

--- a/apps/api/src/order/backtest/shared/price-window/price-window.service.ts
+++ b/apps/api/src/order/backtest/shared/price-window/price-window.service.ts
@@ -242,16 +242,16 @@ export class PriceWindowService {
         id: string
       ): Promise<{ getMinDataPoints?: (params: Record<string, unknown>) => number } | null | undefined>;
     }
-  ): Promise<{ filtered: Coin[]; excludedCount: number }> {
+  ): Promise<{ filtered: Coin[]; excludedCount: number; excludedDetails: string[] }> {
     const strategy = await algorithmRegistry.getStrategyForAlgorithm(algorithmId);
 
     if (!strategy?.getMinDataPoints) {
-      return { filtered: coins, excludedCount: 0 };
+      return { filtered: coins, excludedCount: 0, excludedDetails: [] };
     }
 
     const minRequired = strategy.getMinDataPoints(parameters);
     if (minRequired <= 0) {
-      return { filtered: coins, excludedCount: 0 };
+      return { filtered: coins, excludedCount: 0, excludedDetails: [] };
     }
 
     const excluded: string[] = [];
@@ -264,6 +264,6 @@ export class PriceWindowService {
       return true;
     });
 
-    return { filtered, excludedCount: excluded.length };
+    return { filtered, excludedCount: excluded.length, excludedDetails: excluded };
   }
 }


### PR DESCRIPTION
## Summary

- Reduce noisy per-combination coin exclusion logs during optimization runs by downgrading from `warn` to `debug`
- Add a single summary warning per price window precomputation with excluded coin details
- Return `excludedDetails` from `filterCoinsWithSufficientData` for structured logging upstream

## Changes

- `optimization-evaluation.service.ts` — Log excluded coin details once per window in `precomputeAllWindowData` instead of per-combo
- `optimization-core.service.ts` — Downgrade per-combo coin filtering log from `warn` to `debug`
- `price-window.service.ts` — Return `excludedDetails` alongside filtered coins from `filterCoinsWithSufficientData`
- Updated corresponding test files for new return shape and log levels

## Test Plan

- [ ] `npx nx test api -- --testPathPattern='optimization-core.service.spec'` passes
- [ ] `npx nx test api -- --testPathPattern='price-window.service.spec'` passes
- [ ] `npx nx test api -- --testPathPattern='optimization-evaluation.service.spec'` passes
- [ ] Optimization runs produce cleaner logs with one summary warning instead of per-combo spam