### PR TITLE
feat(api): extract correlation scoring into dedicated service

### DIFF
--- a/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
@@ -8,6 +8,7 @@ import { PipelineProgressionService } from './pipeline-progression.service';
 import { PipelineStageExecutionService } from './pipeline-stage-execution.service';
 
 import { MarketRegimeService } from '../../market-regime/market-regime.service';
+import { CorrelationScoringService } from '../../scoring/correlation-scoring.service';
 import { ScoringService } from '../../scoring/scoring.service';
 import { DegradationCalculator } from '../../scoring/walk-forward/degradation.calculator';
 import { type User } from '../../users/users.entity';
@@ -76,6 +77,10 @@ describe('PipelineProgressionService', () => {
         {
           provide: DegradationCalculator,
           useValue: { calculateFromValues: jest.fn().mockReturnValue(50) }
+        },
+        {
+          provide: CorrelationScoringService,
+          useValue: { calculateMaxCorrelation: jest.fn().mockResolvedValue(0) }
         }
       ]
     }).compile();
@@ -217,7 +222,7 @@ describe('PipelineProgressionService', () => {
       expect(scoringService.calculateScoreFromMetrics).toHaveBeenCalledWith(
         expect.objectContaining({ calmarRatio: expect.closeTo(1.5) }),
         50,
-        { marketRegime: 'BULL' }
+        { marketRegime: 'BULL', correlationValue: 0 }
       );
     });
 
@@ -231,11 +236,12 @@ describe('PipelineProgressionService', () => {
       expect(result.degradation).toBe(0);
       expect(degradationCalculator.calculateFromValues).not.toHaveBeenCalled();
       expect(scoringService.calculateScoreFromMetrics).toHaveBeenCalledWith(expect.any(Object), 0, {
-        marketRegime: undefined
+        marketRegime: undefined,
+        correlationValue: 0
       });
     });
 
