### PR TITLE
perf(api): reduce CoinGecko API usage via batching and caching

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [file-path] | [commit-hash] | --staged | --full
+argument-hint: [file-path] | [commit-hash] | --staged | --full | --plan <path> | --no-plan
 description: Comprehensive code quality review with security, performance, and architecture analysis
 ---
 
@@ -74,6 +74,32 @@ highest-risk files (services > strategies > processors > entities > DTOs > const
 4. **Read neighboring files**: For each file in scope, look at sibling files in the same directory to understand
    established patterns. If every service in a directory uses a particular error handling pattern, that's a convention —
    not an issue.
+
+5. **Read the planning document if one exists** (skip if `--no-plan` was passed). Plans capture intentional design
+   decisions made before implementation — without them, you'll re-litigate trade-offs the author already weighed.
+
+   Discovery order:
+   - If `--plan <path>` was passed in `$ARGUMENTS`, read that file directly.
+   - Otherwise, list the three most recently modified plan files:
+
+     ```bash
+     ls -lt ~/.claude/plans/*.md 2>/dev/null | head -3
+     ```
+
+     For each candidate (most recent first), check whether it references files or modules in the review scope by
+     grepping for path fragments (e.g., `clients/binance-announcement` or `listing-tracker`). The first plan that
+     mentions in-scope files is the one to use. If none match, proceed without a plan.
+
+   When a plan is found, read it in full before analyzing code. Pay special attention to these sections:
+   - **"Out of scope" / "What we're NOT doing"** — items here were deliberately excluded. Never flag them as gaps.
+   - **"Approach" / "Why X" / "Design decisions"** — trade-offs that were already reasoned through. Don't propose
+     reverting them.
+   - **"Test plan"** — describes intended coverage. Real findings are gaps versus the plan; not gaps the plan itself
+     declares acceptable.
+   - **"Verification"** — commands the author intended to run. If they're documented, assume they were run.
+
+   In the final report, state which plan file was used (or that none was found), so the reader can audit your
+   assumptions.
 
 **Key principle**: Assume patterns that are consistent across the codebase are intentional. Only flag something as an
 issue if it deviates from the project's own conventions OR poses a genuine correctness/security/performance risk.
@@ -159,6 +185,7 @@ it through this evaluation before including it in the report:
 | Criteria            | Question to answer                                                                             |
 | ------------------- | ---------------------------------------------------------------------------------------------- |
 | **Intentional?**    | Is this pattern used consistently in the codebase? Was it recently added/changed deliberately? |
+| **Plan-documented** | Does the plan file mark this as out-of-scope, an explicit trade-off, or a "Why X" decision?    |
 | **Correctness**     | Is this actually wrong, or just different from what I'd write?                                 |
 | **Project Context** | Does CLAUDE.md, a rules file, or the project's conventions explain this choice?                |
 | **Impact**          | Would changing this meaningfully improve correctness, security, or performance?                |
@@ -180,6 +207,8 @@ Group validated findings by verdict, not by analysis category. Format:
 
 ```markdown
 ## Code Review: <scope description>
+
+**Plan reference**: `<path to plan file used, or "none found">` <br> **Files in scope**: <count>
 
 ### FIX (<count>) — Issues that should be addressed
 

--- a/apps/api/src/coin/coin-daily-snapshot.service.spec.ts
+++ b/apps/api/src/coin/coin-daily-snapshot.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { type Repository } from 'typeorm';
+import { type EntityManager, type Repository } from 'typeorm';
 
 import { CoinDailySnapshot } from './coin-daily-snapshot.entity';
 import { CoinDailySnapshotService } from './coin-daily-snapshot.service';
@@ -25,8 +25,10 @@ describe('CoinDailySnapshotService', () => {
   let service: CoinDailySnapshotService;
   let repo: jest.Mocked<Repository<CoinDailySnapshot>>;
 
-  // Reusable mock query builder
+  // Reusable mock query builder for the repo
   let mockQb: Record<string, jest.Mock>;
+  // Separate query builder used by getCoinsNeedingBackfill() against entity manager
+  let mockBackfillQb: Record<string, jest.Mock>;
 
   beforeEach(async () => {
     mockQb = {
@@ -46,6 +48,19 @@ describe('CoinDailySnapshotService', () => {
       getRawMany: jest.fn().mockResolvedValue([])
     };
 
+    mockBackfillQb = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([])
+    };
+
+    const manager = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockBackfillQb)
+    } as unknown as EntityManager;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CoinDailySnapshotService,
@@ -54,7 +69,8 @@ describe('CoinDailySnapshotService', () => {
           useValue: {
             createQueryBuilder: jest.fn().mockReturnValue(mockQb),
             count: jest.fn().mockResolvedValue(0),
-            delete: jest.fn().mockResolvedValue({ affected: 0 })
+            delete: jest.fn().mockResolvedValue({ affected: 0 }),
+            manager
           }
         }
       ]
@@ -335,15 +351,29 @@ describe('CoinDailySnapshotService', () => {
   // getCoinsNeedingBackfill()
   // ===========================================================================
   describe('getCoinsNeedingBackfill()', () => {
-    it('returns coins with fewer than minDays snapshots', async () => {
-      mockQb.getRawMany.mockResolvedValueOnce([
-        { coinId: 'coin-1', cnt: '10' },
-        { coinId: 'coin-2', cnt: '45' }
-      ]);
+    it('returns only coins whose snapshotBackfillCompletedAt is null', async () => {
+      // Step 1 (manager): unflagged coins via partial index
+      mockBackfillQb.getRawMany.mockResolvedValueOnce([{ id: 'coin-1' }, { id: 'coin-3' }]);
+      // Step 2 (repo): safety-net count for flagged coins (just coin-2)
+      mockQb.getRawMany.mockResolvedValueOnce([{ coinId: 'coin-2', cnt: '365' }]);
 
       const result = await service.getCoinsNeedingBackfill(['coin-1', 'coin-2', 'coin-3'], 30);
 
-      expect(result).toEqual(['coin-1', 'coin-3']); // coin-3 has 0, coin-1 has 10
+      expect(result).toEqual(['coin-1', 'coin-3']);
+    });
+
+    it('reconsiders a flagged coin when snapshot count is below minDays (safety net)', async () => {
+      // Step 1 (manager): no unflagged coins
+      mockBackfillQb.getRawMany.mockResolvedValueOnce([]);
+      // Step 2 (repo): safety-net count for all flagged coins
+      mockQb.getRawMany.mockResolvedValueOnce([
+        { coinId: 'coin-flagged-but-sparse', cnt: '12' },
+        { coinId: 'coin-flagged-full', cnt: '365' }
+      ]);
+
+      const result = await service.getCoinsNeedingBackfill(['coin-flagged-but-sparse', 'coin-flagged-full'], 30);
+
+      expect(result).toEqual(['coin-flagged-but-sparse']);
     });
 
     it('returns empty array for empty coinIds', async () => {

--- a/apps/api/src/coin/coin-daily-snapshot.service.ts
+++ b/apps/api/src/coin/coin-daily-snapshot.service.ts
@@ -142,23 +142,49 @@ export class CoinDailySnapshotService {
   }
 
   /**
-   * Find coins that have fewer than `minDays` snapshots, indicating they need backfill.
+   * Find coins that need historical snapshot backfill.
+   * Primary signal: `coin.snapshotBackfillCompletedAt IS NULL` — backfill is one-shot,
+   * so once the flag is set we never re-fetch. `minDays` is retained as a secondary
+   * safety net for coins that are flagged but have unexpectedly few snapshots (e.g.
+   * manually marked by an admin) — those get reconsidered.
+   *
+   * Split into two queries so Step 1 uses IDX_coin_backfill_pending (partial index
+   * on `WHERE snapshotBackfillCompletedAt IS NULL`). A single correlated-count
+   * query cannot use that index and defeats the point of the flag.
    */
   async getCoinsNeedingBackfill(coinIds: string[], minDays = 30): Promise<string[]> {
     if (coinIds.length === 0) return [];
 
-    const results = await this.repo
-      .createQueryBuilder('s')
-      .select('s.coinId', 'coinId')
-      .addSelect('COUNT(*)', 'cnt')
-      .where('s.coinId IN (:...coinIds)', { coinIds })
-      .groupBy('s.coinId')
-      .getRawMany<{ coinId: string; cnt: string }>();
+    // Step 1: unflagged coins — uses IDX_coin_backfill_pending.
+    const pendingRows = await this.repo.manager
+      .createQueryBuilder()
+      .select('c.id', 'id')
+      .from('coin', 'c')
+      .where('c.id IN (:...coinIds)', { coinIds })
+      .andWhere('c."snapshotBackfillCompletedAt" IS NULL')
+      .getRawMany<{ id: string }>();
 
-    const countMap = new Map(results.map((r) => [r.coinId, parseInt(r.cnt, 10)]));
+    const pendingIds = pendingRows.map((r) => r.id);
+    const pendingSet = new Set(pendingIds);
+    const flaggedIds = coinIds.filter((id) => !pendingSet.has(id));
 
-    // Return coins with fewer than minDays snapshots (including coins with zero)
-    return coinIds.filter((id) => (countMap.get(id) ?? 0) < minDays);
+    // Step 2: safety net — flagged coins whose snapshot count is below minDays.
+    // Skip entirely when nothing is flagged.
+    let undercountedIds: string[] = [];
+    if (flaggedIds.length > 0) {
+      const counts = await this.repo
+        .createQueryBuilder('s')
+        .select('s.coinId', 'coinId')
+        .addSelect('COUNT(*)', 'cnt')
+        .where('s.coinId IN (:...flaggedIds)', { flaggedIds })
+        .groupBy('s.coinId')
+        .getRawMany<{ coinId: string; cnt: string }>();
+
+      const countMap = new Map(counts.map((r) => [r.coinId, parseInt(r.cnt, 10)]));
+      undercountedIds = flaggedIds.filter((id) => (countMap.get(id) ?? 0) < minDays);
+    }
+
+    return [...pendingIds, ...undercountedIds];
   }
 
   /**

--- a/apps/api/src/coin/coin.entity.ts
+++ b/apps/api/src/coin/coin.entity.ts
@@ -379,6 +379,15 @@ export class Coin {
 
   @Column({ type: 'timestamptz', nullable: true, default: null })
   @ApiProperty({
+    description: 'Timestamp when historical snapshot backfill completed (null = needs backfill)',
+    example: '2026-04-16T00:00:00Z',
+    required: false,
+    type: Date
+  })
+  snapshotBackfillCompletedAt?: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true, default: null })
+  @ApiProperty({
     description: 'Timestamp when the coin was soft-delisted (null if active)',
     example: '2026-03-15T00:00:00Z',
     required: false,

--- a/apps/api/src/coin/coin.module.ts
+++ b/apps/api/src/coin/coin.module.ts
@@ -14,6 +14,7 @@ import { SimplePriceController } from './simple-price.controller';
 import { CoinDetailSyncService } from './tasks/coin-detail-sync.service';
 import { CoinSnapshotPruneTask } from './tasks/coin-snapshot-prune.task';
 import { CoinSyncTask } from './tasks/coin-sync.task';
+import { ExchangeTickerFetcherService } from './ticker-pairs/services/exchange-ticker-fetcher.service';
 import { TickerPairSyncTask } from './ticker-pairs/tasks/ticker-pairs-sync.task';
 import { TickerPairs } from './ticker-pairs/ticker-pairs.entity';
 import { TickerPairService } from './ticker-pairs/ticker-pairs.service';
@@ -54,6 +55,7 @@ import { SharedCacheModule } from '../shared-cache.module';
     CoinDetailSyncService,
     CoinSnapshotPruneTask,
     CoinSyncTask,
+    ExchangeTickerFetcherService,
     TickerPairService,
     TickerPairSyncTask
   ]

--- a/apps/api/src/coin/coin.service.ts
+++ b/apps/api/src/coin/coin.service.ts
@@ -288,6 +288,10 @@ export class CoinService {
     await this.coin.update(coinId, { currentPrice: price });
   }
 
+  async markSnapshotBackfillComplete(coinId: string): Promise<void> {
+    await this.coin.update(coinId, { snapshotBackfillCompletedAt: new Date() });
+  }
+
   async clearRank() {
     await this.coin.createQueryBuilder().update().set({ geckoRank: null }).execute();
   }

--- a/apps/api/src/coin/dto/update-coin.dto.ts
+++ b/apps/api/src/coin/dto/update-coin.dto.ts
@@ -111,4 +111,10 @@ export class UpdateCoinDto {
 
   @IsDate()
   geckoLastUpdatedAt?: Date | null;
+
+  @IsDate()
+  metadataLastUpdated?: Date | null;
+
+  @IsDate()
+  snapshotBackfillCompletedAt?: Date | null;
 }

--- a/apps/api/src/coin/tasks/coin-detail-sync.service.spec.ts
+++ b/apps/api/src/coin/tasks/coin-detail-sync.service.spec.ts
@@ -5,6 +5,7 @@ import { type CoinGeckoClientService } from '../../shared/coingecko-client.servi
 import { type CoinService } from '../coin.service';
 
 // Mock CoinGecko SDK calls
+const mockMarkets = jest.fn();
 const mockCoinId = jest.fn();
 const mockTrending = jest.fn();
 
@@ -20,10 +21,16 @@ jest.mock('../../shared/retry.util', () => ({
   })
 }));
 
-// Mock mapCoinGeckoDetailToUpdate to track calls
-const mockMapDetail = jest.fn().mockReturnValue({ description: 'mapped' });
+// Track the markets mapper
+const mockMapMarkets = jest.fn().mockImplementation((entry: any) => ({ currentPrice: entry.current_price }));
+jest.mock('./map-coingecko-markets.util', () => ({
+  mapCoinGeckoMarketsToUpdate: (...args: any[]) => mockMapMarkets(...args)
+}));
+
+// Track the metadata mapper
+const mockMapMetadata = jest.fn().mockImplementation(() => ({ description: 'refreshed' }));
 jest.mock('./map-coingecko-detail.util', () => ({
-  mapCoinGeckoDetailToUpdate: (...args: any[]) => mockMapDetail(...args)
+  mapCoinGeckoDetailToMetadataUpdate: (...args: any[]) => mockMapMetadata(...args)
 }));
 
 jest.useFakeTimers();
@@ -36,12 +43,21 @@ describe('CoinDetailSyncService', () => {
     Pick<CircuitBreakerService, 'configure' | 'isOpen' | 'recordSuccess' | 'recordFailure'>
   >;
 
-  const makeCoin = (overrides: Partial<{ id: string; slug: string; symbol: string; geckoRank: number | null }> = {}) =>
+  const makeCoin = (
+    overrides: Partial<{
+      id: string;
+      slug: string;
+      symbol: string;
+      geckoRank: number | null;
+      metadataLastUpdated: Date | null;
+    }> = {}
+  ) =>
     ({
       id: overrides.id ?? 'coin-1',
       slug: overrides.slug ?? 'bitcoin',
       symbol: overrides.symbol ?? 'btc',
-      geckoRank: overrides.geckoRank ?? null
+      geckoRank: overrides.geckoRank ?? null,
+      metadataLastUpdated: overrides.metadataLastUpdated ?? null
     }) as any;
 
   beforeEach(() => {
@@ -57,7 +73,8 @@ describe('CoinDetailSyncService', () => {
     geckoService = {
       client: {
         coins: {
-          getID: mockCoinId
+          getID: mockCoinId,
+          markets: { get: mockMarkets }
         },
         search: {
           trending: { get: mockTrending }
@@ -79,290 +96,279 @@ describe('CoinDetailSyncService', () => {
     jest.clearAllTimers();
   });
 
-  it('clears rank data before processing coins', async () => {
-    await service.syncCoinDetails();
+  describe('syncCoinDetails (batched markets path)', () => {
+    it('clears rank data before processing coins', async () => {
+      await service.syncCoinDetails();
 
-    expect(coinService.clearRank).toHaveBeenCalled();
-  });
-
-  it('awaits clearRank before getCoins and applyTrendingRanks', async () => {
-    const order: string[] = [];
-
-    coinService.clearRank.mockImplementation(async () => {
-      order.push('clearRank');
-    });
-    coinService.getCoins.mockImplementation(async () => {
-      order.push('getCoins');
-      return [];
-    });
-    mockTrending.mockImplementation(async () => {
-      order.push('trending');
-      return { coins: [] };
+      expect(coinService.clearRank).toHaveBeenCalled();
     });
 
-    await service.syncCoinDetails();
+    it('issues a single /coins/markets call for a 250-coin batch', async () => {
+      const coins = Array.from({ length: 250 }, (_, i) =>
+        makeCoin({ id: `c${i}`, slug: `coin-${i}`, symbol: `s${i}` })
+      );
+      coinService.getCoins.mockResolvedValue(coins);
+      mockMarkets.mockResolvedValue(coins.map((c) => ({ id: c.slug, current_price: 100 })));
 
-    expect(order.indexOf('clearRank')).toBeLessThan(order.indexOf('getCoins'));
-  });
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      const result = await promise;
 
-  it('applies trending rank scores to matching coins by slug', async () => {
-    const btc = makeCoin({ id: 'btc-id', slug: 'bitcoin', symbol: 'btc' });
-    const eth = makeCoin({ id: 'eth-id', slug: 'ethereum', symbol: 'eth' });
-    coinService.getCoins.mockResolvedValue([btc, eth]);
-    mockTrending.mockResolvedValue({
-      coins: [
-        { id: 'bitcoin', score: 3 },
-        { id: 'unknown-coin', score: 1 } // no match — should be ignored
-      ]
-    });
-    mockCoinId.mockResolvedValue({ market_data: {} });
-
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    await promise;
-
-    expect(btc.geckoRank).toBe(3);
-    expect(eth.geckoRank).toBeNull(); // not in trending
-  });
-
-  it('skips trending items with missing item.id', async () => {
-    const btc = makeCoin({ slug: 'bitcoin' });
-    coinService.getCoins.mockResolvedValue([btc]);
-    mockTrending.mockResolvedValue({
-      coins: [{}, { id: 'bitcoin', score: 5 }]
-    });
-    mockCoinId.mockResolvedValue({ market_data: {} });
-
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    await promise;
-
-    expect(btc.geckoRank).toBe(5);
-  });
-
-  it('passes gecko response, geckoRank, and symbol to mapping util', async () => {
-    const coin = makeCoin({ id: 'c1', slug: 'bitcoin', symbol: 'btc', geckoRank: 7 });
-    coinService.getCoins.mockResolvedValue([coin]);
-    const geckoResponse = { market_data: { total_volume: { usd: 100 } } };
-    mockCoinId.mockResolvedValue(geckoResponse);
-
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    await promise;
-
-    expect(mockMapDetail).toHaveBeenCalledWith(geckoResponse, 7, 'btc');
-    expect(coinService.update).toHaveBeenCalledWith('c1', { description: 'mapped' });
-  });
-
-  it('skips coin update when withRateLimitRetry reports failure', async () => {
-    coinService.getCoins.mockResolvedValue([makeCoin({ id: 'c1', slug: 'fail-coin', symbol: 'fail' })]);
-    mockCoinId.mockRejectedValue(new Error('Rate limited'));
-
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    const result = await promise;
-
-    expect(coinService.update).not.toHaveBeenCalled();
-    expect(result).toEqual({ totalCoins: 1, updatedSuccessfully: 0, errors: 1 });
-  });
-
-  it('returns correct counts on mixed success/failure', async () => {
-    const coins = [
-      makeCoin({ id: 'c1', slug: 'ok-coin', symbol: 'ok' }),
-      makeCoin({ id: 'c2', slug: 'bad-coin', symbol: 'bad' })
-    ];
-    coinService.getCoins.mockResolvedValue(coins);
-
-    mockCoinId.mockImplementation(async (id: string) => {
-      if (id === 'bad-coin') throw new Error('API error');
-      return { market_data: {} };
+      expect(mockMarkets).toHaveBeenCalledTimes(1);
+      expect(mockMarkets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vs_currency: 'usd',
+          ids: expect.stringContaining('coin-0'),
+          per_page: 250
+        })
+      );
+      expect(result.totalCoins).toBe(250);
+      expect(result.updatedSuccessfully).toBe(250);
+      expect(result.errors).toBe(0);
     });
 
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    const result = await promise;
+    it('splits >250 coins into multiple batches', async () => {
+      const coins = Array.from({ length: 260 }, (_, i) =>
+        makeCoin({ id: `c${i}`, slug: `coin-${i}`, symbol: `s${i}` })
+      );
+      coinService.getCoins.mockResolvedValue(coins);
+      mockMarkets.mockImplementation(async (params: any) => {
+        const ids = String(params.ids).split(',');
+        return ids.map((id) => ({ id, current_price: 10 }));
+      });
 
-    expect(result).toEqual({
-      totalCoins: 2,
-      updatedSuccessfully: 1,
-      errors: 1
-    });
-    // update should only be called for the successful coin
-    expect(coinService.update).toHaveBeenCalledTimes(1);
-  });
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      await promise;
 
-  it('counts error when coinService.update throws', async () => {
-    coinService.getCoins.mockResolvedValue([makeCoin({ id: 'c1', slug: 'coin-1', symbol: 'sym' })]);
-    mockCoinId.mockResolvedValue({ market_data: {} });
-    coinService.update.mockRejectedValue(new Error('DB write failed'));
-
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    const result = await promise;
-
-    expect(result).toEqual({ totalCoins: 1, updatedSuccessfully: 0, errors: 1 });
-  });
-
-  it('handles trending fetch failure gracefully and still updates coins', async () => {
-    coinService.getCoins.mockResolvedValue([makeCoin()]);
-    mockTrending.mockRejectedValue(new Error('Trending API down'));
-    mockCoinId.mockResolvedValue({ market_data: {} });
-
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    const result = await promise;
-
-    expect(result.updatedSuccessfully).toBe(1);
-    expect(result.errors).toBe(0);
-  });
-
-  it('returns zeroes when no coins exist', async () => {
-    const result = await service.syncCoinDetails();
-
-    expect(result).toEqual({ totalCoins: 0, updatedSuccessfully: 0, errors: 0 });
-    expect(coinService.update).not.toHaveBeenCalled();
-  });
-
-  it('reports progress through all stages', async () => {
-    coinService.getCoins.mockResolvedValue([makeCoin()]);
-    mockCoinId.mockResolvedValue({ market_data: {} });
-
-    const progress = jest.fn();
-    const promise = service.syncCoinDetails(progress);
-    await jest.runAllTimersAsync();
-    await promise;
-
-    const calls = progress.mock.calls.map(([v]: [number]) => v);
-    // Must start at 5, pass through 10, 30, and end at 100
-    expect(calls[0]).toBe(5);
-    expect(calls[1]).toBe(10);
-    expect(calls[2]).toBe(30);
-    expect(calls[calls.length - 1]).toBe(100);
-    // All values should be monotonically non-decreasing
-    for (let i = 1; i < calls.length; i++) {
-      expect(calls[i]).toBeGreaterThanOrEqual(calls[i - 1]);
-    }
-  });
-
-  it('records circuit breaker success on API success and failure on API error', async () => {
-    const coins = [
-      makeCoin({ id: 'c1', slug: 'ok-coin', symbol: 'ok' }),
-      makeCoin({ id: 'c2', slug: 'bad-coin', symbol: 'bad' })
-    ];
-    coinService.getCoins.mockResolvedValue(coins);
-
-    mockCoinId.mockImplementation(async (id: string) => {
-      if (id === 'bad-coin') throw new Error('API error');
-      return { market_data: {} };
+      expect(mockMarkets).toHaveBeenCalledTimes(2);
     });
 
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    await promise;
+    it('passes the mapped markets entry, geckoRank, and symbol to the markets mapper', async () => {
+      const coin = makeCoin({ id: 'c1', slug: 'bitcoin', symbol: 'btc', geckoRank: 7 });
+      coinService.getCoins.mockResolvedValue([coin]);
+      const marketsEntry = { id: 'bitcoin', current_price: 42000, market_cap: 1e12 };
+      mockMarkets.mockResolvedValue([marketsEntry]);
 
-    expect(circuitBreaker.recordSuccess).toHaveBeenCalledWith('coingecko-detail');
-    expect(circuitBreaker.recordFailure).toHaveBeenCalledWith('coingecko-detail');
-  });
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      await promise;
 
-  it('pauses with exponential backoff when circuit opens then resumes and processes all coins', async () => {
-    const coins = [
-      makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1' }),
-      makeCoin({ id: 'c2', slug: 'coin-2', symbol: 's2' }),
-      makeCoin({ id: 'c3', slug: 'coin-3', symbol: 's3' }),
-      makeCoin({ id: 'c4', slug: 'coin-4', symbol: 's4' })
-    ];
-    coinService.getCoins.mockResolvedValue(coins);
-    mockCoinId.mockResolvedValue({ market_data: {} });
-
-    // Circuit opens after first batch, stays open for one check, then closes
-    let circuitCallCount = 0;
-    circuitBreaker.isOpen.mockImplementation(() => {
-      circuitCallCount++;
-      // Open on the 2nd call (before second batch), closed on retry
-      return circuitCallCount === 2;
+      expect(mockMapMarkets).toHaveBeenCalledWith(marketsEntry, 7, 'btc');
+      expect(coinService.update).toHaveBeenCalledWith('c1', { currentPrice: 42000 });
     });
 
-    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    it('counts batch-level API failure as all-coins-failed', async () => {
+      const coins = [makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1' })];
+      coinService.getCoins.mockResolvedValue(coins);
+      mockMarkets.mockRejectedValue(new Error('API down'));
 
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    const result = await promise;
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      const result = await promise;
 
-    // All 4 coins should be processed — no abort
-    expect(result.totalCoins).toBe(4);
-    expect(result.updatedSuccessfully).toBe(4);
-    expect(result.errors).toBe(0);
-
-    // First circuit pause should be at base backoff (CIRCUIT_RESET_MS = 45s)
-    const circuitPauseDelays = setTimeoutSpy.mock.calls
-      .map(([, ms]) => ms)
-      .filter((ms): ms is number => typeof ms === 'number' && ms >= 45_000);
-    expect(circuitPauseDelays[0]).toBe(45_000);
-
-    setTimeoutSpy.mockRestore();
-  });
-
-  it('resets backoff after successful batch', async () => {
-    const coins = Array.from({ length: 9 }, (_, i) => makeCoin({ id: `c${i}`, slug: `coin-${i}`, symbol: `s${i}` }));
-    coinService.getCoins.mockResolvedValue(coins);
-    mockCoinId.mockResolvedValue({ market_data: {} });
-
-    // Circuit opens twice with a success in between — second pause should reset to base backoff
-    let isOpenCallCount = 0;
-    circuitBreaker.isOpen.mockImplementation(() => {
-      isOpenCallCount++;
-      // Open before batch 2 (call 2) and before batch 3's retry (call 4)
-      return isOpenCallCount === 2 || isOpenCallCount === 4;
+      expect(result).toEqual({ totalCoins: 1, updatedSuccessfully: 0, errors: 1 });
+      expect(coinService.update).not.toHaveBeenCalled();
     });
 
-    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    it('counts coins missing from the markets response as failures', async () => {
+      const coins = [
+        makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1' }),
+        makeCoin({ id: 'c2', slug: 'coin-2', symbol: 's2' })
+      ];
+      coinService.getCoins.mockResolvedValue(coins);
+      // Only one coin in response
+      mockMarkets.mockResolvedValue([{ id: 'coin-1', current_price: 10 }]);
 
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    const result = await promise;
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      const result = await promise;
 
-    // All coins processed despite two circuit pauses
-    expect(result.totalCoins).toBe(9);
-    expect(result.updatedSuccessfully).toBe(9);
-
-    // Both pauses should be at base backoff (45s) since consecutivePauses resets between them
-    const circuitPauses = setTimeoutSpy.mock.calls
-      .map(([, ms]) => ms)
-      .filter((ms): ms is number => typeof ms === 'number' && ms >= 45_000);
-    expect(circuitPauses).toHaveLength(2);
-    expect(circuitPauses.every((ms) => ms === 45_000)).toBe(true);
-
-    setTimeoutSpy.mockRestore();
-  });
-
-  it('uses elevated batch delay after circuit pause, normalizes after 3 successes', async () => {
-    // 4 batches of 3 = 12 coins. Circuit opens before batch 1.
-    const coins = Array.from({ length: 12 }, (_, i) => makeCoin({ id: `c${i}`, slug: `coin-${i}`, symbol: `s${i}` }));
-    coinService.getCoins.mockResolvedValue(coins);
-    mockCoinId.mockResolvedValue({ market_data: {} });
-
-    // Circuit open only on the very first check
-    let isOpenCallCount = 0;
-    circuitBreaker.isOpen.mockImplementation(() => {
-      isOpenCallCount++;
-      return isOpenCallCount === 1;
+      expect(result).toEqual({ totalCoins: 2, updatedSuccessfully: 1, errors: 1 });
     });
 
-    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    it('records circuit breaker success on successful batch and failure on batch API error', async () => {
+      const coins = [makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1' })];
+      coinService.getCoins.mockResolvedValue(coins);
+      mockMarkets.mockResolvedValueOnce([{ id: 'coin-1', current_price: 10 }]);
 
-    const promise = service.syncCoinDetails();
-    await jest.runAllTimersAsync();
-    await promise;
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      await promise;
 
-    const delays = setTimeoutSpy.mock.calls
-      .map(([, ms]) => ms)
-      .filter((ms): ms is number => typeof ms === 'number' && ms > 1000);
+      expect(circuitBreaker.recordSuccess).toHaveBeenCalledWith('coingecko-detail');
+    });
 
-    // First timeout is the circuit pause (45s), then elevated delays (6s) until normalization
-    expect(delays[0]).toBe(45_000); // circuit backoff
-    // After circuit pause, first inter-batch delays should be elevated (6000ms)
-    expect(delays.filter((t) => t === 6000).length).toBeGreaterThanOrEqual(1);
+    it('applies trending rank scores to matching coins by slug', async () => {
+      const btc = makeCoin({ id: 'btc-id', slug: 'bitcoin', symbol: 'btc' });
+      const eth = makeCoin({ id: 'eth-id', slug: 'ethereum', symbol: 'eth' });
+      coinService.getCoins.mockResolvedValue([btc, eth]);
+      mockTrending.mockResolvedValue({
+        coins: [{ id: 'bitcoin', score: 3 }]
+      });
+      mockMarkets.mockResolvedValue([
+        { id: 'bitcoin', current_price: 100 },
+        { id: 'ethereum', current_price: 50 }
+      ]);
 
-    setTimeoutSpy.mockRestore();
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      await promise;
+
+      expect(btc.geckoRank).toBe(3);
+      expect(eth.geckoRank).toBeNull();
+    });
+
+    it('handles trending fetch failure gracefully and still updates coins', async () => {
+      const coin = makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1' });
+      coinService.getCoins.mockResolvedValue([coin]);
+      mockTrending.mockRejectedValue(new Error('Trending API down'));
+      mockMarkets.mockResolvedValue([{ id: 'coin-1', current_price: 10 }]);
+
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.updatedSuccessfully).toBe(1);
+    });
+
+    it('returns zeroes when no coins exist', async () => {
+      const result = await service.syncCoinDetails();
+
+      expect(result).toEqual({ totalCoins: 0, updatedSuccessfully: 0, errors: 0 });
+      expect(coinService.update).not.toHaveBeenCalled();
+      expect(mockMarkets).not.toHaveBeenCalled();
+    });
+
+    it('reports progress through all stages', async () => {
+      const coins = [makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1' })];
+      coinService.getCoins.mockResolvedValue(coins);
+      mockMarkets.mockResolvedValue([{ id: 'coin-1', current_price: 10 }]);
+
+      const progress = jest.fn();
+      const promise = service.syncCoinDetails(progress);
+      await jest.runAllTimersAsync();
+      await promise;
+
+      const calls = progress.mock.calls.map(([v]: [number]) => v);
+      expect(calls[0]).toBe(5);
+      expect(calls[calls.length - 1]).toBe(100);
+      for (let i = 1; i < calls.length; i++) {
+        expect(calls[i]).toBeGreaterThanOrEqual(calls[i - 1]);
+      }
+    });
+
+    it('pauses with backoff when circuit opens, then resumes', async () => {
+      const coins = Array.from({ length: 251 }, (_, i) =>
+        makeCoin({ id: `c${i}`, slug: `coin-${i}`, symbol: `s${i}` })
+      );
+      coinService.getCoins.mockResolvedValue(coins);
+      mockMarkets.mockImplementation(async (params: any) => {
+        const ids = String(params.ids).split(',');
+        return ids.map((id) => ({ id, current_price: 1 }));
+      });
+
+      let circuitCallCount = 0;
+      circuitBreaker.isOpen.mockImplementation(() => {
+        circuitCallCount++;
+        return circuitCallCount === 2; // open between batch 1 and batch 2, closed after
+      });
+
+      const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+
+      const promise = service.syncCoinDetails();
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.totalCoins).toBe(251);
+      expect(result.updatedSuccessfully).toBe(251);
+      const circuitPauseDelays = setTimeoutSpy.mock.calls
+        .map(([, ms]) => ms)
+        .filter((ms): ms is number => typeof ms === 'number' && ms >= 45_000);
+      expect(circuitPauseDelays[0]).toBe(45_000);
+
+      setTimeoutSpy.mockRestore();
+    });
+  });
+
+  describe('syncCoinMetadata', () => {
+    it('refreshes coins with stale metadata and persists metadataLastUpdated', async () => {
+      const oldDate = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000); // 60 days ago
+      const staleCoin = makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1', metadataLastUpdated: oldDate });
+      coinService.getCoins.mockResolvedValue([staleCoin]);
+      mockCoinId.mockResolvedValue({ description: { en: 'refreshed' }, genesis_date: '2009-01-03' });
+
+      const promise = service.syncCoinMetadata();
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(mockCoinId).toHaveBeenCalledWith('coin-1', expect.any(Object));
+      expect(coinService.update).toHaveBeenCalledWith(
+        'c1',
+        expect.objectContaining({
+          description: 'refreshed',
+          metadataLastUpdated: expect.any(Date)
+        })
+      );
+      expect(result.updatedSuccessfully).toBe(1);
+      expect(result.skipped).toBe(0);
+    });
+
+    it('skips coins whose metadata was refreshed within 25 days', async () => {
+      const freshDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // 10 days ago
+      const oldDate = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000); // 60 days ago
+      coinService.getCoins.mockResolvedValue([
+        makeCoin({ id: 'c-fresh', slug: 'fresh', symbol: 'fr', metadataLastUpdated: freshDate }),
+        makeCoin({ id: 'c-old', slug: 'old', symbol: 'ol', metadataLastUpdated: oldDate })
+      ]);
+      mockCoinId.mockResolvedValue({ description: { en: 'x' } });
+
+      const promise = service.syncCoinMetadata();
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(mockCoinId).toHaveBeenCalledTimes(1);
+      expect(mockCoinId).toHaveBeenCalledWith('old', expect.any(Object));
+      expect(result.updatedSuccessfully).toBe(1);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('treats null metadataLastUpdated as stale', async () => {
+      const coin = makeCoin({ id: 'c-null', slug: 'never', symbol: 'nv', metadataLastUpdated: null });
+      coinService.getCoins.mockResolvedValue([coin]);
+      mockCoinId.mockResolvedValue({ description: { en: 'x' } });
+
+      const promise = service.syncCoinMetadata();
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(mockCoinId).toHaveBeenCalledTimes(1);
+      expect(result.updatedSuccessfully).toBe(1);
+    });
+
+    it('records API failures without throwing', async () => {
+      const staleCoin = makeCoin({ id: 'c1', slug: 'coin-1', symbol: 's1', metadataLastUpdated: null });
+      coinService.getCoins.mockResolvedValue([staleCoin]);
+      mockCoinId.mockRejectedValue(new Error('Rate limited'));
+
+      const promise = service.syncCoinMetadata();
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.errors).toBe(1);
+      expect(result.updatedSuccessfully).toBe(0);
+    });
+
+    it('returns zeroes when nothing needs refresh', async () => {
+      const freshDate = new Date();
+      coinService.getCoins.mockResolvedValue([
+        makeCoin({ id: 'c1', slug: 'bitcoin', symbol: 'btc', metadataLastUpdated: freshDate })
+      ]);
+
+      const result = await service.syncCoinMetadata();
+
+      expect(mockCoinId).not.toHaveBeenCalled();
+      expect(result).toEqual({ totalCoins: 1, updatedSuccessfully: 0, skipped: 1, errors: 0 });
+    });
   });
 });

--- a/apps/api/src/coin/tasks/coin-detail-sync.service.ts
+++ b/apps/api/src/coin/tasks/coin-detail-sync.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
-import { mapCoinGeckoDetailToUpdate } from './map-coingecko-detail.util';
+import { mapCoinGeckoDetailToMetadataUpdate } from './map-coingecko-detail.util';
+import { mapCoinGeckoMarketsToUpdate } from './map-coingecko-markets.util';
 
 import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { CoinGeckoClientService } from '../../shared/coingecko-client.service';
@@ -18,6 +19,8 @@ export class CoinDetailSyncService {
   private static readonly NORMAL_BATCH_DELAY_MS = 3000;
   private static readonly ELEVATED_BATCH_DELAY_MS = 6000;
   private static readonly SUCCESS_BATCHES_TO_NORMALIZE = 3;
+  private static readonly MARKETS_BATCH_SIZE = 250;
+  private static readonly METADATA_MIN_AGE_MS = 25 * 24 * 60 * 60 * 1000; // skip coins refreshed within 25 days
   private readonly logger = new Logger(CoinDetailSyncService.name);
 
   constructor(
@@ -32,13 +35,17 @@ export class CoinDetailSyncService {
   }
 
   /**
-   * Syncs detailed coin information from CoinGecko for all coins in the database.
+   * Daily sync — batches all coins through /coins/markets (250 per call) to refresh
+   * price, market cap, volume, supply, ATH/ATL, and price-change percentages.
+   * Metadata fields (description, links, scores, sentiment) are refreshed separately
+   * by syncCoinMetadata() on a monthly cadence.
+   *
    * @param onProgress Optional callback to report progress (0-100).
    */
   async syncCoinDetails(
     onProgress?: (percent: number) => Promise<void>
   ): Promise<{ totalCoins: number; updatedSuccessfully: number; errors: number }> {
-    this.logger.log('Starting Detailed Coins Update');
+    this.logger.log('Starting Coin Markets Sync');
     await onProgress?.(5);
 
     this.logger.log('Clearing previous rank data...');
@@ -50,14 +57,20 @@ export class CoinDetailSyncService {
     await this.applyTrendingRanks(allCoins);
     await onProgress?.(30);
 
+    if (allCoins.length === 0) {
+      await onProgress?.(100);
+      return { totalCoins: 0, updatedSuccessfully: 0, errors: 0 };
+    }
+
     let updatedCount = 0;
     let errorCount = 0;
-    const batchSize = 1;
     const startedAt = Date.now();
-    let batchIndex = 0;
     let consecutivePauses = 0;
     let currentBatchDelay = CoinDetailSyncService.NORMAL_BATCH_DELAY_MS;
     let successBatchesSincePause = 0;
+
+    const coinsBySlug = new Map(allCoins.map((c) => [c.slug, c]));
+    const batchSize = CoinDetailSyncService.MARKETS_BATCH_SIZE;
 
     for (let i = 0; i < allCoins.length; i += batchSize) {
       if (this.circuitBreaker.isOpen(CoinDetailSyncService.CIRCUIT_KEY)) {
@@ -78,7 +91,104 @@ export class CoinDetailSyncService {
       }
 
       const batch = allCoins.slice(i, i + batchSize);
-      const results = await this.updateCoinBatch(batch);
+      const { success, fail } = await this.updateMarketsBatch(batch, coinsBySlug);
+      updatedCount += success;
+      errorCount += fail;
+
+      if (success > 0) {
+        consecutivePauses = 0;
+        if (fail === 0) {
+          successBatchesSincePause++;
+          if (successBatchesSincePause >= CoinDetailSyncService.SUCCESS_BATCHES_TO_NORMALIZE) {
+            currentBatchDelay = CoinDetailSyncService.NORMAL_BATCH_DELAY_MS;
+          }
+        } else {
+          successBatchesSincePause = 0;
+        }
+      }
+
+      const elapsedMinutes = ((Date.now() - startedAt) / 60_000).toFixed(1);
+      this.logger.log(
+        `coin-market-sync progress: ${Math.min(i + batchSize, allCoins.length)}/${allCoins.length} (${elapsedMinutes}m elapsed)`
+      );
+
+      const progressPercent = Math.min(35 + Math.floor(((i + batchSize) / allCoins.length) * 60), 95);
+      await onProgress?.(progressPercent);
+
+      if (i + batchSize < allCoins.length) {
+        await new Promise((resolve) => setTimeout(resolve, currentBatchDelay));
+      }
+    }
+
+    await onProgress?.(100);
+    this.logger.log('Coin Markets Sync Complete');
+
+    return {
+      totalCoins: allCoins.length,
+      updatedSuccessfully: updatedCount,
+      errors: errorCount
+    };
+  }
+
+  /**
+   * Monthly sync — refreshes metadata fields (description, genesis, scores, sentiment)
+   * via per-coin /coins/{id}. Coins whose metadata was updated within
+   * `METADATA_MIN_AGE_MS` (25 days) are skipped — popular coins get refreshed lazily
+   * when users view their detail pages via CoinMarketDataService.
+   */
+  async syncCoinMetadata(
+    onProgress?: (percent: number) => Promise<void>
+  ): Promise<{ totalCoins: number; updatedSuccessfully: number; skipped: number; errors: number }> {
+    this.logger.log('Starting Coin Metadata Sync');
+    await onProgress?.(5);
+
+    const allCoins = await this.coinService.getCoins();
+    const cutoff = Date.now() - CoinDetailSyncService.METADATA_MIN_AGE_MS;
+    const coinsToRefresh = allCoins.filter((c) => {
+      const lastUpdated = c.metadataLastUpdated ? new Date(c.metadataLastUpdated).getTime() : 0;
+      return lastUpdated < cutoff;
+    });
+    const skipped = allCoins.length - coinsToRefresh.length;
+
+    this.logger.log(
+      `Metadata sync: ${coinsToRefresh.length} coins need refresh, ${skipped} skipped (refreshed within 25d)`
+    );
+    await onProgress?.(10);
+
+    if (coinsToRefresh.length === 0) {
+      await onProgress?.(100);
+      return { totalCoins: allCoins.length, updatedSuccessfully: 0, skipped, errors: 0 };
+    }
+
+    let updatedCount = 0;
+    let errorCount = 0;
+    const batchSize = 1;
+    const startedAt = Date.now();
+    let batchIndex = 0;
+    let consecutivePauses = 0;
+    let currentBatchDelay = CoinDetailSyncService.NORMAL_BATCH_DELAY_MS;
+    let successBatchesSincePause = 0;
+
+    for (let i = 0; i < coinsToRefresh.length; i += batchSize) {
+      if (this.circuitBreaker.isOpen(CoinDetailSyncService.CIRCUIT_KEY)) {
+        consecutivePauses++;
+        const backoffMs = Math.min(
+          CoinDetailSyncService.CIRCUIT_RESET_MS *
+            Math.pow(CoinDetailSyncService.BACKOFF_MULTIPLIER, consecutivePauses - 1),
+          CoinDetailSyncService.MAX_BACKOFF_MS
+        );
+        this.logger.warn(
+          `Circuit open — pausing metadata sync for ${(backoffMs / 1000).toFixed(0)}s (pause #${consecutivePauses})`
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        currentBatchDelay = CoinDetailSyncService.ELEVATED_BATCH_DELAY_MS;
+        successBatchesSincePause = 0;
+        i -= batchSize;
+        continue;
+      }
+
+      const batch = coinsToRefresh.slice(i, i + batchSize);
+      const results = await this.updateMetadataBatch(batch);
 
       const successCount = results.filter((r) => r.success).length;
       const failCount = results.filter((r) => !r.success).length;
@@ -97,31 +207,29 @@ export class CoinDetailSyncService {
         }
       }
 
