### PR TITLE
refactor(api): improve strategy signals and transient error resilience

### DIFF
--- a/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.spec.ts
@@ -611,7 +611,7 @@ describe('ATRTrailingStopStrategy', () => {
       const confidenceSchema = schema['minConfidence'] as Record<string, unknown>;
 
       expect(multiplierSchema['default']).toBe(4.5);
-      expect(multiplierSchema['min']).toBe(3.5);
+      expect(multiplierSchema['min']).toBe(2.0);
       expect(confidenceSchema['default']).toBe(0.4);
     });
   });

--- a/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
+++ b/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
@@ -155,8 +155,8 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
 
   private getConfigWithDefaults(config: Record<string, unknown>): ATRTrailingStopConfig {
     return {
-      atrPeriod: Math.max(14, Math.min(25, (config.atrPeriod as number) ?? 20)),
-      atrMultiplier: Math.max(3.5, Math.min(6, (config.atrMultiplier as number) ?? 4.5)),
+      atrPeriod: Math.max(8, Math.min(25, (config.atrPeriod as number) ?? 20)),
+      atrMultiplier: Math.max(2.0, Math.min(6, (config.atrMultiplier as number) ?? 4.5)),
       tradeDirection: (config.tradeDirection as 'long' | 'short' | 'both') ?? 'long',
       useHighLow: (config.useHighLow as boolean) ?? true,
       minConfidence: (config.minConfidence as number) ?? 0.4,
@@ -477,11 +477,11 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
   getConfigSchema(): Record<string, unknown> {
     return {
       ...super.getConfigSchema(),
-      atrPeriod: { type: 'number', default: 20, min: 14, max: 25, description: 'ATR calculation period' },
+      atrPeriod: { type: 'number', default: 20, min: 8, max: 25, description: 'ATR calculation period' },
       atrMultiplier: {
         type: 'number',
         default: 4.5,
-        min: 3.5,
+        min: 2.0,
         max: 6,
         description: 'ATR multiplier for stop distance'
       },

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.spec.ts
@@ -172,7 +172,7 @@ describe('TripleEMAStrategy', () => {
       expect(result.signals[0].reason).toContain('Triple EMA bearish alignment');
     });
 
-    it('should block signal when EMA spread is below minSpread', async () => {
+    it('should block entry signal when EMA spread is below minSpread', async () => {
       const prices = createMockPrices(70);
 
       const fastEMA = Array(70).fill(NaN);
@@ -182,17 +182,17 @@ describe('TripleEMAStrategy', () => {
       // Set up transition to bullish alignment but with tiny spread
       for (let i = 55; i < 70; i++) {
         slowEMA[i] = 100;
-        mediumEMA[i] = 100.05;
-        fastEMA[i] = 100.1; // Spread = 0.1% — below default minSpread of 0.3%
+        mediumEMA[i] = 100.02;
+        fastEMA[i] = 100.04; // Spread = 0.04% — below default minSpread of 0.1%
       }
       // Previous bar was not aligned
-      fastEMA[68] = 99.95;
-      mediumEMA[68] = 100.05;
+      fastEMA[68] = 99.98;
+      mediumEMA[68] = 100.02;
       slowEMA[68] = 100;
 
       // Current bar is aligned but tiny spread
-      fastEMA[69] = 100.1;
-      mediumEMA[69] = 100.05;
+      fastEMA[69] = 100.04;
+      mediumEMA[69] = 100.02;
       slowEMA[69] = 100;
 
       indicatorService.calculateEMA
@@ -210,7 +210,139 @@ describe('TripleEMAStrategy', () => {
       const result = await strategy.execute(context);
 
       expect(result.success).toBe(true);
+      // Bullish entry blocked by minSpread, but breakdown signal (bullish→neutral won't fire
+      // since previous was also not bullish in this setup — net result is no signals)
       expect(result.signals).toHaveLength(0);
+    });
+
+    it('should generate SELL breakdown signal when alignment transitions bullish → neutral', async () => {
+      const prices = createMockPrices(70);
+
+      const fastEMA = Array(70).fill(NaN);
+      const mediumEMA = Array(70).fill(NaN);
+      const slowEMA = Array(70).fill(NaN);
+
+      for (let i = 55; i < 70; i++) {
+        slowEMA[i] = 95;
+        mediumEMA[i] = 98;
+        fastEMA[i] = 101;
+      }
+      // Previous bar was bullish aligned (fast > medium > slow)
+      fastEMA[68] = 101;
+      mediumEMA[68] = 98;
+      slowEMA[68] = 95;
+
+      // Current bar: fast dropped below medium — alignment breaks to neutral
+      fastEMA[69] = 97;
+      mediumEMA[69] = 98;
+      slowEMA[69] = 95;
+
+      indicatorService.calculateEMA
+        .mockResolvedValueOnce({ values: fastEMA, validCount: 60, period: 8, fromCache: false })
+        .mockResolvedValueOnce({ values: mediumEMA, validCount: 50, period: 21, fromCache: false })
+        .mockResolvedValueOnce({ values: slowEMA, validCount: 15, period: 55, fromCache: false });
+
+      const context: AlgorithmContext = {
+        coins: [{ id: 'btc', symbol: 'BTC', name: 'Bitcoin' }] as any,
+        priceData: { btc: prices as any },
+        timestamp: new Date(),
+        config: { fastPeriod: 8, mediumPeriod: 21, slowPeriod: 55 }
+      };
+
+      const result = await strategy.execute(context);
+
+      expect(result.success).toBe(true);
+      expect(result.signals).toHaveLength(1);
+      expect(result.signals[0].type).toBe(SignalType.SELL);
+      expect(result.signals[0].metadata!.alignmentType).toBe('breakdown');
+      expect(result.signals[0].metadata!.previousAlignment).toBe('bullish');
+      expect(result.signals[0].reason).toContain('Bullish alignment lost');
+    });
+
+    it('should generate BUY breakdown signal when alignment transitions bearish → neutral', async () => {
+      const prices = createMockPrices(70);
+
+      const fastEMA = Array(70).fill(NaN);
+      const mediumEMA = Array(70).fill(NaN);
+      const slowEMA = Array(70).fill(NaN);
+
+      for (let i = 55; i < 70; i++) {
+        slowEMA[i] = 105;
+        mediumEMA[i] = 102;
+        fastEMA[i] = 99;
+      }
+      // Previous bar was bearish aligned (fast < medium < slow)
+      fastEMA[68] = 99;
+      mediumEMA[68] = 102;
+      slowEMA[68] = 105;
+
+      // Current bar: fast rose above medium — alignment breaks to neutral
+      fastEMA[69] = 103;
+      mediumEMA[69] = 102;
+      slowEMA[69] = 105;
+
+      indicatorService.calculateEMA
+        .mockResolvedValueOnce({ values: fastEMA, validCount: 60, period: 8, fromCache: false })
+        .mockResolvedValueOnce({ values: mediumEMA, validCount: 50, period: 21, fromCache: false })
+        .mockResolvedValueOnce({ values: slowEMA, validCount: 15, period: 55, fromCache: false });
+
+      const context: AlgorithmContext = {
+        coins: [{ id: 'btc', symbol: 'BTC', name: 'Bitcoin' }] as any,
+        priceData: { btc: prices as any },
+        timestamp: new Date(),
+        config: { fastPeriod: 8, mediumPeriod: 21, slowPeriod: 55 }
+      };
+
+      const result = await strategy.execute(context);
+
+      expect(result.success).toBe(true);
+      expect(result.signals).toHaveLength(1);
+      expect(result.signals[0].type).toBe(SignalType.BUY);
+      expect(result.signals[0].metadata!.alignmentType).toBe('breakdown');
+      expect(result.signals[0].metadata!.previousAlignment).toBe('bearish');
+      expect(result.signals[0].reason).toContain('Bearish alignment lost');
+    });
+
+    it('should bypass minSpread filter for breakdown signals', async () => {
+      const prices = createMockPrices(70);
+
+      const fastEMA = Array(70).fill(NaN);
+      const mediumEMA = Array(70).fill(NaN);
+      const slowEMA = Array(70).fill(NaN);
+
+      for (let i = 55; i < 70; i++) {
+        slowEMA[i] = 100;
+        mediumEMA[i] = 100.05;
+        fastEMA[i] = 100.1;
+      }
+      // Previous bar was bullish aligned
+      fastEMA[68] = 100.1;
+      mediumEMA[68] = 100.05;
+      slowEMA[68] = 100;
+
+      // Current bar: fast dropped below medium — tiny spread but breakdown should still fire
+      fastEMA[69] = 100.03;
+      mediumEMA[69] = 100.05;
+      slowEMA[69] = 100;
+
+      indicatorService.calculateEMA
+        .mockResolvedValueOnce({ values: fastEMA, validCount: 60, period: 8, fromCache: false })
+        .mockResolvedValueOnce({ values: mediumEMA, validCount: 50, period: 21, fromCache: false })
+        .mockResolvedValueOnce({ values: slowEMA, validCount: 15, period: 55, fromCache: false });
+
+      const context: AlgorithmContext = {
+        coins: [{ id: 'btc', symbol: 'BTC', name: 'Bitcoin' }] as any,
+        priceData: { btc: prices as any },
+        timestamp: new Date(),
+        config: { fastPeriod: 8, mediumPeriod: 21, slowPeriod: 55, minSpread: 0.01 }
+      };
+
+      const result = await strategy.execute(context);
+
+      expect(result.success).toBe(true);
+      expect(result.signals).toHaveLength(1);
+      expect(result.signals[0].type).toBe(SignalType.SELL);
+      expect(result.signals[0].metadata!.alignmentType).toBe('breakdown');
     });
 
     it('should return no signals when EMAs are not aligned', async () => {

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
@@ -141,10 +141,10 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
       fastPeriod: (config.fastPeriod as number) ?? 8,
       mediumPeriod: (config.mediumPeriod as number) ?? 21,
       slowPeriod: (config.slowPeriod as number) ?? 55,
-      requireFullAlignment: (config.requireFullAlignment as boolean) ?? true,
+      requireFullAlignment: (config.requireFullAlignment as boolean) ?? false,
       signalOnPartialCross: (config.signalOnPartialCross as boolean) ?? true,
-      minConfidence: (config.minConfidence as number) ?? 0.5,
-      minSpread: (config.minSpread as number) ?? 0.003
+      minConfidence: (config.minConfidence as number) ?? 0.3,
+      minSpread: (config.minSpread as number) ?? 0.001
     };
   }
 
@@ -232,19 +232,14 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
       return null;
     }
 
-    // Minimum EMA spread filter: skip if EMAs are too close (noise cross)
-    if (alignmentState.emaSpread < config.minSpread) {
-      return null;
-    }
-
     const currentPrice = prices[currentIndex].avg;
     const currentFast = fastEMA[currentIndex];
     const currentMedium = mediumEMA[currentIndex];
     const currentSlow = slowEMA[currentIndex];
 
-    // Check for full alignment change (strongest signal)
+    // Check for alignment change (strongest signal)
     if (alignmentState.current !== alignmentState.previous) {
-      if (alignmentState.current === 'bullish') {
+      if (alignmentState.current === 'bullish' && alignmentState.emaSpread >= config.minSpread) {
         // Transition to bullish alignment
         const strength = this.calculateSignalStrength(alignmentState);
         const confidence = this.calculateConfidence(fastEMA, mediumEMA, slowEMA, alignmentState, currentIndex, true);
@@ -269,7 +264,7 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         };
       }
 
-      if (alignmentState.current === 'bearish') {
+      if (alignmentState.current === 'bearish' && alignmentState.emaSpread >= config.minSpread) {
         // Transition to bearish alignment
         const strength = this.calculateSignalStrength(alignmentState);
         const confidence = this.calculateConfidence(fastEMA, mediumEMA, slowEMA, alignmentState, currentIndex, false);
@@ -293,6 +288,60 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
           }
         };
       }
+
+      // Breakdown: alignment lost — exit signal (bypasses minSpread since converging EMAs ARE the signal)
+      if (alignmentState.current === 'neutral') {
+        if (alignmentState.previous === 'bullish') {
+          const strength = this.calculateSignalStrength(alignmentState) * 0.6;
+
+          return {
+            type: SignalType.SELL,
+            coinId,
+            strength,
+            price: currentPrice,
+            confidence: 0.5,
+            reason: `Triple EMA breakdown: Bullish alignment lost — Fast EMA (${currentFast.toFixed(4)}) no longer above Medium EMA (${currentMedium.toFixed(4)}) and Slow EMA (${currentSlow.toFixed(4)})`,
+            metadata: {
+              symbol: coinSymbol,
+              fastEMA: currentFast,
+              mediumEMA: currentMedium,
+              slowEMA: currentSlow,
+              alignment: 'neutral',
+              previousAlignment: 'bullish',
+              emaSpread: alignmentState.emaSpread,
+              alignmentType: 'breakdown'
+            }
+          };
+        }
+
+        if (alignmentState.previous === 'bearish') {
+          const strength = this.calculateSignalStrength(alignmentState) * 0.6;
+
+          return {
+            type: SignalType.BUY,
+            coinId,
+            strength,
+            price: currentPrice,
+            confidence: 0.5,
+            reason: `Triple EMA breakdown: Bearish alignment lost — Fast EMA (${currentFast.toFixed(4)}) no longer below Medium EMA (${currentMedium.toFixed(4)}) and Slow EMA (${currentSlow.toFixed(4)})`,
+            metadata: {
+              symbol: coinSymbol,
+              fastEMA: currentFast,
+              mediumEMA: currentMedium,
+              slowEMA: currentSlow,
+              alignment: 'neutral',
+              previousAlignment: 'bearish',
+              emaSpread: alignmentState.emaSpread,
+              alignmentType: 'breakdown'
+            }
+          };
+        }
+      }
+    }
+
+    // Minimum EMA spread filter for partial cross signals
+    if (alignmentState.emaSpread < config.minSpread) {
+      return null;
     }
 
     // Optional: Signal on partial crossover (fast/medium cross while medium/slow aligned)
@@ -470,13 +519,13 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
       ...super.getConfigSchema(),
       fastPeriod: { type: 'number', default: 8, min: 3, max: 15, description: 'Fast EMA period' },
       mediumPeriod: { type: 'number', default: 21, min: 10, max: 30, description: 'Medium EMA period' },
-      slowPeriod: { type: 'number', default: 55, min: 45, max: 100, description: 'Slow EMA period' },
-      requireFullAlignment: { type: 'boolean', default: true, description: 'Require all 3 EMAs aligned for signal' },
+      slowPeriod: { type: 'number', default: 55, min: 30, max: 100, description: 'Slow EMA period' },
+      requireFullAlignment: { type: 'boolean', default: false, description: 'Require all 3 EMAs aligned for signal' },
       signalOnPartialCross: { type: 'boolean', default: true, description: 'Signal on fast/medium crossover' },
-      minConfidence: { type: 'number', default: 0.5, min: 0, max: 1, description: 'Minimum confidence required' },
+      minConfidence: { type: 'number', default: 0.3, min: 0, max: 1, description: 'Minimum confidence required' },
       minSpread: {
         type: 'number',
-        default: 0.003,
+        default: 0.001,
         min: 0,
         max: 0.05,
         description: 'Minimum EMA spread to generate signal. Filters noise crosses.'

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
@@ -292,15 +292,15 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
       // Breakdown: alignment lost — exit signal (bypasses minSpread since converging EMAs ARE the signal)
       if (alignmentState.current === 'neutral') {
         if (alignmentState.previous === 'bullish') {
-          const strength = this.calculateSignalStrength(alignmentState) * 0.6;
+          const strength = Math.max(0.7, this.calculateSignalStrength(alignmentState));
 
           return {
             type: SignalType.SELL,
             coinId,
             strength,
             price: currentPrice,
-            confidence: 0.5,
-            reason: `Triple EMA breakdown: Bullish alignment lost — Fast EMA (${currentFast.toFixed(4)}) no longer above Medium EMA (${currentMedium.toFixed(4)}) and Slow EMA (${currentSlow.toFixed(4)})`,
+            confidence: Math.max(0.7, config.minConfidence),
+            reason: `Triple EMA breakdown: Bullish alignment lost — Fast > Medium > Slow no longer holds (Fast: ${currentFast.toFixed(4)}, Medium: ${currentMedium.toFixed(4)}, Slow: ${currentSlow.toFixed(4)})`,
             metadata: {
               symbol: coinSymbol,
               fastEMA: currentFast,
@@ -315,15 +315,15 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         }
 
         if (alignmentState.previous === 'bearish') {
-          const strength = this.calculateSignalStrength(alignmentState) * 0.6;
+          const strength = Math.max(0.7, this.calculateSignalStrength(alignmentState));
 
           return {
             type: SignalType.BUY,
             coinId,
             strength,
             price: currentPrice,
-            confidence: 0.5,
-            reason: `Triple EMA breakdown: Bearish alignment lost — Fast EMA (${currentFast.toFixed(4)}) no longer below Medium EMA (${currentMedium.toFixed(4)}) and Slow EMA (${currentSlow.toFixed(4)})`,
+            confidence: Math.max(0.7, config.minConfidence),
+            reason: `Triple EMA breakdown: Bearish alignment lost — Fast < Medium < Slow no longer holds (Fast: ${currentFast.toFixed(4)}, Medium: ${currentMedium.toFixed(4)}, Slow: ${currentSlow.toFixed(4)})`,
             metadata: {
               symbol: coinSymbol,
               fastEMA: currentFast,

--- a/apps/api/src/shared/retry.util.spec.ts
+++ b/apps/api/src/shared/retry.util.spec.ts
@@ -64,6 +64,15 @@ describe('retry.util', () => {
       expect(isTransientError(new Error('could not connect to server: Connection refused'))).toBe(true);
       expect(isTransientError(new Error('the database system is starting up'))).toBe(true);
       expect(isTransientError(new Error('the database system is shutting down'))).toBe(true);
+      expect(isTransientError(new Error('Connection terminated due to connection timeout'))).toBe(true);
+      expect(isTransientError(new Error('timeout exceeded when trying to connect'))).toBe(true);
+      expect(isTransientError(new Error('canceling statement due to statement timeout'))).toBe(true);
+      expect(isTransientError(new Error('connection timeout expired'))).toBe(true);
+    });
+
+    it('should identify Redis loading errors as transient', () => {
+      expect(isTransientError(new Error('LOADING Redis is loading the dataset in memory'))).toBe(true);
+      expect(isTransientError(new Error('redis is loading'))).toBe(true);
     });
 
     it('should not identify business errors as transient', () => {

--- a/apps/api/src/shared/retry.util.ts
+++ b/apps/api/src/shared/retry.util.ts
@@ -94,7 +94,7 @@ export function isTransientError(error: Error): boolean {
 
   // PostgreSQL connection errors
   if (
-    message.includes('connection terminated unexpectedly') ||
+    message.includes('connection terminated') ||
     message.includes('server closed the connection unexpectedly') ||
     message.includes('connection is not open') ||
     message.includes('too many connections') ||
@@ -102,8 +102,16 @@ export function isTransientError(error: Error): boolean {
     message.includes('terminating connection due to administrator command') ||
     message.includes('could not connect to server') ||
     message.includes('the database system is starting up') ||
-    message.includes('the database system is shutting down')
+    message.includes('the database system is shutting down') ||
+    message.includes('timeout exceeded when trying to connect') ||
+    (message.includes('canceling statement due to') && message.includes('timeout')) ||
+    message.includes('connection timeout')
   ) {
+    return true;
+  }
+
+  // Redis transient errors
+  if (message.includes('redis is loading') || message.includes('loading the dataset in memory')) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- Add breakdown exit signals to Triple EMA strategy when alignment transitions to neutral, improving exit timing
- Widen ATR trailing stop and Triple EMA parameter ranges for broader optimization search space
- Expand transient error detection to cover PostgreSQL timeout variants and Redis loading states

## Changes

### Triple EMA Strategy
- Breakdown signals: bullish→neutral emits SELL, bearish→neutral emits BUY (bypasses minSpread filter)
- Relaxed defaults: minConfidence 0.5→0.3, minSpread 0.003→0.001, requireFullAlignment true→false, slowPeriod min 45→30
- minSpread filter now only blocks entry signals, not breakdown exits

### ATR Trailing Stop Strategy
- Widened atrPeriod min 14→8 and atrMultiplier min 3.5→2.0

### Retry Utility
- Broadened PostgreSQL transient error matching: connection timeout, statement timeout, connect timeout
- Added Redis `LOADING` dataset errors as transient

## Test Plan
- [x] Breakdown signal generation tests (bullish→neutral, bearish→neutral)
- [x] minSpread bypass for breakdown signals test
- [x] PostgreSQL timeout transient error detection tests
- [x] Redis loading error detection tests
- [x] All existing tests pass