-    it('passes degradation clamped at 0 when calculator returns negative (improvement)', async () => {
+    it('applies half penalty for small negative degradation (-10 → effective 5)', async () => {
       marketRegimeService.getCurrentRegime.mockResolvedValue(null as never);
       degradationCalculator.calculateFromValues.mockReturnValue(-10);
       const pipeline = makePipeline({
@@ -244,10 +250,28 @@ describe('PipelineProgressionService', () => {
         } as never
       });
 
-      await service.calculatePipelineScore(pipeline, metrics);
+      const result = await service.calculatePipelineScore(pipeline, metrics);
 
-      // raw degradation negative; clamped to 0 for scoring
-      expect(scoringService.calculateScoreFromMetrics).toHaveBeenCalledWith(expect.any(Object), 0, expect.any(Object));
+      // raw degradation stays in result for debugging
+      expect(result.degradation).toBe(-10);
+      // effective degradation = abs(-10) * 0.5 = 5
+      expect(scoringService.calculateScoreFromMetrics).toHaveBeenCalledWith(expect.any(Object), 5, expect.any(Object));
+    });
+
+    it('applies half penalty for large negative degradation (-60 → effective 30)', async () => {
+      marketRegimeService.getCurrentRegime.mockResolvedValue(null as never);
+      degradationCalculator.calculateFromValues.mockReturnValue(-60);
+      const pipeline = makePipeline({
+        stageResults: {
+          historical: { sharpeRatio: 1.0, totalReturn: 0.05, maxDrawdown: 0.1, winRate: 0.5, totalTrades: 30 }
+        } as never
+      });
+
+      const result = await service.calculatePipelineScore(pipeline, metrics);
+
+      expect(result.degradation).toBe(-60);
+      // effective degradation = abs(-60) * 0.5 = 30
+      expect(scoringService.calculateScoreFromMetrics).toHaveBeenCalledWith(expect.any(Object), 30, expect.any(Object));
     });
 
     it('uses calmarRatio of 0 when drawdown is 0', async () => {
@@ -341,7 +365,7 @@ describe('PipelineProgressionService', () => {
       expect(result).toBe(DeploymentRecommendation.DO_NOT_DEPLOY);
     });
 
-    it('clamps negative degradation to 0 (improvement does not block deployment)', () => {
+    it('applies half penalty for negative degradation (-15 → effective 7.5, still within DEPLOY threshold)', () => {
       degradationCalculator.calculateFromValues.mockReturnValue(-15);
       const result = service.generateRecommendation({
         historical: { status: 'COMPLETED', sharpeRatio: 1.0, totalReturn: 0.1, maxDrawdown: 0.15, winRate: 0.5 },
@@ -354,8 +378,7 @@ describe('PipelineProgressionService', () => {
           winRate: 0.65
         }
       } as never);
-      // With Math.abs, -15 would become 15 (penalizing improvement).
-      // With Math.max(0, -15) it becomes 0, so strong metrics should yield DEPLOY.
+      // effective = abs(-15) * 0.5 = 7.5, which is ≤ 20 threshold → DEPLOY
       expect(result).toBe(DeploymentRecommendation.DEPLOY);
     });
 

--- a/apps/api/src/pipeline/services/pipeline-progression.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.ts
@@ -9,6 +9,7 @@ import { MarketRegimeType } from '@chansey/api-interfaces';
 import { PipelineStageExecutionService } from './pipeline-stage-execution.service';
 
 import { MarketRegimeService } from '../../market-regime/market-regime.service';
+import { CorrelationScoringService } from '../../scoring/correlation-scoring.service';
 import { ScoringService } from '../../scoring/scoring.service';
 import { DegradationCalculator } from '../../scoring/walk-forward/degradation.calculator';
 import { Pipeline } from '../entities/pipeline.entity';
@@ -36,7 +37,9 @@ export class PipelineProgressionService {
     @Inject(forwardRef(() => MarketRegimeService))
     private readonly marketRegimeService: MarketRegimeService,
     @Inject(forwardRef(() => DegradationCalculator))
-    private readonly degradationCalculator: DegradationCalculator
+    private readonly degradationCalculator: DegradationCalculator,
+    @Inject(forwardRef(() => CorrelationScoringService))
+    private readonly correlationScoringService: CorrelationScoringService
   ) {}
 
   evaluateOptimizationProgression(pipeline: Pipeline, improvement: number): { passed: boolean; failures: string[] } {
@@ -132,9 +135,21 @@ export class PipelineProgressionService {
       volatility: metrics.volatility
     };
 
-    const result = this.scoringService.calculateScoreFromMetrics(scoringMetrics, Math.max(0, degradation), {
-      marketRegime: regimeType
-    });
+    let correlationValue = 0;
+    try {
+      correlationValue = await this.correlationScoringService.calculateMaxCorrelation(
+        pipeline.strategyConfigId,
+        pipeline.user.id
+      );
+    } catch (error) {
+      this.logger.warn(`Failed to calculate correlation for strategy ${pipeline.strategyConfigId}: ${error}`);
+    }
+
+    const result = this.scoringService.calculateScoreFromMetrics(
+      scoringMetrics,
+      this.toEffectiveDegradation(degradation),
+      { marketRegime: regimeType, correlationValue }
+    );
 
     return {
       overallScore: result.overallScore,
@@ -176,8 +191,7 @@ export class PipelineProgressionService {
 
     const avgDegradation =
       hist && paper
-        ? Math.max(
-            0,
+        ? this.toEffectiveDegradation(
             this.degradationCalculator.calculateFromValues({
               sharpeRatio: { train: hist.sharpeRatio, test: paper.sharpeRatio ?? 0 },
               totalReturn: { train: hist.totalReturn, test: paper.totalReturn ?? 0 },
@@ -270,6 +284,15 @@ export class PipelineProgressionService {
       recommendation: pipeline.recommendation,
       timestamp: new Date().toISOString()
     });
+  }
+
+  /**
+   * Converts raw degradation to an effective value for scoring.
+   * Positive (overfitting): full penalty.
+   * Negative (inconsistency): half penalty — large swings are unreliable regardless of direction.
+   */
+  private toEffectiveDegradation(raw: number): number {
+    return raw >= 0 ? raw : Math.abs(raw) * 0.5;
   }
 
   async failPipeline(pipeline: Pipeline, reason: string): Promise<void> {

--- a/apps/api/src/scoring/correlation-scoring.service.spec.ts
+++ b/apps/api/src/scoring/correlation-scoring.service.spec.ts
@@ -1,0 +1,252 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { CorrelationScoringService } from './correlation-scoring.service';
+
+import { CorrelationCalculator } from '../common/metrics/correlation.calculator';
+import { BacktestPerformanceSnapshot } from '../order/backtest/backtest-performance-snapshot.entity';
+import { Pipeline } from '../pipeline/entities/pipeline.entity';
+import { Deployment } from '../strategy/entities/deployment.entity';
+import { PerformanceMetric } from '../strategy/entities/performance-metric.entity';
+
+describe('CorrelationScoringService', () => {
+  let service: CorrelationScoringService;
+  let mockDeploymentRepo: Record<string, jest.Mock>;
+  let mockPerformanceMetricRepo: Record<string, jest.Mock>;
+  let mockSnapshotRepo: Record<string, jest.Mock>;
+  let mockPipelineRepo: Record<string, jest.Mock>;
+
+  const createQueryBuilder = () => ({
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([])
+  });
+
+  /** Generate N snapshots with linearly growing portfolio values */
+  const makeSnapshots = (count: number, startValue = 100, step = 5) =>
+    Array.from({ length: count }, (_, i) => ({
+      portfolioValue: startValue + i * step,
+      timestamp: new Date(`2024-01-${String(i + 1).padStart(2, '0')}`)
+    }));
+
+  /** Generate N daily-return metrics with a repeating pattern */
+  const makeMetrics = (count: number, baseFn: (i: number) => number = (i) => 0.05 + (i % 2 === 0 ? 0.02 : -0.01)) =>
+    Array.from({ length: count }, (_, i) => ({ dailyReturn: baseFn(i) }));
+
+  /** Wire snapshot and metric query builders in one call */
+  const setupQueryBuilders = (snapshots: unknown[], metrics: unknown[]) => {
+    const snapshotQb = createQueryBuilder();
+    snapshotQb.getMany.mockResolvedValue(snapshots);
+    mockSnapshotRepo.createQueryBuilder.mockReturnValue(snapshotQb);
+
+    const metricQb = createQueryBuilder();
+    metricQb.getMany.mockResolvedValue(metrics);
+    mockPerformanceMetricRepo.createQueryBuilder.mockReturnValue(metricQb);
+  };
+
+  beforeEach(async () => {
+    mockDeploymentRepo = { find: jest.fn().mockResolvedValue([]) };
+    mockPerformanceMetricRepo = { createQueryBuilder: jest.fn().mockReturnValue(createQueryBuilder()) };
+    mockSnapshotRepo = { createQueryBuilder: jest.fn().mockReturnValue(createQueryBuilder()) };
+    mockPipelineRepo = { findOne: jest.fn().mockResolvedValue(null) };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CorrelationScoringService,
+        CorrelationCalculator,
+        { provide: getRepositoryToken(Deployment), useValue: mockDeploymentRepo },
+        { provide: getRepositoryToken(PerformanceMetric), useValue: mockPerformanceMetricRepo },
+        { provide: getRepositoryToken(BacktestPerformanceSnapshot), useValue: mockSnapshotRepo },
+        { provide: getRepositoryToken(Pipeline), useValue: mockPipelineRepo }
+      ]
+    }).compile();
+
+    service = module.get(CorrelationScoringService);
+  });
+
+  it('returns 0 when no active deployments exist', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([]);
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when candidate has no pipeline with backtest', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue(null);
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when candidate has insufficient backtest snapshots', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    const snapshotQb = createQueryBuilder();
+    // Only 3 snapshots → 2 returns, below MIN_OVERLAP of 10
+    snapshotQb.getMany.mockResolvedValue(makeSnapshots(3));
+    mockSnapshotRepo.createQueryBuilder.mockReturnValue(snapshotQb);
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when snapshots contain a zero portfolio value', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    // 12 snapshots but several have portfolioValue=0, so returns array shrinks below MIN_OVERLAP
+    const snapshots = Array.from({ length: 12 }, (_, i) => ({
+      portfolioValue: i < 6 ? 0 : 100 + i * 10,
+      timestamp: new Date(`2024-01-${String(i + 1).padStart(2, '0')}`)
+    }));
+    const snapshotQb = createQueryBuilder();
+    snapshotQb.getMany.mockResolvedValue(snapshots);
+    mockSnapshotRepo.createQueryBuilder.mockReturnValue(snapshotQb);
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    // 12 snapshots but first 6 are 0 → prev=0 skipped → only ~5 valid returns < MIN_OVERLAP(10)
+    expect(result).toBe(0);
+  });
+
+  it('computes a specific correlation value for known linear series', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    // 12 linear snapshots → 11 returns that are all positive and decreasing
+    const snapshots = makeSnapshots(12, 100, 10);
+    // Deployment metrics matching the same growth pattern → high correlation
+    const metrics = Array.from({ length: 11 }, (_, i) => ({
+      dailyReturn: 10 / (100 + i * 10)
+    }));
+
+    setupQueryBuilders(snapshots, metrics);
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    // Both series represent the same linear growth pattern — correlation should be very high
+    expect(result).toBeGreaterThan(0.9);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('returns absolute value for negatively correlated series', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    // Linear growth snapshots → positive returns
+    const snapshots = makeSnapshots(12, 100, 10);
+    // Deployment with inverted returns (negative of the candidate pattern)
+    const metrics = Array.from({ length: 11 }, (_, i) => ({
+      dailyReturn: -(10 / (100 + i * 10))
+    }));
+
+    setupQueryBuilders(snapshots, metrics);
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    // Math.abs applied to negative correlation → should still be > 0
+    expect(result).toBeGreaterThan(0.9);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('returns the highest correlation across multiple deployments', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([
+      { id: 'dep-1', strategyConfigId: 'strat-2' },
+      { id: 'dep-2', strategyConfigId: 'strat-3' }
+    ]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    // 12 linear snapshots → 11 returns
+    const snapshots = makeSnapshots(12, 100, 10);
+    const snapshotQb = createQueryBuilder();
+    snapshotQb.getMany.mockResolvedValue(snapshots);
+    mockSnapshotRepo.createQueryBuilder.mockReturnValue(snapshotQb);
+
+    // First deployment: uncorrelated (alternating sign)
+    const uncorrelatedMetrics = makeMetrics(11, (i) => (i % 2 === 0 ? 0.05 : -0.05));
+    // Second deployment: perfectly correlated with candidate
+    const correlatedMetrics = Array.from({ length: 11 }, (_, i) => ({
+      dailyReturn: 10 / (100 + i * 10)
+    }));
+
+    let callCount = 0;
+    mockPerformanceMetricRepo.createQueryBuilder.mockImplementation(() => {
+      const qb = createQueryBuilder();
+      qb.getMany.mockResolvedValue(callCount++ === 0 ? uncorrelatedMetrics : correlatedMetrics);
+      return qb;
+    });
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    // Should pick the higher correlation from the second deployment
+    expect(result).toBeGreaterThan(0.9);
+  });
+
+  it('skips deployment pairs with insufficient overlap', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    // 15 snapshots → 14 returns (enough for candidate)
+    const snapshotQb = createQueryBuilder();
+    snapshotQb.getMany.mockResolvedValue(makeSnapshots(15));
+    mockSnapshotRepo.createQueryBuilder.mockReturnValue(snapshotQb);
+
+    // Only 5 metrics for deployment (below MIN_OVERLAP)
+    const metricQb = createQueryBuilder();
+    metricQb.getMany.mockResolvedValue(makeMetrics(5, (i) => 0.01 * (i + 1)));
+    mockPerformanceMetricRepo.createQueryBuilder.mockReturnValue(metricQb);
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    expect(result).toBe(0);
+  });
+
+  it('excludes self-correlation by filtering own strategyConfigId from deployments', async () => {
+    // The deployment belongs to the same strategy — should be excluded by the Not() filter
+    mockDeploymentRepo.find.mockResolvedValue([]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    expect(result).toBe(0);
+
+    // Verify the find was called with filters including Not(strategyConfigId) and user scoping
+    expect(mockDeploymentRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          strategyConfig: { createdBy: 'user-1' }
+        })
+      })
+    );
+  });
+
+  it('scopes pipeline query by userId via user relation filter', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue(null);
+
+    await service.calculateMaxCorrelation('strat-1', 'user-1');
+
+    expect(mockPipelineRepo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user: { id: 'user-1' }
+        })
+      })
+    );
+  });
+
+  it('returns 0 when aligned length drops below MIN_OVERLAP', async () => {
+    mockDeploymentRepo.find.mockResolvedValue([{ id: 'dep-1', strategyConfigId: 'strat-2' }]);
+    mockPipelineRepo.findOne.mockResolvedValue({ id: 'pipe-1', historicalBacktestId: 'bt-1' });
+
+    // 12 snapshots → 11 candidate returns (above MIN_OVERLAP)
+    const snapshotQb = createQueryBuilder();
+    snapshotQb.getMany.mockResolvedValue(makeSnapshots(12));
+    mockSnapshotRepo.createQueryBuilder.mockReturnValue(snapshotQb);
+
+    // 8 deployment metrics — after alignment min(11,8)=8 < MIN_OVERLAP(10) → skipped
+    const metricQb = createQueryBuilder();
+    metricQb.getMany.mockResolvedValue(makeMetrics(8));
+    mockPerformanceMetricRepo.createQueryBuilder.mockReturnValue(metricQb);
+
+    const result = await service.calculateMaxCorrelation('strat-1', 'user-1');
+    expect(result).toBe(0);
+  });
+});

--- a/apps/api/src/scoring/correlation-scoring.service.ts
+++ b/apps/api/src/scoring/correlation-scoring.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Not, IsNull, Repository } from 'typeorm';
+
+import { DeploymentStatus } from '@chansey/api-interfaces';
+
+import { CorrelationCalculator } from '../common/metrics/correlation.calculator';
+import { BacktestPerformanceSnapshot } from '../order/backtest/backtest-performance-snapshot.entity';
+import { Pipeline } from '../pipeline/entities/pipeline.entity';
+import { Deployment } from '../strategy/entities/deployment.entity';
+import { PerformanceMetric } from '../strategy/entities/performance-metric.entity';
+
+/** Minimum overlapping data points for a statistically meaningful correlation */
+const MIN_OVERLAP = 10;
+
+/** How many days of deployment performance to consider */
+const LOOKBACK_DAYS = 90;
+
+@Injectable()
+export class CorrelationScoringService {
+  private readonly logger = new Logger(CorrelationScoringService.name);
+
+  constructor(
+    @InjectRepository(Deployment)
+    private readonly deploymentRepo: Repository<Deployment>,
+    @InjectRepository(PerformanceMetric)
+    private readonly performanceMetricRepo: Repository<PerformanceMetric>,
+    @InjectRepository(BacktestPerformanceSnapshot)
+    private readonly snapshotRepo: Repository<BacktestPerformanceSnapshot>,
+    @InjectRepository(Pipeline)
+    private readonly pipelineRepo: Repository<Pipeline>,
+    private readonly correlationCalculator: CorrelationCalculator
+  ) {}
+
+  /**
+   * Calculate the maximum absolute correlation between a candidate strategy
+   * and all currently active deployments.
+   *
+   * Returns 0 if there are no active deployments (first strategy),
+   * if the candidate has no backtest snapshots, or if no pair has
+   * enough overlapping data points.
+   */
+  async calculateMaxCorrelation(strategyConfigId: string, userId: string): Promise<number> {
+    const activeDeployments = await this.deploymentRepo.find({
+      where: {
+        status: DeploymentStatus.ACTIVE,
+        strategyConfigId: Not(strategyConfigId),
+        strategyConfig: { createdBy: userId }
+      },
+      select: ['id', 'strategyConfigId'],
+      relations: ['strategyConfig']
+    });
+
+    if (activeDeployments.length === 0) {
+      return 0;
+    }
+
+    const candidateReturns = await this.getCandidateReturns(strategyConfigId, userId);
+    if (candidateReturns.length < MIN_OVERLAP) {
+      this.logger.debug(
+        `Strategy ${strategyConfigId}: only ${candidateReturns.length} candidate return points, skipping correlation`
+      );
+      return 0;
+    }
+
+    let maxCorrelation = 0;
+
+    for (const deployment of activeDeployments) {
+      const deploymentReturns = await this.getDeploymentReturns(deployment.id);
+      if (deploymentReturns.length < MIN_OVERLAP) continue;
+
+      // Align series lengths — use shorter length, trim from start
+      const minLength = Math.min(candidateReturns.length, deploymentReturns.length);
+      if (minLength < MIN_OVERLAP) continue;
+
+      const alignedCandidate = candidateReturns.slice(candidateReturns.length - minLength);
+      const alignedDeployment = deploymentReturns.slice(deploymentReturns.length - minLength);
+
+      const correlation = Math.abs(
+        this.correlationCalculator.calculatePearsonCorrelation(alignedCandidate, alignedDeployment)
+      );
+
+      if (correlation > maxCorrelation) {
+        maxCorrelation = correlation;
+      }
+    }
+
+    return maxCorrelation;
+  }
+
+  /**
+   * Extract return series from the candidate strategy's most recent completed
+   * backtest performance snapshots (via Pipeline → Backtest → Snapshots).
+   */
+  private async getCandidateReturns(strategyConfigId: string, userId: string): Promise<number[]> {
+    // Find the most recent completed pipeline for this strategy that has a historical backtest
+    const pipeline = await this.pipelineRepo.findOne({
+      where: {
+        strategyConfigId,
+        user: { id: userId },
+        historicalBacktestId: Not(IsNull())
+      },
+      order: { createdAt: 'DESC' },
+      select: ['id', 'historicalBacktestId']
+    });
+
+    if (!pipeline?.historicalBacktestId) return [];
+
+    const snapshots = await this.snapshotRepo
+      .createQueryBuilder('s')
+      .select(['s.portfolioValue', 's.timestamp'])
+      .where('s.backtestId = :backtestId', { backtestId: pipeline.historicalBacktestId })
+      .orderBy('s.timestamp', 'ASC')
+      .getMany();
+
+    if (snapshots.length < 2) return [];
+
+    // Convert portfolio values to returns: (current - previous) / previous
+    const returns: number[] = [];
+    for (let i = 1; i < snapshots.length; i++) {
+      const prev = snapshots[i - 1].portfolioValue;
+      if (prev === 0) continue;
+      returns.push((snapshots[i].portfolioValue - prev) / prev);
+    }
+
+    return returns;
+  }
+
+  /**
+   * Extract daily return series from a deployment's PerformanceMetric records.
+   */
+  private async getDeploymentReturns(deploymentId: string): Promise<number[]> {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - LOOKBACK_DAYS);
+
+    const metrics = await this.performanceMetricRepo
+      .createQueryBuilder('pm')
+      .select('pm.dailyReturn')
+      .where('pm.deploymentId = :deploymentId', { deploymentId })
+      .andWhere('pm.date >= :cutoff', { cutoff: cutoffDate.toISOString().split('T')[0] })
+      .orderBy('pm.date', 'ASC')
+      .getMany();
+
+    return metrics.map((m) => Number(m.dailyReturn));
+  }
+}

--- a/apps/api/src/scoring/scoring.module.ts
+++ b/apps/api/src/scoring/scoring.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { CorrelationScoringService } from './correlation-scoring.service';
 import { CalmarRatioCalculator } from './metrics/calmar-ratio.calculator';
 import { ProfitFactorCalculator } from './metrics/profit-factor.calculator';
 import { StabilityCalculator } from './metrics/stability.calculator';
@@ -13,12 +14,19 @@ import { WindowProcessor } from './walk-forward/window-processor';
 import { CorrelationCalculator } from '../common/metrics/correlation.calculator';
 import { DrawdownCalculator } from '../common/metrics/drawdown.calculator';
 import { SharpeRatioCalculator } from '../common/metrics/sharpe-ratio.calculator';
+import { BacktestPerformanceSnapshot } from '../order/backtest/backtest-performance-snapshot.entity';
+import { Pipeline } from '../pipeline/entities/pipeline.entity';
+import { Deployment } from '../strategy/entities/deployment.entity';
+import { PerformanceMetric } from '../strategy/entities/performance-metric.entity';
 import { StrategyScore } from '../strategy/entities/strategy-score.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([StrategyScore])],
+  imports: [
+    TypeOrmModule.forFeature([StrategyScore, Deployment, PerformanceMetric, BacktestPerformanceSnapshot, Pipeline])
+  ],
   providers: [
     ScoringService,
+    CorrelationScoringService,
     WalkForwardService,
     DegradationCalculator,
     WindowProcessor,
@@ -30,6 +38,6 @@ import { StrategyScore } from '../strategy/entities/strategy-score.entity';
     DrawdownCalculator,
     CorrelationCalculator
   ],
-  exports: [ScoringService, WalkForwardService, WindowProcessor, DegradationCalculator]
+  exports: [ScoringService, CorrelationScoringService, WalkForwardService, WindowProcessor, DegradationCalculator]
 })
 export class ScoringModule {}

