### PR TITLE
perf(api): skip indicator cache in backtest contexts

### DIFF
--- a/.claude/rules/optimization-module.md
+++ b/.claude/rules/optimization-module.md
@@ -1,7 +1,7 @@
 ---
 description: Grid search parameter optimization with walk-forward validation
 globs:
-  - "apps/api/src/optimization/**"
+  - 'apps/api/src/optimization/**'
 ---
 
 # Optimization Module
@@ -17,11 +17,11 @@ globs:
 
 ## Config Presets
 
-| Preset | Iterations | Max Combos | Notes |
-|--------|-----------|------------|-------|
-| DEFAULT | 100 | 75 | Standard |
-| FAST | — | 20 | Quick validation |
-| THOROUGH | — | 5000 | Composite objective |
+| Preset   | Iterations | Max Combos | Notes               |
+| -------- | ---------- | ---------- | ------------------- |
+| DEFAULT  | 100        | 75         | Standard            |
+| FAST     | —          | 20         | Quick validation    |
+| THOROUGH | —          | 5000       | Composite objective |
 
 ## GridSearchService
 
@@ -29,11 +29,13 @@ Cartesian product → constraint filtering → random-sample if exceeding `maxCo
 
 ## ParameterSpaceBuilder
 
-Auto-derives from algorithm's `getConfigSchema()`. Excludes: `enabled, riskLevel, cooldownMs, maxTradesPerDay, minSellPercent`.
+Auto-derives from algorithm's `getConfigSchema()`. Excludes:
+`enabled, riskLevel, cooldownMs, maxTradesPerDay, minSellPercent`.
 
 ## Recovery
 
-`OptimizationRecoveryService` (`OnApplicationBootstrap`): auto-resumes RUNNING/PENDING at boot (max 3 retries, 6-hour stale threshold).
+`OptimizationRecoveryService` (`OnApplicationBootstrap`): auto-resumes RUNNING/PENDING at boot (max 3 retries, 6-hour
+stale threshold).
 
 ## Processor
 
@@ -45,7 +47,7 @@ Emits `PIPELINE_EVENTS.OPTIMIZATION_COMPLETED/FAILED` via `EventEmitter2`.
 
 ## BullMQ
 
-Queue: `optimization` (concurrency via `OPTIMIZATION_CONCURRENCY` env, default 5).
+Queue: `optimization` (concurrency via `OPTIMIZATION_CONCURRENCY` env, default 3).
 
 ## Key Constants
 

--- a/apps/api/src/algorithm/base/base-algorithm-strategy.ts
+++ b/apps/api/src/algorithm/base/base-algorithm-strategy.ts
@@ -243,6 +243,16 @@ export abstract class BaseAlgorithmStrategy implements AlgorithmStrategy {
   }
 
   /**
+   * Determines whether indicator calls should bypass Redis cache.
+   * Skipped for contexts with ~0% hit rate (historical + live-replay backtests).
+   * Kept enabled for optimization (grid search may share indicator params across combos)
+   * and live/paper trading (repeated calls on stable windows benefit from cache).
+   */
+  protected shouldSkipIndicatorCache(context: AlgorithmContext): boolean {
+    return !!(context.metadata?.backtestId || context.metadata?.isLiveReplay);
+  }
+
+  /**
    * Retrieve a precomputed indicator slice matching the current price window.
    * Returns undefined when precomputed data is not available (legacy path).
    */

--- a/apps/api/src/algorithm/indicators/indicator.service.ts
+++ b/apps/api/src/algorithm/indicators/indicator.service.ts
@@ -140,14 +140,14 @@ export class IndicatorService {
    * @returns MACD result with macd, signal, and histogram arrays
    */
   async calculateMACD(options: MACDOptions, provider?: IIndicatorProvider): Promise<MACDResult> {
-    const cacheKey = this.buildCacheKey(IndicatorType.MACD, options.coinId, options.prices, {
-      fastPeriod: options.fastPeriod,
-      slowPeriod: options.slowPeriod,
-      signalPeriod: options.signalPeriod
-    });
+    let cacheKey: string | undefined;
 
-    // Check cache first
     if (!options.skipCache) {
+      cacheKey = this.buildCacheKey(IndicatorType.MACD, options.coinId, options.prices, {
+        fastPeriod: options.fastPeriod,
+        slowPeriod: options.slowPeriod,
+        signalPeriod: options.signalPeriod
+      });
       const cached = await this.getFromCache<MACDResult>(cacheKey);
       if (cached) {
         return { ...cached, fromCache: true };
@@ -186,7 +186,9 @@ export class IndicatorService {
       fromCache: false
     };
 
-    await this.setInCache(cacheKey, result);
+    if (cacheKey) {
+      await this.setInCache(cacheKey, result);
+    }
     return result;
   }
 
@@ -201,13 +203,13 @@ export class IndicatorService {
     options: BollingerBandsOptions,
     provider?: IIndicatorProvider
   ): Promise<BollingerBandsResult> {
-    const cacheKey = this.buildCacheKey(IndicatorType.BOLLINGER_BANDS, options.coinId, options.prices, {
-      period: options.period,
-      stdDev: options.stdDev
-    });
+    let cacheKey: string | undefined;
 
-    // Check cache first
     if (!options.skipCache) {
+      cacheKey = this.buildCacheKey(IndicatorType.BOLLINGER_BANDS, options.coinId, options.prices, {
+        period: options.period,
+        stdDev: options.stdDev
+      });
       const cached = await this.getFromCache<BollingerBandsResult>(cacheKey);
       if (cached) {
         return { ...cached, fromCache: true };
@@ -252,7 +254,9 @@ export class IndicatorService {
       fromCache: false
     };
 
-    await this.setInCache(cacheKey, result);
+    if (cacheKey) {
+      await this.setInCache(cacheKey, result);
+    }
     return result;
   }
 
@@ -264,12 +268,12 @@ export class IndicatorService {
    * @returns ATR result with values array
    */
   async calculateATR(options: ATROptions, provider?: IIndicatorProvider): Promise<ATRResult> {
-    const cacheKey = this.buildCacheKey(IndicatorType.ATR, options.coinId, options.prices, {
-      period: options.period
-    });
+    let cacheKey: string | undefined;
 
-    // Check cache first
     if (!options.skipCache) {
+      cacheKey = this.buildCacheKey(IndicatorType.ATR, options.coinId, options.prices, {
+        period: options.period
+      });
       const cached = await this.getFromCache<ATRResult>(cacheKey);
       if (cached) {
         return { ...cached, fromCache: true };
@@ -297,7 +301,9 @@ export class IndicatorService {
       fromCache: false
     };
 
-    await this.setInCache(cacheKey, result);
+    if (cacheKey) {
+      await this.setInCache(cacheKey, result);
+    }
     return result;
   }
 
@@ -354,12 +360,12 @@ export class IndicatorService {
     calcOptions: { values: number[]; period: number },
     options: PeriodIndicatorOptions
   ): Promise<IndicatorResult> {
-    const cacheKey = this.buildCacheKey(type, options.coinId, options.prices, {
-      period: options.period
-    });
+    let cacheKey: string | undefined;
 
-    // Check cache first
     if (!options.skipCache) {
+      cacheKey = this.buildCacheKey(type, options.coinId, options.prices, {
+        period: options.period
+      });
       const cached = await this.getFromCache<IndicatorResult>(cacheKey);
       if (cached) {
         return { ...cached, fromCache: true };
@@ -376,7 +382,9 @@ export class IndicatorService {
       fromCache: false
     };
 
-    await this.setInCache(cacheKey, result);
+    if (cacheKey) {
+      await this.setInCache(cacheKey, result);
+    }
     return result;
   }
 

--- a/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
+++ b/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
@@ -73,6 +73,7 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       const directions: Direction[] = config.tradeDirection === 'both' ? ['long', 'short'] : [config.tradeDirection];
 
@@ -88,7 +89,7 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
           this.getPrecomputedSlice(context, coin.id, `atr_${config.atrPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateATR(
-              { coinId: coin.id, prices: priceHistory, period: config.atrPeriod },
+              { coinId: coin.id, prices: priceHistory, period: config.atrPeriod, skipCache },
               this
             )
           ).values;

