### PR TITLE
feat(api): reject losing strategies before paper trading

### DIFF
--- a/.claude/rules/risk-module.md
+++ b/.claude/rules/risk-module.md
@@ -44,3 +44,6 @@ duration.
 | 3     | Moderate (default) | 40         | 120        | 25%          |
 | 4     | Moderate-High      | 35         | 90         | 35%          |
 | 5     | Aggressive         | 30         | 60         | 40%          |
+
+Sessions terminate early (as COMPLETED with `stoppedReason=insufficient_signals`) if the risk-band signal check fires:
+Level 1 @ day 7 / <3 trades, Level 2 @ day 6 / <3, Level 3-4 @ day 5 / <2, Level 5 @ day 4 / <2.

--- a/apps/api/src/admin/backtest-monitoring/dto/paper-trading-analytics.dto.ts
+++ b/apps/api/src/admin/backtest-monitoring/dto/paper-trading-analytics.dto.ts
@@ -183,6 +183,7 @@ export class PaperTradingSessionListItemDto {
   @ApiProperty() duration: string;
   @ApiProperty({ nullable: true }) startedAt: string | null;
   @ApiProperty() createdAt: string;
+  @ApiProperty({ nullable: true, required: false }) stoppedReason?: string | null;
 }
 
 export class PaginatedPaperTradingSessionsDto {

--- a/apps/api/src/admin/backtest-monitoring/paper-trading-monitoring.service.spec.ts
+++ b/apps/api/src/admin/backtest-monitoring/paper-trading-monitoring.service.spec.ts
@@ -227,6 +227,7 @@ describe('PaperTradingMonitoringService', () => {
           sharpeRatio: 1.2,
           duration: 'N/A',
           startedAt: null,
+          stoppedReason: null,
           createdAt: createdAt.toISOString()
         }
       ]);

--- a/apps/api/src/admin/backtest-monitoring/paper-trading-monitoring.service.ts
+++ b/apps/api/src/admin/backtest-monitoring/paper-trading-monitoring.service.ts
@@ -93,7 +93,8 @@ export class PaperTradingMonitoringService {
       sharpeRatio: s.sharpeRatio ?? null,
       duration: s.duration || 'N/A',
       startedAt: s.startedAt?.toISOString() ?? null,
-      createdAt: s.createdAt.toISOString()
+      createdAt: s.createdAt.toISOString(),
+      stoppedReason: s.stoppedReason ?? null
     }));
 
     const totalPages = Math.ceil(total / limit);

--- a/apps/api/src/algorithm/strategies/rsi-divergence.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/rsi-divergence.strategy.spec.ts
@@ -502,16 +502,97 @@ describe('RSIDivergenceStrategy', () => {
   });
 
   describe('getConfigSchema', () => {
-    it('should include all new parameters', () => {
+    it('should include all tunable parameters including pivotStrength', () => {
       const schema = strategy.getConfigSchema();
       expect(schema).toHaveProperty('rsiPeriod');
       expect(schema).toHaveProperty('emaPeriod');
       expect(schema).toHaveProperty('lookbackPeriod');
+      expect(schema).toHaveProperty('pivotStrength');
       expect(schema).toHaveProperty('pivotTolerance');
       expect(schema).toHaveProperty('minDivergencePercent');
       expect(schema).toHaveProperty('rsiOversold');
       expect(schema).toHaveProperty('rsiOverbought');
       expect(schema).toHaveProperty('minConfidence');
+    });
+
+    it('exposes pivotStrength with sensible bounds (2-5, default 3)', () => {
+      const schema = strategy.getConfigSchema() as Record<string, { default: number; min: number; max: number }>;
+      expect(schema.pivotStrength.default).toBe(3);
+      expect(schema.pivotStrength.min).toBe(2);
+      expect(schema.pivotStrength.max).toBe(5);
+    });
+  });
+
+  describe('pivotStrength config override', () => {
+    it('getMinDataPoints scales with pivotStrength (2 → 48, 3 → 50, 5 → 54)', () => {
+      expect(strategy.getMinDataPoints({ rsiPeriod: 14, emaPeriod: 8, lookbackPeriod: 30, pivotStrength: 2 })).toBe(48);
+      expect(strategy.getMinDataPoints({ rsiPeriod: 14, emaPeriod: 8, lookbackPeriod: 30, pivotStrength: 3 })).toBe(50);
+      expect(strategy.getMinDataPoints({ rsiPeriod: 14, emaPeriod: 8, lookbackPeriod: 30, pivotStrength: 5 })).toBe(54);
+    });
+
+    it('uses default pivotStrength=3 when unset', () => {
+      expect(strategy.getMinDataPoints({ rsiPeriod: 14, emaPeriod: 8, lookbackPeriod: 30 })).toBe(50);
+    });
+
+    it('wider pivotStrength rejects spike-style pivots that narrower strength accepts', async () => {
+      // Build two pivot lows where only the immediate ±2 bars confirm the low.
+      // Bars at ±3 from each pivot are PUNCHED DOWN to the same level as the
+      // pivot itself — with pivotStrength=3 that ±3 bar breaches the threshold
+      // and the pivot is rejected; with pivotStrength=2 only ±2 are checked and
+      // the pivot survives.
+      const buildPrices = () => {
+        const prices = createFlatPrices(90);
+
+        // Pivot low #1 at index 70 (low=80); bars at ±3 also sit at 80
+        prices[70].low = 80;
+        prices[70].avg = 83;
+        prices[67].low = 80; // ±3 breaches threshold when pivotStrength=3
+        prices[73].low = 80;
+        prices[68].low = 95;
+        prices[69].low = 95;
+        prices[71].low = 95;
+        prices[72].low = 95;
+
+        // Pivot low #2 at index 83 (low=74); bars at ±3 also sit at 74
+        prices[83].low = 74;
+        prices[83].avg = 77;
+        prices[80].low = 74;
+        prices[86].low = 74;
+        prices[81].low = 95;
+        prices[82].low = 95;
+        prices[84].low = 95;
+        prices[85].low = 95;
+
+        return prices;
+      };
+
+      const rsiValues = createMockRSI(90, 50);
+      rsiValues[70] = 22;
+      rsiValues[83] = 30;
+      rsiValues[89] = 32;
+      const emaValues = createMockEMA(90, 100);
+      const atrValues = createMockATR(90, 5);
+
+      // pivotStrength=2 → pivots survive, signal emitted
+      setupIndicatorMocks(rsiValues, emaValues, atrValues);
+      const narrowResult = await strategy.execute({
+        coins: [{ id: 'btc', symbol: 'BTC', name: 'Bitcoin' }] as any,
+        priceData: { btc: buildPrices() as any },
+        timestamp: new Date(),
+        config: { ...baseConfig, pivotStrength: 2 }
+      });
+      expect(narrowResult.signals).toHaveLength(1);
+      expect(narrowResult.signals[0].type).toBe(SignalType.BUY);
+
+      // pivotStrength=3 → ±3 bars at same low as pivot breach threshold, no pivots, no signal
+      setupIndicatorMocks(rsiValues, emaValues, atrValues);
+      const wideResult = await strategy.execute({
+        coins: [{ id: 'btc', symbol: 'BTC', name: 'Bitcoin' }] as any,
+        priceData: { btc: buildPrices() as any },
+        timestamp: new Date(),
+        config: { ...baseConfig, pivotStrength: 3 }
+      });
+      expect(wideResult.signals).toHaveLength(0);
     });
   });
 });