--- a/apps/api/src/scoring/scoring.service.spec.ts
+++ b/apps/api/src/scoring/scoring.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { MarketRegimeType, StrategyGrade } from '@chansey/api-interfaces';
 
+import { CorrelationScoringService } from './correlation-scoring.service';
 import { CalmarRatioCalculator } from './metrics/calmar-ratio.calculator';
 import { ProfitFactorCalculator } from './metrics/profit-factor.calculator';
 import { StabilityCalculator } from './metrics/stability.calculator';
@@ -17,6 +18,7 @@ import { StrategyScore } from '../strategy/entities/strategy-score.entity';
 describe('ScoringService', () => {
   let service: ScoringService;
   let mockRepo: Record<string, jest.Mock>;
+  let mockCorrelationScoringService: { calculateMaxCorrelation: jest.Mock };
 
   /** Metrics that score "excellent" on every component → baseScore = 100 */
   const excellentMetrics = {
@@ -55,6 +57,10 @@ describe('ScoringService', () => {
       }))
     };
 
+    mockCorrelationScoringService = {
+      calculateMaxCorrelation: jest.fn().mockResolvedValue(0)
+    };
+
     const module = await Test.createTestingModule({
       providers: [
         ScoringService,
@@ -65,6 +71,7 @@ describe('ScoringService', () => {
         WinRateCalculator,
         ProfitFactorCalculator,
         StabilityCalculator,
+        { provide: CorrelationScoringService, useValue: mockCorrelationScoringService },
         { provide: getRepositoryToken(StrategyScore), useValue: mockRepo }
       ]
     }).compile();
@@ -294,7 +301,7 @@ describe('ScoringService', () => {
   describe('calculateScore (full pipeline)', () => {
     it('throws when backtest has no results', async () => {
       const backtestRun = { id: 'run-1', results: null } as any;
-      await expect(service.calculateScore('strat-1', backtestRun, 10)).rejects.toThrow(
+      await expect(service.calculateScore('strat-1', backtestRun, 10, 'user-1')).rejects.toThrow(
         'Backtest results not available'
       );
     });
@@ -305,7 +312,7 @@ describe('ScoringService', () => {
         results: excellentMetrics
       } as any;
 
-      const result = await service.calculateScore('strat-1', backtestRun, 5);
+      const result = await service.calculateScore('strat-1', backtestRun, 5, 'user-1');
 
       expect(mockRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -325,7 +332,7 @@ describe('ScoringService', () => {
   describe('checkPromotionEligibility (via calculateScore)', () => {
     it('is eligible with excellent metrics, low degradation, sufficient trades', async () => {
       const backtestRun = { id: 'run-1', results: excellentMetrics } as any;
-      const result = await service.calculateScore('strat-1', backtestRun, 5);
+      const result = await service.calculateScore('strat-1', backtestRun, 5, 'user-1');
       expect(result.promotionEligible).toBe(true);
     });
 
@@ -334,7 +341,7 @@ describe('ScoringService', () => {
         id: 'run-1',
         results: { ...excellentMetrics, totalTrades: 20 }
       } as any;
-      const result = await service.calculateScore('strat-1', backtestRun, 5);
+      const result = await service.calculateScore('strat-1', backtestRun, 5, 'user-1');
       expect(result.promotionEligible).toBe(false);
     });
 
@@ -343,7 +350,7 @@ describe('ScoringService', () => {
         id: 'run-1',
         results: { ...excellentMetrics, maxDrawdown: 50 }
       } as any;
-      const result = await service.calculateScore('strat-1', backtestRun, 5);
+      const result = await service.calculateScore('strat-1', backtestRun, 5, 'user-1');
       expect(result.promotionEligible).toBe(false);
     });
 
@@ -352,7 +359,7 @@ describe('ScoringService', () => {
         id: 'run-1',
         results: { ...excellentMetrics, totalReturn: -0.1 }
       } as any;
-      const result = await service.calculateScore('strat-1', backtestRun, 5);
+      const result = await service.calculateScore('strat-1', backtestRun, 5, 'user-1');
       expect(result.promotionEligible).toBe(false);
     });
 
@@ -361,8 +368,84 @@ describe('ScoringService', () => {
         id: 'run-1',
         results: excellentMetrics
       } as any;
-      const result = await service.calculateScore('strat-1', backtestRun, 35);
+      const result = await service.calculateScore('strat-1', backtestRun, 35, 'user-1');
       expect(result.promotionEligible).toBe(false);
+    });
+  });
+
+  describe('correlation scoring tiers (via calculateScoreFromMetrics)', () => {
+    it('assigns score 100 for correlation 0 (uncorrelated)', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0 });
+      expect(result.componentScores.correlation.score).toBe(100);
+      expect(result.componentScores.correlation.value).toBe(0);
+    });
+
+    it('assigns score 75 for moderate correlation (0.3)', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0.3 });
+      expect(result.componentScores.correlation.score).toBe(75);
+      expect(result.componentScores.correlation.value).toBe(0.3);
+    });
+
+    it('assigns score 50 for correlation 0.5', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0.5 });
+      expect(result.componentScores.correlation.score).toBe(50);
+      expect(result.componentScores.correlation.value).toBe(0.5);
+    });
+
+    it('assigns score 25 for high correlation (0.8)', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0.8 });
+      expect(result.componentScores.correlation.score).toBe(25);
+      expect(result.componentScores.correlation.value).toBe(0.8);
+    });
+
+    it('assigns score 0 for very high correlation (0.95)', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0.95 });
+      expect(result.componentScores.correlation.score).toBe(0);
+      expect(result.componentScores.correlation.value).toBe(0.95);
+    });
+
+    it('reduces overall score when correlation is high', () => {
+      const uncorrelated = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0 });
+      const correlated = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0.8 });
+      expect(uncorrelated.overallScore).toBeGreaterThan(correlated.overallScore);
+    });
+
+    it('handles negative correlation via abs value', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: -0.8 });
+      expect(result.componentScores.correlation.score).toBe(25);
+    });
+  });
+
+  describe('correlation warnings', () => {
+    it('warns when correlation exceeds 0.7', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0.75 });
+      expect(result.warnings).toContain('High correlation with existing deployment reduces diversification');
+    });
+
+    it('does not warn when correlation is below 0.7', () => {
+      const result = service.calculateScoreFromMetrics(excellentMetrics, 0, { correlationValue: 0.5 });
+      expect(result.warnings).not.toContain('High correlation with existing deployment reduces diversification');
+    });
+  });
+
+  describe('calculateScore with correlation', () => {
+    it('calls correlationScoringService and uses result', async () => {
+      mockCorrelationScoringService.calculateMaxCorrelation.mockResolvedValue(0.5);
+      const backtestRun = { id: 'run-1', results: excellentMetrics } as any;
+      const result = await service.calculateScore('strat-1', backtestRun, 0, 'user-1');
+
+      expect(mockCorrelationScoringService.calculateMaxCorrelation).toHaveBeenCalledWith('strat-1', 'user-1');
+      expect(result.componentScores.correlation.value).toBe(0.5);
+      expect(result.componentScores.correlation.score).toBe(50);
+    });
+
+    it('defaults correlation to 0 when correlationScoringService throws', async () => {
+      mockCorrelationScoringService.calculateMaxCorrelation.mockRejectedValue(new Error('DB connection failed'));
+      const backtestRun = { id: 'run-1', results: excellentMetrics } as any;
+      const result = await service.calculateScore('strat-1', backtestRun, 0, 'user-1');
+
+      expect(result.componentScores.correlation.value).toBe(0);
+      expect(result.componentScores.correlation.score).toBe(100);
     });
   });
 });