--- a/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
@@ -80,6 +80,7 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
       const eligibleCoins = context.coins.filter((coin) => this.hasEnoughData(context.priceData[coin.id], config));
 
       this.logger.debug(
@@ -96,7 +97,7 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
 
         const coinStart = Date.now();
 
-        const bands = await this.loadBollingerBands(coin, priceHistory, context, config);
+        const bands = await this.loadBollingerBands(coin, priceHistory, context, config, skipCache);
         if (!bands) continue;
 
         const bbDuration = Date.now() - coinStart;
@@ -207,7 +208,8 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
     coin: { id: string; symbol: string },
     priceHistory: CandleData[],
     context: AlgorithmContext,
-    config: BollingerSqueezeConfig
+    config: BollingerSqueezeConfig,
+    skipCache: boolean
   ): Promise<BollingerBandsData | null> {
     const bbKey = `bb_${config.period}_${config.stdDev}`;
     const preUpper = this.getPrecomputedSlice(context, coin.id, `${bbKey}_upper`, priceHistory.length);
@@ -226,7 +228,7 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
     let bbResult: Awaited<ReturnType<typeof this.indicatorService.calculateBollingerBands>>;
     try {
       const bbPromise = this.indicatorService.calculateBollingerBands(
-        { coinId: coin.id, prices: priceHistory, period: config.period, stdDev: config.stdDev },
+        { coinId: coin.id, prices: priceHistory, period: config.period, stdDev: config.stdDev, skipCache },
         this
       );
 

--- a/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
@@ -61,6 +61,7 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -101,7 +102,8 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
               coinId: coin.id,
               prices: priceHistory,
               period: config.period,
-              stdDev: config.stdDev
+              stdDev: config.stdDev,
+              skipCache
             },
             this
           );