-      // Heartbeat every 30 batches (~75–150s depending on batch delay).
-      // Gives Loki enough datapoints to alert via `absent_over_time`
-      // with a tight window, without spamming.
       batchIndex++;
       if (batchIndex % 30 === 0) {
         const elapsedMinutes = ((Date.now() - startedAt) / 60_000).toFixed(1);
         this.logger.log(
-          `coin-detail progress: ${Math.min(i + batchSize, allCoins.length)}/${allCoins.length} (${elapsedMinutes}m elapsed)`
+          `coin-metadata-sync progress: ${Math.min(i + batchSize, coinsToRefresh.length)}/${coinsToRefresh.length} (${elapsedMinutes}m elapsed)`
         );
       }
 
-      const progressPercent = Math.min(35 + Math.floor(((i + batchSize) / allCoins.length) * 60), 95);
+      const progressPercent = Math.min(15 + Math.floor(((i + batchSize) / coinsToRefresh.length) * 80), 95);
       await onProgress?.(progressPercent);
 
-      if (i + batchSize < allCoins.length) {
+      if (i + batchSize < coinsToRefresh.length) {
         await new Promise((resolve) => setTimeout(resolve, currentBatchDelay));
       }
     }
 
     await onProgress?.(100);
-    this.logger.log('Detailed Coins Update Complete');
+    this.logger.log('Coin Metadata Sync Complete');
 
     return {
       totalCoins: allCoins.length,
       updatedSuccessfully: updatedCount,
+      skipped,
       errors: errorCount
     };
   }