--- a/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
@@ -18,6 +18,7 @@ interface RSIDivergenceConfig {
   rsiPeriod: number;
   emaPeriod: number;
   lookbackPeriod: number;
+  pivotStrength: number;
   pivotTolerance: number;
   minDivergencePercent: number;
   rsiOversold: number;
@@ -41,7 +42,6 @@ interface DivergenceResult {
   score: number;
 }
 
-const PIVOT_STRENGTH = 3;
 const MIN_RSI_DIVERGENCE = 2;
 
 /**
@@ -145,6 +145,7 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
       rsiPeriod: (config.rsiPeriod as number) ?? 14,
       emaPeriod: (config.emaPeriod as number) ?? 50,
       lookbackPeriod: (config.lookbackPeriod as number) ?? 30,
+      pivotStrength: (config.pivotStrength as number) ?? 3,
       pivotTolerance: (config.pivotTolerance as number) ?? 0.3,
       minDivergencePercent: (config.minDivergencePercent as number) ?? 2,
       rsiOversold: (config.rsiOversold as number) ?? 40,
@@ -154,7 +155,7 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
   }
 
   private hasEnoughData(priceHistory: CandleData[] | undefined, config: RSIDivergenceConfig): boolean {
-    const minRequired = Math.max(config.rsiPeriod, config.emaPeriod) + config.lookbackPeriod + PIVOT_STRENGTH * 2;
+    const minRequired = Math.max(config.rsiPeriod, config.emaPeriod) + config.lookbackPeriod + config.pivotStrength * 2;
     return !!priceHistory && priceHistory.length >= minRequired;
   }
 
@@ -167,19 +168,20 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
     rsi: number[],
     atr: number[],
     tolerance: number,
+    pivotStrength: number,
     startIndex: number,
     endIndex: number
   ): PivotPoint[] {
     const pivots: PivotPoint[] = [];
 
-    for (let i = startIndex + PIVOT_STRENGTH; i <= endIndex - PIVOT_STRENGTH; i++) {
+    for (let i = startIndex + pivotStrength; i <= endIndex - pivotStrength; i++) {
       if (!Number.isFinite(rsi[i]) || !Number.isFinite(atr[i]) || atr[i] <= 0) continue;
 
       const currentHigh = prices[i].high;
       const threshold = currentHigh - atr[i] * tolerance;
       let isPivot = true;
 
-      for (let j = 1; j <= PIVOT_STRENGTH; j++) {
+      for (let j = 1; j <= pivotStrength; j++) {
         if (prices[i - j].high > threshold || prices[i + j].high > threshold) {
           isPivot = false;
           break;
@@ -203,19 +205,20 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
     rsi: number[],
     atr: number[],
     tolerance: number,
+    pivotStrength: number,
     startIndex: number,
     endIndex: number
   ): PivotPoint[] {
     const pivots: PivotPoint[] = [];
 
-    for (let i = startIndex + PIVOT_STRENGTH; i <= endIndex - PIVOT_STRENGTH; i++) {
+    for (let i = startIndex + pivotStrength; i <= endIndex - pivotStrength; i++) {
       if (!Number.isFinite(rsi[i]) || !Number.isFinite(atr[i]) || atr[i] <= 0) continue;
 
       const currentLow = prices[i].low;
       const threshold = currentLow + atr[i] * tolerance;
       let isPivot = true;
 
-      for (let j = 1; j <= PIVOT_STRENGTH; j++) {
+      for (let j = 1; j <= pivotStrength; j++) {
         if (prices[i - j].low < threshold || prices[i + j].low < threshold) {
           isPivot = false;
           break;
@@ -240,11 +243,27 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
     config: RSIDivergenceConfig
   ): DivergenceResult | null {
     const currentIndex = prices.length - 1;
-    const lookbackStart = Math.max(0, currentIndex - config.lookbackPeriod - PIVOT_STRENGTH);
+    const lookbackStart = Math.max(0, currentIndex - config.lookbackPeriod - config.pivotStrength);
     const lookbackEnd = currentIndex;
 
-    const pivotHighs = this.findPivotHighs(prices, rsi, atr, config.pivotTolerance, lookbackStart, lookbackEnd);
-    const pivotLows = this.findPivotLows(prices, rsi, atr, config.pivotTolerance, lookbackStart, lookbackEnd);
+    const pivotHighs = this.findPivotHighs(
+      prices,
+      rsi,
+      atr,
+      config.pivotTolerance,
+      config.pivotStrength,
+      lookbackStart,
+      lookbackEnd
+    );
+    const pivotLows = this.findPivotLows(
+      prices,
+      rsi,
+      atr,
+      config.pivotTolerance,
+      config.pivotStrength,
+      lookbackStart,
+      lookbackEnd
+    );
 
     let best: DivergenceResult | null = null;
 
@@ -455,7 +474,8 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
     const rsiPeriod = (config.rsiPeriod as number) ?? 14;
     const emaPeriod = (config.emaPeriod as number) ?? 50;
     const lookbackPeriod = (config.lookbackPeriod as number) ?? 30;
-    return Math.max(rsiPeriod, emaPeriod) + lookbackPeriod + PIVOT_STRENGTH * 2;
+    const pivotStrength = (config.pivotStrength as number) ?? 3;
+    return Math.max(rsiPeriod, emaPeriod) + lookbackPeriod + pivotStrength * 2;
   }
 
   getIndicatorRequirements(_config: Record<string, unknown>): IndicatorRequirement[] {
@@ -477,6 +497,13 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
         min: 15,
         max: 60,
         description: 'Lookback period for finding pivots'
+      },
+      pivotStrength: {
+        type: 'number',
+        default: 3,
+        min: 2,
+        max: 5,
+        description: 'Bars on each side required to form a pivot high/low'
       },
       pivotTolerance: {
         type: 'number',

--- a/apps/api/src/migrations/1776449885990-add-inconclusive-retry-recommendation.ts
+++ b/apps/api/src/migrations/1776449885990-add-inconclusive-retry-recommendation.ts
@@ -1,0 +1,14 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddInconclusiveRetryRecommendation1776449885990 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Adding a new enum value requires running outside of a transaction in PostgreSQL
+    await queryRunner.query(`COMMIT`);
+    await queryRunner.query(`ALTER TYPE "pipeline_recommendation_enum" ADD VALUE IF NOT EXISTS 'INCONCLUSIVE_RETRY'`);
+    await queryRunner.query(`BEGIN`);
+  }
+
+  public async down(): Promise<void> {
+    // PostgreSQL does not support removing enum values.
+  }
+}

--- a/apps/api/src/order/paper-trading/paper-trading-session.util.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-session.util.spec.ts
@@ -1,0 +1,161 @@
+import { PaperTradingStatus, type PaperTradingSession } from './entities';
+import { evaluateStopReason } from './paper-trading-session.util';
+
+const ONE_DAY_MS = 86_400_000;
+
+function makeSession(overrides: Partial<PaperTradingSession> = {}): PaperTradingSession {
+  return {
+    id: 'session-123',
+    status: PaperTradingStatus.ACTIVE,
+    initialCapital: 10_000,
+    totalTrades: 0,
+    startedAt: new Date(Date.now() - ONE_DAY_MS), // 1 day ago by default
+    ...overrides
+  } as PaperTradingSession;
+}
+
+describe('evaluateStopReason', () => {
+  describe('insufficient_signals gate', () => {
+    it('returns insufficient_signals at day 5 with 0 trades for risk=3 (default)', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 5 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBe('insufficient_signals');
+    });
+
+    it('does NOT return insufficient_signals at day 3 for risk=3 (too early)', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 3 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBeNull();
+    });
+
+    it('does NOT return insufficient_signals at day 6 with 2 trades (signal present)', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 2,
+        startedAt: new Date(Date.now() - 6 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBeNull();
+    });
+
+    it('uses 7-day patience window for risk=1 (conservative)', () => {
+      const atDay6 = makeSession({
+        riskLevel: 1,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 6 * ONE_DAY_MS)
+      });
+      const atDay7 = makeSession({
+        riskLevel: 1,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 7 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(atDay6, 10_000, 0)).toBeNull();
+      expect(evaluateStopReason(atDay7, 10_000, 0)).toBe('insufficient_signals');
+    });
+
+    it('uses 4-day patience window for risk=5 (aggressive)', () => {
+      const atDay3 = makeSession({
+        riskLevel: 5,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 3 * ONE_DAY_MS)
+      });
+      const atDay4 = makeSession({
+        riskLevel: 5,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 4 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(atDay3, 10_000, 0)).toBeNull();
+      expect(evaluateStopReason(atDay4, 10_000, 0)).toBe('insufficient_signals');
+    });
+
+    it('falls back to default (risk=3) thresholds when riskLevel is missing', () => {
+      const session = makeSession({
+        riskLevel: undefined,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 5 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBe('insufficient_signals');
+    });
+  });
+
+  describe('precedence', () => {
+    it('fires max_drawdown before insufficient_signals even when starvation condition is also met', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 10 * ONE_DAY_MS),
+        stopConditions: { maxDrawdown: 0.2 }
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0.5)).toBe('max_drawdown');
+    });
+
+    it('fires target_reached before insufficient_signals even when starvation condition is also met', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 10 * ONE_DAY_MS),
+        stopConditions: { targetReturn: 0.1 }
+      });
+
+      expect(evaluateStopReason(session, 12_000, 0)).toBe('target_reached');
+    });
+
+    it('fires min_trades_reached before insufficient_signals', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 30,
+        minTrades: 30,
+        startedAt: new Date(Date.now() - 10 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBe('min_trades_reached');
+    });
+
+    it('fires insufficient_signals before duration_reached', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 0,
+        duration: '1d',
+        startedAt: new Date(Date.now() - 10 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBe('insufficient_signals');
+    });
+  });
+
+  describe('existing behavior unchanged', () => {
+    it('returns null when session is not ACTIVE', () => {
+      const session = makeSession({
+        status: PaperTradingStatus.PAUSED,
+        riskLevel: 3,
+        totalTrades: 0,
+        startedAt: new Date(Date.now() - 10 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBeNull();
+    });
+
+    it('still returns duration_reached when min trades satisfied but time cap hit', () => {
+      const session = makeSession({
+        riskLevel: 3,
+        totalTrades: 5,
+        duration: '1d',
+        startedAt: new Date(Date.now() - 2 * ONE_DAY_MS)
+      });
+
+      expect(evaluateStopReason(session, 10_000, 0)).toBe('duration_reached');
+    });
+  });
+});

--- a/apps/api/src/order/paper-trading/paper-trading-session.util.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-session.util.ts
@@ -1,6 +1,13 @@
 import { type PaperTradingSession, PaperTradingStatus } from './entities';
 
-export type StopReason = 'max_drawdown' | 'target_reached' | 'min_trades_reached' | 'duration_reached';
+import { getInsufficientSignalThreshold } from '../../tasks/dto/pipeline-orchestration.dto';
+
+export type StopReason =
+  | 'max_drawdown'
+  | 'target_reached'
+  | 'min_trades_reached'
+  | 'duration_reached'
+  | 'insufficient_signals';
 
 /**
  * Parse duration string (e.g. "30d", "24h") to milliseconds.
@@ -31,7 +38,14 @@ export function parseDuration(duration: string): number {
  * Precedence (order matters):
  *   1. Safety overrides — maxDrawdown / targetReturn protect capital
  *   2. Min-trades gate — ensures statistical significance before graduation
- *   3. Duration cap — hard time limit prevents runaway sessions
+ *   3. Insufficient-signals gate — early termination when the strategy is
+ *      not producing enough signals to ever satisfy the trade-count gate
+ *   4. Duration cap — hard time limit prevents runaway sessions
+ *
+ * Min-trades runs before insufficient-signals because satisfying the target
+ * trade count is the primary completion path — once hit, starvation no
+ * longer applies. In practice, min-trades thresholds (30-50) are much
+ * higher than starvation floors (2-3), so the two rarely race.
  *
  * Returns the first triggered reason, or null if none apply.
  * Pure function — does not mutate the session or perform I/O. The caller
@@ -63,7 +77,16 @@ export function evaluateStopReason(
     return 'min_trades_reached';
   }
 
-  // 3. Duration cap
+  // 3. Insufficient-signals gate
+  if (session.startedAt) {
+    const { checkAfterDays, minTradesByThen } = getInsufficientSignalThreshold(session.riskLevel);
+    const daysRun = (Date.now() - session.startedAt.getTime()) / 86_400_000;
+    if (daysRun >= checkAfterDays && (session.totalTrades ?? 0) < minTradesByThen) {
+      return 'insufficient_signals';
+    }
+  }
+
+  // 4. Duration cap
   if (session.duration && session.startedAt) {
     const startTime = session.startedAt.getTime();
     const now = Date.now();

--- a/apps/api/src/pipeline/entities/pipeline.entity.ts
+++ b/apps/api/src/pipeline/entities/pipeline.entity.ts
@@ -148,11 +148,11 @@ export class Pipeline {
 
   @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true, transformer: NUMERIC_TRANSFORMER })
   @ApiProperty({ description: 'Composite pipeline score (0-100)', required: false })
-  pipelineScore?: number;
+  pipelineScore?: number | null;
 
   @Column({ type: 'varchar', length: 2, nullable: true })
   @ApiProperty({ description: 'Letter grade (A-F)', required: false })
-  scoreGrade?: string;
+  scoreGrade?: string | null;
 
   @Column({ type: 'varchar', length: 50, nullable: true })
   @ApiProperty({ description: 'Market regime at time of scoring', required: false })
@@ -166,7 +166,7 @@ export class Pipeline {
   @IsOptional()
   @Column({ type: 'text', nullable: true })
   @ApiProperty({ description: 'Reason for failure if status is FAILED', required: false })
-  failureReason?: string;
+  failureReason?: string | null;
 
   @CreateDateColumn({ type: 'timestamptz' })
   @ApiProperty({ description: 'When the pipeline was created' })

--- a/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
@@ -39,7 +39,13 @@ export enum PipelineStage {
 export enum DeploymentRecommendation {
   DEPLOY = 'DEPLOY',
   NEEDS_REVIEW = 'NEEDS_REVIEW',
-  DO_NOT_DEPLOY = 'DO_NOT_DEPLOY'
+  DO_NOT_DEPLOY = 'DO_NOT_DEPLOY',
+  /**
+   * Neutral outcome when the strategy could not produce enough signals to
+   * satisfy the trade-count gate during paper trading. Not a failure — the
+   * orchestrator is expected to retry with fresh optimization parameters.
+   */
+  INCONCLUSIVE_RETRY = 'INCONCLUSIVE_RETRY'
 }
 
 /**
@@ -160,6 +166,12 @@ export interface PipelineProgressionRules {
   optimization: {
     /** Minimum improvement over baseline (percentage) */
     minImprovement: number;