--- a/apps/api/src/algorithm/strategies/confluence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/confluence.strategy.ts
@@ -84,6 +84,7 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -94,7 +95,7 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
         }
 
         // Calculate confluence score for this coin
-        const confluenceScore = await this.calculateConfluenceScore(context, coin.id, priceHistory, config, isBacktest);
+        const confluenceScore = await this.calculateConfluenceScore(context, coin.id, priceHistory, config, skipCache);
 
         // Generate trading signal if confluence is met
         const currentPrice = priceHistory[priceHistory.length - 1].avg;

--- a/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
+++ b/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
@@ -62,6 +62,7 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -96,19 +97,19 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
             preFastEMA
               ? Promise.resolve({ values: preFastEMA })
               : this.indicatorService.calculateEMA(
-                  { coinId: coin.id, prices: priceHistory, period: config.fastEmaPeriod },
+                  { coinId: coin.id, prices: priceHistory, period: config.fastEmaPeriod, skipCache },
                   this
                 ),
             preSlowEMA
               ? Promise.resolve({ values: preSlowEMA })
               : this.indicatorService.calculateEMA(
-                  { coinId: coin.id, prices: priceHistory, period: config.slowEmaPeriod },
+                  { coinId: coin.id, prices: priceHistory, period: config.slowEmaPeriod, skipCache },
                   this
                 ),
             preRSI
               ? Promise.resolve({ values: preRSI })
               : this.indicatorService.calculateRSI(
-                  { coinId: coin.id, prices: priceHistory, period: config.rsiPeriod },
+                  { coinId: coin.id, prices: priceHistory, period: config.rsiPeriod, skipCache },
                   this
                 )
           ]);

--- a/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
+++ b/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
@@ -55,6 +55,7 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -69,7 +70,7 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
           this.getPrecomputedSlice(context, coin.id, `ema_${fastPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateEMA(
-              { coinId: coin.id, prices: priceHistory, period: fastPeriod },
+              { coinId: coin.id, prices: priceHistory, period: fastPeriod, skipCache },
               this
             )
           ).values;
@@ -77,7 +78,7 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
           this.getPrecomputedSlice(context, coin.id, `ema_${slowPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateEMA(
-              { coinId: coin.id, prices: priceHistory, period: slowPeriod },
+              { coinId: coin.id, prices: priceHistory, period: slowPeriod, skipCache },
               this
             )
           ).values;

--- a/apps/api/src/algorithm/strategies/macd.strategy.ts
+++ b/apps/api/src/algorithm/strategies/macd.strategy.ts
@@ -59,6 +59,7 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -93,7 +94,8 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
               prices: priceHistory,
               fastPeriod: config.fastPeriod,
               slowPeriod: config.slowPeriod,
-              signalPeriod: config.signalPeriod
+              signalPeriod: config.signalPeriod,
+              skipCache
             },
             this
           );

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
@@ -61,6 +61,7 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -103,7 +104,7 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
             this.logger.warn(`Partial BB cache for ${coin.symbol} (${bbKey}), recalculating`);
           }
           bollingerBandsResult = await this.indicatorService.calculateBollingerBands(
-            { coinId: coin.id, prices: priceHistory, period, stdDev: threshold },
+            { coinId: coin.id, prices: priceHistory, period, stdDev: threshold, skipCache },
             this // Pass this strategy as IIndicatorProvider for custom override support
           );
         }