--- a/apps/api/src/scoring/scoring.service.ts
+++ b/apps/api/src/scoring/scoring.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 
 import { ComponentScores, GRADE_RANGES, MarketRegimeType, StrategyGrade } from '@chansey/api-interfaces';
 
+import { CorrelationScoringService } from './correlation-scoring.service';
 import { CalmarRatioCalculator } from './metrics/calmar-ratio.calculator';
 import { ProfitFactorCalculator } from './metrics/profit-factor.calculator';
 import { StabilityCalculator } from './metrics/stability.calculator';
@@ -35,7 +36,8 @@ export class ScoringService {
     private readonly calmarCalculator: CalmarRatioCalculator,
     private readonly winRateCalculator: WinRateCalculator,
     private readonly profitFactorCalculator: ProfitFactorCalculator,
-    private readonly stabilityCalculator: StabilityCalculator
+    private readonly stabilityCalculator: StabilityCalculator,
+    private readonly correlationScoringService: CorrelationScoringService
   ) {}
 
   /**
@@ -44,15 +46,24 @@ export class ScoringService {
   async calculateScore(
     strategyConfigId: string,
     backtestRun: BacktestRun,
-    wfaDegradation: number
+    wfaDegradation: number,
+    userId: string
   ): Promise<StrategyScore> {
     const results = backtestRun.results;
     if (!results) {
       throw new Error('Backtest results not available');
     }
 
+    // Calculate correlation with active deployments
+    let correlationValue = 0;
+    try {
+      correlationValue = await this.correlationScoringService.calculateMaxCorrelation(strategyConfigId, userId);
+    } catch (error) {
+      this.logger.warn(`Failed to calculate correlation for strategy ${strategyConfigId}: ${error}`);
+    }
+
     // Calculate component scores
-    const componentScores = this.calculateComponentScores(results, wfaDegradation);
+    const componentScores = this.calculateComponentScores(results, wfaDegradation, correlationValue);
 
     // Calculate overall weighted score
     const overallScore = this.calculateOverallScore(componentScores);
@@ -67,7 +78,7 @@ export class ScoringService {
     const promotionEligible = this.checkPromotionEligibility(overallScore, componentScores, results);
 
     // Generate warnings
-    const warnings = this.generateWarnings(componentScores, results, wfaDegradation);
+    const warnings = this.generateWarnings(componentScores, results, wfaDegradation, correlationValue);
 
     // Create and save score
     const score = this.strategyScoreRepo.create({
@@ -107,7 +118,7 @@ export class ScoringService {
       volatility: number;
     },
     wfaDegradation: number,
-    options?: { marketRegime?: MarketRegimeType }
+    options?: { marketRegime?: MarketRegimeType; correlationValue?: number }
   ): {
     overallScore: number;
     grade: StrategyGrade;
@@ -115,12 +126,13 @@ export class ScoringService {
     warnings: string[];
     regimeModifier: number;
   } {
-    const componentScores = this.calculateComponentScores(metrics, wfaDegradation);
+    const correlationValue = options?.correlationValue ?? 0;
+    const componentScores = this.calculateComponentScores(metrics, wfaDegradation, correlationValue);
     const baseScore = this.calculateOverallScore(componentScores);
     const regimeModifier = this.getRegimeModifier(options?.marketRegime);
     const overallScore = Math.max(0, Math.min(100, baseScore + regimeModifier));
     const grade = this.determineGrade(overallScore);
-    const warnings = this.generateWarnings(componentScores, metrics, wfaDegradation);
+    const warnings = this.generateWarnings(componentScores, metrics, wfaDegradation, correlationValue);
 
     return { overallScore, grade, componentScores, warnings, regimeModifier };
   }
@@ -153,7 +165,7 @@ export class ScoringService {
   /**
    * Calculate component scores for all metrics
    */