+    /**
+     * Minimum absolute walk-forward test score. Runs where the best combination
+     * scores below this are rejected outright — prevents shipping losing params
+     * that only look good relative to a worse baseline. Default: 0
+     */
+    minAbsoluteScore?: number;
   };
   paperTrading: StageProgressionThresholds;
   /** Minimum composite score (0-100) to pass LIVE_REPLAY gate. Default: 30 */
@@ -171,7 +183,8 @@ export interface PipelineProgressionRules {
  */
 export const DEFAULT_PROGRESSION_RULES: PipelineProgressionRules = {
   optimization: {
-    minImprovement: 3 // 3% improvement over baseline
+    minImprovement: 3, // 3% improvement over baseline
+    minAbsoluteScore: 0 // reject runs whose best combo scored negative
   },
   paperTrading: {
     minSharpeRatio: 0.3,

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.spec.ts
@@ -78,7 +78,8 @@ describe('PipelineEventHandlerService', () => {
             failPipeline: jest.fn(),
             calculatePipelineScore: jest.fn(),
             evaluateStageProgression: jest.fn(),
-            completePipeline: jest.fn()
+            completePipeline: jest.fn(),
+            markInconclusiveAndComplete: jest.fn()
           }
         }
       ]
@@ -121,6 +122,32 @@ describe('PipelineEventHandlerService', () => {
       expect(progressionService.failPipeline).toHaveBeenCalledWith(
         expect.any(Object),
         expect.stringContaining('Optimization did not meet')
+      );
+      expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
+    });
+
+    it('passes bestScore to evaluateOptimizationProgression', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline());
+      progressionService.evaluateOptimizationProgression.mockReturnValue({ passed: true, failures: [] });
+
+      await service.handleOptimizationComplete('run-123', 'strategy-123', {}, 80, 10);
+
+      expect(progressionService.evaluateOptimizationProgression).toHaveBeenCalledWith(expect.any(Object), 10, 80);
+    });
+
+    it('fails pipeline when bestScore is negative (absolute-score gate)', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline());
+      progressionService.evaluateOptimizationProgression.mockReturnValue({
+        passed: false,
+        failures: ['Best test score -4.00 < minimum 0.00 — all tested combinations lost money in walk-forward testing']
+      });
+
+      await service.handleOptimizationComplete('run-123', 'strategy-123', { rsi: 14 }, -4, 200);
+
+      expect(progressionService.evaluateOptimizationProgression).toHaveBeenCalledWith(expect.any(Object), 200, -4);
+      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.stringContaining('Best test score')
       );
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
     });