--- a/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
@@ -82,6 +82,7 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -95,7 +96,7 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
           this.getPrecomputedSlice(context, coin.id, `rsi_${config.rsiPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateRSI(
-              { coinId: coin.id, prices: priceHistory, period: config.rsiPeriod },
+              { coinId: coin.id, prices: priceHistory, period: config.rsiPeriod, skipCache },
               this
             )
           ).values;
@@ -104,15 +105,19 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
           this.getPrecomputedSlice(context, coin.id, `ema_${config.emaPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateEMA(
-              { coinId: coin.id, prices: priceHistory, period: config.emaPeriod },
+              { coinId: coin.id, prices: priceHistory, period: config.emaPeriod, skipCache },
               this
             )
           ).values;
 
         const atr =
           this.getPrecomputedSlice(context, coin.id, 'atr_14', priceHistory.length) ??
-          (await this.indicatorService.calculateATR({ coinId: coin.id, prices: priceHistory, period: 14 }, this))
-            .values;
+          (
+            await this.indicatorService.calculateATR(
+              { coinId: coin.id, prices: priceHistory, period: 14, skipCache },
+              this
+            )
+          ).values;
 
         const divergence = this.detectDivergence(priceHistory, rsi, atr, config);
 

--- a/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
@@ -71,6 +71,7 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -85,7 +86,7 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
           this.getPrecomputedSlice(context, coin.id, `rsi_${config.rsiPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateRSI(
-              { coinId: coin.id, prices: priceHistory, period: config.rsiPeriod },
+              { coinId: coin.id, prices: priceHistory, period: config.rsiPeriod, skipCache },
               this
             )
           ).values;
@@ -115,7 +116,8 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
               prices: priceHistory,
               fastPeriod: config.macdFast,
               slowPeriod: config.macdSlow,
-              signalPeriod: config.macdSignal
+              signalPeriod: config.macdSignal,
+              skipCache
             },
             this
           );

--- a/apps/api/src/algorithm/strategies/rsi.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.ts
@@ -56,6 +56,7 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -70,7 +71,7 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
           this.getPrecomputedSlice(context, coin.id, `rsi_${config.period}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateRSI(
-              { coinId: coin.id, prices: priceHistory, period: config.period },
+              { coinId: coin.id, prices: priceHistory, period: config.period, skipCache },
               this
             )
           ).values;

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
@@ -56,6 +56,7 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -70,7 +71,7 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
           this.getPrecomputedSlice(context, coin.id, `sma_${fastPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateSMA(
-              { coinId: coin.id, prices: priceHistory, period: fastPeriod },
+              { coinId: coin.id, prices: priceHistory, period: fastPeriod, skipCache },
               this
             )
           ).values;
@@ -78,7 +79,7 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
           this.getPrecomputedSlice(context, coin.id, `sma_${slowPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateSMA(
-              { coinId: coin.id, prices: priceHistory, period: slowPeriod },
+              { coinId: coin.id, prices: priceHistory, period: slowPeriod, skipCache },
               this
             )
           ).values;

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
@@ -74,6 +74,7 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         context.metadata?.isOptimization ||
         context.metadata?.isLiveReplay
       );
+      const skipCache = this.shouldSkipIndicatorCache(context);
 
       for (const coin of context.coins) {
         const priceHistory = context.priceData[coin.id];
@@ -88,7 +89,7 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
           this.getPrecomputedSlice(context, coin.id, `ema_${config.fastPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateEMA(
-              { coinId: coin.id, prices: priceHistory, period: config.fastPeriod },
+              { coinId: coin.id, prices: priceHistory, period: config.fastPeriod, skipCache },
               this
             )
           ).values;
@@ -96,7 +97,7 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
           this.getPrecomputedSlice(context, coin.id, `ema_${config.mediumPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateEMA(
-              { coinId: coin.id, prices: priceHistory, period: config.mediumPeriod },
+              { coinId: coin.id, prices: priceHistory, period: config.mediumPeriod, skipCache },
               this
             )
           ).values;
@@ -104,7 +105,7 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
           this.getPrecomputedSlice(context, coin.id, `ema_${config.slowPeriod}`, priceHistory.length) ??
           (
             await this.indicatorService.calculateEMA(
-              { coinId: coin.id, prices: priceHistory, period: config.slowPeriod },
+              { coinId: coin.id, prices: priceHistory, period: config.slowPeriod, skipCache },
               this
             )
           ).values;

--- a/apps/api/src/optimization/optimization.config.ts
+++ b/apps/api/src/optimization/optimization.config.ts
@@ -12,6 +12,6 @@ const parseInteger = (value: string | undefined, fallback: number): number => {
 export const optimizationConfig = registerAs(
   'optimization',
   (): OptimizationAppConfig => ({
-    concurrency: parseInteger(process.env.OPTIMIZATION_CONCURRENCY, 5)
+    concurrency: parseInteger(process.env.OPTIMIZATION_CONCURRENCY, 3)
   })
 );

--- a/apps/api/src/tasks/backtest-watchdog.service.ts
+++ b/apps/api/src/tasks/backtest-watchdog.service.ts
@@ -129,7 +129,7 @@ export class BacktestWatchdogService {
         }
 
         const reason = isPending
-          ? `Stuck PENDING for ${Math.round(thresholdMs / 60000)} min — BullMQ job likely lost`
+          ? `Stuck PENDING for ${Math.round(thresholdMs / 60000)} min without being picked up by worker (possible worker crash, job loss, or Redis state reset)`
           : `Stale: no heartbeat progress for ${Math.round(thresholdMs / 60000)} min. ` +
             `Last index: ${backtest.checkpointState?.lastProcessedIndex ?? 'unknown'}`;
 


### PR DESCRIPTION
## Summary

- Add `shouldSkipIndicatorCache()` helper on `BaseAlgorithmStrategy` — returns true for historical backtests and live-replay where per-iteration cache keys have ~0% hit rate
- Thread `skipCache` through all `IndicatorService.calculate*()` calls across 13 strategies plus the confluence indicators util
- Fix `IndicatorService` write-bug: `setInCache` was still writing when `skipCache=true` (only the read was being skipped), causing unnecessary Redis write pressure
- Lower default `OPTIMIZATION_CONCURRENCY` from 5 to 3 to reduce parallel Redis write pressure during the 02:00 UTC cron window

## Changes

**Core helper**
- `apps/api/src/algorithm/base/base-algorithm-strategy.ts` — new `shouldSkipIndicatorCache(context)` helper
- `apps/api/src/algorithm/indicators/indicator.service.ts` — gate `setInCache` behind `!options.skipCache` in all 4 cache-aware calculators (SMA/EMA/RSI/SD via shared method, MACD, Bollinger Bands, ATR)

**Strategy threading (13 strategies)**
- ATR trailing stop, Bollinger band squeeze, Bollinger bands breakout, Confluence, EMA-RSI filter, Exponential MA, MACD, Mean reversion, RSI divergence, RSI-MACD combo, RSI, SMA crossover, Triple EMA

**Tuning**
- `apps/api/src/optimization/optimization.config.ts` — default concurrency 5 → 3
- `.claude/rules/optimization-module.md` — updated to reflect new default + reformat
- `apps/api/src/tasks/backtest-watchdog.service.ts` — clarify stuck-PENDING diagnostic message

## Why

During the 02:00 UTC auto-backtest cron, the indicator cache was being written on every iteration despite a ~0% read hit rate (per-iteration unique price windows produce unique cache keys). This created significant Redis write pressure with no benefit. The helper keeps caching enabled for contexts where it helps (live trading, paper trading, and optimization where grid search may share indicator params across combos).

## Test Plan

- [ ] Existing strategy unit tests pass
- [ ] Run a historical backtest and verify Redis write volume drops during execution
- [ ] Verify live trading and paper trading paths still populate the indicator cache (metadata without `backtestId`/`isLiveReplay`)
- [ ] Verify `OPTIMIZATION_CONCURRENCY` env override still works when set explicitly