@@ -148,24 +256,92 @@ export class CoinDetailSyncService {
   }
 
   /**
-   * Fetches detailed info for a batch of coins and updates the database.
+   * Fetches /coins/markets for a batch of up to 250 coins and updates the DB.
+   * One API call per batch.
    */
-  private async updateCoinBatch(batch: Coin[]): Promise<{ success: boolean; error?: string }[]> {
+  private async updateMarketsBatch(
+    batch: Coin[],
+    coinsBySlug: Map<string, Coin>
+  ): Promise<{ success: number; fail: number }> {
+    if (batch.length === 0) return { success: 0, fail: 0 };
+
+    const ids = batch.map((c) => c.slug).join(',');
+
+    const retryResult = await withRateLimitRetry(
+      () =>
+        this.gecko.client.coins.markets.get({
+          vs_currency: 'usd',
+          ids,
+          per_page: CoinDetailSyncService.MARKETS_BATCH_SIZE,
+          price_change_percentage: '24h,7d,14d,30d,200d,1y'
+        } as any),
+      {
+        maxRetries: 3,
+        logger: this.logger,
+        operationName: `markets(${batch.length} coins)`
+      }
+    );
+
+    if (retryResult.success) {
+      this.circuitBreaker.recordSuccess(CoinDetailSyncService.CIRCUIT_KEY);
+    } else {
+      this.circuitBreaker.recordFailure(CoinDetailSyncService.CIRCUIT_KEY);
+      const { message } = toErrorInfo(retryResult.error);
+      this.logger.error(`Failed to fetch markets batch: ${message}`);
+      return { success: 0, fail: batch.length };
+    }
+
+    const entries = (retryResult.result ?? []) as Array<Record<string, any>>;
+    let success = 0;
+    let fail = 0;
+
+    for (const entry of entries) {
+      const slug = entry.id;
+      if (!slug) continue;
+      const coin = coinsBySlug.get(slug);
+      if (!coin) continue;
+
+      try {
+        const updateDto = mapCoinGeckoMarketsToUpdate(entry, coin.geckoRank, coin.symbol);
+        await this.coinService.update(coin.id, updateDto);
+        success++;
+      } catch (error: unknown) {
+        const { message } = toErrorInfo(error);
+        this.logger.error(`Failed to persist markets update for ${coin.symbol}: ${message}`);
+        fail++;
+      }
+    }
+
+    // Coins in batch that had no entry in the response are counted as failures
+    const returnedSlugs = new Set(entries.map((e) => e.id).filter(Boolean));
+    const missing = batch.filter((c) => !returnedSlugs.has(c.slug)).length;
+    fail += missing;
+
+    return { success, fail };
+  }
+
+  /**
+   * Fetches detailed info for a batch of coins and updates the database (metadata only).
+   */
+  private async updateMetadataBatch(batch: Coin[]): Promise<{ success: boolean; error?: string }[]> {
     return Promise.all(
-      batch.map(async ({ id, slug, symbol, geckoRank }) => {
+      batch.map(async ({ id, slug, symbol }) => {
         try {
-          this.logger.debug(`Updating details for ${symbol} (${slug})`);
+          this.logger.debug(`Refreshing metadata for ${symbol} (${slug})`);
 
           const retryResult = await withRateLimitRetry(
             () =>
               this.gecko.client.coins.getID(slug, {
                 localization: false,
-                tickers: false
-              }),
+                tickers: false,
+                market_data: false,
+                community_data: true,
+                developer_data: true
+              } as any),
             {
               maxRetries: 3,
               logger: this.logger,
-              operationName: `coinId(${symbol})`
+              operationName: `coinMetadata(${symbol})`
             }
           );
 
@@ -177,20 +353,23 @@ export class CoinDetailSyncService {
 
           if (!retryResult.success) {
             const { message } = toErrorInfo(retryResult.error);
-            this.logger.error(`Failed to update ${symbol}: ${message}`);
+            this.logger.error(`Failed to refresh metadata for ${symbol}: ${message}`);
             return { success: false, error: message };
           }
 
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by retryResult.success check
           const coin = retryResult.result!;
-          const updateDto = mapCoinGeckoDetailToUpdate(coin, geckoRank, symbol);
+          const updateDto = {
+            ...mapCoinGeckoDetailToMetadataUpdate(coin, symbol),
+            metadataLastUpdated: new Date()
+          };
           await this.coinService.update(id, updateDto);
 
-          this.logger.debug(`Successfully updated ${symbol}`);
+          this.logger.debug(`Successfully refreshed metadata for ${symbol}`);
           return { success: true };
         } catch (error: unknown) {
           const { message } = toErrorInfo(error);
-          this.logger.error(`Failed to update ${symbol}: ${message}`);
+          this.logger.error(`Failed to refresh metadata for ${symbol}: ${message}`);
           return { success: false, error: message };
         }
       })

--- a/apps/api/src/coin/tasks/coin-sync.task.spec.ts
+++ b/apps/api/src/coin/tasks/coin-sync.task.spec.ts
@@ -9,24 +9,28 @@ import { type CoinDailySnapshotService } from '../coin-daily-snapshot.service';
 import { type CoinListingEventService } from '../coin-listing-event.service';
 import { type CoinMarketDataService } from '../coin-market-data.service';
 import { type CoinService } from '../coin.service';
+import { type ExchangeTickerFetcherService } from '../ticker-pairs/services/exchange-ticker-fetcher.service';
 
 // Mock CoinGecko SDK calls
 const mockCoinList = jest.fn();
-const mockExchangeIdTickers = jest.fn();
 
 describe('CoinSyncTask', () => {
   let task: CoinSyncTask;
-  let queue: { getRepeatableJobs: jest.Mock; add: jest.Mock };
+  let queue: { getRepeatableJobs: jest.Mock; add: jest.Mock; removeRepeatableByKey: jest.Mock };
   let coinService: jest.Mocked<
-    Pick<CoinService, 'getCoins' | 'createMany' | 'update' | 'removeMany' | 'relistMany' | 'clearRank'>
+    Pick<
+      CoinService,
+      'getCoins' | 'createMany' | 'update' | 'removeMany' | 'relistMany' | 'clearRank' | 'markSnapshotBackfillComplete'
+    >
   >;
   let exchangeService: jest.Mocked<Pick<ExchangeService, 'getExchanges'>>;
   let listingEventService: jest.Mocked<Pick<CoinListingEventService, 'recordBulkDelistings' | 'recordBulkRelistings'>>;
-  let coinDetailSync: jest.Mocked<Pick<CoinDetailSyncService, 'syncCoinDetails'>>;
+  let coinDetailSync: jest.Mocked<Pick<CoinDetailSyncService, 'syncCoinDetails' | 'syncCoinMetadata'>>;
   let snapshotService: jest.Mocked<
     Pick<CoinDailySnapshotService, 'captureSnapshots' | 'getCoinsNeedingBackfill' | 'backfillFromHistoricalData'>
   >;
   let coinMarketData: jest.Mocked<Pick<CoinMarketDataService, 'getCoinHistoricalData'>>;
+  let tickerFetcher: jest.Mocked<Pick<ExchangeTickerFetcherService, 'fetchAllTickersForExchange'>>;
   let geckoService: CoinGeckoClientService;
 
   const originalEnv = process.env;
@@ -43,7 +47,8 @@ describe('CoinSyncTask', () => {
 
     queue = {
       getRepeatableJobs: jest.fn().mockResolvedValue([]),
-      add: jest.fn().mockResolvedValue(undefined)
+      add: jest.fn().mockResolvedValue(undefined),
+      removeRepeatableByKey: jest.fn().mockResolvedValue(true)
     };
 
     coinService = {
@@ -52,7 +57,8 @@ describe('CoinSyncTask', () => {
       update: jest.fn().mockResolvedValue(undefined),
       removeMany: jest.fn().mockResolvedValue(undefined),
       relistMany: jest.fn().mockResolvedValue(undefined),
-      clearRank: jest.fn()
+      clearRank: jest.fn(),
+      markSnapshotBackfillComplete: jest.fn().mockResolvedValue(undefined)
     } as any;
 
     exchangeService = {
@@ -65,7 +71,8 @@ describe('CoinSyncTask', () => {
     } as any;
 
     coinDetailSync = {
-      syncCoinDetails: jest.fn().mockResolvedValue({ totalCoins: 0, updatedSuccessfully: 0, errors: 0 })
+      syncCoinDetails: jest.fn().mockResolvedValue({ totalCoins: 0, updatedSuccessfully: 0, errors: 0 }),
+      syncCoinMetadata: jest.fn().mockResolvedValue({ totalCoins: 0, updatedSuccessfully: 0, skipped: 0, errors: 0 })
     } as any;
 
     snapshotService = {
@@ -78,13 +85,14 @@ describe('CoinSyncTask', () => {
       getCoinHistoricalData: jest.fn().mockResolvedValue([])
     } as any;
 
+    tickerFetcher = {
+      fetchAllTickersForExchange: jest.fn().mockResolvedValue([])
+    } as any;
+
     geckoService = {
       client: {
         coins: {
           list: { get: mockCoinList }
-        },
-        exchanges: {
-          tickers: { get: mockExchangeIdTickers }
         }
       }
     } as unknown as CoinGeckoClientService;
@@ -97,6 +105,7 @@ describe('CoinSyncTask', () => {
       coinDetailSync as any,
       snapshotService as any,
       coinMarketData as any,
+      tickerFetcher as any,
       geckoService,
       { acquire: jest.fn().mockResolvedValue({ acquired: true, lockId: 'test' }), release: jest.fn() } as any,
       { isOpen: jest.fn().mockReturnValue(false), recordSuccess: jest.fn(), recordFailure: jest.fn() } as any,
@@ -127,27 +136,41 @@ describe('CoinSyncTask', () => {
       expect(queue.add).not.toHaveBeenCalled();
     });
 
-    it('schedules both coin-sync and coin-detail jobs in production', async () => {
+    it('schedules coin-sync, coin-market-sync, and coin-metadata-sync jobs in production', async () => {
       process.env.NODE_ENV = 'production';
       process.env.DISABLE_BACKGROUND_TASKS = 'false';
 
       await task.onModuleInit();
 
-      expect(queue.add).toHaveBeenCalledTimes(2);
+      expect(queue.add).toHaveBeenCalledTimes(3);
       expect(queue.add).toHaveBeenCalledWith(
         'coin-sync',
-        expect.objectContaining({ description: expect.stringContaining('coin-sync') }),
+        expect.any(Object),
         expect.objectContaining({
           attempts: 3,
-          repeat: { pattern: expect.any(String) },
-          backoff: { type: 'exponential', delay: 5000 }
+          repeat: { pattern: expect.any(String) }
         })
       );
       expect(queue.add).toHaveBeenCalledWith(
-        'coin-detail',
-        expect.objectContaining({ description: expect.stringContaining('coin-detail') }),
+        'coin-market-sync',
+        expect.any(Object),
         expect.objectContaining({ attempts: 3, repeat: { pattern: expect.any(String) } })
       );
+      expect(queue.add).toHaveBeenCalledWith(
+        'coin-metadata-sync',
+        expect.any(Object),
+        expect.objectContaining({ attempts: 3, repeat: { pattern: '0 2 1 * *' } })
+      );
+    });
+
+    it('removes the legacy coin-detail repeatable job if still scheduled', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.DISABLE_BACKGROUND_TASKS = 'false';
+      queue.getRepeatableJobs.mockResolvedValue([{ name: 'coin-detail', pattern: '0 23 * * *', key: 'legacy-key' }]);
+
+      await task.onModuleInit();
+
+      expect(queue.removeRepeatableByKey).toHaveBeenCalledWith('legacy-key');
     });
 
     it('skips scheduling if jobs already exist', async () => {
@@ -155,23 +178,13 @@ describe('CoinSyncTask', () => {
       process.env.DISABLE_BACKGROUND_TASKS = 'false';
       queue.getRepeatableJobs.mockResolvedValue([
         { name: 'coin-sync', pattern: '0 0 * * 0' },
-        { name: 'coin-detail', pattern: '0 23 * * *' }
+        { name: 'coin-market-sync', pattern: '0 23 * * *' },
+        { name: 'coin-metadata-sync', pattern: '0 2 1 * *' }
       ]);
 
       await task.onModuleInit();
 
       expect(queue.add).not.toHaveBeenCalled();
-    });
-
-    it('schedules only the missing job when one already exists', async () => {
-      process.env.NODE_ENV = 'production';
-      process.env.DISABLE_BACKGROUND_TASKS = 'false';
-      queue.getRepeatableJobs.mockResolvedValue([{ name: 'coin-sync', pattern: '0 0 * * 0' }]);
-
-      await task.onModuleInit();
-
-      expect(queue.add).toHaveBeenCalledTimes(1);
-      expect(queue.add).toHaveBeenCalledWith('coin-detail', expect.any(Object), expect.any(Object));
     });
 
     it('does not schedule again on second call (jobScheduled guard)', async () => {
@@ -181,7 +194,7 @@ describe('CoinSyncTask', () => {
       await task.onModuleInit();
       await task.onModuleInit();
 
-      expect(queue.add).toHaveBeenCalledTimes(2); // only first call
+      expect(queue.add).toHaveBeenCalledTimes(3); // only first call
     });
   });
 
@@ -198,10 +211,32 @@ describe('CoinSyncTask', () => {
       expect(result).toEqual({ added: 0, updated: 0, delisted: 0, relisted: 0, total: 0 });
     });
 
-    it('routes coin-detail to handleCoinDetail', async () => {
+    it('routes coin-market-sync to handleCoinMarketSync', async () => {
       const expected = { totalCoins: 5, updatedSuccessfully: 4, errors: 1, snapshotsCaptured: 5 };
-      const spy = jest.spyOn(task, 'handleCoinDetail').mockResolvedValue(expected);
-      const job = { name: 'coin-detail', id: 'job-2' } as Job;
+      const spy = jest.spyOn(task, 'handleCoinMarketSync').mockResolvedValue(expected);
+      const job = { name: 'coin-market-sync', id: 'job-2' } as Job;
+
+      const result = await task.process(job);
+
+      expect(spy).toHaveBeenCalledWith(job);
+      expect(result).toEqual(expected);
+    });
+
+    it('routes legacy coin-detail job name to handleCoinMarketSync', async () => {
+      const expected = { totalCoins: 5, updatedSuccessfully: 4, errors: 1, snapshotsCaptured: 5 };
+      const spy = jest.spyOn(task, 'handleCoinMarketSync').mockResolvedValue(expected);
+      const job = { name: 'coin-detail', id: 'job-legacy' } as Job;
+
+      const result = await task.process(job);
+
+      expect(spy).toHaveBeenCalledWith(job);
+      expect(result).toEqual(expected);
+    });
+
+    it('routes coin-metadata-sync to handleCoinMetadataSync', async () => {
+      const expected = { totalCoins: 10, updatedSuccessfully: 8, skipped: 2, errors: 0 };
+      const spy = jest.spyOn(task, 'handleCoinMetadataSync').mockResolvedValue(expected);
+      const job = { name: 'coin-metadata-sync', id: 'job-meta' } as Job;
 
       const result = await task.process(job);
 
@@ -246,10 +281,10 @@ describe('CoinSyncTask', () => {
 
       exchangeService.getExchanges.mockResolvedValue([{ slug: 'binance', name: 'Binance' }] as any);
 
-      mockExchangeIdTickers.mockResolvedValueOnce({
-        tickers: [{ coin_id: 'ethereum' }, { coin_id: 'bitcoin' }]
-      });
-      mockExchangeIdTickers.mockResolvedValueOnce({ tickers: [] });
+      tickerFetcher.fetchAllTickersForExchange.mockResolvedValue([
+        { coin_id: 'ethereum' },
+        { coin_id: 'bitcoin' }
+      ] as any);
 
       const job = makeJob();
       const result = await task.handleSyncCoins(job);
@@ -271,7 +306,6 @@ describe('CoinSyncTask', () => {
       ];
       coinService.getCoins.mockResolvedValue(existingCoins as any);
 
-      // Both coins exist in gecko
       mockCoinList.mockResolvedValue([
         { id: 'bitcoin', symbol: 'btc', name: 'Bitcoin' },
         { id: 'litecoin', symbol: 'ltc', name: 'Litecoin' }
@@ -280,10 +314,7 @@ describe('CoinSyncTask', () => {
       exchangeService.getExchanges.mockResolvedValue([{ slug: 'binance', name: 'Binance' }] as any);
 
       // Only bitcoin is in ticker pairs, litecoin is not
-      mockExchangeIdTickers.mockResolvedValueOnce({
-        tickers: [{ coin_id: 'bitcoin' }]
-      });
-      mockExchangeIdTickers.mockResolvedValueOnce({ tickers: [] });
+      tickerFetcher.fetchAllTickersForExchange.mockResolvedValue([{ coin_id: 'bitcoin' }] as any);
 
       const job = makeJob();
       const result = await task.handleSyncCoins(job);
@@ -313,10 +344,10 @@ describe('CoinSyncTask', () => {
 
       exchangeService.getExchanges.mockResolvedValue([{ slug: 'binance', name: 'Binance' }] as any);
 
-      mockExchangeIdTickers.mockResolvedValueOnce({
-        tickers: [{ coin_id: 'bitcoin' }, { coin_id: 'relisted-coin' }]
-      });
-      mockExchangeIdTickers.mockResolvedValueOnce({ tickers: [] });
+      tickerFetcher.fetchAllTickersForExchange.mockResolvedValue([
+        { coin_id: 'bitcoin' },
+        { coin_id: 'relisted-coin' }
+      ] as any);
 
       const job = makeJob();
       const result = await task.handleSyncCoins(job);
@@ -324,34 +355,6 @@ describe('CoinSyncTask', () => {
       expect(coinService.relistMany).toHaveBeenCalledWith(['id-relisted']);
       expect(listingEventService.recordBulkRelistings).toHaveBeenCalledWith(['id-relisted'], 'coin_sync');
       expect(result.relisted).toBe(1);
-    });
-
-    it('continues updating remaining coins when one update fails', async () => {
-      const existingCoins = [
-        { id: 'id-1', slug: 'bitcoin', symbol: 'btc', name: 'Bitcoin', delistedAt: null },
-        { id: 'id-2', slug: 'ethereum', symbol: 'eth', name: 'Ethereum', delistedAt: null }
-      ];
-      coinService.getCoins.mockResolvedValue(existingCoins as any);
-
-      mockCoinList.mockResolvedValue([
-        { id: 'bitcoin', symbol: 'btc', name: 'Bitcoin v2' },
-        { id: 'ethereum', symbol: 'eth', name: 'Ethereum v2' }
-      ]);
-
-      exchangeService.getExchanges.mockResolvedValue([{ slug: 'binance', name: 'Binance' }] as any);
-      mockExchangeIdTickers.mockResolvedValueOnce({
-        tickers: [{ coin_id: 'bitcoin' }, { coin_id: 'ethereum' }]
-      });
-      mockExchangeIdTickers.mockResolvedValueOnce({ tickers: [] });
-
-      // First update fails, second succeeds
-      coinService.update.mockRejectedValueOnce(new Error('DB error')).mockResolvedValueOnce(undefined as any);
-
-      const job = makeJob();
-      const result = await task.handleSyncCoins(job);
-
-      expect(coinService.update).toHaveBeenCalledTimes(2);
-      expect(result.updated).toBe(2); // counts attempted, not successful
     });
 
     it('returns correct counts when nothing changes', async () => {
@@ -374,19 +377,20 @@ describe('CoinSyncTask', () => {
       expect(job.updateProgress).toHaveBeenCalledWith(100);
     });
 
-    it('maps coinbase exchange slug to gdax for CoinGecko API', async () => {
+    it('delegates ticker fetching to the shared fetcher for each exchange', async () => {
       coinService.getCoins.mockResolvedValue([]);
       mockCoinList.mockResolvedValue([{ id: 'bitcoin', symbol: 'btc', name: 'Bitcoin' }]);
-      exchangeService.getExchanges.mockResolvedValue([{ slug: 'coinbase', name: 'Coinbase' }] as any);
+      exchangeService.getExchanges.mockResolvedValue([
+        { slug: 'binance', name: 'Binance' },
+        { slug: 'coinbase', name: 'Coinbase' }
+      ] as any);
 
-      mockExchangeIdTickers.mockResolvedValueOnce({
-        tickers: [{ coin_id: 'bitcoin' }]
-      });
-      mockExchangeIdTickers.mockResolvedValueOnce({ tickers: [] });
+      tickerFetcher.fetchAllTickersForExchange.mockResolvedValue([{ coin_id: 'bitcoin' }] as any);
 
       await task.handleSyncCoins(makeJob());
 
-      expect(mockExchangeIdTickers).toHaveBeenCalledWith('gdax', expect.objectContaining({ page: 1 }));
+      expect(tickerFetcher.fetchAllTickersForExchange).toHaveBeenCalledWith('binance');
+      expect(tickerFetcher.fetchAllTickersForExchange).toHaveBeenCalledWith('coinbase');
     });
 
     it('collects both base and target coin IDs from tickers', async () => {
@@ -397,14 +401,12 @@ describe('CoinSyncTask', () => {
       ]);
       exchangeService.getExchanges.mockResolvedValue([{ slug: 'binance', name: 'Binance' }] as any);
 
-      mockExchangeIdTickers.mockResolvedValueOnce({
-        tickers: [{ coin_id: 'bitcoin', target_coin_id: 'tether' }]
-      });
-      mockExchangeIdTickers.mockResolvedValueOnce({ tickers: [] });
+      tickerFetcher.fetchAllTickersForExchange.mockResolvedValue([
+        { coin_id: 'bitcoin', target_coin_id: 'tether' }
+      ] as any);
 
       const result = await task.handleSyncCoins(makeJob());
 
-      // Both bitcoin (base) and tether (target) should be recognized as used
       expect(coinService.createMany).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ slug: 'bitcoin' }),
@@ -414,7 +416,7 @@ describe('CoinSyncTask', () => {
       expect(result.added).toBe(2);
     });
 
-    it('skips exchange and continues when ticker fetch fails on first page', async () => {
+    it('continues remaining exchanges when ticker fetch fails for one', async () => {
       coinService.getCoins.mockResolvedValue([]);
       mockCoinList.mockResolvedValue([{ id: 'bitcoin', symbol: 'btc', name: 'Bitcoin' }]);
       exchangeService.getExchanges.mockResolvedValue([
@@ -422,13 +424,9 @@ describe('CoinSyncTask', () => {
         { slug: 'binance', name: 'Binance' }
       ] as any);
 
-      // First exchange fails on page 1
-      mockExchangeIdTickers.mockRejectedValueOnce(new Error('API error'));
-      // Second exchange works
-      mockExchangeIdTickers.mockResolvedValueOnce({
-        tickers: [{ coin_id: 'bitcoin' }]
-      });
-      mockExchangeIdTickers.mockResolvedValueOnce({ tickers: [] });
+      tickerFetcher.fetchAllTickersForExchange
+        .mockRejectedValueOnce(new Error('API error'))
+        .mockResolvedValueOnce([{ coin_id: 'bitcoin' }] as any);
 
       const result = await task.handleSyncCoins(makeJob());
 
@@ -436,13 +434,13 @@ describe('CoinSyncTask', () => {
     });
   });
 
-  describe('handleCoinDetail', () => {
+  describe('handleCoinMarketSync', () => {
     it('delegates to CoinDetailSyncService and returns its result with snapshots', async () => {
       const detailResult = { totalCoins: 5, updatedSuccessfully: 4, errors: 1 };
       coinDetailSync.syncCoinDetails.mockResolvedValue(detailResult);
 
-      const job = { updateProgress: jest.fn(), name: 'coin-detail', id: 'detail-1' } as unknown as Job;
-      const result = await task.handleCoinDetail(job);
+      const job = { updateProgress: jest.fn(), name: 'coin-market-sync', id: 'detail-1' } as unknown as Job;
+      const result = await task.handleCoinMarketSync(job);
 
       expect(coinDetailSync.syncCoinDetails).toHaveBeenCalledWith(expect.any(Function));
       expect(result).toEqual({ ...detailResult, snapshotsCaptured: 5 });
@@ -454,8 +452,8 @@ describe('CoinSyncTask', () => {
         return { totalCoins: 0, updatedSuccessfully: 0, errors: 0 };
       });
 
-      const job = { updateProgress: jest.fn(), name: 'coin-detail', id: 'detail-2' } as unknown as Job;
-      await task.handleCoinDetail(job);
+      const job = { updateProgress: jest.fn(), name: 'coin-market-sync', id: 'detail-2' } as unknown as Job;
+      await task.handleCoinMarketSync(job);
 
       expect(job.updateProgress).toHaveBeenCalledWith(50);
     });
@@ -464,12 +462,12 @@ describe('CoinSyncTask', () => {
       const error = new Error('detail sync failed');
       coinDetailSync.syncCoinDetails.mockRejectedValue(error);
 
-      const job = { updateProgress: jest.fn(), name: 'coin-detail', id: 'detail-3' } as unknown as Job;
-      await expect(task.handleCoinDetail(job)).rejects.toThrow(error);
+      const job = { updateProgress: jest.fn(), name: 'coin-market-sync', id: 'detail-3' } as unknown as Job;
+      await expect(task.handleCoinMarketSync(job)).rejects.toThrow(error);
     });
   });
 
-  describe('handleCoinDetail snapshots', () => {
+  describe('handleCoinMarketSync snapshots', () => {
     const freshCoins = [
       { id: 'id-btc', slug: 'bitcoin', symbol: 'btc', name: 'Bitcoin' },
       { id: 'id-eth', slug: 'ethereum', symbol: 'eth', name: 'Ethereum' }
@@ -478,7 +476,7 @@ describe('CoinSyncTask', () => {
     const makeJob = () =>
       ({
         updateProgress: jest.fn(),
-        name: 'coin-detail',
+        name: 'coin-market-sync',
         id: 'detail-snap-1'
       }) as unknown as Job;
 
@@ -486,8 +484,8 @@ describe('CoinSyncTask', () => {
       coinService.getCoins.mockResolvedValue(freshCoins as any);
     });
 
-    it('calls captureSnapshots after coin detail sync', async () => {
-      const result = await task.handleCoinDetail(makeJob());
+    it('calls captureSnapshots after coin market sync', async () => {
+      const result = await task.handleCoinMarketSync(makeJob());
 
       expect(snapshotService.captureSnapshots).toHaveBeenCalledWith(freshCoins);
       expect(result).toEqual(
@@ -500,7 +498,7 @@ describe('CoinSyncTask', () => {
     it('continues successfully even if snapshot capture fails', async () => {
       snapshotService.captureSnapshots.mockRejectedValue(new Error('DB connection lost'));
 
-      const result = await task.handleCoinDetail(makeJob());
+      const result = await task.handleCoinMarketSync(makeJob());
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -510,24 +508,34 @@ describe('CoinSyncTask', () => {
       );
     });
 
-    it('backfills coins that need historical snapshots', async () => {
+    it('backfills coins that need historical snapshots and marks them complete', async () => {
       snapshotService.getCoinsNeedingBackfill.mockResolvedValue(['id-btc']);
       const historicalData = [
         { timestamp: 1704067200000, price: 42000, volume: 10_000_000_000, marketCap: 800_000_000_000 }
       ];
       coinMarketData.getCoinHistoricalData.mockResolvedValue(historicalData as any);
 
-      await task.handleCoinDetail(makeJob());
+      await task.handleCoinMarketSync(makeJob());
 
       expect(snapshotService.getCoinsNeedingBackfill).toHaveBeenCalled();
       expect(coinMarketData.getCoinHistoricalData).toHaveBeenCalledWith('id-btc');
       expect(snapshotService.backfillFromHistoricalData).toHaveBeenCalledWith('id-btc', historicalData);
+      expect(coinService.markSnapshotBackfillComplete).toHaveBeenCalledWith('id-btc');
+    });
+
+    it('does not mark backfill complete when backfill throws', async () => {
+      snapshotService.getCoinsNeedingBackfill.mockResolvedValue(['id-btc']);
+      coinMarketData.getCoinHistoricalData.mockRejectedValue(new Error('CoinGecko down'));
+
+      await task.handleCoinMarketSync(makeJob());
+
+      expect(coinService.markSnapshotBackfillComplete).not.toHaveBeenCalled();
     });
 
     it('continues successfully even if backfill fails', async () => {
       snapshotService.getCoinsNeedingBackfill.mockRejectedValue(new Error('DB error'));
 
-      const result = await task.handleCoinDetail(makeJob());
+      const result = await task.handleCoinMarketSync(makeJob());
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -540,10 +548,32 @@ describe('CoinSyncTask', () => {
     it('skips backfill when no coins need it', async () => {
       snapshotService.getCoinsNeedingBackfill.mockResolvedValue([]);
 
-      await task.handleCoinDetail(makeJob());
+      await task.handleCoinMarketSync(makeJob());
 
       expect(coinMarketData.getCoinHistoricalData).not.toHaveBeenCalled();
       expect(snapshotService.backfillFromHistoricalData).not.toHaveBeenCalled();
+      expect(coinService.markSnapshotBackfillComplete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCoinMetadataSync', () => {
+    it('delegates to CoinDetailSyncService.syncCoinMetadata and returns its result', async () => {
+      const metadataResult = { totalCoins: 10, updatedSuccessfully: 8, skipped: 1, errors: 1 };
+      coinDetailSync.syncCoinMetadata.mockResolvedValue(metadataResult);
+
+      const job = { updateProgress: jest.fn(), name: 'coin-metadata-sync', id: 'meta-1' } as unknown as Job;
+      const result = await task.handleCoinMetadataSync(job);
+
+      expect(coinDetailSync.syncCoinMetadata).toHaveBeenCalledWith(expect.any(Function));
+      expect(result).toEqual(metadataResult);
+    });
+
+    it('rethrows errors from syncCoinMetadata', async () => {
+      const error = new Error('metadata sync failed');
+      coinDetailSync.syncCoinMetadata.mockRejectedValue(error);
+
+      const job = { updateProgress: jest.fn(), name: 'coin-metadata-sync', id: 'meta-2' } as unknown as Job;
+      await expect(task.handleCoinMetadataSync(job)).rejects.toThrow(error);
     });
   });
 });

--- a/apps/api/src/coin/tasks/coin-sync.task.ts
+++ b/apps/api/src/coin/tasks/coin-sync.task.ts
@@ -14,12 +14,12 @@ import { CoinGeckoClientService } from '../../shared/coingecko-client.service';
 import { LOCK_DEFAULTS, LOCK_KEYS } from '../../shared/distributed-lock.constants';
 import { DistributedLockService } from '../../shared/distributed-lock.service';
 import { toErrorInfo } from '../../shared/error.util';
-import { withRateLimitRetry } from '../../shared/retry.util';
 import { withTimeout } from '../../shared/with-timeout.util';
 import { CoinDailySnapshotService } from '../coin-daily-snapshot.service';
 import { CoinListingEventService } from '../coin-listing-event.service';
 import { CoinMarketDataService } from '../coin-market-data.service';
 import { CoinService } from '../coin.service';
+import { ExchangeTickerFetcherService } from '../ticker-pairs/services/exchange-ticker-fetcher.service';
 
 // BullMQ auto-renews its internal worker lock every `lockDuration / 2` ms, so
 // a short value here gives fast stall detection without affecting long-running
@@ -43,6 +43,7 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
     private readonly coinDetailSync: CoinDetailSyncService,
     private readonly snapshotService: CoinDailySnapshotService,
     private readonly coinMarketData: CoinMarketDataService,
+    private readonly tickerFetcher: ExchangeTickerFetcherService,
     private readonly gecko: CoinGeckoClientService,
     private readonly lockService: DistributedLockService,
     private readonly circuitBreaker: CircuitBreakerService,
@@ -59,8 +60,23 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
 
     if (!this.jobScheduled) {
       await this.scheduleRepeatableJob('coin-sync', CronExpression.EVERY_WEEK);
-      await this.scheduleRepeatableJob('coin-detail', CronExpression.EVERY_DAY_AT_11PM);
+      await this.scheduleRepeatableJob('coin-market-sync', CronExpression.EVERY_DAY_AT_11PM);
+      await this.scheduleRepeatableJob('coin-metadata-sync', '0 2 1 * *');
+      await this.removeLegacyRepeatableJob('coin-detail');
       this.jobScheduled = true;
+    }
+  }
+
+  private async removeLegacyRepeatableJob(name: string): Promise<void> {
+    const repeatedJobs = await this.coinQueue.getRepeatableJobs();
+    const legacy = repeatedJobs.find((job) => job.name === name);
+    if (!legacy) return;
+    try {
+      await this.coinQueue.removeRepeatableByKey(legacy.key);
+      this.logger.log(`Removed legacy repeatable job '${name}' (key=${legacy.key})`);
+    } catch (error: unknown) {
+      const { message } = toErrorInfo(error);
+      this.logger.warn(`Failed to remove legacy repeatable job '${name}': ${message}`);
     }
   }
 
@@ -97,8 +113,7 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
   async process(job: Job) {
     this.logger.log(`Processing job ${job.id} of type ${job.name}`);
 
-    const lockKey = job.name === 'coin-detail' ? LOCK_KEYS.COIN_DETAIL : LOCK_KEYS.COIN_SYNC;
-    const lockTtl = job.name === 'coin-detail' ? LOCK_DEFAULTS.COIN_DETAIL_TTL_MS : LOCK_DEFAULTS.COIN_SYNC_TTL_MS;
+    const { lockKey, lockTtl } = this.resolveLock(job.name);
 
     const lock = await this.lockService.acquire({ key: lockKey, ttlMs: lockTtl });
     if (!lock.acquired) {
@@ -111,11 +126,16 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
 
       // Timeouts must fire before the distributed-lock TTL expires so the
       // finally block can release the lock before another run claims it.
-      // coin-sync TTL 45m → 40m timeout; coin-detail TTL 5h → 4h timeout.
       if (job.name === 'coin-sync') {
         result = await withTimeout(this.handleSyncCoins(job), 40 * 60 * 1000, 'coin-sync');
-      } else if (job.name === 'coin-detail') {
-        result = await withTimeout(this.handleCoinDetail(job), 4 * 60 * 60 * 1000, 'coin-detail');
+      } else if (job.name === 'coin-market-sync' || job.name === 'coin-detail') {
+        // 'coin-detail' retained so in-flight legacy workers after rename don't fail.
+        // 40m timeout is unreachable in normal ops (~25m fresh-install runtime) and
+        // leaves a 5m gap before the 45m lock TTL so the invariant "timeout fires
+        // before lock TTL" still holds for genuinely hung runs.
+        result = await withTimeout(this.handleCoinMarketSync(job), 40 * 60 * 1000, 'coin-market-sync');
+      } else if (job.name === 'coin-metadata-sync') {
+        result = await withTimeout(this.handleCoinMetadataSync(job), 4 * 60 * 60 * 1000, 'coin-metadata-sync');
       } else {
         throw new Error(`Unknown job name: ${job.name}`);
       }
@@ -131,8 +151,21 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
     }
   }
 
+  private resolveLock(jobName: string): { lockKey: string; lockTtl: number } {
+    switch (jobName) {
+      case 'coin-market-sync':
+      case 'coin-detail':
+        return { lockKey: LOCK_KEYS.COIN_MARKET_SYNC, lockTtl: LOCK_DEFAULTS.COIN_MARKET_SYNC_TTL_MS };
+      case 'coin-metadata-sync':
+        return { lockKey: LOCK_KEYS.COIN_METADATA_SYNC, lockTtl: LOCK_DEFAULTS.COIN_METADATA_SYNC_TTL_MS };
+      default:
+        return { lockKey: LOCK_KEYS.COIN_SYNC, lockTtl: LOCK_DEFAULTS.COIN_SYNC_TTL_MS };
+    }
+  }
+
   /**
-   * Helper method to get all coin slugs that are used in ticker pairs on supported exchanges
+   * Helper method to get all coin slugs that are used in ticker pairs on supported exchanges.
+   * Delegates to the shared ticker fetcher so the ticker-pairs-sync job can reuse the result.
    */
   private async getUsedCoinSlugs(supportedExchanges: { slug: string; name: string }[]): Promise<Set<string>> {
     this.logger.log('Checking CoinGecko for coins used in ticker pairs');
@@ -141,49 +174,13 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
     for (const exchange of supportedExchanges) {
       try {
         this.logger.log(`Checking exchange: ${exchange.name} (${exchange.slug}) for ticker pairs`);
+        const tickers = await this.tickerFetcher.fetchAllTickersForExchange(exchange.slug);
 
-        let page = 1;
-        let totalProcessedTickers = 0;
-
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          const id = exchange.slug === 'coinbase' ? 'gdax' : exchange.slug.toLowerCase();
-          const retryResult = await withRateLimitRetry(() => this.gecko.client.exchanges.tickers.get(id, { page }), {
-            maxRetries: 2,
-            logger: this.logger,
-            operationName: `tickers(${id}, page=${page})`
-          });
-
-          if (!retryResult.success) {
-            const err = toErrorInfo(retryResult.error);
-            this.logger.error(`Failed to fetch page ${page} tickers for ${exchange.name}: ${err.message}`);
-            if (page === 1) break;
-            await new Promise((r) => setTimeout(r, this.API_RATE_LIMIT_DELAY));
-            page++;
-            continue;
-          }
-
-          const tickers = retryResult.result?.tickers || [];
-
-          if (tickers.length === 0) {
-            this.logger.log(
-              `Completed loading ticker data for ${exchange.name}, total processed: ${totalProcessedTickers}`
-            );
-            break;
-          }
-
-          totalProcessedTickers += tickers.length;
-
-          for (const ticker of tickers) {
-            const baseId = ticker.coin_id?.toLowerCase();
-            const quoteId = ticker.target_coin_id?.toLowerCase();
-
-            if (baseId) usedCoinSlugs.add(baseId);
-            if (quoteId) usedCoinSlugs.add(quoteId);
-          }
-
-          await new Promise((r) => setTimeout(r, this.API_RATE_LIMIT_DELAY));
-          page++;
+        for (const ticker of tickers) {
+          const baseId = ticker.coin_id?.toLowerCase();
+          const quoteId = ticker.target_coin_id?.toLowerCase();
+          if (baseId) usedCoinSlugs.add(baseId);
+          if (quoteId) usedCoinSlugs.add(quoteId);
         }
       } catch (error: unknown) {
         const err = toErrorInfo(error);
@@ -338,14 +335,15 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
   }
 
   /**
-   * Handler for detailed coin information update job.
-   * Delegates to CoinDetailSyncService.
+   * Handler for the daily batched markets sync.
+   * Refreshes market data via /coins/markets and captures daily snapshots.
+   * Runs a bounded historical-snapshot backfill for coins that have never been backfilled.
    */
-  async handleCoinDetail(job: Job) {
+  async handleCoinMarketSync(job: Job) {
     try {
       const detailResult = await this.coinDetailSync.syncCoinDetails((percent) => job.updateProgress(percent));
 
-      // Cooldown after detail sync to let CoinGecko rate limits recover before snapshot/backfill
+      // Cooldown after markets sync to let CoinGecko rate limits recover before snapshot/backfill
       this.logger.log(`Cooling down ${CoinSyncTask.POST_DETAIL_COOLDOWN_MS / 1000}s before snapshot/backfill`);
       await new Promise((resolve) => setTimeout(resolve, CoinSyncTask.POST_DETAIL_COOLDOWN_MS));
 
@@ -386,6 +384,10 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
                   try {
                     const historicalData = await this.coinMarketData.getCoinHistoricalData(coinId);
                     const inserted = await this.snapshotService.backfillFromHistoricalData(coinId, historicalData);
+                    // Mark backfill as complete even when the result set is empty —
+                    // a successful API call with no historical data means CoinGecko
+                    // has nothing to return, so there's no point re-asking tomorrow.
+                    await this.coin.markSnapshotBackfillComplete(coinId);
                     this.logger.debug(`Backfilled ${inserted} snapshots for coin ${coinId}`);
                   } catch (err: unknown) {
                     const { message } = toErrorInfo(err);
@@ -409,6 +411,21 @@ export class CoinSyncTask extends FailSafeWorkerHost implements OnModuleInit {
     } catch (e: unknown) {
       const errInfo = toErrorInfo(e);
       this.logger.error(`Failed to process coin details: ${errInfo.message}`, errInfo.stack);
+      throw e;
+    }
+  }
+
+  /**
+   * Handler for the monthly metadata refresh job.
+   * Delegates to CoinDetailSyncService.syncCoinMetadata() which per-coin fetches
+   * /coins/{id} for coins with stale metadata (>25 days old).
+   */
+  async handleCoinMetadataSync(job: Job) {
+    try {
+      return await this.coinDetailSync.syncCoinMetadata((percent) => job.updateProgress(percent));
+    } catch (e: unknown) {
+      const errInfo = toErrorInfo(e);
+      this.logger.error(`Failed to refresh coin metadata: ${errInfo.message}`, errInfo.stack);
       throw e;
     }
   }

--- a/apps/api/src/coin/tasks/map-coingecko-detail.util.ts
+++ b/apps/api/src/coin/tasks/map-coingecko-detail.util.ts
@@ -134,3 +134,59 @@ export function mapCoinGeckoDetailToUpdate(
     geckoLastUpdatedAt: md?.last_updated ?? null
   };
 }
+
+/**
+ * Maps a CoinGecko coin detail response to a metadata-only UpdateCoinDto.
+ * Used by the monthly metadata sync to refresh fields that are NOT available
+ * on the daily /coins/markets endpoint: description, genesis, scores, sentiment.
+ * Links are persisted by the lazy refresh in CoinMarketDataService.
+ */
+export function mapCoinGeckoDetailToMetadataUpdate(
+  coin: Record<string, any>,
+  symbol: string
+): Pick<
+  UpdateCoinDto,
+  | 'description'
+  | 'genesis'
+  | 'developerScore'
+  | 'communityScore'
+  | 'liquidityScore'
+  | 'publicInterestScore'
+  | 'sentimentUp'
+  | 'sentimentDown'
+> {
+  return {
+    description: coin.description?.en ?? null,
+    genesis: coin.genesis_date ?? null,
+    developerScore: sanitizeNumericValue(coin.developer_score, {
+      maxIntegerDigits: 3,
+      fieldName: `${symbol}.developerScore`,
+      allowNegative: false
+    }),
+    communityScore: sanitizeNumericValue(coin.community_score, {
+      maxIntegerDigits: 3,
+      fieldName: `${symbol}.communityScore`,
+      allowNegative: false
+    }),
+    liquidityScore: sanitizeNumericValue(coin.liquidity_score, {
+      maxIntegerDigits: 3,
+      fieldName: `${symbol}.liquidityScore`,
+      allowNegative: false
+    }),
+    publicInterestScore: sanitizeNumericValue(coin.public_interest_score, {
+      maxIntegerDigits: 3,
+      fieldName: `${symbol}.publicInterestScore`,
+      allowNegative: false
+    }),
+    sentimentUp: sanitizeNumericValue(coin.sentiment_votes_up_percentage, {
+      maxIntegerDigits: 3,
+      fieldName: `${symbol}.sentimentUp`,
+      allowNegative: false
+    }),
+    sentimentDown: sanitizeNumericValue(coin.sentiment_votes_down_percentage, {
+      maxIntegerDigits: 3,
+      fieldName: `${symbol}.sentimentDown`,
+      allowNegative: false
+    })
+  };
+}

--- a/apps/api/src/coin/tasks/map-coingecko-markets.util.spec.ts
+++ b/apps/api/src/coin/tasks/map-coingecko-markets.util.spec.ts
@@ -1,0 +1,100 @@
+import { mapCoinGeckoMarketsToUpdate } from './map-coingecko-markets.util';
+
+describe('mapCoinGeckoMarketsToUpdate', () => {
+  const fullEntry = {
+    id: 'bitcoin',
+    image: 'https://img/large.png',
+    current_price: 45000,
+    market_cap: 1_000_000_000_000,
+    market_cap_rank: 1,
+    total_volume: 30_000_000_000,
+    circulating_supply: 19_000_000,
+    total_supply: 21_000_000,
+    max_supply: 21_000_000,
+    ath: 69000,
+    atl: 0.01,
+    ath_date: '2021-11-10',
+    atl_date: '2010-07-17',
+    ath_change_percentage: -35,
+    atl_change_percentage: 999999,
+    price_change_24h: -100,
+    price_change_percentage_24h: -1.5,
+    market_cap_change_24h: -5_000_000_000,
+    market_cap_change_percentage_24h: -0.5,
+    last_updated: '2024-01-01T00:00:00Z',
+    price_change_percentage_7d_in_currency: 5.2,
+    price_change_percentage_14d_in_currency: -3.1,
+    price_change_percentage_30d_in_currency: 10,
+    price_change_percentage_200d_in_currency: 20,
+    price_change_percentage_1y_in_currency: 30
+  };
+
+  it('maps every field from a full /coins/markets entry', () => {
+    const result = mapCoinGeckoMarketsToUpdate(fullEntry, 7, 'btc');
+
+    expect(result).toEqual({
+      image: 'https://img/large.png',
+      marketRank: 1,
+      geckoRank: 7,
+      totalSupply: 21_000_000,
+      totalVolume: 30_000_000_000,
+      circulatingSupply: 19_000_000,
+      maxSupply: 21_000_000,
+      marketCap: 1_000_000_000_000,
+      currentPrice: 45000,
+      ath: 69000,
+      atl: 0.01,
+      athDate: '2021-11-10',
+      atlDate: '2010-07-17',
+      athChange: -35,
+      atlChange: 999999,
+      priceChange24h: -100,
+      priceChangePercentage24h: -1.5,
+      priceChangePercentage7d: 5.2,
+      priceChangePercentage14d: -3.1,
+      priceChangePercentage30d: 10,
+      priceChangePercentage200d: 20,
+      priceChangePercentage1y: 30,
+      marketCapChange24h: -5_000_000_000,
+      marketCapChangePercentage24h: -0.5,
+      geckoLastUpdatedAt: '2024-01-01T00:00:00Z'
+    });
+  });
+
+  it('returns null for every field when given an empty object', () => {
+    const result = mapCoinGeckoMarketsToUpdate({}, null, 'btc');
+
+    const allNull = Object.fromEntries(Object.keys(result).map((k) => [k, null]));
+    expect(result).toEqual(allNull);
+  });
+
+  it('does NOT include metadata fields (description, scores, etc.)', () => {
+    const result = mapCoinGeckoMarketsToUpdate(fullEntry, 7, 'btc') as Record<string, unknown>;
+
+    expect(result.description).toBeUndefined();
+    expect(result.genesis).toBeUndefined();
+    expect(result.developerScore).toBeUndefined();
+    expect(result.communityScore).toBeUndefined();
+    expect(result.liquidityScore).toBeUndefined();
+    expect(result.publicInterestScore).toBeUndefined();
+    expect(result.sentimentUp).toBeUndefined();
+    expect(result.sentimentDown).toBeUndefined();
+  });
+
+  it('falls back to null geckoRank when not provided', () => {
+    expect(mapCoinGeckoMarketsToUpdate({}, null, 'x').geckoRank).toBeNull();
+    expect(mapCoinGeckoMarketsToUpdate({}, 5, 'x').geckoRank).toBe(5);
+  });
+
+  it('sanitizes invalid numeric values to null', () => {
+    const result = mapCoinGeckoMarketsToUpdate(
+      { current_price: Infinity, market_cap: NaN, total_volume: -1 },
+      null,
+      'bad'
+    );
+
+    expect(result.currentPrice).toBeNull();
+    expect(result.marketCap).toBeNull();
+    expect(result.totalVolume).toBeNull(); // negative rejected
+  });
+});

--- a/apps/api/src/coin/tasks/map-coingecko-markets.util.ts
+++ b/apps/api/src/coin/tasks/map-coingecko-markets.util.ts
@@ -1,0 +1,104 @@
+import { sanitizeNumericValue } from '../../utils/validators/numeric-sanitizer';
+import { type UpdateCoinDto } from '../dto/update-coin.dto';
+
+/**
+ * Maps a CoinGecko /coins/markets entry to an UpdateCoinDto.
+ * Pure function — no side effects, no DI dependencies.
+ *
+ * Unlike mapCoinGeckoDetailToUpdate, this only touches fields the markets endpoint
+ * returns: price, market cap, volume, supply, ATH/ATL, price-change percentages,
+ * and image. Metadata fields (description, genesis, links, scores, sentiment) are
+ * intentionally omitted and sourced from the monthly /coins/{id} sync instead.
+ */
+export function mapCoinGeckoMarketsToUpdate(
+  entry: Record<string, any>,
+  geckoRank: number | null | undefined,
+  symbol: string
+): UpdateCoinDto {
+  return {
+    image: entry.image ?? null,
+    marketRank: entry.market_cap_rank ?? null,
+    geckoRank: geckoRank ?? null,
+    totalSupply: sanitizeNumericValue(entry.total_supply, {
+      fieldName: `${symbol}.totalSupply`,
+      allowNegative: false
+    }),
+    totalVolume: sanitizeNumericValue(entry.total_volume, {
+      fieldName: `${symbol}.totalVolume`,
+      allowNegative: false
+    }),
+    circulatingSupply: sanitizeNumericValue(entry.circulating_supply, {
+      fieldName: `${symbol}.circulatingSupply`,
+      allowNegative: false
+    }),
+    maxSupply: sanitizeNumericValue(entry.max_supply, {
+      fieldName: `${symbol}.maxSupply`,
+      allowNegative: false
+    }),
+    marketCap: sanitizeNumericValue(entry.market_cap, {
+      fieldName: `${symbol}.marketCap`,
+      allowNegative: false
+    }),
+    currentPrice: sanitizeNumericValue(entry.current_price, {
+      maxIntegerDigits: 17,
+      fieldName: `${symbol}.currentPrice`,
+      allowNegative: false
+    }),
+    ath: sanitizeNumericValue(entry.ath, {
+      maxIntegerDigits: 17,
+      fieldName: `${symbol}.ath`,
+      allowNegative: false
+    }),
+    atl: sanitizeNumericValue(entry.atl, {
+      maxIntegerDigits: 17,
+      fieldName: `${symbol}.atl`,
+      allowNegative: false
+    }),
+    athDate: entry.ath_date ?? null,
+    atlDate: entry.atl_date ?? null,
+    athChange: sanitizeNumericValue(entry.ath_change_percentage, {
+      maxIntegerDigits: 4,
+      fieldName: `${symbol}.athChange`
+    }),
+    atlChange: sanitizeNumericValue(entry.atl_change_percentage, {
+      maxIntegerDigits: 9,
+      fieldName: `${symbol}.atlChange`
+    }),
+    priceChange24h: sanitizeNumericValue(entry.price_change_24h, {
+      maxIntegerDigits: 17,
+      fieldName: `${symbol}.priceChange24h`
+    }),
+    priceChangePercentage24h: sanitizeNumericValue(entry.price_change_percentage_24h, {
+      maxIntegerDigits: 5,
+      fieldName: `${symbol}.priceChangePercentage24h`
+    }),
+    priceChangePercentage7d: sanitizeNumericValue(entry.price_change_percentage_7d_in_currency, {
+      maxIntegerDigits: 5,
+      fieldName: `${symbol}.priceChangePercentage7d`
+    }),
+    priceChangePercentage14d: sanitizeNumericValue(entry.price_change_percentage_14d_in_currency, {
+      maxIntegerDigits: 5,
+      fieldName: `${symbol}.priceChangePercentage14d`
+    }),
+    priceChangePercentage30d: sanitizeNumericValue(entry.price_change_percentage_30d_in_currency, {
+      maxIntegerDigits: 5,
+      fieldName: `${symbol}.priceChangePercentage30d`
+    }),
+    priceChangePercentage200d: sanitizeNumericValue(entry.price_change_percentage_200d_in_currency, {
+      maxIntegerDigits: 5,
+      fieldName: `${symbol}.priceChangePercentage200d`
+    }),
+    priceChangePercentage1y: sanitizeNumericValue(entry.price_change_percentage_1y_in_currency, {
+      maxIntegerDigits: 5,
+      fieldName: `${symbol}.priceChangePercentage1y`
+    }),
+    marketCapChange24h: sanitizeNumericValue(entry.market_cap_change_24h, {
+      fieldName: `${symbol}.marketCapChange24h`
+    }),
+    marketCapChangePercentage24h: sanitizeNumericValue(entry.market_cap_change_percentage_24h, {
+      maxIntegerDigits: 5,
+      fieldName: `${symbol}.marketCapChangePercentage24h`
+    }),
+    geckoLastUpdatedAt: entry.last_updated ?? null
+  };
+}

--- a/apps/api/src/coin/ticker-pairs/services/exchange-ticker-fetcher.service.spec.ts
+++ b/apps/api/src/coin/ticker-pairs/services/exchange-ticker-fetcher.service.spec.ts
@@ -1,0 +1,129 @@
+import { ExchangeTickerFetcherService } from './exchange-ticker-fetcher.service';
+
+import { type CoinGeckoClientService } from '../../../shared/coingecko-client.service';
+
+const mockExchangeTickers = jest.fn();
+
+// Pass-through retry wrapper so the tests observe real pagination / error behavior
+jest.mock('../../../shared/retry.util', () => ({
+  withRateLimitRetry: jest.fn(async (fn: () => Promise<any>) => {
+    try {
+      const result = await fn();
+      return { success: true, result };
+    } catch (error) {
+      return { success: false, error };
+    }
+  })
+}));
+
+jest.useFakeTimers();
+
+describe('ExchangeTickerFetcherService', () => {
+  let service: ExchangeTickerFetcherService;
+  let cache: { get: jest.Mock; set: jest.Mock };
+  let gecko: CoinGeckoClientService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    cache = {
+      get: jest.fn().mockResolvedValue(undefined),
+      set: jest.fn().mockResolvedValue(undefined)
+    };
+
+    gecko = {
+      client: {
+        exchanges: {
+          tickers: { get: mockExchangeTickers }
+        }
+      }
+    } as unknown as CoinGeckoClientService;
+
+    service = new ExchangeTickerFetcherService(gecko, cache as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('returns cached tickers on hit without hitting the API', async () => {
+    const cachedTickers = [{ coin_id: 'bitcoin', target_coin_id: 'tether' }];
+    cache.get.mockResolvedValue(cachedTickers);
+
+    const result = await service.fetchAllTickersForExchange('binance');
+
+    expect(result).toEqual(cachedTickers);
+    expect(mockExchangeTickers).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('paginates CoinGecko on cache miss and caches the result', async () => {
+    cache.get.mockResolvedValue(undefined);
+    mockExchangeTickers
+      .mockResolvedValueOnce({ tickers: [{ coin_id: 'bitcoin' }] })
+      .mockResolvedValueOnce({ tickers: [{ coin_id: 'ethereum' }] })
+      .mockResolvedValueOnce({ tickers: [] });
+
+    const promise = service.fetchAllTickersForExchange('binance');
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(mockExchangeTickers).toHaveBeenCalledTimes(3);
+    expect(result).toEqual([{ coin_id: 'bitcoin' }, { coin_id: 'ethereum' }]);
+    expect(cache.set).toHaveBeenCalledWith(
+      'coingecko:exchange-tickers:binance',
+      [{ coin_id: 'bitcoin' }, { coin_id: 'ethereum' }],
+      expect.any(Number)
+    );
+  });
+
+  it('maps coinbase slug to gdax when querying CoinGecko', async () => {
+    mockExchangeTickers.mockResolvedValueOnce({ tickers: [] });
+
+    const promise = service.fetchAllTickersForExchange('coinbase');
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(mockExchangeTickers).toHaveBeenCalledWith('gdax', { page: 1 });
+  });
+
+  it('returns empty array when first page fails (and does not cache)', async () => {
+    mockExchangeTickers.mockRejectedValueOnce(new Error('upstream error'));
+
+    const promise = service.fetchAllTickersForExchange('binance');
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('caches partial results when a later page fails', async () => {
+    mockExchangeTickers
+      .mockResolvedValueOnce({ tickers: [{ coin_id: 'bitcoin' }] })
+      .mockRejectedValueOnce(new Error('page 2 error'));
+
+    const promise = service.fetchAllTickersForExchange('binance');
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual([{ coin_id: 'bitcoin' }]);
+    expect(cache.set).toHaveBeenCalledWith(
+      'coingecko:exchange-tickers:binance',
+      [{ coin_id: 'bitcoin' }],
+      expect.any(Number)
+    );
+  });
+
+  it('falls back to API when cache read throws', async () => {
+    cache.get.mockRejectedValue(new Error('redis down'));
+    mockExchangeTickers.mockResolvedValueOnce({ tickers: [{ coin_id: 'bitcoin' }] });
+    mockExchangeTickers.mockResolvedValueOnce({ tickers: [] });
+
+    const promise = service.fetchAllTickersForExchange('binance');
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual([{ coin_id: 'bitcoin' }]);
+  });
+});

--- a/apps/api/src/coin/ticker-pairs/services/exchange-ticker-fetcher.service.ts
+++ b/apps/api/src/coin/ticker-pairs/services/exchange-ticker-fetcher.service.ts
@@ -1,0 +1,111 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { Cache } from 'cache-manager';
+
+import { CoinGeckoClientService } from '../../../shared/coingecko-client.service';
+import { toErrorInfo } from '../../../shared/error.util';
+import { withRateLimitRetry } from '../../../shared/retry.util';
+
+/**
+ * Minimal shape of a CoinGecko ticker — only fields both callers care about.
+ * The full ticker object is cached, so downstream code can read any additional fields.
+ */
+export interface CachedTicker {
+  coin_id?: string;
+  target_coin_id?: string;
+  base?: string;
+  target?: string;
+  volume?: number | string;
+  bid_ask_spread_percentage?: number | string;
+  trade_url?: string;
+  last_traded_at?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Fetches and caches the full ticker list for a CoinGecko exchange.
+ *
+ * Both `coin-sync` and `ticker-pairs-sync` run weekly and need the same ticker data
+ * per exchange. This service paginates /exchanges/{id}/tickers once per week and
+ * stores the result in Redis for 8 days so the second caller reads from cache.
+ * TTL > cadence (7d) ensures the cache is never stale-expired when the next
+ * Sunday fires — shorter TTLs defeat the shared cache entirely.
+ */
+@Injectable()
+export class ExchangeTickerFetcherService {
+  private static readonly CACHE_TTL_MS = 8 * 24 * 60 * 60 * 1000; // 8 days (> weekly cadence + buffer)
+  private static readonly PAGE_DELAY_MS = 2500;
+  private readonly logger = new Logger(ExchangeTickerFetcherService.name);
+
+  constructor(
+    private readonly gecko: CoinGeckoClientService,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache
+  ) {}
+
+  /**
+   * Returns every ticker for the given exchange slug, using the Redis cache
+   * when available. On cache miss, paginates CoinGecko and populates the cache.
+   * Returns [] on fatal error so callers can continue with remaining exchanges.
+   */
+  async fetchAllTickersForExchange(exchangeSlug: string): Promise<CachedTicker[]> {
+    const cacheKey = `coingecko:exchange-tickers:${exchangeSlug}`;
+
+    try {
+      const cached = await this.cacheManager.get<CachedTicker[]>(cacheKey);
+      if (cached && cached.length > 0) {
+        this.logger.log(`Ticker cache HIT for ${exchangeSlug} (${cached.length} tickers)`);
+        return cached;
+      }
+    } catch (error: unknown) {
+      const { message } = toErrorInfo(error);
+      this.logger.warn(`Ticker cache read failed for ${exchangeSlug}: ${message}, treating as miss`);
+    }
+
+    this.logger.log(`Ticker cache MISS for ${exchangeSlug}, paginating CoinGecko`);
+
+    const geckoId = exchangeSlug === 'coinbase' ? 'gdax' : exchangeSlug.toLowerCase();
+    const all: CachedTicker[] = [];
+    let page = 1;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const retryResult = await withRateLimitRetry(() => this.gecko.client.exchanges.tickers.get(geckoId, { page }), {
+        maxRetries: 2,
+        logger: this.logger,
+        operationName: `tickers(${geckoId}, page=${page})`
+      });
+
+      if (!retryResult.success) {
+        const { message } = toErrorInfo(retryResult.error);
+        this.logger.error(`Failed to fetch page ${page} tickers for ${exchangeSlug}: ${message}`);
+        if (page === 1) return [];
+        // Partial data is better than none — break and cache what we have
+        break;
+      }
+
+      const tickers = (retryResult.result?.tickers ?? []) as CachedTicker[];
+      if (tickers.length === 0) {
+        this.logger.log(`Completed pagination for ${exchangeSlug} (${all.length} tickers)`);
+        break;
+      }
+
+      all.push(...tickers);
+      page++;
+
+      await new Promise((resolve) => setTimeout(resolve, ExchangeTickerFetcherService.PAGE_DELAY_MS));
+    }
+
+    if (all.length > 0) {
+      try {
+        await this.cacheManager.set(cacheKey, all, ExchangeTickerFetcherService.CACHE_TTL_MS);
+        this.logger.log(`Cached ${all.length} tickers for ${exchangeSlug} (TTL: 8d)`);
+      } catch (error: unknown) {
+        const { message } = toErrorInfo(error);
+        this.logger.warn(`Failed to cache tickers for ${exchangeSlug}: ${message}`);
+      }
+    }
+
+    return all;
+  }
+}

--- a/apps/api/src/coin/ticker-pairs/tasks/ticker-pairs-sync.task.ts
+++ b/apps/api/src/coin/ticker-pairs/tasks/ticker-pairs-sync.task.ts
@@ -1,17 +1,16 @@
 import { InjectQueue, Processor } from '@nestjs/bullmq';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { CronExpression } from '@nestjs/schedule';
 
 import { Job, Queue } from 'bullmq';
 
 import { ExchangeService } from '../../../exchange/exchange.service';
 import { FailSafeWorkerHost } from '../../../failed-jobs/fail-safe-worker-host';
 import { FailedJobService } from '../../../failed-jobs/failed-job.service';
-import { CoinGeckoClientService } from '../../../shared/coingecko-client.service';
 import { LOCK_DEFAULTS, LOCK_KEYS } from '../../../shared/distributed-lock.constants';
 import { DistributedLockService } from '../../../shared/distributed-lock.service';
 import { toErrorInfo } from '../../../shared/error.util';
 import { CoinService } from '../../coin.service';
+import { ExchangeTickerFetcherService } from '../services/exchange-ticker-fetcher.service';
 import { TickerPairStatus, TickerPairs } from '../ticker-pairs.entity';
 import { TickerPairService } from '../ticker-pairs.service';
 
@@ -34,7 +33,7 @@ export class TickerPairSyncTask extends FailSafeWorkerHost implements OnModuleIn
     private readonly coin: CoinService,
     private readonly exchange: ExchangeService,
     private readonly tickerPair: TickerPairService,
-    private readonly gecko: CoinGeckoClientService,
+    private readonly tickerFetcher: ExchangeTickerFetcherService,
     private readonly lockService: DistributedLockService,
     failedJobService: FailedJobService
   ) {
@@ -78,7 +77,10 @@ export class TickerPairSyncTask extends FailSafeWorkerHost implements OnModuleIn
         description: 'Scheduled ticker pair sync job'
       },
       {
-        repeat: { pattern: CronExpression.EVERY_WEEK },
+        // Staggered 2h after coin-sync (Sunday 00:00 UTC) so the shared ticker
+        // cache populated by coin-sync is warm when this job runs. Running both
+        // at the same cron defeats the cache — both miss, both paginate.
+        repeat: { pattern: '0 2 * * 0' },
         attempts: 3,
         backoff: {
           type: 'exponential',
@@ -89,7 +91,7 @@ export class TickerPairSyncTask extends FailSafeWorkerHost implements OnModuleIn
       }
     );
 
-    this.logger.log('Ticker pair sync job scheduled with weekly cron pattern');
+    this.logger.log('Ticker pair sync job scheduled for Sunday 02:00 UTC');
   }
 
   /**
@@ -167,152 +169,124 @@ export class TickerPairSyncTask extends FailSafeWorkerHost implements OnModuleIn
       for (const exchange of supportedExchanges) {
         try {
           this.logger.log(`Processing ticker pairs for ${exchange.name} (${exchange.slug})`);
-          let page = 1;
           const exchangePairs = new Set<string>();
-          let totalProcessedTickers = 0;
 
-          // Paginate through all tickers for this exchange
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            let tickers = [];
-            const id = exchange.slug === 'coinbase' ? 'gdax' : exchange.slug.toLowerCase();
+          // Fetch all tickers (cached by ExchangeTickerFetcherService — no per-page loop needed)
+          const tickers = await this.tickerFetcher.fetchAllTickersForExchange(exchange.slug);
 
-            try {
-              // Get tickers from CoinGecko for this exchange
-              const response = await this.gecko.client.exchanges.tickers.get(id, { page });
+          if (tickers.length === 0) {
+            this.logger.warn(`No tickers returned for ${exchange.name}, skipping`);
+            processedExchanges++;
+            await job.updateProgress(40 + Math.floor((processedExchanges / totalExchanges) * 50));
+            continue;
+          }
 
-              tickers = response.tickers || [];
+          // Process each ticker
+          for (const ticker of tickers) {
+            // Extract coin IDs from the ticker data
+            const baseId = ticker.coin_id?.toLowerCase();
+            const quoteId = ticker.target_coin_id?.toLowerCase();
+            const baseSymbol = String(ticker.base ?? '');
+            const targetSymbol = String(ticker.target ?? '');
 
-              if (tickers.length === 0) {
-                this.logger.log(
-                  `Completed loading ticker data for ${exchange.name}, total processed: ${totalProcessedTickers}`
-                );
-                break;
-              }
-
-              totalProcessedTickers += tickers.length;
-            } catch (tickerError: unknown) {
-              const err = toErrorInfo(tickerError);
-              this.logger.error(`Failed to fetch page ${page} tickers for ${exchange.name}: ${err.message}`);
-              // If we're on the first page and encounter an error, break out completely
-              if (page === 1) break;
-
-              // Otherwise try to move to the next page and continue
-              page++;
+            // Skip tickers with missing symbols
+            if (!baseSymbol || !targetSymbol) {
+              this.logger.debug(`Skipping ticker with missing base or target symbol`);
               continue;
             }
 
-            // Process each ticker from the current page
-            for (const ticker of tickers) {
-              // Extract coin IDs from the ticker data
-              const baseId = ticker.coin_id?.toLowerCase();
-              const quoteId = ticker.target_coin_id?.toLowerCase();
-              const baseSymbol = String(ticker.base ?? '');
-              const targetSymbol = String(ticker.target ?? '');
+            // Get the coin objects from our database
+            const baseCoin = baseId ? coinsBySlug.get(baseId) : undefined;
+            const quoteCoin = quoteId ? coinsBySlug.get(quoteId) : undefined;
 
-              // Skip tickers with missing symbols
-              if (!baseSymbol || !targetSymbol) {
-                this.logger.debug(`Skipping ticker with missing base or target symbol`);
-                continue;
-              }
+            // Determine if this is a fiat pair
+            const baseIsFiat = !baseCoin && this.isFiatCurrency(baseSymbol);
+            const quoteIsFiat = !quoteCoin && this.isFiatCurrency(targetSymbol);
+            const isFiatPair = baseIsFiat || quoteIsFiat;
 
-              // Get the coin objects from our database
-              const baseCoin = baseId ? coinsBySlug.get(baseId) : undefined;
-              const quoteCoin = quoteId ? coinsBySlug.get(quoteId) : undefined;
-
-              // Determine if this is a fiat pair
-              const baseIsFiat = !baseCoin && this.isFiatCurrency(baseSymbol);
-              const quoteIsFiat = !quoteCoin && this.isFiatCurrency(targetSymbol);
-              const isFiatPair = baseIsFiat || quoteIsFiat;
-
-              // Skip if neither coin exists and it's not a fiat pair
-              if (!baseCoin && !quoteCoin && !isFiatPair) {
-                this.logger.debug(
-                  `Skipping ticker ${baseSymbol}/${targetSymbol}: coins not found in database and not fiat pair`
-                );
-                continue;
-              }
-
-              // Skip if one coin exists but the other doesn't and it's not fiat
-              if ((!baseCoin && !baseIsFiat) || (!quoteCoin && !quoteIsFiat)) {
-                this.logger.debug(
-                  `Skipping ticker ${baseSymbol}/${targetSymbol}: missing coin in database (base: ${!!baseCoin || baseIsFiat}, quote: ${!!quoteCoin || quoteIsFiat})`
-                );
-                continue;
-              }
-
-              // Create a unique key for this ticker pair
-              const baseKey = baseCoin?.id || baseSymbol;
-              const quoteKey = quoteCoin?.id || targetSymbol;
-              const pairKey = `${baseKey}-${quoteKey}-${exchange.id}`;
-              exchangePairs.add(pairKey);
-
-              // Look for an existing ticker pair matching this one
-              const existingPair = existingPairs.find((p) => {
-                if (isFiatPair) {
-                  // For fiat pairs, match by symbol and exchange
-                  const expectedSymbol = `${baseSymbol}${targetSymbol}`.toUpperCase();
-                  return p.symbol === expectedSymbol && p.exchange.id === exchange.id;
-                } else {
-                  // For regular pairs, match by coin IDs
-                  return (
-                    p.baseAsset?.id === baseCoin?.id &&
-                    p.quoteAsset?.id === quoteCoin?.id &&
-                    p.exchange.id === exchange.id
-                  );
-                }
-              });
-
-              if (!existingPair) {
-                // Create a new ticker pair
-                const pairData: any = {
-                  exchange,
-                  volume: Number(ticker.volume ?? 0),
-                  tradeUrl: ticker.trade_url,
-                  spreadPercentage: Number(ticker.bid_ask_spread_percentage ?? 0),
-                  lastTraded: ticker.last_traded_at ?? new Date(),
-                  fetchAt: new Date(),
-                  status: DEFAULT_STATUS,
-                  isSpotTradingAllowed: DEFAULT_SPOT_TRADING_ALLOWED,
-                  isMarginTradingAllowed: DEFAULT_MARGIN_TRADING_ALLOWED,
-                  isFiatPair
-                };
-
-                if (isFiatPair) {
-                  // For fiat pairs, store symbols instead of coin references
-                  pairData.baseAssetSymbol = baseSymbol.toLowerCase();
-                  pairData.quoteAssetSymbol = targetSymbol.toLowerCase();
-                  // Only set coin references if they exist
-                  if (baseCoin) pairData.baseAsset = baseCoin;
-                  if (quoteCoin) pairData.quoteAsset = quoteCoin;
-                } else {
-                  // For regular pairs, use coin references
-                  pairData.baseAsset = baseCoin;
-                  pairData.quoteAsset = quoteCoin;
-                }
-
-                const newPair = await this.tickerPair.createTickerPair(pairData);
-
-                newPairs.push(newPair);
-              } else {
-                // Update the existing pair with new data
-                Object.assign(existingPair, {
-                  volume: Number(ticker.volume ?? existingPair.volume),
-                  tradeUrl: ticker.trade_url ?? existingPair.tradeUrl,
-                  spreadPercentage: Number(ticker.bid_ask_spread_percentage ?? existingPair.spreadPercentage),
-                  lastTraded: ticker.last_traded_at ?? existingPair.lastTraded,
-                  fetchAt: new Date()
-                  // Not updating status or trading flags as they should be managed separately
-                });
-              }
+            // Skip if neither coin exists and it's not a fiat pair
+            if (!baseCoin && !quoteCoin && !isFiatPair) {
+              this.logger.debug(
+                `Skipping ticker ${baseSymbol}/${targetSymbol}: coins not found in database and not fiat pair`
+              );
+              continue;
             }
 
-            this.logger.log(`Processed page ${page} for ${exchange.name}, found ${tickers.length} ticker pairs`);
+            // Skip if one coin exists but the other doesn't and it's not fiat
+            if ((!baseCoin && !baseIsFiat) || (!quoteCoin && !quoteIsFiat)) {
+              this.logger.debug(
+                `Skipping ticker ${baseSymbol}/${targetSymbol}: missing coin in database (base: ${!!baseCoin || baseIsFiat}, quote: ${!!quoteCoin || quoteIsFiat})`
+              );
+              continue;
+            }
 
-            // Apply standard rate limiting to avoid CoinGecko API issues
-            await new Promise((r) => setTimeout(r, 1000));
-            page++;
+            // Create a unique key for this ticker pair
+            const baseKey = baseCoin?.id || baseSymbol;
+            const quoteKey = quoteCoin?.id || targetSymbol;
+            const pairKey = `${baseKey}-${quoteKey}-${exchange.id}`;
+            exchangePairs.add(pairKey);
+
+            // Look for an existing ticker pair matching this one
+            const existingPair = existingPairs.find((p) => {
+              if (isFiatPair) {
+                // For fiat pairs, match by symbol and exchange
+                const expectedSymbol = `${baseSymbol}${targetSymbol}`.toUpperCase();
+                return p.symbol === expectedSymbol && p.exchange.id === exchange.id;
+              } else {
+                // For regular pairs, match by coin IDs
+                return (
+                  p.baseAsset?.id === baseCoin?.id &&
+                  p.quoteAsset?.id === quoteCoin?.id &&
+                  p.exchange.id === exchange.id
+                );
+              }
+            });
+
+            if (!existingPair) {
+              // Create a new ticker pair
+              const pairData: any = {
+                exchange,
+                volume: Number(ticker.volume ?? 0),
+                tradeUrl: ticker.trade_url,
+                spreadPercentage: Number(ticker.bid_ask_spread_percentage ?? 0),
+                lastTraded: ticker.last_traded_at ?? new Date(),
+                fetchAt: new Date(),
+                status: DEFAULT_STATUS,
+                isSpotTradingAllowed: DEFAULT_SPOT_TRADING_ALLOWED,
+                isMarginTradingAllowed: DEFAULT_MARGIN_TRADING_ALLOWED,
+                isFiatPair
+              };
+
+              if (isFiatPair) {
+                // For fiat pairs, store symbols instead of coin references
+                pairData.baseAssetSymbol = baseSymbol.toLowerCase();
+                pairData.quoteAssetSymbol = targetSymbol.toLowerCase();
+                // Only set coin references if they exist
+                if (baseCoin) pairData.baseAsset = baseCoin;
+                if (quoteCoin) pairData.quoteAsset = quoteCoin;
+              } else {
+                // For regular pairs, use coin references
+                pairData.baseAsset = baseCoin;
+                pairData.quoteAsset = quoteCoin;
+              }
+
+              const newPair = await this.tickerPair.createTickerPair(pairData);
+
+              newPairs.push(newPair);
+            } else {
+              // Update the existing pair with new data
+              Object.assign(existingPair, {
+                volume: Number(ticker.volume ?? existingPair.volume),
+                tradeUrl: ticker.trade_url ?? existingPair.tradeUrl,
+                spreadPercentage: Number(ticker.bid_ask_spread_percentage ?? existingPair.spreadPercentage),
+                lastTraded: ticker.last_traded_at ?? existingPair.lastTraded,
+                fetchAt: new Date()
+                // Not updating status or trading flags as they should be managed separately
+              });
+            }
           }
+
+          this.logger.log(`Processed ${tickers.length} ticker pairs for ${exchange.name}`);
 
           // Find pairs that are no longer present in the exchange data
           // and should be removed or marked as inactive

--- a/apps/api/src/migrations/1776388300942-add-coin-snapshot-backfill-completed.ts
+++ b/apps/api/src/migrations/1776388300942-add-coin-snapshot-backfill-completed.ts
@@ -1,0 +1,36 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddCoinSnapshotBackfillCompleted1776388300942 implements MigrationInterface {
+  name = 'AddCoinSnapshotBackfillCompleted1776388300942';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "coin" ADD COLUMN IF NOT EXISTS "snapshotBackfillCompletedAt" TIMESTAMP WITH TIME ZONE`
+    );
+
+    // Coins with 30+ existing snapshots don't need re-backfill — mark them complete.
+    await queryRunner.query(`
+      UPDATE "coin"
+         SET "snapshotBackfillCompletedAt" = NOW()
+        FROM (
+          SELECT "coinId", COUNT(*) AS cnt
+            FROM "coin_daily_snapshots"
+           GROUP BY "coinId"
+        ) s
+       WHERE "coin"."id" = s."coinId"
+         AND s.cnt >= 30
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_coin_backfill_pending"
+          ON "coin" ("id")
+       WHERE "snapshotBackfillCompletedAt" IS NULL
+         AND "delistedAt" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_coin_backfill_pending"`);
+    await queryRunner.query(`ALTER TABLE "coin" DROP COLUMN IF EXISTS "snapshotBackfillCompletedAt"`);
+  }
+}

--- a/apps/api/src/shared/distributed-lock.constants.ts
+++ b/apps/api/src/shared/distributed-lock.constants.ts
@@ -3,7 +3,10 @@ export const LOCK_KEYS = {
   OHLC_SYNC_SCHEDULE: 'ohlc-sync:schedule-lock',
   SYMBOL_MAP_REFRESH: 'ohlc-sync:symbol-map-refresh-lock',
   COIN_SYNC: 'coin-sync:lock',
+  /** @deprecated Replaced by COIN_MARKET_SYNC / COIN_METADATA_SYNC. Retained for one release so in-flight workers do not error. */
   COIN_DETAIL: 'coin-detail:lock',
+  COIN_MARKET_SYNC: 'coin-market-sync:lock',
+  COIN_METADATA_SYNC: 'coin-metadata-sync:lock',
   TICKER_PAIRS_SYNC: 'ticker-pairs-sync:lock',
   CATEGORY_SYNC: 'category-sync:lock',
   EXCHANGE_SYNC: 'exchange-sync:lock'
@@ -21,6 +24,8 @@ export const LOCK_DEFAULTS = {
   SCHEDULE_LOCK_TTL_MS: 30 * 1000, // 30 seconds for scheduling operations
   COIN_SYNC_TTL_MS: 45 * 60 * 1000, // 45 minutes — observed ~34.8 min, ~30% buffer
   COIN_DETAIL_TTL_MS: 5 * 60 * 60 * 1000, // 5 hours — observed runtime ~3h 46m (1500 coins × 2.5s/batch + 429 retries); ~33% buffer
+  COIN_MARKET_SYNC_TTL_MS: 45 * 60 * 1000, // 45 minutes — up to ~25 min on fresh install (500 coins × per-coin chart backfill) + batched markets + snapshot + 30s cooldown, ~80% headroom
+  COIN_METADATA_SYNC_TTL_MS: 5 * 60 * 60 * 1000, // 5 hours — monthly per-coin metadata refresh (same budget as former coin-detail)
   TICKER_PAIRS_SYNC_TTL_MS: 30 * 60 * 1000, // 30 minutes — paginated ticker fetching, 1s between pages
   CATEGORY_SYNC_TTL_MS: 2 * 60 * 1000, // 2 minutes — single API call with retry
   EXCHANGE_SYNC_TTL_MS: 10 * 60 * 1000, // 10 minutes — observed ~5.3 min, ~90% buffer


### PR DESCRIPTION
## Summary

- Cut projected monthly CoinGecko calls from ~24k to ~3.5k (under the 10k Demo plan limit) by eliminating three sources of redundant API traffic
- Restructured the daily/weekly/monthly sync cadence so the Sunday spike drops from ~1,495 to ~750 calls
- Hardened three structural issues surfaced in post-commit review: shared-cache race, timeout/lock zombie window, and an unused partial index

## Changes

### Primary reductions
- **Batch market data**: Replace per-coin `/coins/{id}` loop with `/coins/markets` (250 coins/call). Move metadata refresh to a separate monthly cron that skips coins refreshed within 25 days.
- **Shared ticker fetcher**: New `ExchangeTickerFetcherService` paginates `/exchanges/{id}/tickers` once per week and caches in Redis so both `coin-sync` and `ticker-pairs-sync` reuse the result.
- **One-shot snapshot backfill**: New `Coin.snapshotBackfillCompletedAt` flag gates historical backfill. Migration back-populates the flag for coins with 30+ existing snapshots.

### Follow-up structural fixes
- **Stagger + TTL**: `ticker-pair-sync` now runs at Sunday 02:00 UTC (2h after `coin-sync` at 00:00) so the shared cache is warm for the second caller. TTL extended from 6d to 8d so it outlives the weekly cadence.
- **Timeout/lock realignment**: `coin-market-sync` lock TTL 20m → 45m, `withTimeout` 18m → 40m. The timeout is now unreachable in normal ops (~25m fresh-install runtime), so the zombie-write window only opens on genuinely hung runs.
- **Partial-index query rewrite**: `getCoinsNeedingBackfill` split into two queries so `IDX_coin_backfill_pending` is actually used. The original single correlated-COUNT query could not hit the partial index.

### Tooling
- `/code-review` command now reads planning documents (so it respects intentional design decisions).

## Test Plan

- [x] `npx nx test api -- --testPathPattern='coin-daily-snapshot'` — 21/21 pass
- [x] `npx nx test api -- --testPathPattern='exchange-ticker-fetcher'` — 6/6 pass
- [x] `npx nx test api -- --testPathPattern='coin-sync.task'` — 31/31 pass
- [x] `npx nx test api -- --testPathPattern='coin-detail-sync'` — passes
- [x] `npx nx test api -- --testPathPattern='map-coingecko-markets'` — passes
- [x] `npx nx build api` — clean type-check
- [x] Pre-commit hooks (lint + full test suite) passed
- [ ] Manual EXPLAIN check post-deploy: `EXPLAIN SELECT id FROM coin WHERE id IN (...) AND "snapshotBackfillCompletedAt" IS NULL` should show `Index Scan using IDX_coin_backfill_pending`
- [ ] Post-deploy Sunday monitoring — weekly spike should drop from ~1,495 to ~750 API calls
- [ ] Watch for absence of `coin-market-sync timed out after 2400000ms` log lines (timeout should be unreachable in normal ops)