-  private calculateComponentScores(results: any, wfaDegradation: number): ComponentScores {
+  private calculateComponentScores(results: any, wfaDegradation: number, correlationValue = 0): ComponentScores {
     // Sharpe Ratio (25% weight)
     const sharpeScore = this.scoreMetric(results.sharpeRatio, {
       excellent: 2.0,
@@ -202,8 +214,13 @@ export class ScoringService {
       poor: 10
     });
 
-    // Correlation (10% weight) - will be calculated separately with other strategies
-    const correlationScore = 100; // Default to perfect score, updated later
+    // Correlation (10% weight) - inverse scoring: lower abs(correlation) is better
+    const correlationScore = this.scoreMetricInverse(Math.abs(correlationValue), {
+      excellent: 0.2,
+      good: 0.4,
+      acceptable: 0.7,
+      poor: 0.9
+    });
 
     return {
       sharpeRatio: {
@@ -243,7 +260,7 @@ export class ScoringService {
         percentile: 0
       },
       correlation: {
-        value: 0,
+        value: correlationValue,
         score: correlationScore,
         weight: SCORING_WEIGHTS.correlation,
         percentile: 0
@@ -350,7 +367,12 @@ export class ScoringService {
   /**
    * Generate warnings for concerning metrics
    */
-  private generateWarnings(componentScores: ComponentScores, results: any, wfaDegradation: number): string[] {
+  private generateWarnings(
+    componentScores: ComponentScores,
+    results: any,
+    wfaDegradation: number,
+    correlationValue = 0
+  ): string[] {
     const warnings: string[] = [];
 
     if (componentScores.sharpeRatio.value < 0.5) {
@@ -375,6 +397,10 @@ export class ScoringService {
 
     if (results.volatility > 1.5) {
       warnings.push('High volatility exceeds 150% annualized threshold');
+    }
+
+    if (Math.abs(correlationValue) > 0.7) {
+      warnings.push('High correlation with existing deployment reduces diversification');
     }
 
     return warnings;

--- a/apps/api/src/tasks/strategy-evaluation.service.ts
+++ b/apps/api/src/tasks/strategy-evaluation.service.ts
@@ -168,7 +168,7 @@ export class StrategyEvaluationService {
 
     // 10. Calculate score — wfaDegradation = 0 because single-backtest evaluation
     // has no train/test split, so no walk-forward analysis data exists.
-    const score = await this.scoringService.calculateScore(strategyConfigId, backtestRun, 0);
+    const score = await this.scoringService.calculateScore(strategyConfigId, backtestRun, 0, user.id);
 
     const passed = Number(score.overallScore) >= PASS_THRESHOLD;
     this.logger.log(`Strategy ${strategyConfigId} evaluation: score=${score.overallScore}, passed=${passed}`);


### PR DESCRIPTION
## Summary

- Extract correlation scoring logic into a dedicated `CorrelationScoringService` that calculates max absolute correlation between a candidate strategy and active deployments
- Replace the hardcoded correlation default (100) with real correlation calculation using backtest snapshots and deployment performance metrics
- Wire correlation scoring into the pipeline progression path for live-replay score gating

## Changes

- **`correlation-scoring.service.ts`** — New service computing max absolute Pearson correlation between candidate backtest snapshots and existing deployment performance metrics
- **`scoring.service.ts`** — Inject `CorrelationScoringService`, use real correlation in `calculateScore()` instead of hardcoded default
- **`pipeline-progression.service.ts`** — Pass `userId` through to `calculatePipelineScore()` so correlation can query user-specific deployments
- **`scoring.module.ts`** — Register new service and required entities (Deployment, PerformanceMetric, BacktestPerformanceSnapshot, Pipeline)
- **Test files** — Comprehensive tests for the new service and updated tests for scoring and pipeline progression

## Test Plan

- [ ] `npx nx test api -- --testPathPattern='correlation-scoring'` passes
- [ ] `npx nx test api -- --testPathPattern='scoring.service'` passes
- [ ] `npx nx test api -- --testPathPattern='pipeline-progression'` passes
- [ ] Pipeline score gating correctly uses real correlation values instead of default 100