@@ -506,6 +533,61 @@ describe('PipelineEventHandlerService', () => {
           })
         })
       );
+    });
+
+    describe('insufficient_signals early termination', () => {
+      it('routes to markInconclusiveAndComplete (not failPipeline) when stoppedReason=insufficient_signals', async () => {
+        const pipeline = makePipeline({ currentStage: PipelineStage.PAPER_TRADE });
+        pipelineRepository.findOne.mockResolvedValue(pipeline);
+
+        await service.handlePaperTradingComplete(
+          'session-123',
+          'pipeline-123',
+          { ...paperMetrics, totalTrades: 0 },
+          'insufficient_signals'
+        );
+
+        expect(progressionService.markInconclusiveAndComplete).toHaveBeenCalledWith(
+          pipeline,
+          expect.stringContaining('insufficient signals')
+        );
+        expect(progressionService.failPipeline).not.toHaveBeenCalled();
+        expect(progressionService.completePipeline).not.toHaveBeenCalled();
+      });
+
+      it('records paperTrading.status as COMPLETED (not STOPPED) for insufficient_signals', async () => {
+        const pipeline = makePipeline({ currentStage: PipelineStage.PAPER_TRADE });
+        pipelineRepository.findOne.mockResolvedValue(pipeline);
+
+        await service.handlePaperTradingComplete(
+          'session-123',
+          'pipeline-123',
+          { ...paperMetrics, totalTrades: 0 },
+          'insufficient_signals'
+        );
+
+        expect(pipelineRepository.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            stageResults: expect.objectContaining({
+              paperTrading: expect.objectContaining({ status: 'COMPLETED' })
+            })
+          })
+        );
+      });
+
+      it('does not evaluate progression thresholds for insufficient_signals', async () => {
+        const pipeline = makePipeline({ currentStage: PipelineStage.PAPER_TRADE });
+        pipelineRepository.findOne.mockResolvedValue(pipeline);
+
+        await service.handlePaperTradingComplete(
+          'session-123',
+          'pipeline-123',
+          { ...paperMetrics, totalTrades: 0 },
+          'insufficient_signals'
+        );
+
+        expect(progressionService.evaluateStageProgression).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
@@ -70,7 +70,11 @@ export class PipelineEventHandlerService {
 
     await this.pipelineRepository.save(pipeline);
 
-    const { passed, failures } = this.progressionService.evaluateOptimizationProgression(pipeline, improvement);
+    const { passed, failures } = this.progressionService.evaluateOptimizationProgression(
+      pipeline,
+      improvement,
+      bestScore
+    );
 
     if (!passed) {
       await this.progressionService.failPipeline(
@@ -334,7 +338,8 @@ export class PipelineEventHandlerService {
       status:
         stoppedReason === 'duration_reached' ||
         stoppedReason === 'target_reached' ||
-        stoppedReason === 'min_trades_reached'
+        stoppedReason === 'min_trades_reached' ||
+        stoppedReason === 'insufficient_signals'
           ? 'COMPLETED'
           : 'STOPPED',
       sharpeRatio: metrics.sharpeRatio ?? 0,
@@ -357,6 +362,14 @@ export class PipelineEventHandlerService {
     };
 
     await this.pipelineRepository.save(pipeline);
+
+    if (stoppedReason === 'insufficient_signals') {
+      await this.progressionService.markInconclusiveAndComplete(
+        pipeline,
+        `Paper trading terminated early: insufficient signals (${metrics.totalTrades} trades over ${metrics.durationHours.toFixed(1)}h)`
+      );
+      return;
+    }
 
     const thresholds = pipeline.progressionRules.paperTrading;
     const { passed, failures } = this.progressionService.evaluateStageProgression(

--- a/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
@@ -95,19 +95,59 @@ describe('PipelineProgressionService', () => {
   });
 
   describe('evaluateOptimizationProgression', () => {
-    it('passes when improvement meets threshold', () => {
+    it('passes when improvement meets threshold and bestScore is non-negative', () => {
       const { passed, failures } = service.evaluateOptimizationProgression(
         makePipeline(),
-        DEFAULT_PROGRESSION_RULES.optimization.minImprovement
+        DEFAULT_PROGRESSION_RULES.optimization.minImprovement,
+        10
       );
       expect(passed).toBe(true);
       expect(failures).toHaveLength(0);
     });
 
-    it('fails when improvement is below threshold', () => {
-      const { passed, failures } = service.evaluateOptimizationProgression(makePipeline(), 0);
+    it('passes when bestScore equals the threshold (boundary)', () => {
+      const { passed, failures } = service.evaluateOptimizationProgression(
+        makePipeline(),
+        DEFAULT_PROGRESSION_RULES.optimization.minImprovement,
+        0
+      );
+      expect(passed).toBe(true);
+      expect(failures).toHaveLength(0);
+    });
+
+    it('fails with only absolute-score reason when bestScore < 0 but improvement is strong', () => {
+      const { passed, failures } = service.evaluateOptimizationProgression(makePipeline(), 200, -2);
       expect(passed).toBe(false);
       expect(failures).toHaveLength(1);
+      expect(failures[0]).toContain('Best test score');
+      expect(failures[0]).toContain('lost money');
+    });
+
+    it('fails with only improvement reason when bestScore is non-negative but improvement is too low', () => {
+      const { passed, failures } = service.evaluateOptimizationProgression(makePipeline(), 0, 5);
+      expect(passed).toBe(false);
+      expect(failures).toHaveLength(1);
+      expect(failures[0]).toContain('Improvement');
+    });
+
+    it('fails with both reasons when bestScore < 0 and improvement is too low', () => {
+      const { passed, failures } = service.evaluateOptimizationProgression(makePipeline(), 0, -4);
+      expect(passed).toBe(false);
+      expect(failures).toHaveLength(2);
+      expect(failures.some((f) => f.includes('Best test score'))).toBe(true);
+      expect(failures.some((f) => f.includes('Improvement'))).toBe(true);
+    });
+
+    it('honors a custom minAbsoluteScore override in progressionRules', () => {
+      const pipeline = makePipeline({
+        progressionRules: {
+          ...DEFAULT_PROGRESSION_RULES,
+          optimization: { minImprovement: 3, minAbsoluteScore: 20 }
+        }
+      });
+      const { passed, failures } = service.evaluateOptimizationProgression(pipeline, 10, 15);
+      expect(passed).toBe(false);
+      expect(failures.some((f) => f.includes('Best test score'))).toBe(true);
     });
   });
 
@@ -486,6 +526,53 @@ describe('PipelineProgressionService', () => {
       expect(pipeline.status).toBe(PipelineStatus.COMPLETED);
       expect(pipeline.currentStage).toBe(PipelineStage.COMPLETED);
       expect(eventEmitter.emit).toHaveBeenCalledWith(PIPELINE_EVENTS.PIPELINE_COMPLETED, expect.any(Object));
+    });
+  });
+
+  describe('markInconclusiveAndComplete', () => {
+    it('sets recommendation=INCONCLUSIVE_RETRY and clears score/failureReason', async () => {
+      const pipeline = makePipeline({
+        pipelineScore: 42,
+        scoreGrade: 'C',
+        failureReason: 'should be cleared'
+      });
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      await service.markInconclusiveAndComplete(pipeline, 'insufficient signals over 5 days');
+
+      expect(pipeline.status).toBe(PipelineStatus.COMPLETED);
+      expect(pipeline.currentStage).toBe(PipelineStage.COMPLETED);
+      expect(pipeline.recommendation).toBe(DeploymentRecommendation.INCONCLUSIVE_RETRY);
+      expect(pipeline.pipelineScore).toBeNull();
+      expect(pipeline.scoreGrade).toBeNull();
+      expect(pipeline.failureReason).toBeNull();
+      expect(pipeline.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('emits PIPELINE_COMPLETED with inconclusive flag', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      await service.markInconclusiveAndComplete(pipeline, 'starved');
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        PIPELINE_EVENTS.PIPELINE_COMPLETED,
+        expect.objectContaining({
+          pipelineId: pipeline.id,
+          recommendation: DeploymentRecommendation.INCONCLUSIVE_RETRY,
+          inconclusive: true
+        })
+      );
+    });
+
+    it('does NOT set status to FAILED (distinct from failPipeline)', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      await service.markInconclusiveAndComplete(pipeline, 'starved');
+
+      expect(pipeline.status).not.toBe(PipelineStatus.FAILED);
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(PIPELINE_EVENTS.PIPELINE_FAILED, expect.anything());
     });
   });
 });

--- a/apps/api/src/pipeline/services/pipeline-progression.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.ts
@@ -42,11 +42,23 @@ export class PipelineProgressionService {
     private readonly correlationScoringService: CorrelationScoringService
   ) {}
 
-  evaluateOptimizationProgression(pipeline: Pipeline, improvement: number): { passed: boolean; failures: string[] } {
-    const threshold = pipeline.progressionRules.optimization.minImprovement;
+  evaluateOptimizationProgression(
+    pipeline: Pipeline,
+    improvement: number,
+    bestScore: number
+  ): { passed: boolean; failures: string[] } {
+    const minImprovement = pipeline.progressionRules.optimization.minImprovement;
+    const minAbsoluteScore = pipeline.progressionRules.optimization.minAbsoluteScore ?? 0;
     const failures: string[] = [];
-    if (improvement < threshold) {
-      failures.push(`Improvement ${improvement.toFixed(2)}% < min ${threshold.toFixed(2)}%`);
+
+    if (bestScore < minAbsoluteScore) {
+      failures.push(
+        `Best test score ${bestScore.toFixed(2)} < minimum ${minAbsoluteScore.toFixed(2)} ` +
+          `— all tested combinations lost money in walk-forward testing`
+      );
+    }
+    if (improvement < minImprovement) {
+      failures.push(`Improvement ${improvement.toFixed(2)}% < min ${minImprovement.toFixed(2)}%`);
     }
     return { passed: failures.length === 0, failures };
   }
@@ -307,6 +319,36 @@ export class PipelineProgressionService {
 
     this.eventEmitter.emit(PIPELINE_EVENTS.PIPELINE_FAILED, {
       pipelineId: pipeline.id,
+      reason,
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  /**
+   * Mark a pipeline as COMPLETED with an INCONCLUSIVE_RETRY recommendation.
+   *
+   * Used when the paper-trading stage terminated early due to signal starvation
+   * — the strategy is not a fit for the current market regime, but this is a
+   * neutral outcome (not a bug / not a failure). The orchestrator will retry
+   * on its next cycle with fresh optimization parameters.
+   */
+  async markInconclusiveAndComplete(pipeline: Pipeline, reason: string): Promise<void> {
+    pipeline.status = PipelineStatus.COMPLETED;
+    pipeline.currentStage = PipelineStage.COMPLETED;
+    pipeline.completedAt = new Date();
+    pipeline.recommendation = DeploymentRecommendation.INCONCLUSIVE_RETRY;
+    pipeline.pipelineScore = null;
+    pipeline.scoreGrade = null;
+    pipeline.failureReason = null;
+
+    await this.pipelineRepository.save(pipeline);
+
+    this.logger.log(`Pipeline ${pipeline.id} marked inconclusive: ${reason}`);
+
+    this.eventEmitter.emit(PIPELINE_EVENTS.PIPELINE_COMPLETED, {
+      pipelineId: pipeline.id,
+      recommendation: pipeline.recommendation,
+      inconclusive: true,
       reason,
       timestamp: new Date().toISOString()
     });

--- a/apps/api/src/pipeline/services/pipeline-report.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-report.service.ts
@@ -73,7 +73,9 @@ export class PipelineReportService {
 
     // Save report to pipeline
     pipeline.summaryReport = report;
-    pipeline.recommendation = recommendation;
+    if (pipeline.recommendation !== DeploymentRecommendation.INCONCLUSIVE_RETRY) {
+      pipeline.recommendation = recommendation;
+    }
     await this.pipelineRepository.save(pipeline);
 
     this.logger.log(

--- a/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
+++ b/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
@@ -89,6 +89,39 @@ export const PAPER_TRADING_MIN_TRADES: Record<number, number> = {
 };
 
 /**
+ * Insufficient-Signal Early Termination Matrix
+ *
+ * When a paper-trading session is clearly starved of signals, we terminate
+ * it early as COMPLETED (with `stoppedReason = 'insufficient_signals'`) so
+ * that the (user × algorithm) dedup lock is released and the orchestrator
+ * can retry with fresh parameters.
+ *
+ * Evaluated AFTER safety (drawdown/target) but BEFORE the duration cap.
+ *
+ * | Level | Description      | Check After | Min Trades By Then |
+ * |-------|------------------|-------------|--------------------|
+ * | 1     | Conservative     | 7 days      | 3                  |
+ * | 2     | Low-Moderate     | 6 days      | 3                  |
+ * | 3     | Moderate         | 5 days      | 2                  |
+ * | 4     | Moderate-High    | 5 days      | 2                  |
+ * | 5     | Aggressive       | 4 days      | 2                  |
+ */
+export interface InsufficientSignalThreshold {
+  /** Earliest day at which the gate can fire */
+  checkAfterDays: number;
+  /** Minimum trades required by the check-after day to avoid early termination */
+  minTradesByThen: number;
+}
+
+export const INSUFFICIENT_SIGNAL_THRESHOLDS: Record<number, InsufficientSignalThreshold> = {
+  1: { checkAfterDays: 7, minTradesByThen: 3 },
+  2: { checkAfterDays: 6, minTradesByThen: 3 },
+  3: { checkAfterDays: 5, minTradesByThen: 2 },
+  4: { checkAfterDays: 5, minTradesByThen: 2 },
+  5: { checkAfterDays: 4, minTradesByThen: 2 }
+};
+
+/**
  * Optimization Configuration Matrix
  *
  * Maps user risk levels (1-5) to optimization parameters.
@@ -187,6 +220,15 @@ export function getPaperTradingDuration(riskLevel: number): string {
  */
 export function getPaperTradingMinTrades(riskLevel: number): number {
   return PAPER_TRADING_MIN_TRADES[riskLevel] ?? PAPER_TRADING_MIN_TRADES[DEFAULT_RISK_LEVEL];
+}
+
+/**
+ * Get the insufficient-signal early-termination threshold for a given risk level
+ * Falls back to default (level 3) if level is missing/invalid
+ */
+export function getInsufficientSignalThreshold(riskLevel?: number | null): InsufficientSignalThreshold {
+  const level = riskLevel ?? DEFAULT_RISK_LEVEL;
+  return INSUFFICIENT_SIGNAL_THRESHOLDS[level] ?? INSUFFICIENT_SIGNAL_THRESHOLDS[DEFAULT_RISK_LEVEL];
 }
 
 /**

--- a/apps/chansey/src/app/pages/admin/backtest-monitoring/components/paper-trading-panel/paper-trading-panel.component.ts
+++ b/apps/chansey/src/app/pages/admin/backtest-monitoring/components/paper-trading-panel/paper-trading-panel.component.ts
@@ -11,8 +11,16 @@ import { TooltipModule } from 'primeng/tooltip';
 import {
   PaginatedPaperTradingSessionsDto,
   PaperTradingMonitoringDto,
+  PaperTradingSessionListItemDto,
   PaperTradingStatus
 } from '@chansey/api-interfaces';
+
+type TagSeverity = 'success' | 'info' | 'warn' | 'danger' | 'secondary' | 'contrast';
+
+interface StatusPresentation {
+  label: string;
+  severity: TagSeverity;
+}
 
 @Component({
   selector: 'app-paper-trading-panel',
@@ -205,7 +213,8 @@ import {
               <td>{{ session.name }}</td>
               <td>{{ session.algorithmName }}</td>
               <td>
-                <p-tag [severity]="getSessionStatusSeverity(session.status)" [value]="session.status" />
+                @let presentation = getSessionStatusPresentation(session);
+                <p-tag [severity]="presentation.severity" [value]="presentation.label" />
                 @if (session.status === PaperTradingStatus.ACTIVE) {
                   <p-progressBar [value]="session.progressPercent" [showValue]="false" styleClass="h-1 mt-1" />
                 }
@@ -259,22 +268,40 @@ export class PaperTradingPanelComponent {
     this.pageChange.emit(page);
   }
 
-  getSessionStatusSeverity(
-    status: PaperTradingStatus
-  ): 'success' | 'info' | 'warn' | 'danger' | 'secondary' | 'contrast' {
-    switch (status) {
+  /**
+   * Map (status, stoppedReason) to a user-facing label and tag severity.
+   *
+   * Keeps `insufficient_signals` visually distinct from real failures — it's a
+   * neutral "this strategy isn't a fit right now" outcome, not a bug/crash.
+   */
+  getSessionStatusPresentation(session: PaperTradingSessionListItemDto): StatusPresentation {
+    switch (session.status) {
       case PaperTradingStatus.ACTIVE:
-        return 'info';
-      case PaperTradingStatus.COMPLETED:
-        return 'success';
+        return { label: 'Active', severity: 'info' };
       case PaperTradingStatus.PAUSED:
-        return 'warn';
-      case PaperTradingStatus.FAILED:
-        return 'danger';
+        return { label: 'Paused', severity: 'warn' };
       case PaperTradingStatus.STOPPED:
-        return 'secondary';
+        return { label: 'Stopped', severity: 'secondary' };
+      case PaperTradingStatus.FAILED:
+        return { label: 'Error', severity: 'danger' };
+      case PaperTradingStatus.COMPLETED: {
+        switch (session.stoppedReason) {
+          case 'target_reached':
+            return { label: 'Target Reached', severity: 'success' };
+          case 'min_trades_reached':
+            return { label: 'Completed', severity: 'success' };
+          case 'duration_reached':
+            return { label: 'Time Cap Reached', severity: 'info' };
+          case 'max_drawdown':
+            return { label: 'Risk Limit Hit', severity: 'warn' };
+          case 'insufficient_signals':
+            return { label: 'Inconclusive — Low Activity', severity: 'secondary' };
+          default:
+            return { label: 'Completed', severity: 'success' };
+        }
+      }
       default:
-        return 'secondary';
+        return { label: session.status, severity: 'secondary' };
     }
   }
 }

--- a/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
+++ b/libs/api-interfaces/src/lib/admin/backtest-monitoring.interface.ts
@@ -392,6 +392,8 @@ export interface PaperTradingSessionListItemDto {
   duration: string;
   startedAt: string | null;
   createdAt: string;
+  /** Reason the session stopped (e.g. duration_reached, insufficient_signals) */
+  stoppedReason?: string | null;
 }
 
 export interface PaginatedPaperTradingSessionsDto {

--- a/libs/api-interfaces/src/lib/paper-trading/paper-trading.interface.ts
+++ b/libs/api-interfaces/src/lib/paper-trading/paper-trading.interface.ts
@@ -53,6 +53,20 @@ export enum PaperTradingSignalStatus {
   ERROR = 'ERROR'
 }
 
+/**
+ * Reason a paper-trading session was stopped / completed.
+ *
+ * Mirrors the backend `StopReason` union (see
+ * `apps/api/src/order/paper-trading/paper-trading-session.util.ts`). Exported
+ * for use by the admin UI when rendering status labels/severity.
+ */
+export type PaperTradingStopReason =
+  | 'max_drawdown'
+  | 'target_reached'
+  | 'min_trades_reached'
+  | 'duration_reached'
+  | 'insufficient_signals';
+
 export interface StopConditions {
   maxDrawdown?: number;
   targetReturn?: number;

--- a/libs/api-interfaces/src/lib/pipeline/pipeline.interface.ts
+++ b/libs/api-interfaces/src/lib/pipeline/pipeline.interface.ts
@@ -25,7 +25,13 @@ export enum PipelineStage {
 export enum DeploymentRecommendation {
   DEPLOY = 'DEPLOY',
   NEEDS_REVIEW = 'NEEDS_REVIEW',
-  DO_NOT_DEPLOY = 'DO_NOT_DEPLOY'
+  DO_NOT_DEPLOY = 'DO_NOT_DEPLOY',
+  /**
+   * Neutral outcome when the strategy could not produce enough signals to
+   * satisfy the trade-count gate during paper trading. Not a failure — the
+   * orchestrator is expected to retry with fresh optimization parameters.
+   */
+  INCONCLUSIVE_RETRY = 'INCONCLUSIVE_RETRY'
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fail walk-forward losers at OPTIMIZE→HISTORICAL (~15 min) instead of letting them zombie through paper trading.
- Terminate paper-trading sessions early when signal volume is too low to reach the per-risk trade-count gate, releasing the dedup lock so the orchestrator can retry with fresh parameters.
- Promote RSI Divergence `pivotStrength` to a tunable config field so seeded values and optimizer sweeps actually take effect.

## Changes

- **Pipeline gating** (`pipeline-progression.service.ts`, `pipeline-event-handler.service.ts`, `pipeline-config.interface.ts`): absolute-score gate on OPTIMIZE transition; new `markInconclusiveAndComplete` path; `INCONCLUSIVE_RETRY` recommendation synced into shared `libs/api-interfaces` enum.
- **Paper trading** (`paper-trading-session.util.ts`, `paper-trading-monitoring.service.ts`): risk-band starvation thresholds (L1 day 7 / <3 trades … L5 day 4 / <2); `insufficient_signals` stop reason surfaced in analytics DTO and admin panel.
- **Orchestration config** (`tasks/dto/pipeline-orchestration.dto.ts`): per-risk-level starvation thresholds added to stage config.
- **RSI Divergence** (`rsi-divergence.strategy.ts`): `pivotStrength` wired through schema, defaults, and all 5 usages.
- **Frontend** (`paper-trading-panel.component.ts`): renders new `insufficient_signals` stop reason.
- **Docs** (`.claude/rules/risk-module.md`): risk-level starvation thresholds documented.

## Test Plan

- [x] `nx test api` — 5 new pipeline-progression cases, 2 new event-handler cases, 3 new RSI Divergence cases, full `paper-trading-session.util` spec
- [x] `nx build api-interfaces` — shared enum compiles
- [x] `nx build api` — backend type check
- [x] `nx lint api-interfaces`
- [ ] Manual: trigger an optimization run where all combos are negative — confirm pipeline fails at HISTORICAL boundary instead of advancing
- [ ] Manual: start a paper-trading session on a low-signal strategy at risk level 3 — confirm it terminates at day 5 with `insufficient_signals` stop reason and dedup lock is released