### PR TITLE
feat: give users visibility into automated trading timeline

### DIFF
--- a/apps/api/src/migrations/1776533051872-add-pipeline-stage-transitioned-at.ts
+++ b/apps/api/src/migrations/1776533051872-add-pipeline-stage-transitioned-at.ts
@@ -1,0 +1,21 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddPipelineStageTransitionedAt1776533051872 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "pipelines" ADD COLUMN "stageTransitionedAt" TIMESTAMPTZ NULL
+    `);
+
+    // Backfill in-flight pipelines so stall detection has a sane baseline.
+    // Historical rows remain NULL — no read path needs stageTransitionedAt for completed pipelines.
+    await queryRunner.query(`
+      UPDATE "pipelines"
+      SET "stageTransitionedAt" = COALESCE("updatedAt", "createdAt")
+      WHERE "status" IN ('RUNNING', 'PENDING', 'PAUSED')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "pipelines" DROP COLUMN IF EXISTS "stageTransitionedAt"`);
+  }
+}

--- a/apps/api/src/notification/interfaces/notification-events.interface.ts
+++ b/apps/api/src/notification/interfaces/notification-events.interface.ts
@@ -1,4 +1,4 @@
-import { type NotificationEventType, type NotificationSeverity } from '@chansey/api-interfaces';
+import { type NotificationEventType, type NotificationSeverity, type PipelineStage } from '@chansey/api-interfaces';
 
 /**
  * Event name constants for EventEmitter2
@@ -13,7 +13,12 @@ export const NOTIFICATION_EVENTS = {
   STRATEGY_DEPLOYED: 'notification.strategy-deployed',
   STRATEGY_DEMOTED: 'notification.strategy-demoted',
   DAILY_LOSS_LIMIT: 'notification.daily-loss-limit',
-  REGIME_STALE: 'notification.regime-stale'
+  REGIME_STALE: 'notification.regime-stale',
+  PIPELINE_STARTED: 'notification.pipeline-started',
+  PIPELINE_STAGE_COMPLETED: 'notification.pipeline-stage-completed',
+  PIPELINE_COMPLETED: 'notification.pipeline-completed',
+  PIPELINE_REJECTED: 'notification.pipeline-rejected',
+  STRATEGY_LIVE: 'notification.strategy-live'
 } as const;
 
 /**
@@ -90,6 +95,34 @@ export interface RegimeStaleNotification {
   cachedRegime: string;
 }
 
+export interface PipelineStartedNotification extends BaseNotificationPayload {
+  pipelineId: string;
+  strategyName: string;
+}
+
+export interface PipelineStageCompletedNotification extends BaseNotificationPayload {
+  pipelineId: string;
+  strategyName: string;
+  completedStage: PipelineStage;
+  nextStage?: PipelineStage;
+}
+
+export interface PipelineCompletedNotification extends BaseNotificationPayload {
+  pipelineId: string;
+  strategyName: string;
+}
+
+export interface PipelineRejectedNotification extends BaseNotificationPayload {
+  pipelineId: string;
+  strategyName: string;
+  reason: string;
+}
+
+export interface StrategyLiveNotification extends BaseNotificationPayload {
+  strategyName: string;
+  deploymentId: string;
+}
+
 export type NotificationPayload =
   | TradeExecutedNotification
   | TradeErrorNotification
@@ -100,7 +133,12 @@ export type NotificationPayload =
   | StrategyDeployedNotification
   | StrategyDemotedNotification
   | DailyLossLimitNotification
-  | RegimeStaleNotification;
+  | RegimeStaleNotification
+  | PipelineStartedNotification
+  | PipelineStageCompletedNotification
+  | PipelineCompletedNotification
+  | PipelineRejectedNotification
+  | StrategyLiveNotification;
 
 /**
  * BullMQ job data for the notification queue

--- a/apps/api/src/notification/listeners/pipeline-notification.listener.ts
+++ b/apps/api/src/notification/listeners/pipeline-notification.listener.ts
@@ -1,0 +1,235 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import {
+  DeploymentRecommendation,
+  NotificationEventType,
+  PipelineStage,
+  PipelineStatus
+} from '@chansey/api-interfaces';
+
+import { Pipeline } from '../../pipeline/entities/pipeline.entity';
+import {
+  PIPELINE_EVENTS,
+  type PipelineStageTransitionEvent,
+  type PipelineStatusChangeEvent
+} from '../../pipeline/interfaces';
+import { toErrorInfo } from '../../shared/error.util';
+import { NotificationService } from '../notification.service';
+
+/** Maps a newly-entered pipeline stage to a user-facing label */
+const STAGE_FRIENDLY_LABEL: Record<string, string> = {
+  [PipelineStage.OPTIMIZE]: 'Training your strategy',
+  [PipelineStage.HISTORICAL]: 'Testing against history',
+  [PipelineStage.LIVE_REPLAY]: 'Replaying recent market data',
+  [PipelineStage.PAPER_TRADE]: 'Practicing with pretend money',
+  [PipelineStage.COMPLETED]: 'Final safety review'
+};
+
+/** Maps the stage a pipeline just left into a "just finished" label */
+const STAGE_COMPLETED_LABEL: Record<string, string> = {
+  [PipelineStage.OPTIMIZE]: 'training complete',
+  [PipelineStage.HISTORICAL]: 'historical testing complete',
+  [PipelineStage.LIVE_REPLAY]: 'recent market replay complete',
+  [PipelineStage.PAPER_TRADE]: 'paper trading complete'
+};
+
+interface PipelineCompletedPayload {
+  pipelineId: string;
+  recommendation: DeploymentRecommendation;
+  inconclusive?: boolean;
+  reason?: string;
+  timestamp: string;
+}
+
+interface PipelineFailedPayload {
+  pipelineId: string;
+  reason: string;
+  timestamp: string;
+}
+
+/**
+ * Translates domain-level pipeline events into user-facing notifications.
+ * Each pipeline event maps to exactly one notification enqueue via the shared
+ * NotificationService (which applies preferences + rate-limit + quiet hours).
+ */
+@Injectable()
+export class PipelineNotificationListener {
+  private readonly logger = new Logger(PipelineNotificationListener.name);
+
+  constructor(
+    private readonly notificationService: NotificationService,
+    @InjectRepository(Pipeline) private readonly pipelineRepository: Repository<Pipeline>
+  ) {}
+
+  @OnEvent(PIPELINE_EVENTS.PIPELINE_STATUS_CHANGE, { async: true })
+  async handleStatusChange(payload: PipelineStatusChangeEvent): Promise<void> {
+    if (payload.newStatus !== PipelineStatus.RUNNING) return;
+    if (payload.previousStatus !== PipelineStatus.PENDING) return;
+
+    try {
+      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
+      if (!pipeline) return;
+
+      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
+
+      await this.notificationService.send(
+        pipeline.user.id,
+        NotificationEventType.PIPELINE_STARTED,
+        'We started building your strategy',
+        `${strategyName} is being trained and tested — you'll get an update as it progresses.`,
+        'info',
+        {
+          userId: pipeline.user.id,
+          pipelineId: pipeline.id,
+          strategyName
+        }
+      );
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to send PIPELINE_STARTED notification for ${payload.pipelineId}: ${err.message}`,
+        err.stack
+      );
+    }
+  }
+
+  @OnEvent(PIPELINE_EVENTS.PIPELINE_STAGE_TRANSITION, { async: true })
+  async handleStageTransition(payload: PipelineStageTransitionEvent): Promise<void> {
+    // Skip the transition into COMPLETED — handled by PIPELINE_COMPLETED instead.
+    if (payload.newStage === PipelineStage.COMPLETED) return;
+
+    try {
+      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
+      if (!pipeline) return;
+
+      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
+      const completedLabel = STAGE_COMPLETED_LABEL[payload.previousStage] ?? 'stage complete';
+      const nextLabel = STAGE_FRIENDLY_LABEL[payload.newStage] ?? 'next stage';
+
+      await this.notificationService.send(
+        pipeline.user.id,
+        NotificationEventType.PIPELINE_STAGE_COMPLETED,
+        `${strategyName}: ${completedLabel}`,
+        `Moving on to: ${nextLabel}.`,
+        'info',
+        {
+          userId: pipeline.user.id,
+          pipelineId: pipeline.id,
+          strategyName,
+          completedStage: payload.previousStage,
+          nextStage: payload.newStage
+        }
+      );
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to send PIPELINE_STAGE_COMPLETED notification for ${payload.pipelineId}: ${err.message}`,
+        err.stack
+      );
+    }
+  }
+
+  @OnEvent(PIPELINE_EVENTS.PIPELINE_COMPLETED, { async: true })
+  async handleCompleted(payload: PipelineCompletedPayload): Promise<void> {
+    try {
+      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
+      if (!pipeline) return;
+
+      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
+
+      if (payload.recommendation === DeploymentRecommendation.DO_NOT_DEPLOY) {
+        await this.notificationService.send(
+          pipeline.user.id,
+          NotificationEventType.PIPELINE_REJECTED,
+          `${strategyName} didn't pass the safety review`,
+          `We'll try a different strategy on your next cycle.`,
+          'medium',
+          {
+            userId: pipeline.user.id,
+            pipelineId: pipeline.id,
+            strategyName,
+            reason: pipeline.failureReason ?? payload.reason ?? 'Failed final review'
+          }
+        );
+        return;
+      }
+
+      if (payload.recommendation === DeploymentRecommendation.INCONCLUSIVE_RETRY) {
+        await this.notificationService.send(
+          pipeline.user.id,
+          NotificationEventType.PIPELINE_REJECTED,
+          `${strategyName} couldn't find enough opportunities`,
+          `We'll retry with fresh parameters — no action needed from you.`,
+          'low',
+          {
+            userId: pipeline.user.id,
+            pipelineId: pipeline.id,
+            strategyName,
+            reason: payload.reason ?? 'Insufficient trading signals'
+          }
+        );
+        return;
+      }
+
+      await this.notificationService.send(
+        pipeline.user.id,
+        NotificationEventType.PIPELINE_COMPLETED,
+        `${strategyName} is ready for live trading`,
+        `Your strategy passed every check and is being activated.`,
+        'info',
+        {
+          userId: pipeline.user.id,
+          pipelineId: pipeline.id,
+          strategyName
+        }
+      );
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to send PIPELINE_COMPLETED notification for ${payload.pipelineId}: ${err.message}`,
+        err.stack
+      );
+    }
+  }
+
+  @OnEvent(PIPELINE_EVENTS.PIPELINE_FAILED, { async: true })
+  async handleFailed(payload: PipelineFailedPayload): Promise<void> {
+    try {
+      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
+      if (!pipeline) return;
+
+      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
+
+      await this.notificationService.send(
+        pipeline.user.id,
+        NotificationEventType.PIPELINE_REJECTED,
+        `${strategyName} couldn't finish building`,
+        `We'll try again on the next cycle.`,
+        'medium',
+        {
+          userId: pipeline.user.id,
+          pipelineId: pipeline.id,
+          strategyName,
+          reason: payload.reason
+        }
+      );
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to send PIPELINE_REJECTED notification for ${payload.pipelineId}: ${err.message}`,
+        err.stack
+      );
+    }
+  }
+
+  private async loadPipelineWithUser(pipelineId: string): Promise<Pipeline | null> {
+    return this.pipelineRepository.findOne({
+      where: { id: pipelineId },
+      relations: ['user', 'strategyConfig']
+    });
+  }
+}

--- a/apps/api/src/notification/notification.module.ts
+++ b/apps/api/src/notification/notification.module.ts
@@ -9,6 +9,7 @@ import { PushNotificationService } from './channels/push-notification.service';
 import { SmsNotificationService } from './channels/sms-notification.service';
 import { Notification } from './entities/notification.entity';
 import { PushSubscription } from './entities/push-subscription.entity';
+import { PipelineNotificationListener } from './listeners/pipeline-notification.listener';
 import { NOTIFICATION_REDIS, notificationRedisProvider } from './notification-redis.provider';
 import { NotificationController } from './notification.controller';
 import { NotificationListener } from './notification.listener';
@@ -16,12 +17,13 @@ import { NotificationProcessor } from './notification.processor';
 import { NotificationService } from './notification.service';
 
 import { EmailModule } from '../email/email.module';
+import { Pipeline } from '../pipeline/entities/pipeline.entity';
 import { toErrorInfo } from '../shared/error.util';
 import { User } from '../users/users.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, PushSubscription, Notification]),
+    TypeOrmModule.forFeature([User, PushSubscription, Notification, Pipeline]),
     BullModule.registerQueue({ name: 'notification' }),
     EmailModule
   ],
@@ -31,6 +33,7 @@ import { User } from '../users/users.entity';
     NotificationService,
     NotificationProcessor,
     NotificationListener,
+    PipelineNotificationListener,
     EmailNotificationService,
     PushNotificationService,
     SmsNotificationService

--- a/apps/api/src/notification/notification.service.spec.ts
+++ b/apps/api/src/notification/notification.service.spec.ts
@@ -20,7 +20,12 @@ const DEFAULT_PREFS: NotificationPreferences = {
     strategy_deployed: true,
     strategy_demoted: true,
     daily_loss_limit: true,
-    regime_stale: true
+    regime_stale: true,
+    pipeline_started: true,
+    pipeline_stage_completed: true,
+    pipeline_completed: true,
+    pipeline_rejected: true,
+    strategy_live: true
   },
   quietHours: { enabled: false, startHourUtc: 22, endHourUtc: 7 }
 };

--- a/apps/api/src/pipeline/entities/pipeline.entity.ts
+++ b/apps/api/src/pipeline/entities/pipeline.entity.ts
@@ -181,6 +181,10 @@ export class Pipeline {
   startedAt?: Date;
 
   @Column({ type: 'timestamptz', nullable: true })
+  @ApiProperty({ description: 'When the pipeline last transitioned stages', required: false })
+  stageTransitionedAt?: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
   @ApiProperty({ description: 'When the pipeline completed', required: false })
   completedAt?: Date;
 

--- a/apps/api/src/pipeline/pipeline.module.ts
+++ b/apps/api/src/pipeline/pipeline.module.ts
@@ -9,11 +9,13 @@ import { PipelineEventListener } from './listeners/pipeline-event.listener';
 import { pipelineConfig } from './pipeline.config';
 import { PipelineController } from './pipeline.controller';
 import { PipelineProcessor } from './processors/pipeline.processor';
+import { PipelineEtaService } from './services/pipeline-eta.service';
 import { PipelineEventHandlerService } from './services/pipeline-event-handler.service';
 import { PipelineOrchestratorService } from './services/pipeline-orchestrator.service';
 import { PipelineProgressionService } from './services/pipeline-progression.service';
 import { PipelineReportService } from './services/pipeline-report.service';
 import { PipelineStageExecutionService } from './services/pipeline-stage-execution.service';
+import { UserPipelineController } from './user-pipeline.controller';
 
 import { AlgorithmModule } from '../algorithm/algorithm.module';
 import { AuthenticationModule } from '../authentication/authentication.module';
@@ -22,6 +24,7 @@ import { ExchangeSelectionModule } from '../exchange/exchange-selection/exchange
 import { MarketRegimeModule } from '../market-regime/market-regime.module';
 import { OptimizationModule } from '../optimization/optimization.module';
 import { OrderModule } from '../order/order.module';
+import { PaperTradingSession } from '../order/paper-trading/entities/paper-trading-session.entity';
 import { PaperTradingModule } from '../order/paper-trading/paper-trading.module';
 import { ScoringModule } from '../scoring/scoring.module';
 import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
@@ -31,7 +34,7 @@ const PIPELINE_CONFIG = pipelineConfig();
 @Module({
   imports: [
     ConfigModule.forFeature(pipelineConfig),
-    TypeOrmModule.forFeature([Pipeline, StrategyConfig]),
+    TypeOrmModule.forFeature([Pipeline, StrategyConfig, PaperTradingSession]),
     BullModule.registerQueue({ name: PIPELINE_CONFIG.queue }),
     EventEmitterModule.forRoot(),
     forwardRef(() => AlgorithmModule),
@@ -44,7 +47,7 @@ const PIPELINE_CONFIG = pipelineConfig();
     forwardRef(() => CoinSelectionModule),
     ExchangeSelectionModule
   ],
-  controllers: [PipelineController],
+  controllers: [PipelineController, UserPipelineController],
   providers: [
     PipelineOrchestratorService,
     PipelineStageExecutionService,
@@ -52,8 +55,9 @@ const PIPELINE_CONFIG = pipelineConfig();
     PipelineEventHandlerService,
     PipelineProcessor,
     PipelineEventListener,
-    PipelineReportService
+    PipelineReportService,
+    PipelineEtaService
   ],
-  exports: [PipelineOrchestratorService]
+  exports: [PipelineOrchestratorService, PipelineEtaService]
 })
 export class PipelineModule {}

--- a/apps/api/src/pipeline/services/pipeline-eta.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-eta.service.spec.ts
@@ -1,0 +1,281 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { type Repository } from 'typeorm';
+
+import { DeploymentRecommendation, PipelineStage, PipelineStatus } from '@chansey/api-interfaces';
+
+import { PipelineEtaService } from './pipeline-eta.service';
+
+import { PaperTradingSession } from '../../order/paper-trading/entities/paper-trading-session.entity';
+import { Pipeline } from '../entities/pipeline.entity';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+describe('PipelineEtaService', () => {
+  let service: PipelineEtaService;
+  let pipelineRepository: jest.Mocked<Repository<Pipeline>>;
+  let paperTradingSessionRepository: jest.Mocked<Repository<PaperTradingSession>>;
+
+  const makePipeline = (overrides: Partial<Pipeline> = {}): Pipeline =>
+    ({
+      id: 'pipeline-1',
+      name: 'Test Pipeline',
+      status: PipelineStatus.RUNNING,
+      currentStage: PipelineStage.OPTIMIZE,
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+      updatedAt: new Date(),
+      user: { id: 'user-1', coinRisk: { level: 3 } },
+      strategyConfig: { name: 'My Strategy' },
+      ...overrides
+    }) as unknown as Pipeline;
+
+  const makeSession = (overrides: Partial<PaperTradingSession> = {}): PaperTradingSession =>
+    ({
+      id: 'session-1',
+      totalTrades: 0,
+      minTrades: 40,
+      startedAt: new Date(),
+      createdAt: new Date(),
+      ...overrides
+    }) as PaperTradingSession;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PipelineEtaService,
+        {
+          provide: getRepositoryToken(Pipeline),
+          useValue: { findOne: jest.fn() }
+        },
+        {
+          provide: getRepositoryToken(PaperTradingSession),
+          useValue: { findOne: jest.fn() }
+        }
+      ]
+    }).compile();
+
+    service = module.get(PipelineEtaService);
+    pipelineRepository = module.get(getRepositoryToken(Pipeline));
+    paperTradingSessionRepository = module.get(getRepositoryToken(PaperTradingSession));
+  });
+
+  describe('getStatusForUser', () => {
+    it('returns null when user has no pipeline', async () => {
+      pipelineRepository.findOne.mockResolvedValue(null);
+      const status = await service.getStatusForUser('user-1');
+      expect(status).toBeNull();
+    });
+
+    it('returns null when pipeline completed more than PROMOTION_WINDOW_DAYS.max ago', async () => {
+      pipelineRepository.findOne.mockResolvedValue(
+        makePipeline({
+          status: PipelineStatus.COMPLETED,
+          currentStage: PipelineStage.COMPLETED,
+          recommendation: DeploymentRecommendation.DEPLOY,
+          completedAt: new Date(Date.now() - 10 * MS_PER_DAY)
+        })
+      );
+      const status = await service.getStatusForUser('user-1');
+      expect(status).toBeNull();
+    });
+
+    it('maps currentStage to stageIndex', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline({ currentStage: PipelineStage.LIVE_REPLAY }));
+      const status = await service.getStatusForUser('user-1');
+      expect(status?.stageIndex).toBe(2);
+    });
+
+    it('surfaces strategyName from strategyConfig', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline());
+      const status = await service.getStatusForUser('user-1');
+      expect(status?.strategyName).toBe('My Strategy');
+    });
+
+    it('falls back to pipeline.name when strategyConfig is missing', async () => {
+      pipelineRepository.findOne.mockResolvedValue(
+        makePipeline({ name: 'Fallback Name', strategyConfig: undefined } as unknown as Partial<Pipeline>)
+      );
+      const status = await service.getStatusForUser('user-1');
+      expect(status?.strategyName).toBe('Fallback Name');
+    });
+
+    describe('rejection classification', () => {
+      it('wasRejected=true when status FAILED, surfaces failureReason', async () => {
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({ status: PipelineStatus.FAILED, failureReason: 'optimization failed' })
+        );
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.wasRejected).toBe(true);
+        expect(status?.rejectionReason).toBe('optimization failed');
+      });
+
+      it('wasRejected=true with generic reason when FAILED has no failureReason', async () => {
+        pipelineRepository.findOne.mockResolvedValue(makePipeline({ status: PipelineStatus.FAILED }));
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.wasRejected).toBe(true);
+        expect(status?.rejectionReason).toBe('The strategy build could not finish.');
+      });
+
+      it('wasRejected=true with safety-review reason for DO_NOT_DEPLOY', async () => {
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({
+            status: PipelineStatus.COMPLETED,
+            recommendation: DeploymentRecommendation.DO_NOT_DEPLOY,
+            completedAt: undefined
+          })
+        );
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.wasRejected).toBe(true);
+        expect(status?.isRetrying).toBe(false);
+        expect(status?.rejectionReason).toBe('Your strategy did not pass the final safety review.');
+      });
+
+      it('isRetrying=true with explanatory reason for INCONCLUSIVE_RETRY', async () => {
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({
+            status: PipelineStatus.COMPLETED,
+            recommendation: DeploymentRecommendation.INCONCLUSIVE_RETRY,
+            completedAt: undefined
+          })
+        );
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.isRetrying).toBe(true);
+        expect(status?.wasRejected).toBe(false);
+        expect(status?.retryReason).toContain("couldn't find enough opportunities");
+      });
+    });
+
+    describe('stall detection', () => {
+      it('stalled when RUNNING and stageTransitionedAt older than 48h', async () => {
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({
+            status: PipelineStatus.RUNNING,
+            stageTransitionedAt: new Date(Date.now() - 50 * 60 * 60 * 1000)
+          })
+        );
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.isStalled).toBe(true);
+      });
+
+      it('not stalled when updatedAt is old but stageTransitionedAt is fresh', async () => {
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({
+            status: PipelineStatus.RUNNING,
+            updatedAt: new Date(Date.now() - 50 * 60 * 60 * 1000),
+            stageTransitionedAt: new Date(Date.now() - 60 * 60 * 1000)
+          })
+        );
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.isStalled).toBe(false);
+      });
+
+      it('falls back to startedAt when stageTransitionedAt is null', async () => {
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({
+            status: PipelineStatus.RUNNING,
+            stageTransitionedAt: null,
+            startedAt: new Date(Date.now() - 50 * 60 * 60 * 1000)
+          })
+        );
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.isStalled).toBe(true);
+      });
+    });
+  });
+
+  describe('computeRemaining', () => {
+    it('OPTIMIZE yields cumulative range of all downstream stages', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline({ currentStage: PipelineStage.OPTIMIZE }));
+      const status = await service.getStatusForUser('user-1');
+      // OPTIMIZE (2-4) + HISTORICAL (1-1) + LIVE_REPLAY (1-1) + PAPER_TRADE (1-30) + promotion (1-2)
+      expect(status?.minDaysRemaining).toBe(6);
+      expect(status?.maxDaysRemaining).toBe(38);
+    });
+
+    it('HISTORICAL excludes OPTIMIZE from the range', async () => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline({ currentStage: PipelineStage.HISTORICAL }));
+      const status = await service.getStatusForUser('user-1');
+      // HISTORICAL (1-1) + LIVE_REPLAY (1-1) + PAPER_TRADE (1-30) + promotion (1-2)
+      expect(status?.minDaysRemaining).toBe(4);
+      expect(status?.maxDaysRemaining).toBe(34);
+    });
+
+    describe('PAPER_TRADE stage', () => {
+      it('projects from trade rate when session has data (5d/20 trades → ~5 days remaining)', async () => {
+        const startedAt = new Date(Date.now() - 5 * MS_PER_DAY);
+        paperTradingSessionRepository.findOne.mockResolvedValue(
+          makeSession({ totalTrades: 20, startedAt, createdAt: startedAt })
+        );
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({ currentStage: PipelineStage.PAPER_TRADE, paperTradingSessionId: 'session-1' })
+        );
+        const status = await service.getStatusForUser('user-1');
+        // 4/day rate → 5 more days. ±20% band + promotion (1-2)
+        expect(status?.minDaysRemaining).toBeGreaterThanOrEqual(5);
+        expect(status?.maxDaysRemaining).toBeLessThanOrEqual(32);
+        expect(status?.currentStageProgress).toEqual({ tradesCompleted: 20, tradesRequired: 40 });
+      });
+
+      it('returns near-zero range when trade target is hit', async () => {
+        const startedAt = new Date(Date.now() - 3 * MS_PER_DAY);
+        paperTradingSessionRepository.findOne.mockResolvedValue(
+          makeSession({ totalTrades: 40, startedAt, createdAt: startedAt })
+        );
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({ currentStage: PipelineStage.PAPER_TRADE, paperTradingSessionId: 'session-1' })
+        );
+        const status = await service.getStatusForUser('user-1');
+        // session (0-1) + promotion (1-2)
+        expect(status?.minDaysRemaining).toBe(1);
+        expect(status?.maxDaysRemaining).toBe(3);
+      });
+
+      it('shows wide range bounded by 30-day cap before first trade completes', async () => {
+        const startedAt = new Date(Date.now() - 2 * MS_PER_DAY);
+        paperTradingSessionRepository.findOne.mockResolvedValue(
+          makeSession({ totalTrades: 0, startedAt, createdAt: startedAt })
+        );
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({ currentStage: PipelineStage.PAPER_TRADE, paperTradingSessionId: 'session-1' })
+        );
+        const status = await service.getStatusForUser('user-1');
+        // session (1 to ~28) + promotion (1-2) → roughly (2, 30)
+        expect(status?.minDaysRemaining).toBe(2);
+        expect(status?.maxDaysRemaining).toBeGreaterThanOrEqual(29);
+        expect(status?.maxDaysRemaining).toBeLessThanOrEqual(30);
+      });
+
+      it('derives tradesRequired from risk level when session.minTrades is null', async () => {
+        paperTradingSessionRepository.findOne.mockResolvedValue(
+          makeSession({ totalTrades: 5, minTrades: null as unknown as number })
+        );
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({
+            currentStage: PipelineStage.PAPER_TRADE,
+            paperTradingSessionId: 'session-1',
+            user: { id: 'user-1', coinRisk: { level: 1 } }
+          } as unknown as Partial<Pipeline>)
+        );
+        const status = await service.getStatusForUser('user-1');
+        // Risk level 1 → 50 min trades (see pipeline-orchestration.dto.ts)
+        expect(status?.currentStageProgress).toEqual({ tradesCompleted: 5, tradesRequired: 50 });
+      });
+
+      it('uses DEFAULT_RISK_LEVEL (3 → 40 trades) when user.coinRisk is missing', async () => {
+        paperTradingSessionRepository.findOne.mockResolvedValue(
+          makeSession({ totalTrades: 5, minTrades: null as unknown as number })
+        );
+        pipelineRepository.findOne.mockResolvedValue(
+          makePipeline({
+            currentStage: PipelineStage.PAPER_TRADE,
+            paperTradingSessionId: 'session-1',
+            user: { id: 'user-1' }
+          } as unknown as Partial<Pipeline>)
+        );
+        const status = await service.getStatusForUser('user-1');
+        expect(status?.currentStageProgress).toEqual({ tradesCompleted: 5, tradesRequired: 40 });
+      });
+    });
+  });
+});

--- a/apps/api/src/pipeline/services/pipeline-eta.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-eta.service.ts
@@ -1,0 +1,283 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import {
+  type PipelineStage as SharedPipelineStage,
+  type PipelineStatus as SharedPipelineStatus,
+  type UserPipelineStatus,
+  DeploymentRecommendation,
+  PipelineStage,
+  PipelineStatus
+} from '@chansey/api-interfaces';
+
+import { PaperTradingSession } from '../../order/paper-trading/entities/paper-trading-session.entity';
+import { DEFAULT_RISK_LEVEL } from '../../risk/risk.constants';
+import { getPaperTradingMinTrades } from '../../tasks/dto/pipeline-orchestration.dto';
+import { Pipeline } from '../entities/pipeline.entity';
+
+/**
+ * Minimum / maximum day estimates for stages that have a deterministic range.
+ * These are empirical — tuned to match observed pipeline runtimes.
+ */
+interface StageEstimate {
+  min: number;
+  max: number;
+}
+
+const STAGE_ESTIMATES: Record<Exclude<SharedPipelineStage, 'COMPLETED'>, StageEstimate> = {
+  OPTIMIZE: { min: 2, max: 4 },
+  HISTORICAL: { min: 1, max: 1 },
+  LIVE_REPLAY: { min: 1, max: 1 },
+  PAPER_TRADE: { min: 1, max: 30 }
+};
+
+/** Post-PAPER_TRADE promotion review + activation window */
+const PROMOTION_WINDOW_DAYS: StageEstimate = { min: 1, max: 2 };
+
+/** Paper trading is capped at this many days even if min-trade target not yet hit */
+const PAPER_TRADE_MAX_DAYS = 30;
+
+/** A pipeline is considered stalled when no update has happened within this threshold */
+const STALL_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const DISPLAY_STAGE_ORDER: SharedPipelineStage[] = [
+  PipelineStage.OPTIMIZE,
+  PipelineStage.HISTORICAL,
+  PipelineStage.LIVE_REPLAY,
+  PipelineStage.PAPER_TRADE,
+  PipelineStage.COMPLETED
+];
+
+/**
+ * Provides user-facing pipeline status summaries with timeline estimates.
+ *
+ * Timeline is reported as a range (min–max days) rather than a single date
+ * because paper-trade duration is driven by trade frequency × risk level,
+ * not a fixed calendar.
+ */
+@Injectable()
+export class PipelineEtaService {
+  constructor(
+    @InjectRepository(Pipeline)
+    private readonly pipelineRepository: Repository<Pipeline>,
+    @InjectRepository(PaperTradingSession)
+    private readonly paperTradingSessionRepository: Repository<PaperTradingSession>
+  ) {}
+
+  /**
+   * Returns the user's most recent pipeline status, or null if:
+   * - the user has never had a pipeline, or
+   * - the user has an active live deployment (in which case the status card is hidden)
+   */
+  async getStatusForUser(userId: string): Promise<UserPipelineStatus | null> {
+    const pipeline = await this.pipelineRepository.findOne({
+      where: { user: { id: userId } },
+      relations: ['strategyConfig', 'user', 'user.coinRisk'],
+      order: { createdAt: 'DESC' }
+    });
+
+    if (!pipeline) return null;
+
+    if (pipeline.status === PipelineStatus.CANCELLED) return null;
+
+    // If the pipeline completed successfully and a deployment should be live,
+    // hide the card to avoid showing stale "almost ready" state.
+    if (
+      pipeline.status === PipelineStatus.COMPLETED &&
+      pipeline.recommendation === DeploymentRecommendation.DEPLOY &&
+      pipeline.completedAt !== undefined &&
+      pipeline.completedAt !== null
+    ) {
+      const daysSinceCompleted = (Date.now() - new Date(pipeline.completedAt).getTime()) / MS_PER_DAY;
+      if (daysSinceCompleted > PROMOTION_WINDOW_DAYS.max) return null;
+    }
+
+    const riskLevel = pipeline.user?.coinRisk?.level ?? DEFAULT_RISK_LEVEL;
+
+    let currentStageProgress: UserPipelineStatus['currentStageProgress'] | undefined;
+    let paperTradeSession: PaperTradingSession | null = null;
+
+    if (pipeline.paperTradingSessionId) {
+      paperTradeSession = await this.paperTradingSessionRepository.findOne({
+        where: { id: pipeline.paperTradingSessionId }
+      });
+
+      if (paperTradeSession) {
+        const tradesRequired = paperTradeSession.minTrades ?? getPaperTradingMinTrades(riskLevel);
+        currentStageProgress = {
+          tradesCompleted: paperTradeSession.totalTrades,
+          tradesRequired
+        };
+      }
+    }
+
+    const { minDaysRemaining, maxDaysRemaining } = this.computeRemaining(pipeline, riskLevel, paperTradeSession);
+
+    const wasRejected = this.isRejected(pipeline);
+    const rejectionReason = wasRejected ? this.buildRejectionReason(pipeline) : undefined;
+
+    const isRetrying = this.isRetrying(pipeline);
+    const retryReason = isRetrying ? this.buildRetryReason(pipeline) : undefined;
+
+    const isStalled = this.isStalled(pipeline);
+
+    const stageIndex = DISPLAY_STAGE_ORDER.indexOf(pipeline.currentStage);
+
+    return {
+      pipelineId: pipeline.id,
+      strategyName: pipeline.strategyConfig?.name ?? pipeline.name,
+      currentStage: pipeline.currentStage,
+      status: pipeline.status as SharedPipelineStatus,
+      stageIndex: stageIndex === -1 ? 0 : stageIndex,
+      totalStages: 5,
+      createdAt: pipeline.createdAt.toISOString(),
+      minDaysRemaining,
+      maxDaysRemaining,
+      currentStageProgress,
+      isStalled,
+      wasRejected,
+      isRetrying,
+      retryReason,
+      rejectionReason
+    };
+  }
+
+  /**
+   * Compute lower/upper bound of days until the pipeline completes and a live
+   * deployment could start trading.
+   *
+   * If the pipeline is in PAPER_TRADE with an active session, we project from
+   * the observed trade rate (trades so far / elapsed days) → remaining trades.
+   * Otherwise we use the static stage estimates.
+   */
+  private computeRemaining(
+    pipeline: Pipeline,
+    riskLevel: number,
+    paperTradeSession: PaperTradingSession | null
+  ): { minDaysRemaining: number; maxDaysRemaining: number } {
+    // Terminal states: nothing left
+    if (
+      pipeline.status === PipelineStatus.COMPLETED ||
+      pipeline.status === PipelineStatus.FAILED ||
+      pipeline.status === PipelineStatus.CANCELLED
+    ) {
+      return { minDaysRemaining: 0, maxDaysRemaining: 0 };
+    }
+
+    const stagesLeft = this.stagesAfter(pipeline.currentStage);
+
+    let min = 0;
+    let max = 0;
+
+    // Current stage's remaining time
+    if (pipeline.currentStage === PipelineStage.PAPER_TRADE && paperTradeSession) {
+      const { min: pMin, max: pMax } = this.estimatePaperTradeRemaining(paperTradeSession, riskLevel);
+      min += pMin;
+      max += pMax;
+    } else if (pipeline.currentStage !== PipelineStage.COMPLETED) {
+      const estimate = STAGE_ESTIMATES[pipeline.currentStage as Exclude<SharedPipelineStage, 'COMPLETED'>];
+      min += estimate.min;
+      max += estimate.max;
+    }
+
+    // Add estimates for remaining stages
+    for (const stage of stagesLeft) {
+      if (stage === PipelineStage.COMPLETED) continue;
+      const estimate = STAGE_ESTIMATES[stage as Exclude<SharedPipelineStage, 'COMPLETED'>];
+      min += estimate.min;
+      max += estimate.max;
+    }
+
+    // Promotion review + activation
+    min += PROMOTION_WINDOW_DAYS.min;
+    max += PROMOTION_WINDOW_DAYS.max;
+
+    return {
+      minDaysRemaining: Math.max(0, Math.floor(min)),
+      maxDaysRemaining: Math.max(0, Math.ceil(max))
+    };
+  }
+
+  /**
+   * Estimate days remaining in PAPER_TRADE.
+   *
+   * Uses observed trade rate to project: remainingDays = remainingTrades / tradesPerDay.
+   * Floored at 1 day and capped at the 30-day safety net.
+   * If we don't have enough data yet (e.g., 0 trades in first day), returns a
+   * wide range to reflect genuine uncertainty.
+   */
+  private estimatePaperTradeRemaining(session: PaperTradingSession, riskLevel: number): { min: number; max: number } {
+    const minTrades = session.minTrades ?? getPaperTradingMinTrades(riskLevel);
+    const tradesDone = session.totalTrades;
+
+    const startedAt = session.startedAt ?? session.createdAt;
+    const elapsedMs = Date.now() - new Date(startedAt).getTime();
+    const elapsedDays = Math.max(0.25, elapsedMs / MS_PER_DAY);
+
+    if (tradesDone >= minTrades) {
+      // Target hit — waiting for next tick to finalize.
+      return { min: 0, max: 1 };
+    }
+
+    const remainingTrades = minTrades - tradesDone;
+    const elapsedDaysSoFar = Math.min(elapsedDays, PAPER_TRADE_MAX_DAYS);
+
+    // Not enough data to project yet — show a wide range bounded by the hard cap.
+    if (tradesDone === 0 || elapsedDays < 1) {
+      const remainingToCapDays = Math.max(1, PAPER_TRADE_MAX_DAYS - elapsedDaysSoFar);
+      return { min: 1, max: remainingToCapDays };
+    }
+
+    const tradesPerDay = tradesDone / elapsedDays;
+    const projectedRemainingDays = remainingTrades / tradesPerDay;
+
+    const min = Math.max(1, Math.floor(projectedRemainingDays * 0.8));
+    const maxCandidate = Math.ceil(projectedRemainingDays * 1.2);
+    const max = Math.min(PAPER_TRADE_MAX_DAYS - Math.floor(elapsedDaysSoFar), maxCandidate);
+
+    return { min, max: Math.max(min, max) };
+  }
+
+  private stagesAfter(stage: SharedPipelineStage): SharedPipelineStage[] {
+    const idx = DISPLAY_STAGE_ORDER.indexOf(stage);
+    if (idx === -1) return [];
+    return DISPLAY_STAGE_ORDER.slice(idx + 1);
+  }
+
+  private isStalled(pipeline: Pipeline): boolean {
+    if (pipeline.status !== PipelineStatus.RUNNING) return false;
+    const lastTransition = pipeline.stageTransitionedAt ?? pipeline.startedAt ?? pipeline.createdAt;
+    return Date.now() - new Date(lastTransition).getTime() > STALL_THRESHOLD_MS;
+  }
+
+  private isRejected(pipeline: Pipeline): boolean {
+    return (
+      pipeline.status === PipelineStatus.FAILED ||
+      (pipeline.status === PipelineStatus.COMPLETED &&
+        pipeline.recommendation === DeploymentRecommendation.DO_NOT_DEPLOY)
+    );
+  }
+
+  private isRetrying(pipeline: Pipeline): boolean {
+    return (
+      pipeline.status === PipelineStatus.COMPLETED &&
+      pipeline.recommendation === DeploymentRecommendation.INCONCLUSIVE_RETRY
+    );
+  }
+
+  private buildRejectionReason(pipeline: Pipeline): string {
+    if (pipeline.failureReason) return pipeline.failureReason;
+    if (pipeline.recommendation === DeploymentRecommendation.DO_NOT_DEPLOY) {
+      return 'Your strategy did not pass the final safety review.';
+    }
+    return 'The strategy build could not finish.';
+  }
+
+  private buildRetryReason(_pipeline: Pipeline): string {
+    return "The strategy couldn't find enough opportunities in the current market — we'll retry with fresh parameters.";
+  }
+}

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
@@ -93,6 +94,10 @@ describe('PipelineOrchestratorService', () => {
         {
           provide: PipelineProgressionService,
           useValue: { advanceToNextStage: jest.fn() }
+        },
+        {
+          provide: EventEmitter2,
+          useValue: { emit: jest.fn() }
         }
       ]
     }).compile();
@@ -156,6 +161,30 @@ describe('PipelineOrchestratorService', () => {
         PipelineStage.OPTIMIZE,
         mockUser.id
       );
+    });
+
+    it('initializes stageTransitionedAt on first start', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.findOne.mockResolvedValue(pipeline);
+
+      const before = Date.now();
+      await service.startPipeline('pipeline-123', mockUser);
+      const after = Date.now();
+
+      expect(pipeline.stageTransitionedAt).toBeInstanceOf(Date);
+      const ts = (pipeline.stageTransitionedAt as Date).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
+    it('preserves stageTransitionedAt when resuming after pause', async () => {
+      const original = new Date(Date.now() - 10 * 60 * 1000);
+      const pipeline = makePipeline({ status: PipelineStatus.PENDING, stageTransitionedAt: original });
+      pipelineRepository.findOne.mockResolvedValue(pipeline);
+
+      await service.startPipeline('pipeline-123', mockUser);
+
+      expect(pipeline.stageTransitionedAt).toBe(original);
     });
 
     it.each([[PipelineStatus.RUNNING], [PipelineStatus.COMPLETED], [PipelineStatus.CANCELLED]])(

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
@@ -15,9 +16,11 @@ import { Pipeline } from '../entities/pipeline.entity';
 import {
   DEFAULT_PROGRESSION_RULES,
   OptimizationStageResult,
+  PIPELINE_EVENTS,
   PipelineProgressionRules,
   PipelineStage,
-  PipelineStatus
+  PipelineStatus,
+  type PipelineStatusChangeEvent
 } from '../interfaces';
 
 @Injectable()
@@ -32,7 +35,8 @@ export class PipelineOrchestratorService {
     private readonly dataSource: DataSource,
     private readonly stageExecutionService: PipelineStageExecutionService,
     private readonly eventHandlerService: PipelineEventHandlerService,
-    private readonly progressionService: PipelineProgressionService
+    private readonly progressionService: PipelineProgressionService,
+    private readonly eventEmitter: EventEmitter2
   ) {}
 
   async createPipeline(dto: CreatePipelineInput, user: User): Promise<Pipeline> {
@@ -180,9 +184,19 @@ export class PipelineOrchestratorService {
       throw new BadRequestException('Pipeline has been cancelled');
     }
 
+    const previousStatus = pipeline.status;
     pipeline.status = PipelineStatus.RUNNING;
     pipeline.startedAt = pipeline.startedAt ?? new Date();
+    pipeline.stageTransitionedAt = pipeline.stageTransitionedAt ?? new Date();
     await this.pipelineRepository.save(pipeline);
+
+    const statusChange: PipelineStatusChangeEvent = {
+      pipelineId: pipeline.id,
+      previousStatus,
+      newStatus: PipelineStatus.RUNNING,
+      timestamp: new Date().toISOString()
+    };
+    this.eventEmitter.emit(PIPELINE_EVENTS.PIPELINE_STATUS_CHANGE, statusChange);
 
     try {
       await this.stageExecutionService.enqueueStageJob(pipeline, pipeline.currentStage, user.id);

--- a/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
@@ -455,6 +455,20 @@ describe('PipelineProgressionService', () => {
       );
     });
 
+    it('bumps stageTransitionedAt when advancing', async () => {
+      const pipeline = makePipeline({ currentStage: PipelineStage.OPTIMIZE });
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      const before = Date.now();
+      await service.advanceToNextStage(pipeline);
+      const after = Date.now();
+
+      expect(pipeline.stageTransitionedAt).toBeInstanceOf(Date);
+      const ts = (pipeline.stageTransitionedAt as Date).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
     it('calls completePipeline when advancing past PAPER_TRADE', async () => {
       const pipeline = makePipeline({ currentStage: PipelineStage.PAPER_TRADE });
       pipelineRepository.save.mockResolvedValue(pipeline);
@@ -527,6 +541,20 @@ describe('PipelineProgressionService', () => {
       expect(pipeline.currentStage).toBe(PipelineStage.COMPLETED);
       expect(eventEmitter.emit).toHaveBeenCalledWith(PIPELINE_EVENTS.PIPELINE_COMPLETED, expect.any(Object));
     });
+
+    it('bumps stageTransitionedAt on completion', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      const before = Date.now();
+      await service.completePipeline(pipeline);
+      const after = Date.now();
+
+      expect(pipeline.stageTransitionedAt).toBeInstanceOf(Date);
+      const ts = (pipeline.stageTransitionedAt as Date).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
   });
 
   describe('markInconclusiveAndComplete', () => {
@@ -573,6 +601,20 @@ describe('PipelineProgressionService', () => {
 
       expect(pipeline.status).not.toBe(PipelineStatus.FAILED);
       expect(eventEmitter.emit).not.toHaveBeenCalledWith(PIPELINE_EVENTS.PIPELINE_FAILED, expect.anything());
+    });
+
+    it('bumps stageTransitionedAt on inconclusive completion', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      const before = Date.now();
+      await service.markInconclusiveAndComplete(pipeline, 'starved');
+      const after = Date.now();
+
+      expect(pipeline.stageTransitionedAt).toBeInstanceOf(Date);
+      const ts = (pipeline.stageTransitionedAt as Date).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
     });
   });
 });

--- a/apps/api/src/pipeline/services/pipeline-progression.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.ts
@@ -255,6 +255,7 @@ export class PipelineProgressionService {
 
     const previousStage = pipeline.currentStage;
     pipeline.currentStage = nextStage;
+    pipeline.stageTransitionedAt = new Date();
     await this.pipelineRepository.save(pipeline);
 
     this.logger.log(`Pipeline ${pipeline.id} advanced from ${previousStage} to ${nextStage}`);
@@ -285,6 +286,7 @@ export class PipelineProgressionService {
     pipeline.status = PipelineStatus.COMPLETED;
     pipeline.currentStage = PipelineStage.COMPLETED;
     pipeline.completedAt = new Date();
+    pipeline.stageTransitionedAt = new Date();
     pipeline.recommendation = this.generateRecommendation(pipeline.stageResults);
 
     await this.pipelineRepository.save(pipeline);
@@ -336,6 +338,7 @@ export class PipelineProgressionService {
     pipeline.status = PipelineStatus.COMPLETED;
     pipeline.currentStage = PipelineStage.COMPLETED;
     pipeline.completedAt = new Date();
+    pipeline.stageTransitionedAt = new Date();
     pipeline.recommendation = DeploymentRecommendation.INCONCLUSIVE_RETRY;
     pipeline.pipelineScore = null;
     pipeline.scoreGrade = null;

--- a/apps/api/src/pipeline/user-pipeline.controller.ts
+++ b/apps/api/src/pipeline/user-pipeline.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { type UserPipelineStatus } from '@chansey/api-interfaces';
+
+import { PipelineEtaService } from './services/pipeline-eta.service';
+
+import GetUser from '../authentication/decorator/get-user.decorator';
+import { JwtAuthenticationGuard } from '../authentication/guard/jwt-authentication.guard';
+import { User } from '../users/users.entity';
+
+/**
+ * User-facing pipeline status endpoint.
+ *
+ * Unlike the admin pipeline controller at `/admin/pipelines`, this exposes a
+ * minimal summary scoped to the logged-in user — used by the dashboard
+ * status card to tell a beginner where their automated trading sits in the
+ * OPTIMIZE → HISTORICAL → LIVE_REPLAY → PAPER_TRADE → live deployment flow.
+ */
+@Controller('pipelines')
+@ApiTags('Pipelines')
+@ApiBearerAuth('token')
+@UseGuards(JwtAuthenticationGuard)
+export class UserPipelineController {
+  constructor(private readonly pipelineEtaService: PipelineEtaService) {}
+
+  @Get('status')
+  @ApiOperation({ summary: "Get the authenticated user's most recent pipeline status" })
+  @ApiOkResponse({ description: 'Pipeline status with ETA range, or null if the user has no active pipeline' })
+  async getStatus(@GetUser() user: User): Promise<UserPipelineStatus | null> {
+    return this.pipelineEtaService.getStatusForUser(user.id);
+  }
+}

--- a/apps/chansey/src/app/layout/app.topbar.ts
+++ b/apps/chansey/src/app/layout/app.topbar.ts
@@ -152,7 +152,12 @@ export class AppTopBar {
       daily_summary: 'pi pi-calendar',
       strategy_deployed: 'pi pi-check-circle',
       strategy_demoted: 'pi pi-arrow-down',
-      daily_loss_limit: 'pi pi-exclamation-circle'
+      daily_loss_limit: 'pi pi-exclamation-circle',
+      pipeline_started: 'pi pi-play-circle',
+      pipeline_stage_completed: 'pi pi-forward',
+      pipeline_completed: 'pi pi-verified',
+      pipeline_rejected: 'pi pi-times-circle',
+      strategy_live: 'pi pi-bolt'
     };
     return icons[eventType] || 'pi pi-bell';
   }

--- a/apps/chansey/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/chansey/src/app/pages/dashboard/dashboard.component.html
@@ -14,6 +14,9 @@
           <app-exchange-status-alert />
         </div>
         <div class="col-span-12">
+          <app-strategy-status-card />
+        </div>
+        <div class="col-span-12">
           <app-exchange-balance />
         </div>
         <div class="col-span-12 md:col-span-6">

--- a/apps/chansey/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/chansey/src/app/pages/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import { ExchangeBalanceComponent } from '../../shared/components/exchange-balan
 import { ExchangeStatusAlertComponent } from '../../shared/components/exchange-status-alert/exchange-status-alert.component';
 import { GettingStartedComponent } from '../../shared/components/getting-started/getting-started.component';
 import { RecentTransactionsComponent } from '../../shared/components/recent-transactions/recent-transactions.component';
+import { StrategyStatusCardComponent } from '../../shared/components/strategy-status-card/strategy-status-card.component';
 import { UserAssetsComponent } from '../../shared/components/user-assets/user-assets.component';
 import { AuthService } from '../../shared/services/auth.service';
 import { LayoutService } from '../../shared/services/layout.service';
@@ -17,6 +18,7 @@ import { LayoutService } from '../../shared/services/layout.service';
     ExchangeBalanceComponent,
     ExchangeStatusAlertComponent,
     GettingStartedComponent,
+    StrategyStatusCardComponent,
     UserAssetsComponent,
     RecentTransactionsComponent
   ],

--- a/apps/chansey/src/app/shared/components/getting-started/getting-started.component.html
+++ b/apps/chansey/src/app/shared/components/getting-started/getting-started.component.html
@@ -15,6 +15,9 @@
       <p-step [value]="3"
         ><span class="hidden sm:inline">Opportunity Selling</span><span class="sm:hidden">Selling</span></p-step
       >
+      <p-step [value]="4"
+        ><span class="hidden sm:inline">What happens next</span><span class="sm:hidden">Next</span></p-step
+      >
     </p-step-list>
     <p-step-panels>
       <!-- Step 1: Connect Exchange -->
@@ -152,11 +155,98 @@
                     (onClick)="activateCallback(2)"
                   />
                   <p-button
-                    label="Save & Finish"
-                    icon="pi pi-check"
+                    label="Save & Continue"
+                    icon="pi pi-arrow-right"
+                    iconPos="right"
                     [loading]="updateOpportunitySellingMutation.isPending()"
                     (onClick)="saveOpportunitySelling()"
                   />
+                </div>
+              </div>
+            </p-panel>
+          </div>
+        </ng-template>
+      </p-step-panel>
+
+      <!-- Step 4: What happens next (educational) -->
+      <p-step-panel [value]="4">
+        <ng-template #content let-activateCallback="activateCallback">
+          <div class="px-2 py-4 sm:px-0">
+            <p class="mt-0 mb-6 text-muted-color">
+              Before {{ appName }} starts trading for you, we carefully test every strategy. Here's what happens next:
+            </p>
+
+            <p-panel>
+              <div class="flex flex-col gap-5">
+                <div class="flex items-start gap-3">
+                  <div
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-50 text-primary dark:bg-primary-900/30"
+                  >
+                    <i class="pi pi-cog" aria-hidden="true"></i>
+                  </div>
+                  <div>
+                    <div class="mb-1 font-semibold">We test against history</div>
+                    <div class="text-sm text-muted-color">
+                      We run your strategy against months of past market data to make sure it has an edge. Takes a few
+                      days.
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex items-start gap-3">
+                  <div
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-50 text-primary dark:bg-primary-900/30"
+                  >
+                    <i class="pi pi-chart-line" aria-hidden="true"></i>
+                  </div>
+                  <div>
+                    <div class="mb-1 font-semibold">We practice with pretend money</div>
+                    <div class="text-sm text-muted-color">
+                      Your strategy trades live markets — but with fake money first. Usually 1 to 4 weeks, depending on
+                      how often your strategy trades.
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex items-start gap-3">
+                  <div
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-50 text-primary dark:bg-primary-900/30"
+                  >
+                    <i class="pi pi-shield" aria-hidden="true"></i>
+                  </div>
+                  <div>
+                    <div class="mb-1 font-semibold">We do a final safety review</div>
+                    <div class="text-sm text-muted-color">
+                      If your strategy passes, you go live. If not, we'll tell you and try a different one — no silent
+                      waiting.
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex items-start gap-3">
+                  <div
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-50 text-primary dark:bg-primary-900/30"
+                  >
+                    <i class="pi pi-envelope" aria-hidden="true"></i>
+                  </div>
+                  <div>
+                    <div class="mb-1 font-semibold">We'll email you at each milestone</div>
+                    <div class="text-sm text-muted-color">
+                      You don't need to watch. We'll reach out when something changes — and your dashboard will always
+                      show where you are.
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex justify-between pt-2">
+                  <p-button
+                    label="Back"
+                    icon="pi pi-arrow-left"
+                    severity="secondary"
+                    [text]="true"
+                    (onClick)="activateCallback(3)"
+                  />
+                  <p-button label="Got it, let's go!" icon="pi pi-check" (onClick)="completeWizard()" />
                 </div>
               </div>
             </p-panel>

--- a/apps/chansey/src/app/shared/components/getting-started/getting-started.component.ts
+++ b/apps/chansey/src/app/shared/components/getting-started/getting-started.component.ts
@@ -191,7 +191,7 @@ export class GettingStartedComponent {
           summary: 'Saved',
           detail: 'Opportunity selling configuration saved'
         });
-        this.completed.emit();
+        this.activeStep.set(4);
       },
       onError: (error: Error) => {
         this.messageService.add({
@@ -201,5 +201,9 @@ export class GettingStartedComponent {
         });
       }
     });
+  }
+
+  completeWizard(): void {
+    this.completed.emit();
   }
 }

--- a/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.html
+++ b/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.html
@@ -1,0 +1,145 @@
+@if (showCard()) {
+  @let data = status();
+  @if (data) {
+    <p-card>
+      <ng-template #header>
+        <div class="flex flex-wrap items-start justify-between gap-3 p-4 pb-0">
+          <div>
+            <h3 class="mt-0 mb-1 text-lg font-semibold">Your strategy</h3>
+            <p class="mt-0 text-sm text-muted-color">
+              {{ data.strategyName }}
+            </p>
+          </div>
+          @if (!data.wasRejected && !data.isRetrying && !data.isStalled) {
+            <span class="rounded-full bg-primary-50 px-3 py-1 text-xs font-medium text-primary dark:bg-primary-900/30">
+              {{ currentStageDisplay()?.label }}
+            </span>
+          }
+        </div>
+      </ng-template>
+
+      @if (data.wasRejected) {
+        <p-message severity="error" [closable]="false" class="mb-3 block">
+          <div class="flex items-start gap-2 p-2">
+            <i class="pi pi-exclamation-circle" aria-hidden="true"></i>
+            <div>
+              <div class="mb-1 font-semibold">Your strategy didn't pass the safety review</div>
+              <div class="text-sm">
+                We'll try a different one on your next cycle. No action needed from you.
+                @if (data.rejectionReason) {
+                  <div class="mt-2 text-xs opacity-80">{{ data.rejectionReason }}</div>
+                }
+              </div>
+            </div>
+          </div>
+        </p-message>
+      } @else if (data.isRetrying) {
+        <p-message severity="warn" [closable]="false" class="mb-3 block">
+          <div class="flex items-start gap-2 p-2">
+            <i class="pi pi-refresh" aria-hidden="true"></i>
+            <div>
+              <div class="mb-1 font-semibold">We're retrying with fresh parameters</div>
+              <div class="text-sm">
+                The strategy couldn't find enough opportunities — a new attempt will start automatically on the next
+                cycle. No action needed from you.
+                @if (data.retryReason) {
+                  <div class="mt-2 text-xs opacity-80">{{ data.retryReason }}</div>
+                }
+              </div>
+            </div>
+          </div>
+        </p-message>
+      } @else {
+        @if (data.isStalled) {
+          <p-message severity="warn" [closable]="false" class="mb-3 block">
+            <div class="flex items-start gap-2 p-2">
+              <i class="pi pi-clock" aria-hidden="true"></i>
+              <span class="text-sm"> Taking longer than expected — our team has been notified. </span>
+            </div>
+          </p-message>
+        }
+
+        <p class="mt-0 mb-4 text-sm text-muted-color">
+          {{ currentStageDisplay()?.description }}
+        </p>
+
+        <!-- 5-dot progress -->
+        <div
+          class="mb-4 flex items-center gap-2"
+          role="progressbar"
+          [attr.aria-valuenow]="data.stageIndex"
+          [attr.aria-valuemin]="0"
+          [attr.aria-valuemax]="data.totalStages - 1"
+          [attr.aria-valuetext]="currentStageDisplay()?.label"
+          aria-label="Pipeline progress"
+        >
+          @for (stage of stages; track stage.stage; let i = $index) {
+            <div
+              class="h-2.5 flex-1 rounded-full transition-colors"
+              [class.bg-primary]="isStageComplete(i) || isStageCurrent(i)"
+              [class.bg-surface-200]="!isStageComplete(i) && !isStageCurrent(i)"
+              [class.dark:bg-surface-700]="!isStageComplete(i) && !isStageCurrent(i)"
+              [class.animate-pulse]="isStageCurrent(i)"
+              [attr.aria-label]="stage.label"
+            ></div>
+          }
+        </div>
+
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="text-sm font-medium">
+            {{ etaLabel() }}
+          </div>
+          @if (data.currentStageProgress) {
+            <div class="text-xs text-muted-color">
+              {{ data.currentStageProgress.tradesCompleted }} of
+              {{ data.currentStageProgress.tradesRequired }} simulated trades completed
+            </div>
+          }
+        </div>
+
+        <div class="mt-2">
+          <p-button
+            label="Learn more"
+            [text]="true"
+            size="small"
+            icon="pi pi-info-circle"
+            styleClass="p-0 text-xs"
+            (onClick)="openLearnMore()"
+          />
+        </div>
+      }
+    </p-card>
+
+    @let learnMore = currentLearnMore();
+    @if (learnMore) {
+      <p-dialog
+        [(visible)]="dialogVisible"
+        [modal]="true"
+        [draggable]="false"
+        [resizable]="false"
+        [dismissableMask]="true"
+        [style]="{ width: '32rem', maxWidth: '95vw' }"
+        [header]="learnMore.title"
+      >
+        <div class="flex flex-col gap-5 p-2">
+          @for (bullet of learnMore.bullets; track bullet.title) {
+            <div class="flex items-start gap-3">
+              <div
+                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-50 text-primary dark:bg-primary-900/30"
+              >
+                <i [class]="bullet.icon" aria-hidden="true"></i>
+              </div>
+              <div>
+                <div class="mb-1 font-semibold">{{ bullet.title }}</div>
+                <div class="text-sm text-muted-color">{{ bullet.body }}</div>
+              </div>
+            </div>
+          }
+        </div>
+        <ng-template pTemplate="footer">
+          <p-button label="Got it" (onClick)="closeLearnMore()" />
+        </ng-template>
+      </p-dialog>
+    }
+  }
+}

--- a/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.spec.ts
+++ b/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.spec.ts
@@ -1,0 +1,116 @@
+import { signal } from '@angular/core';
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { PipelineStage, PipelineStatus, type UserPipelineStatus } from '@chansey/api-interfaces';
+
+import { StrategyStatusCardComponent } from './strategy-status-card.component';
+
+import { PipelineService } from '../../services/pipeline.service';
+
+describe('StrategyStatusCardComponent', () => {
+  let fixture: ComponentFixture<StrategyStatusCardComponent>;
+  let component: StrategyStatusCardComponent;
+  let statusSignal: ReturnType<typeof signal<UserPipelineStatus | null>>;
+
+  const baseStatus: UserPipelineStatus = {
+    pipelineId: 'p1',
+    strategyName: 'Test Strategy',
+    currentStage: PipelineStage.PAPER_TRADE,
+    status: PipelineStatus.RUNNING,
+    stageIndex: 3,
+    totalStages: 5,
+    createdAt: new Date().toISOString(),
+    minDaysRemaining: 3,
+    maxDaysRemaining: 7,
+    isStalled: false,
+    wasRejected: false,
+    isRetrying: false
+  };
+
+  beforeEach(async () => {
+    statusSignal = signal<UserPipelineStatus | null>(baseStatus);
+
+    await TestBed.configureTestingModule({
+      imports: [StrategyStatusCardComponent, NoopAnimationsModule],
+      providers: [
+        {
+          provide: PipelineService,
+          useValue: {
+            usePipelineStatus: () => ({
+              data: statusSignal
+            })
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StrategyStatusCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('renders the retry panel when isRetrying is true', () => {
+    statusSignal.set({
+      ...baseStatus,
+      status: PipelineStatus.COMPLETED,
+      currentStage: PipelineStage.COMPLETED,
+      stageIndex: 4,
+      isRetrying: true,
+      retryReason: "Strategy couldn't find enough opportunities"
+    });
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain("We're retrying with fresh parameters");
+    expect(text).not.toContain("didn't pass the safety review");
+    expect(component.etaLabel()).toBe('');
+  });
+
+  it('renders the rejected panel when wasRejected is true', () => {
+    statusSignal.set({
+      ...baseStatus,
+      status: PipelineStatus.FAILED,
+      wasRejected: true,
+      rejectionReason: 'Test rejected reason'
+    });
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain("didn't pass the safety review");
+    expect(text).not.toContain("We're retrying");
+  });
+
+  it('opens the dialog when openLearnMore is called and exposes stage content', () => {
+    statusSignal.set({ ...baseStatus, currentStage: PipelineStage.OPTIMIZE, stageIndex: 0 });
+    fixture.detectChanges();
+
+    expect(component.dialogVisible()).toBe(false);
+
+    component.openLearnMore();
+
+    expect(component.dialogVisible()).toBe(true);
+    const learnMore = component.currentLearnMore();
+    if (!learnMore) throw new Error('expected learn-more content for OPTIMIZE stage');
+    expect(learnMore.title).toContain('Training');
+    expect(learnMore.bullets.length).toBeGreaterThan(0);
+  });
+
+  it('returns PAPER_TRADE-specific learn-more content', () => {
+    statusSignal.set({ ...baseStatus, currentStage: PipelineStage.PAPER_TRADE, stageIndex: 3 });
+    fixture.detectChanges();
+
+    const learnMore = component.currentLearnMore();
+    if (!learnMore) throw new Error('expected learn-more content for PAPER_TRADE stage');
+    expect(learnMore.title).toContain('Paper Trading');
+    expect(learnMore.bullets.some((b) => b.title.includes('pretend money'))).toBe(true);
+  });
+
+  it('closeLearnMore sets dialogVisible to false', () => {
+    component.openLearnMore();
+    expect(component.dialogVisible()).toBe(true);
+
+    component.closeLearnMore();
+    expect(component.dialogVisible()).toBe(false);
+  });
+});

--- a/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.ts
+++ b/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.ts
@@ -1,0 +1,166 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { DialogModule } from 'primeng/dialog';
+import { MessageModule } from 'primeng/message';
+
+import { PipelineStage, UserPipelineStatus } from '@chansey/api-interfaces';
+
+import { PipelineService } from '../../services/pipeline.service';
+
+interface StageDisplay {
+  stage: PipelineStage;
+  label: string;
+  description: string;
+}
+
+interface LearnMoreBullet {
+  icon: string;
+  title: string;
+  body: string;
+}
+
+interface LearnMoreContent {
+  title: string;
+  bullets: LearnMoreBullet[];
+}
+
+const STAGE_DISPLAY: StageDisplay[] = [
+  {
+    stage: PipelineStage.OPTIMIZE,
+    label: 'Training',
+    description: "We're training your strategy on historical data."
+  },
+  {
+    stage: PipelineStage.HISTORICAL,
+    label: 'Historical Test',
+    description: 'Testing against months of past market data.'
+  },
+  {
+    stage: PipelineStage.LIVE_REPLAY,
+    label: 'Recent Replay',
+    description: 'Replaying the most recent market moves.'
+  },
+  {
+    stage: PipelineStage.PAPER_TRADE,
+    label: 'Paper Trading',
+    description: 'Practicing with pretend money in real market conditions.'
+  },
+  {
+    stage: PipelineStage.COMPLETED,
+    label: 'Safety Review',
+    description: 'Final checks before your strategy goes live.'
+  }
+];
+
+const HISTORY_BULLET: LearnMoreBullet = {
+  icon: 'pi pi-cog',
+  title: 'We test against history',
+  body: 'We run your strategy against months of past market data to make sure it has an edge. Takes a few days.'
+};
+
+const PAPER_BULLET: LearnMoreBullet = {
+  icon: 'pi pi-chart-line',
+  title: 'We practice with pretend money',
+  body: 'Your strategy trades live markets but with fake money first. Usually 1 to 4 weeks, depending on how often your strategy trades.'
+};
+
+const SAFETY_BULLET: LearnMoreBullet = {
+  icon: 'pi pi-shield',
+  title: 'We do a final safety review',
+  body: "If your strategy passes, you go live. If not, we'll tell you and try a different one — no silent waiting."
+};
+
+const EMAIL_BULLET: LearnMoreBullet = {
+  icon: 'pi pi-envelope',
+  title: "We'll email you at each milestone",
+  body: "You don't need to watch. We'll reach out when something changes and your dashboard will always show where you are."
+};
+
+const STAGE_LEARN_MORE: Record<PipelineStage, LearnMoreContent> = {
+  [PipelineStage.OPTIMIZE]: {
+    title: "What's happening during Training",
+    bullets: [HISTORY_BULLET, PAPER_BULLET, SAFETY_BULLET, EMAIL_BULLET]
+  },
+  [PipelineStage.HISTORICAL]: {
+    title: "What's happening during Historical Test",
+    bullets: [HISTORY_BULLET, PAPER_BULLET, SAFETY_BULLET, EMAIL_BULLET]
+  },
+  [PipelineStage.LIVE_REPLAY]: {
+    title: "What's happening during Recent Replay",
+    bullets: [HISTORY_BULLET, PAPER_BULLET, SAFETY_BULLET, EMAIL_BULLET]
+  },
+  [PipelineStage.PAPER_TRADE]: {
+    title: "What's happening during Paper Trading",
+    bullets: [PAPER_BULLET, SAFETY_BULLET, EMAIL_BULLET]
+  },
+  [PipelineStage.COMPLETED]: {
+    title: "What's happening during Safety Review",
+    bullets: [SAFETY_BULLET, EMAIL_BULLET]
+  }
+};
+
+@Component({
+  selector: 'app-strategy-status-card',
+  standalone: true,
+  imports: [ButtonModule, CardModule, DialogModule, MessageModule],
+  templateUrl: './strategy-status-card.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class StrategyStatusCardComponent {
+  private readonly pipelineService = inject(PipelineService);
+
+  readonly statusQuery = this.pipelineService.usePipelineStatus();
+
+  readonly status = computed<UserPipelineStatus | null>(() => this.statusQuery.data() ?? null);
+
+  readonly stages = STAGE_DISPLAY;
+
+  readonly dialogVisible = signal(false);
+
+  readonly currentStageDisplay = computed(() => {
+    const data = this.status();
+    if (!data) return null;
+    return STAGE_DISPLAY.find((s) => s.stage === data.currentStage) ?? STAGE_DISPLAY[0];
+  });
+
+  readonly currentLearnMore = computed<LearnMoreContent | null>(() => {
+    const data = this.status();
+    if (!data) return null;
+    return STAGE_LEARN_MORE[data.currentStage] ?? null;
+  });
+
+  readonly etaLabel = computed(() => {
+    const data = this.status();
+    if (!data) return '';
+    if (data.wasRejected || data.isRetrying) return '';
+    if (data.minDaysRemaining === 0 && data.maxDaysRemaining === 0) return 'Activating soon';
+    if (data.minDaysRemaining === data.maxDaysRemaining) {
+      return `Est. ${data.maxDaysRemaining} day${data.maxDaysRemaining === 1 ? '' : 's'} until live trading`;
+    }
+    return `Est. ${data.minDaysRemaining}–${data.maxDaysRemaining} days until live trading`;
+  });
+
+  readonly showCard = computed(() => this.status() !== null);
+
+  isStageComplete(index: number): boolean {
+    const data = this.status();
+    if (!data) return false;
+    return index < data.stageIndex;
+  }
+
+  isStageCurrent(index: number): boolean {
+    const data = this.status();
+    if (!data) return false;
+    return index === data.stageIndex;
+  }
+
+  openLearnMore(): void {
+    this.dialogVisible.set(true);
+  }
+
+  closeLearnMore(): void {
+    this.dialogVisible.set(false);
+  }
+}

--- a/apps/chansey/src/app/shared/services/index.ts
+++ b/apps/chansey/src/app/shared/services/index.ts
@@ -2,6 +2,7 @@ export * from './auth.service';
 export * from './coin-data.service';
 export * from './exchange.service';
 export * from './layout.service';
+export * from './pipeline.service';
 export * from './pwa.service';
 export * from './session-activity.service';
 export * from './title.service';

--- a/apps/chansey/src/app/shared/services/pipeline.service.ts
+++ b/apps/chansey/src/app/shared/services/pipeline.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+
+import { UserPipelineStatus } from '@chansey/api-interfaces';
+import { STANDARD_POLICY, queryKeys, useAuthQuery } from '@chansey/shared';
+
+/**
+ * Frontend service for the user-facing pipeline status endpoint.
+ * The dashboard status card reads this to show where the user's
+ * automated trading sits in the validation pipeline. The query
+ * refetches on window focus via STANDARD_POLICY.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class PipelineService {
+  usePipelineStatus() {
+    return useAuthQuery<UserPipelineStatus | null>(queryKeys.pipelines.status(), '/api/pipelines/status', {
+      cachePolicy: STANDARD_POLICY
+    });
+  }
+}

--- a/libs/api-interfaces/src/lib/notification/notification.interface.ts
+++ b/libs/api-interfaces/src/lib/notification/notification.interface.ts
@@ -12,7 +12,12 @@ export enum NotificationEventType {
   STRATEGY_DEPLOYED = 'strategy_deployed',
   STRATEGY_DEMOTED = 'strategy_demoted',
   DAILY_LOSS_LIMIT = 'daily_loss_limit',
-  REGIME_STALE = 'regime_stale'
+  REGIME_STALE = 'regime_stale',
+  PIPELINE_STARTED = 'pipeline_started',
+  PIPELINE_STAGE_COMPLETED = 'pipeline_stage_completed',
+  PIPELINE_COMPLETED = 'pipeline_completed',
+  PIPELINE_REJECTED = 'pipeline_rejected',
+  STRATEGY_LIVE = 'strategy_live'
 }
 
 export type NotificationSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
@@ -34,6 +39,11 @@ export interface NotificationEventPreferences {
   [NotificationEventType.STRATEGY_DEMOTED]: boolean;
   [NotificationEventType.DAILY_LOSS_LIMIT]: boolean;
   [NotificationEventType.REGIME_STALE]: boolean;
+  [NotificationEventType.PIPELINE_STARTED]: boolean;
+  [NotificationEventType.PIPELINE_STAGE_COMPLETED]: boolean;
+  [NotificationEventType.PIPELINE_COMPLETED]: boolean;
+  [NotificationEventType.PIPELINE_REJECTED]: boolean;
+  [NotificationEventType.STRATEGY_LIVE]: boolean;
 }
 
 export interface QuietHoursConfig {
@@ -64,7 +74,12 @@ export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
     [NotificationEventType.STRATEGY_DEPLOYED]: true,
     [NotificationEventType.STRATEGY_DEMOTED]: true,
     [NotificationEventType.DAILY_LOSS_LIMIT]: true,
-    [NotificationEventType.REGIME_STALE]: true
+    [NotificationEventType.REGIME_STALE]: true,
+    [NotificationEventType.PIPELINE_STARTED]: true,
+    [NotificationEventType.PIPELINE_STAGE_COMPLETED]: true,
+    [NotificationEventType.PIPELINE_COMPLETED]: true,
+    [NotificationEventType.PIPELINE_REJECTED]: true,
+    [NotificationEventType.STRATEGY_LIVE]: true
   },
   quietHours: {
     enabled: false,

--- a/libs/api-interfaces/src/lib/pipeline/index.ts
+++ b/libs/api-interfaces/src/lib/pipeline/index.ts
@@ -1,3 +1,4 @@
 export * from './allocation-limits';
 export * from './leverage-limits';
 export * from './pipeline.interface';
+export * from './user-pipeline-status.interface';

--- a/libs/api-interfaces/src/lib/pipeline/user-pipeline-status.interface.ts
+++ b/libs/api-interfaces/src/lib/pipeline/user-pipeline-status.interface.ts
@@ -1,0 +1,44 @@
+import { type PipelineStage, type PipelineStatus } from './pipeline.interface';
+
+/**
+ * User-facing pipeline status summary.
+ * Returned from GET /pipelines/status — describes where the user's
+ * most recent active pipeline sits and gives a human-readable timeline range.
+ */
+export interface UserPipelineStatus {
+  pipelineId: string;
+  strategyName: string;
+  currentStage: PipelineStage;
+  status: PipelineStatus;
+  /** 0-based index of the current stage (0-4 for the five displayed dots) */
+  stageIndex: number;
+  /** Total displayed stages (always 5: OPTIMIZE → HISTORICAL → LIVE_REPLAY → PAPER_TRADE → COMPLETED) */
+  totalStages: 5;
+  createdAt: string;
+  /** Lower bound of estimated days remaining until live trading */
+  minDaysRemaining: number;
+  /** Upper bound of estimated days remaining until live trading */
+  maxDaysRemaining: number;
+  /**
+   * Progress within the current stage. Present during PAPER_TRADE and
+   * used to render "X of Y simulated trades completed".
+   */
+  currentStageProgress?: {
+    tradesCompleted: number;
+    tradesRequired: number;
+  };
+  /** True if the pipeline has not transitioned stages in more than 48 hours */
+  isStalled: boolean;
+  /** True if a gate failed and the pipeline ended without going live */
+  wasRejected: boolean;
+  /**
+   * True if the pipeline completed with INCONCLUSIVE_RETRY — the strategy
+   * couldn't find enough opportunities, and a new pipeline will auto-start
+   * on the next orchestration cycle. Distinct from wasRejected (hard failure).
+   */
+  isRetrying: boolean;
+  /** Human-readable reason surfaced to the user when isRetrying is true */
+  retryReason?: string;
+  /** Human-readable reason surfaced to the user when wasRejected is true */
+  rejectionReason?: string;
+}

--- a/libs/shared/src/lib/query/query-keys.ts
+++ b/libs/shared/src/lib/query/query-keys.ts
@@ -202,6 +202,14 @@ export const queryKeys = {
   },
 
   // --------------------------------------------------------------------------
+  // Pipelines Domain
+  // --------------------------------------------------------------------------
+  pipelines: {
+    all: ['pipelines'] as const,
+    status: () => [...queryKeys.pipelines.all, 'status'] as const
+  },
+
+  // --------------------------------------------------------------------------
   // Notifications Domain
   // --------------------------------------------------------------------------
   notifications: {
@@ -323,4 +331,5 @@ export type ComparisonReportsQueryKeys = (typeof queryKeys)['comparisonReports']
 export type PricesQueryKeys = (typeof queryKeys)['prices'];
 export type TradingQueryKeys = (typeof queryKeys)['trading'];
 export type NotificationsQueryKeys = (typeof queryKeys)['notifications'];
+export type PipelinesQueryKeys = (typeof queryKeys)['pipelines'];
 export type AdminQueryKeys = (typeof queryKeys)['admin'];


### PR DESCRIPTION
## Summary

- Introduces a user-facing dashboard status card so members can see exactly where their strategy is in the 5-stage automated trading pipeline (OPTIMIZE → HISTORICAL → LIVE_REPLAY → PAPER_TRADE → COMPLETED)
- Reports a day *range* (not a fixed date) computed from current stage + risk level + observed paper-trade rate, and layers in dedicated states for rejected, retrying (INCONCLUSIVE_RETRY), and stalled pipelines
- Adds five new pipeline-driven notifications (started, stage-completed, completed, rejected, strategy-live) and an educational onboarding step explaining what happens between connecting an exchange and going live

## Changes

### Backend (API)

- `GET /api/pipelines/status` — new user-scoped endpoint returning `UserPipelineStatus`
- `PipelineEtaService` — computes stage index, min/max days remaining, stalled flag, rejected/retrying flags, and surfaces friendly copy
- `PipelineNotificationListener` — translates `PIPELINE_*` events into 5 new notification types with severity-aware copy (INCONCLUSIVE_RETRY → `low` severity, soft retry messaging)
- `PipelineOrchestratorService` — emits `PIPELINE_STATUS_CHANGE` on start, initializes `stageTransitionedAt`
- `PipelineProgressionService` — bumps `stageTransitionedAt` on `advanceToNextStage`, `completePipeline`, and `markInconclusiveAndComplete` so stall detection reflects real stage inactivity rather than any row write
- Migration `1776533051872-add-pipeline-stage-transitioned-at.ts` — adds the column with backfill for in-flight pipelines

### Frontend (Angular)

- `StrategyStatusCardComponent` — new dashboard card with 5-dot progress, range-based ETA copy, three exclusive states (rejected / retrying / normal), and a "Learn more" dialog with per-stage educational content
- `getting-started` step 4 — explains the validation timeline during onboarding without promising false precision
- `AppTopBar` — iconography for the 5 new pipeline notification types
- `PipelineService` — TanStack-query wrapper around the status endpoint

### Shared

- `UserPipelineStatus` interface (with `isRetrying` / `retryReason` distinguishing soft retries from hard rejections)
- New `NotificationEventType` entries for pipeline events
- New query key under `queryKeys.pipelines`

## Test Plan

- [x] `npx nx test api` — 4450 passed (pipeline-eta, pipeline-progression, pipeline-orchestrator specs updated; retry-state and stall-detection coverage added)
- [x] `npx nx test chansey` — strategy-status-card smoke spec covers retry state, rejection state, and Learn more dialog
- [x] `npx nx build api` / `npx nx build chansey` — both succeed
- [x] `npx nx lint api` / `npx nx lint chansey` — 0 warnings, 0 errors
- [ ] Seed a pipeline with `recommendation = INCONCLUSIVE_RETRY` and verify the dashboard shows the amber retry panel (not red rejection, not "activating soon")
- [ ] Click "Learn more" on each stage (OPTIMIZE / HISTORICAL / LIVE_REPLAY / PAPER_TRADE / COMPLETED) and confirm the dialog content matches
- [ ] Seed a pipeline with `stageTransitionedAt` 50h ago → stalled warning appears; seed one with only `updatedAt` 50h ago → stalled warning does NOT appear (the regression this migration prevents)
- [ ] Run the migration against a DB with in-flight pipelines and confirm backfill populates `stageTransitionedAt` for RUNNING / PENDING / PAUSED rows only

## Related

Closes #394