### PR TITLE
feat: tunable strategy exits with re-entry cooldown

### DIFF
--- a/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
+++ b/apps/api/src/algorithm/strategies/atr-trailing-stop.strategy.ts
@@ -157,7 +157,7 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
   private getConfigWithDefaults(config: Record<string, unknown>): ATRTrailingStopConfig {
     return {
       atrPeriod: Math.max(8, Math.min(25, (config.atrPeriod as number) ?? 20)),
-      atrMultiplier: Math.max(2.0, Math.min(6, (config.atrMultiplier as number) ?? 4.5)),
+      atrMultiplier: Math.max(2.0, Math.min(8, (config.atrMultiplier as number) ?? 4.5)),
       tradeDirection: (config.tradeDirection as 'long' | 'short' | 'both') ?? 'long',
       useHighLow: (config.useHighLow as boolean) ?? true,
       minConfidence: (config.minConfidence as number) ?? 0.4,
@@ -483,7 +483,7 @@ export class ATRTrailingStopStrategy extends BaseAlgorithmStrategy implements II
         type: 'number',
         default: 4.5,
         min: 2.0,
-        max: 6,
+        max: 8,
         description: 'ATR multiplier for stop distance'
       },
       tradeDirection: {

--- a/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
@@ -495,6 +496,17 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
         description: 'Take-profit distance as percentage of entry price (must exceed SL for positive expectancy)'
       }
     };
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-band-squeeze.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -14,6 +15,8 @@ interface BollingerSqueezeConfig {
   minSqueezeBars: number;
   breakoutConfirmation: boolean;
   minConfidence: number;
+  stopLossPercent: number;
+  takeProfitPercent: number;
 }
 
 interface SqueezeState {
@@ -128,11 +131,16 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
         );
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        this.buildExitConfig(config)
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(
@@ -153,7 +161,27 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
       squeezeThreshold: (config.squeezeThreshold as number) ?? 0.05, // 5% bandwidth
       minSqueezeBars: (config.minSqueezeBars as number) ?? 4,
       breakoutConfirmation: (config.breakoutConfirmation as boolean) ?? true,
-      minConfidence: (config.minConfidence as number) ?? 0.5
+      minConfidence: (config.minConfidence as number) ?? 0.5,
+      stopLossPercent: (config.stopLossPercent as number) ?? 2.5,
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 5
+    };
+  }
+
+  /**
+   * Build a schema-driven exit configuration for squeeze breakouts.
+   * Takes profit at a wider distance than stop-loss to fix the prior
+   * structurally-inverted risk-reward.
+   */
+  private buildExitConfig(config: BollingerSqueezeConfig): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: config.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: config.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 
@@ -451,7 +479,21 @@ export class BollingerBandSqueezeStrategy extends BaseAlgorithmStrategy implemen
         description: 'Minimum bars in squeeze before breakout signal'
       },
       breakoutConfirmation: { type: 'boolean', default: true, description: 'Require price momentum confirmation' },
-      minConfidence: { type: 'number', default: 0.5, min: 0, max: 1, description: 'Minimum confidence required' }
+      minConfidence: { type: 'number', default: 0.5, min: 0, max: 1, description: 'Minimum confidence required' },
+      stopLossPercent: {
+        type: 'number',
+        default: 2.5,
+        min: 1.5,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 5,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price (must exceed SL for positive expectancy)'
+      }
     };
   }
 

--- a/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -14,6 +15,8 @@ interface BollingerBreakoutConfig {
   confirmationBars: number;
   minConfidence: number;
   squeezeFactor: number;
+  stopLossPercent: number;
+  takeProfitPercent: number;
 }
 
 /**
@@ -132,11 +135,16 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        this.buildExitConfig(config)
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Bollinger Bands Breakout strategy execution failed: ${err.message}`, err.stack);
@@ -154,7 +162,22 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
       requireConfirmation: (config.requireConfirmation as boolean) ?? true,
       confirmationBars: (config.confirmationBars as number) ?? 3,
       minConfidence: (config.minConfidence as number) ?? 0.5,
-      squeezeFactor: (config.squeezeFactor as number) ?? 1.5
+      squeezeFactor: (config.squeezeFactor as number) ?? 1.5,
+      stopLossPercent: (config.stopLossPercent as number) ?? 3.5,
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 6
+    };
+  }
+
+  private buildExitConfig(config: BollingerBreakoutConfig): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: config.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: config.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 
@@ -464,6 +487,20 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
         min: 1.0,
         max: 3.0,
         description: 'Max bandwidth/avg to allow signals (lower = stricter squeeze)'
+      },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1.5,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
       }
     };
   }

--- a/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
+++ b/apps/api/src/algorithm/strategies/bollinger-bands-breakout.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
@@ -503,6 +504,17 @@ export class BollingerBandsBreakoutStrategy extends BaseAlgorithmStrategy implem
         description: 'Take-profit distance as percentage of entry price'
       }
     };
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/confluence-config.spec.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.spec.ts
@@ -16,7 +16,9 @@ describe('getConfluenceParameterConstraints — minConfluence guard', () => {
     rsiBuyThreshold: 55,
     rsiSellThreshold: 45,
     bbBuyThreshold: 0.55,
-    bbSellThreshold: 0.45
+    bbSellThreshold: 0.45,
+    stopLossPercent: 3,
+    takeProfitPercent: 6
   };
 
   it('rejects minConfluence > number of enabled directional indicators', () => {

--- a/apps/api/src/algorithm/strategies/confluence-config.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.ts
@@ -167,13 +167,6 @@ export function getConfluenceConfigSchema(baseSchema: Record<string, unknown>): 
       min: 2,
       max: 20,
       description: 'Take-profit distance as percentage of entry price. Overrides dynamic R:R when set.'
-    },
-    maxHoldBars: {
-      type: 'number',
-      default: 100,
-      min: 50,
-      max: 300,
-      description: 'Maximum bars to hold a position before forcing exit'
     }
   };
 }

--- a/apps/api/src/algorithm/strategies/confluence-config.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.ts
@@ -153,7 +153,13 @@ export function getConfluenceConfigSchema(baseSchema: Record<string, unknown>): 
       description: '%B threshold for bearish (< value = price pushing lower band, confirms downtrend)'
     },
 
-    // Exit management (tunable by optimizer)
+    // Exit management (tunable by optimizer).
+    // NOTE: confluence has ~26 optimizable params total (multi-indicator). With sparse
+    // random samples (e.g. <30) the optimizer can find combos that overfit training
+    // windows — measured wfaDegradation > 30% on a 15-iteration local run. Use the
+    // higher-iteration optimization presets (THOROUGH or DEFAULT) for confluence to
+    // keep walk-forward degradation healthy. The risk-monitoring drift detectors
+    // catch any post-deployment degradation that slips past promotion gates.
     stopLossPercent: {
       type: 'number',
       default: 3.5,

--- a/apps/api/src/algorithm/strategies/confluence-config.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.ts
@@ -151,6 +151,29 @@ export function getConfluenceConfigSchema(baseSchema: Record<string, unknown>): 
       min: 0,
       max: 0.7,
       description: '%B threshold for bearish (< value = price pushing lower band, confirms downtrend)'
+    },
+
+    // Exit management (tunable by optimizer)
+    stopLossPercent: {
+      type: 'number',
+      default: 3.5,
+      min: 1.5,
+      max: 15,
+      description: 'Stop-loss distance as percentage of entry price. Overrides dynamic ATR-based stops when set.'
+    },
+    takeProfitPercent: {
+      type: 'number',
+      default: 6,
+      min: 2,
+      max: 20,
+      description: 'Take-profit distance as percentage of entry price. Overrides dynamic R:R when set.'
+    },
+    maxHoldBars: {
+      type: 'number',
+      default: 100,
+      min: 50,
+      max: 300,
+      description: 'Maximum bars to hold a position before forcing exit'
     }
   };
 }

--- a/apps/api/src/algorithm/strategies/confluence-config.ts
+++ b/apps/api/src/algorithm/strategies/confluence-config.ts
@@ -252,6 +252,12 @@ export function getConfluenceParameterConstraints(): ParameterConstraint[] {
       message: 'bbSellThreshold must be less than bbBuyThreshold'
     },
     {
+      type: 'less_than',
+      param1: 'stopLossPercent',
+      param2: 'takeProfitPercent',
+      message: 'stopLossPercent must be less than takeProfitPercent'
+    },
+    {
       // Reject combinations whose minConfluence requirement exceeds the
       // number of enabled directional indicators — these would never
       // produce a buy signal and waste optimizer iterations on guaranteed

--- a/apps/api/src/algorithm/strategies/confluence-signals.util.ts
+++ b/apps/api/src/algorithm/strategies/confluence-signals.util.ts
@@ -2,6 +2,16 @@ import { type ExitConfig, StopLossType, TakeProfitType } from '../../order/inter
 import { type ConfluenceConfig, type ConfluenceScore, SignalType, type TradingSignal } from '../interfaces';
 
 /**
+ * Optional schema-driven exit overrides. When provided, they bypass the
+ * dynamic ATR/percentage calculation and expose stop-loss and take-profit as
+ * optimizer-tunable parameters.
+ */
+export interface ConfluenceExitOverrides {
+  stopLossPercent?: number;
+  takeProfitPercent?: number;
+}
+
+/**
  * Generate trading signal from confluence score.
  *
  * When `isFuturesShort` is true (enableShortSignals + futures marketType):
@@ -22,7 +32,8 @@ export function generateSignalFromConfluence(
   confluenceScore: ConfluenceScore,
   config: ConfluenceConfig,
   isFuturesShort = false,
-  blockBuy = false
+  blockBuy = false,
+  exitOverrides?: ConfluenceExitOverrides
 ): TradingSignal | null {
   if (confluenceScore.direction === 'hold') {
     return null;
@@ -91,7 +102,7 @@ export function generateSignalFromConfluence(
     confidence,
     reason,
     metadata,
-    exitConfig: buildExitConfig(confluenceScore, currentAtr)
+    exitConfig: buildExitConfig(confluenceScore, currentAtr, exitOverrides)
   };
 }
 
@@ -99,12 +110,34 @@ export function generateSignalFromConfluence(
  * Build strategy-specific exit configuration scaled by confluence score.
  * Higher confluence → tighter stops and wider take-profit (more confident trade).
  *
+ * When `exitOverrides.stopLossPercent` / `takeProfitPercent` are provided, they
+ * short-circuit the dynamic calculation and expose the values as optimizer-
+ * tunable parameters driven directly by the strategy's config schema.
+ *
  * When ATR is available, uses ATR-based stop loss (1.5x-2.5x ATR multiplier)
  * to adapt to actual market volatility instead of fixed percentages.
  * When ATR is unavailable, falls back to wider percentage stops (5-8%)
  * to avoid triggering on normal crypto volatility.
  */
-export function buildExitConfig(confluenceScore: ConfluenceScore, currentAtr?: number): Partial<ExitConfig> {
+export function buildExitConfig(
+  confluenceScore: ConfluenceScore,
+  currentAtr?: number,
+  exitOverrides?: ConfluenceExitOverrides
+): Partial<ExitConfig> {
+  // Schema-driven override path: exposes SL/TP directly to the optimizer
+  if (exitOverrides?.stopLossPercent != null && exitOverrides.takeProfitPercent != null) {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: exitOverrides.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: exitOverrides.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
+    };
+  }
+
   const ratio = confluenceScore.totalEnabled > 0 ? confluenceScore.confluenceCount / confluenceScore.totalEnabled : 0.5;
 
   // Take profit: 1.5:1 to 3:1 risk-reward scaled by confluence

--- a/apps/api/src/algorithm/strategies/confluence.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/confluence.strategy.spec.ts
@@ -610,14 +610,13 @@ describe('ConfluenceStrategy', () => {
       expect(exitConfig.stopLossType).toBe('percentage');
     });
 
-    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+    it('exposes stopLossPercent and takeProfitPercent in schema', () => {
       const schema = strategy.getConfigSchema() as Record<string, { default: number; min?: number; max?: number }>;
       expect(schema.stopLossPercent).toBeDefined();
       expect(schema.stopLossPercent.default).toBe(3.5);
       expect(schema.stopLossPercent.max).toBe(15);
       expect(schema.takeProfitPercent).toBeDefined();
       expect(schema.takeProfitPercent.default).toBe(6);
-      expect(schema.maxHoldBars).toBeDefined();
     });
 
     it('should set confidence and strength between 0 and 1', async () => {

--- a/apps/api/src/algorithm/strategies/confluence.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/confluence.strategy.spec.ts
@@ -592,6 +592,34 @@ describe('ConfluenceStrategy', () => {
       expect(exitConfig.takeProfitValue).toBeGreaterThan(0);
     });
 
+    it('schema stopLossPercent/takeProfitPercent override the dynamic ATR/% logic', async () => {
+      setupBullishIndicators();
+
+      const result = await strategy.execute(
+        buildContext({
+          minConfluence: 3,
+          stopLossPercent: 4.5,
+          takeProfitPercent: 11
+        })
+      );
+
+      expect(result.signals).toHaveLength(1);
+      const exitConfig = result.signals[0].exitConfig as Record<string, unknown>;
+      expect(exitConfig.stopLossValue).toBe(4.5);
+      expect(exitConfig.takeProfitValue).toBe(11);
+      expect(exitConfig.stopLossType).toBe('percentage');
+    });
+
+    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+      const schema = strategy.getConfigSchema() as Record<string, { default: number; min?: number; max?: number }>;
+      expect(schema.stopLossPercent).toBeDefined();
+      expect(schema.stopLossPercent.default).toBe(3.5);
+      expect(schema.stopLossPercent.max).toBe(15);
+      expect(schema.takeProfitPercent).toBeDefined();
+      expect(schema.takeProfitPercent.default).toBe(6);
+      expect(schema.maxHoldBars).toBeDefined();
+    });
+
     it('should set confidence and strength between 0 and 1', async () => {
       setupBullishIndicators();
 

--- a/apps/api/src/algorithm/strategies/confluence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/confluence.strategy.ts
@@ -111,7 +111,11 @@ export class ConfluenceStrategy extends BaseAlgorithmStrategy implements IIndica
           confluenceScore,
           config,
           isFuturesShort,
-          blockBuy
+          blockBuy,
+          {
+            stopLossPercent: (context.config.stopLossPercent as number) ?? undefined,
+            takeProfitPercent: (context.config.takeProfitPercent as number) ?? undefined
+          }
         );
 
         if (tradingSignal) {

--- a/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
+++ b/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -15,6 +16,8 @@ interface EMARSIFilterConfig {
   rsiMaxForBuy: number;
   rsiMinForSell: number;
   minConfidence: number;
+  stopLossPercent: number;
+  takeProfitPercent: number;
 }
 
 /**
@@ -130,11 +133,16 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        this.buildExitConfig(config)
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`EMA RSI Filter strategy execution failed: ${err.message}`, err.stack);
@@ -152,7 +160,22 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
       rsiPeriod: (config.rsiPeriod as number) ?? 14,
       rsiMaxForBuy: (config.rsiMaxForBuy as number) ?? 70,
       rsiMinForSell: (config.rsiMinForSell as number) ?? 30,
-      minConfidence: (config.minConfidence as number) ?? 0.6
+      minConfidence: (config.minConfidence as number) ?? 0.6,
+      stopLossPercent: (config.stopLossPercent as number) ?? 3.5,
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 6
+    };
+  }
+
+  private buildExitConfig(config: EMARSIFilterConfig): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: config.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: config.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 
@@ -423,7 +446,21 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
         max: 50,
         description: 'Min RSI to allow sell signals (avoid selling oversold)'
       },
-      minConfidence: { type: 'number', default: 0.6, min: 0, max: 1, description: 'Minimum confidence required' }
+      minConfidence: { type: 'number', default: 0.6, min: 0, max: 1, description: 'Minimum confidence required' },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1.5,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
+      }
     };
   }
 

--- a/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
+++ b/apps/api/src/algorithm/strategies/ema-rsi-filter.strategy.ts
@@ -471,6 +471,12 @@ export class EMARSIFilterStrategy extends BaseAlgorithmStrategy implements IIndi
         param1: 'fastEmaPeriod',
         param2: 'slowEmaPeriod',
         message: 'fastEmaPeriod must be less than slowEmaPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
       }
     ];
   }

--- a/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
+++ b/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -50,6 +51,18 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
       const fastPeriod = (context.config.fastPeriod as number) || 8;
       const slowPeriod = (context.config.slowPeriod as number) || 50;
       const crossoverLookback = Math.max(1, Math.min(10, (context.config.crossoverLookback as number) || 5));
+      const stopLossPercent = (context.config.stopLossPercent as number) ?? 3.5;
+      const takeProfitPercent = (context.config.takeProfitPercent as number) ?? 6;
+      const exitConfig: Partial<ExitConfig> = {
+        enableStopLoss: true,
+        stopLossType: StopLossType.PERCENTAGE,
+        stopLossValue: stopLossPercent,
+        enableTakeProfit: true,
+        takeProfitType: TakeProfitType.PERCENTAGE,
+        takeProfitValue: takeProfitPercent,
+        enableTrailingStop: false,
+        useOco: true
+      };
       const isBacktest = !!(
         context.metadata?.backtestId ||
         context.metadata?.isOptimization ||
@@ -95,11 +108,16 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        exitConfig
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`EMA algorithm execution failed: ${err.message}`, err.stack);
@@ -288,8 +306,20 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
         description: 'Number of bars to scan for crossover events'
       },
       minConfidence: { type: 'number', default: 0.4, min: 0, max: 1 },
-      enableStopLoss: { type: 'boolean', default: false },
-      stopLossPercentage: { type: 'number', default: 0.05, min: 0.01, max: 0.2 }
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
+      }
     };
   }
 

--- a/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
+++ b/apps/api/src/algorithm/strategies/exponential-moving-average.strategy.ts
@@ -286,6 +286,12 @@ export class ExponentialMovingAverageStrategy extends BaseAlgorithmStrategy impl
         param1: 'fastPeriod',
         param2: 'slowPeriod',
         message: 'fastPeriod must be less than slowPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
       }
     ];
   }

--- a/apps/api/src/algorithm/strategies/macd.strategy.ts
+++ b/apps/api/src/algorithm/strategies/macd.strategy.ts
@@ -380,6 +380,12 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
         param1: 'fastPeriod',
         param2: 'slowPeriod',
         message: 'fastPeriod must be less than slowPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
       }
     ];
   }

--- a/apps/api/src/algorithm/strategies/macd.strategy.ts
+++ b/apps/api/src/algorithm/strategies/macd.strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -15,6 +16,8 @@ interface MACDConfig {
   useHistogramConfirmation: boolean;
   minHistogramStrength: number;
   minConfidence: number;
+  stopLossPercent: number;
+  takeProfitPercent: number;
 }
 
 /**
@@ -116,11 +119,16 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        this.buildExitConfig(config)
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`MACD strategy execution failed: ${err.message}`, err.stack);
@@ -138,7 +146,22 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
       signalPeriod: (config.signalPeriod as number) ?? 9,
       useHistogramConfirmation: (config.useHistogramConfirmation as boolean) ?? true,
       minHistogramStrength: (config.minHistogramStrength as number) ?? 0.0001,
-      minConfidence: (config.minConfidence as number) ?? 0.6
+      minConfidence: (config.minConfidence as number) ?? 0.6,
+      stopLossPercent: (config.stopLossPercent as number) ?? 3.5,
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 6
+    };
+  }
+
+  private buildExitConfig(config: MACDConfig): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: config.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: config.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 
@@ -378,7 +401,21 @@ export class MACDStrategy extends BaseAlgorithmStrategy implements IIndicatorPro
         max: 0.01,
         description: 'Minimum histogram value'
       },
-      minConfidence: { type: 'number', default: 0.6, min: 0, max: 1, description: 'Minimum confidence required' }
+      minConfidence: { type: 'number', default: 0.6, min: 0, max: 1, description: 'Minimum confidence required' },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1,
+        max: 12,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
+      }
     };
   }
 

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.spec.ts
@@ -206,14 +206,13 @@ describe('MeanReversionStrategy', () => {
   });
 
   describe('exit config schema', () => {
-    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+    it('exposes stopLossPercent and takeProfitPercent in schema', () => {
       const schema = strategy.getConfigSchema() as Record<string, { default: number }>;
 
       expect(schema.stopLossPercent).toBeDefined();
       expect(schema.stopLossPercent.default).toBe(3.5);
       expect(schema.takeProfitPercent).toBeDefined();
       expect(schema.takeProfitPercent.default).toBe(6);
-      expect(schema.maxHoldBars).toBeDefined();
     });
 
     it('wires schema stopLossPercent into signal exitConfig (replaces hardcoded 3.5)', async () => {

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.spec.ts
@@ -204,4 +204,42 @@ describe('MeanReversionStrategy', () => {
       expect(strategy.canExecute(context)).toBe(false);
     });
   });
+
+  describe('exit config schema', () => {
+    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+      const schema = strategy.getConfigSchema() as Record<string, { default: number }>;
+
+      expect(schema.stopLossPercent).toBeDefined();
+      expect(schema.stopLossPercent.default).toBe(3.5);
+      expect(schema.takeProfitPercent).toBeDefined();
+      expect(schema.takeProfitPercent.default).toBe(6);
+      expect(schema.maxHoldBars).toBeDefined();
+    });
+
+    it('wires schema stopLossPercent into signal exitConfig (replaces hardcoded 3.5)', async () => {
+      const prices = createMockPrices(30, 100, 90); // oversold
+      const movingAverage = Array(30).fill(NaN);
+      const standardDeviation = Array(30).fill(NaN);
+      movingAverage[29] = 100;
+      standardDeviation[29] = 2;
+
+      mockIndicators(movingAverage, standardDeviation, 2);
+
+      const result = await strategy.execute(
+        buildContext(prices, {
+          period: 20,
+          threshold: 2,
+          stopLossPercent: 7,
+          takeProfitPercent: 10
+        })
+      );
+
+      expect(result.signals).toHaveLength(1);
+      const signal = result.signals[0];
+      expect(signal.type).toBe(SignalType.BUY);
+      expect(signal.exitConfig?.stopLossValue).toBe(7);
+      // Take-profit is scaled by z-score (boost = 0) so base = 10
+      expect(signal.exitConfig?.takeProfitValue).toBeGreaterThanOrEqual(10);
+    });
+  });
 });

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
@@ -246,7 +247,7 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
   ): Partial<ExitConfig> {
     // Scale take-profit by z-score excess: at threshold σ use base, widen beyond
     const zScoreBoost = Math.max(0, (absZScore - threshold) / threshold);
-    const takeProfitPct = Math.max(1, Math.min(20, takeProfitPercent * (1 + zScoreBoost * 0.5)));
+    const takeProfitPct = Math.max(1, Math.min(40, takeProfitPercent * (1 + zScoreBoost * 0.5)));
 
     return {
       enableStopLoss: true,
@@ -329,6 +330,17 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
         description: 'Take-profit base distance as percentage of entry price (scaled by z-score)'
       }
     };
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
@@ -327,13 +327,6 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
         min: 2,
         max: 20,
         description: 'Take-profit base distance as percentage of entry price (scaled by z-score)'
-      },
-      maxHoldBars: {
-        type: 'number',
-        default: 100,
-        min: 50,
-        max: 300,
-        description: 'Maximum bars to hold a position before forcing exit'
       }
     };
   }

--- a/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
+++ b/apps/api/src/algorithm/strategies/mean-reversion.strategy.ts
@@ -56,6 +56,8 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
       // Get configuration with defaults
       const period = (context.config.period as number) || 20;
       const threshold = (context.config.threshold as number) || 2; // Standard deviations
+      const stopLossPercent = (context.config.stopLossPercent as number) ?? 3.5;
+      const takeProfitPercent = (context.config.takeProfitPercent as number) ?? 6;
       const isBacktest = !!(
         context.metadata?.backtestId ||
         context.metadata?.isOptimization ||
@@ -124,7 +126,9 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
           priceHistory,
           movingAverage,
           standardDeviation,
-          threshold
+          threshold,
+          stopLossPercent,
+          takeProfitPercent
         );
 
         if (signal) {
@@ -165,7 +169,9 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
     prices: CandleData[],
     movingAverage: number[],
     standardDeviation: number[],
-    threshold: number
+    threshold: number,
+    stopLossPercent: number,
+    takeProfitPercent: number
   ): TradingSignal | null {
     const currentIndex = prices.length - 1;
     const currentPrice = prices[currentIndex].avg;
@@ -197,7 +203,7 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
           standardDeviation: currentStdDev,
           signalType: 'oversold'
         },
-        exitConfig: this.buildExitConfig(absZScore, threshold)
+        exitConfig: this.buildExitConfig(absZScore, threshold, stopLossPercent, takeProfitPercent)
       };
     }
 
@@ -217,7 +223,7 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
           standardDeviation: currentStdDev,
           signalType: 'overbought'
         },
-        exitConfig: this.buildExitConfig(absZScore, threshold)
+        exitConfig: this.buildExitConfig(absZScore, threshold, stopLossPercent, takeProfitPercent)
       };
     }
 
@@ -227,18 +233,25 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
 
   /**
    * Build strategy-specific exit configuration for mean reversion.
-   * Tight stop loss (mean reversion expects bounded moves) and
-   * take profit scaled by z-score distance from the mean.
+   *
+   * Stop-loss and take-profit base values come from the optimizer-tunable
+   * schema params. Take-profit is scaled up by z-score distance from the mean
+   * so stronger deviations aim for proportionally larger moves.
    */
-  private buildExitConfig(absZScore: number, threshold: number): Partial<ExitConfig> {
-    // Take profit: scaled by z-score distance, capped at 8%
-    // At threshold (e.g., 2σ) → ~3%, at 3σ → ~5%, at 4σ → 8%
-    const takeProfitPct = Math.max(1, Math.min(8, 1.5 + ((absZScore - threshold) / threshold) * 3.5));
+  private buildExitConfig(
+    absZScore: number,
+    threshold: number,
+    stopLossPercent: number,
+    takeProfitPercent: number
+  ): Partial<ExitConfig> {
+    // Scale take-profit by z-score excess: at threshold σ use base, widen beyond
+    const zScoreBoost = Math.max(0, (absZScore - threshold) / threshold);
+    const takeProfitPct = Math.max(1, Math.min(20, takeProfitPercent * (1 + zScoreBoost * 0.5)));
 
     return {
       enableStopLoss: true,
       stopLossType: StopLossType.PERCENTAGE,
-      stopLossValue: 3.5, // 3.5% stop — wide enough to survive normal crypto volatility
+      stopLossValue: stopLossPercent,
       enableTakeProfit: true,
       takeProfitType: TakeProfitType.PERCENTAGE,
       takeProfitValue: takeProfitPct,
@@ -300,7 +313,28 @@ export class MeanReversionStrategy extends BaseAlgorithmStrategy implements IInd
       period: { type: 'number', default: 20, min: 5, max: 100 },
       threshold: { type: 'number', default: 2, min: 1, max: 4 },
       minConfidence: { type: 'number', default: 0.4, min: 0, max: 1 },
-      enableDynamicThreshold: { type: 'boolean', default: true }
+      enableDynamicThreshold: { type: 'boolean', default: true },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1.5,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit base distance as percentage of entry price (scaled by z-score)'
+      },
+      maxHoldBars: {
+        type: 'number',
+        default: 100,
+        min: 50,
+        max: 300,
+        description: 'Maximum bars to hold a position before forcing exit'
+      }
     };
   }
 

--- a/apps/api/src/algorithm/strategies/rsi-divergence.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/rsi-divergence.strategy.spec.ts
@@ -442,11 +442,12 @@ describe('RSIDivergenceStrategy', () => {
       expect(result.signals).toHaveLength(1);
       const exitConfig = result.signals[0].exitConfig ?? {};
       expect(exitConfig.enableStopLoss).toBe(true);
+      // Default bounds (schema defaults): stopLoss 2–15, takeProfit 3–20
       expect(exitConfig.stopLossValue).toBeGreaterThanOrEqual(2);
-      expect(exitConfig.stopLossValue).toBeLessThanOrEqual(6);
+      expect(exitConfig.stopLossValue).toBeLessThanOrEqual(15);
       expect(exitConfig.enableTakeProfit).toBe(true);
       expect(exitConfig.takeProfitValue).toBeGreaterThanOrEqual(3);
-      expect(exitConfig.takeProfitValue).toBeLessThanOrEqual(10);
+      expect(exitConfig.takeProfitValue).toBeLessThanOrEqual(20);
       expect(exitConfig.enableTrailingStop).toBe(true);
       expect(exitConfig.trailingActivationValue).toBe(1.5);
       expect(exitConfig.useOco).toBe(true);

--- a/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import {
   ExitConfig,
   StopLossType,
@@ -596,6 +597,15 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
         description: 'Upper bound for ATR-scaled take-profit percentage'
       }
     };
+  }
+
+  // Prevent the optimizer from picking inverted bounds (e.g. takeProfitMin=10, takeProfitMax=6)
+  // which would silently collapse the ATR-scaled clamp to a constant and disable the dynamic exit.
+  override getParameterConstraints(): ParameterConstraint[] {
+    return [
+      { type: 'less_than', param1: 'stopLossMin', param2: 'stopLossMax' },
+      { type: 'less_than', param1: 'takeProfitMin', param2: 'takeProfitMax' }
+    ];
   }
 
   canExecute(context: AlgorithmContext): boolean {

--- a/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-divergence.strategy.ts
@@ -24,6 +24,10 @@ interface RSIDivergenceConfig {
   rsiOversold: number;
   rsiOverbought: number;
   minConfidence: number;
+  stopLossMin: number;
+  stopLossMax: number;
+  takeProfitMin: number;
+  takeProfitMax: number;
 }
 
 interface PivotPoint {
@@ -155,7 +159,11 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
       minDivergencePercent: (config.minDivergencePercent as number) ?? 2,
       rsiOversold: (config.rsiOversold as number) ?? 40,
       rsiOverbought: (config.rsiOverbought as number) ?? 60,
-      minConfidence: (config.minConfidence as number) ?? 0.5
+      minConfidence: (config.minConfidence as number) ?? 0.5,
+      stopLossMin: (config.stopLossMin as number) ?? 2,
+      stopLossMax: (config.stopLossMax as number) ?? 15,
+      takeProfitMin: (config.takeProfitMin as number) ?? 3,
+      takeProfitMax: (config.takeProfitMax as number) ?? 20
     };
   }
 
@@ -343,7 +351,15 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
 
     const strength = this.calculateSignalStrength(divergence, config);
     const confidence = this.calculateConfidence(prices, rsi, divergence, currentATR, config);
-    const exitConfig = this.buildExitConfig(currentATR, currentPrice, divergence);
+    const exitConfig = this.buildExitConfig(
+      currentATR,
+      currentPrice,
+      divergence,
+      config.stopLossMin,
+      config.stopLossMax,
+      config.takeProfitMin,
+      config.takeProfitMax
+    );
 
     const metadata = {
       symbol: coinSymbol,
@@ -433,17 +449,29 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
   }
 
   /**
-   * ATR-scaled exit configuration.
-   * Stop-loss: max(2%, min(6%, ATR/price * 1.5))
-   * Take-profit: max(3%, min(10%, ATR/price * 2.5 + magBonus)) — ~1.7:1 R:R
-   * Trailing stop: 1x ATR percentage, activates at 1.5% profit
+   * ATR-scaled exit configuration with optimizer-tunable bounds.
+   *
+   * Stop-loss: max(stopLossMin, min(stopLossMax, ATR/price * 1.5))
+   * Take-profit: max(takeProfitMin, min(takeProfitMax, ATR/price * 2.5 + magBonus))
+   * Trailing stop: 1x ATR percentage, activates at 1.5% profit.
+   *
+   * The min/max bounds come from the strategy schema so the optimizer can widen
+   * or tighten the search range.
    */
-  private buildExitConfig(currentATR: number, currentPrice: number, divergence: DivergenceResult): Partial<ExitConfig> {
+  private buildExitConfig(
+    currentATR: number,
+    currentPrice: number,
+    divergence: DivergenceResult,
+    stopLossMin: number,
+    stopLossMax: number,
+    takeProfitMin: number,
+    takeProfitMax: number
+  ): Partial<ExitConfig> {
     const atrPct = currentPrice > 0 ? (currentATR / currentPrice) * 100 : 3;
     const magBonus = Math.min(2, divergence.score / 30);
 
-    const stopLossPct = Math.max(2, Math.min(6, atrPct * 1.5));
-    const takeProfitPct = Math.max(3, Math.min(10, atrPct * 2.5 + magBonus));
+    const stopLossPct = Math.max(stopLossMin, Math.min(stopLossMax, atrPct * 1.5));
+    const takeProfitPct = Math.max(takeProfitMin, Math.min(takeProfitMax, atrPct * 2.5 + magBonus));
     const trailingPct = Math.max(1, Math.min(4, atrPct));
 
     return {
@@ -538,7 +566,35 @@ export class RSIDivergenceStrategy extends BaseAlgorithmStrategy implements IInd
         max: 75,
         description: 'RSI overbought zone gate for bearish signals'
       },
-      minConfidence: { type: 'number', default: 0.5, min: 0, max: 1, description: 'Minimum confidence required' }
+      minConfidence: { type: 'number', default: 0.5, min: 0, max: 1, description: 'Minimum confidence required' },
+      stopLossMin: {
+        type: 'number',
+        default: 2,
+        min: 1,
+        max: 5,
+        description: 'Lower bound for ATR-scaled stop-loss percentage'
+      },
+      stopLossMax: {
+        type: 'number',
+        default: 15,
+        min: 5,
+        max: 15,
+        description: 'Upper bound for ATR-scaled stop-loss percentage'
+      },
+      takeProfitMin: {
+        type: 'number',
+        default: 3,
+        min: 2,
+        max: 10,
+        description: 'Lower bound for ATR-scaled take-profit percentage'
+      },
+      takeProfitMax: {
+        type: 'number',
+        default: 20,
+        min: 6,
+        max: 30,
+        description: 'Upper bound for ATR-scaled take-profit percentage'
+      }
     };
   }
 

--- a/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
@@ -505,6 +505,12 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
         param1: 'macdFast',
         param2: 'macdSlow',
         message: 'macdFast must be less than macdSlow'
+      },
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
       }
     ];
   }

--- a/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi-macd-combo.strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -17,6 +18,8 @@ interface RSIMACDComboConfig {
   macdSignal: number;
   confirmationWindow: number;
   minConfidence: number;
+  stopLossPercent: number;
+  takeProfitPercent: number;
 }
 
 interface SignalState {
@@ -147,11 +150,16 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        this.buildExitConfig(config)
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`RSI MACD Combo strategy execution failed: ${err.message}`, err.stack);
@@ -171,7 +179,22 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
       macdSlow: (config.macdSlow as number) ?? 26,
       macdSignal: (config.macdSignal as number) ?? 9,
       confirmationWindow: (config.confirmationWindow as number) ?? 5,
-      minConfidence: (config.minConfidence as number) ?? 0.5
+      minConfidence: (config.minConfidence as number) ?? 0.5,
+      stopLossPercent: (config.stopLossPercent as number) ?? 3.5,
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 6
+    };
+  }
+
+  private buildExitConfig(config: RSIMACDComboConfig): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: config.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: config.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 
@@ -457,7 +480,21 @@ export class RSIMACDComboStrategy extends BaseAlgorithmStrategy implements IIndi
         max: 10,
         description: 'Bars within which both signals must occur'
       },
-      minConfidence: { type: 'number', default: 0.5, min: 0, max: 1, description: 'Minimum confidence required' }
+      minConfidence: { type: 'number', default: 0.5, min: 0, max: 1, description: 'Minimum confidence required' },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1.5,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
+      }
     };
   }
 

--- a/apps/api/src/algorithm/strategies/rsi.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.spec.ts
@@ -334,10 +334,12 @@ describe('RSIStrategy', () => {
       const result = await strategy.execute(context);
       const buy = result.signals.find((s) => s.type === SignalType.BUY);
       expect(buy).toBeDefined();
-      expect(buy?.exitConfig?.stopLossValue).toBe(5);
-      expect(buy?.exitConfig?.takeProfitValue).toBe(12);
-      expect(buy?.exitConfig?.enableStopLoss).toBe(true);
-      expect(buy?.exitConfig?.enableTakeProfit).toBe(true);
+      // Exit config lives at the result level; mapStrategySignal fans it out
+      // to each signal downstream, so the result-level config is the source of truth.
+      expect(result.exitConfig?.stopLossValue).toBe(5);
+      expect(result.exitConfig?.takeProfitValue).toBe(12);
+      expect(result.exitConfig?.enableStopLoss).toBe(true);
+      expect(result.exitConfig?.enableTakeProfit).toBe(true);
     });
   });
 });

--- a/apps/api/src/algorithm/strategies/rsi.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.spec.ts
@@ -298,7 +298,7 @@ describe('RSIStrategy', () => {
   });
 
   describe('exit config schema', () => {
-    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+    it('exposes stopLossPercent and takeProfitPercent in schema', () => {
       const schema = strategy.getConfigSchema() as Record<string, { default: number; min: number; max: number }>;
 
       expect(schema.stopLossPercent).toBeDefined();
@@ -309,9 +309,6 @@ describe('RSIStrategy', () => {
       expect(schema.takeProfitPercent).toBeDefined();
       expect(schema.takeProfitPercent.default).toBe(6);
       expect(schema.takeProfitPercent.max).toBe(20);
-
-      expect(schema.maxHoldBars).toBeDefined();
-      expect(schema.maxHoldBars.default).toBe(100);
     });
 
     it('attaches schema-driven exitConfig to BUY signals', async () => {

--- a/apps/api/src/algorithm/strategies/rsi.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.spec.ts
@@ -296,4 +296,51 @@ describe('RSIStrategy', () => {
       expect(strategy.canExecute(context)).toBe(false);
     });
   });
+
+  describe('exit config schema', () => {
+    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+      const schema = strategy.getConfigSchema() as Record<string, { default: number; min: number; max: number }>;
+
+      expect(schema.stopLossPercent).toBeDefined();
+      expect(schema.stopLossPercent.default).toBe(3.5);
+      expect(schema.stopLossPercent.min).toBe(1.5);
+      expect(schema.stopLossPercent.max).toBe(15);
+
+      expect(schema.takeProfitPercent).toBeDefined();
+      expect(schema.takeProfitPercent.default).toBe(6);
+      expect(schema.takeProfitPercent.max).toBe(20);
+
+      expect(schema.maxHoldBars).toBeDefined();
+      expect(schema.maxHoldBars.default).toBe(100);
+    });
+
+    it('attaches schema-driven exitConfig to BUY signals', async () => {
+      const prices = createMockPrices(30);
+      // Fill last 5 bars with oversold readings so confidence + signal generate
+      const rsiValues = Array(30).fill(NaN);
+      rsiValues[25] = 25;
+      rsiValues[26] = 24;
+      rsiValues[27] = 23;
+      rsiValues[28] = 22;
+      rsiValues[29] = 20;
+      mockRsi(rsiValues);
+
+      const context = buildContext(prices, {
+        period: 14,
+        oversoldThreshold: 30,
+        overboughtThreshold: 70,
+        minConfidence: 0,
+        stopLossPercent: 5,
+        takeProfitPercent: 12
+      });
+
+      const result = await strategy.execute(context);
+      const buy = result.signals.find((s) => s.type === SignalType.BUY);
+      expect(buy).toBeDefined();
+      expect(buy?.exitConfig?.stopLossValue).toBe(5);
+      expect(buy?.exitConfig?.takeProfitValue).toBe(12);
+      expect(buy?.exitConfig?.enableStopLoss).toBe(true);
+      expect(buy?.exitConfig?.enableTakeProfit).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/algorithm/strategies/rsi.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
 import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
@@ -124,7 +125,7 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
 
   /**
    * Build exit configuration from schema parameters so the optimizer can tune
-   * stop-loss, take-profit, and hold-time directly.
+   * stop-loss and take-profit directly.
    */
   private buildExitConfig(config: RSIConfig): Partial<ExitConfig> {
     return {
@@ -185,8 +186,7 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
           previousRSI,
           threshold: config.oversoldThreshold,
           condition: 'oversold'
-        },
-        exitConfig: this.buildExitConfig(config)
+        }
       };
     }
 
@@ -321,6 +321,17 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
         description: 'Take-profit distance as percentage of entry price'
       }
     };
+  }
+
+  getParameterConstraints(): ParameterConstraint[] {
+    return [
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
+      }
+    ];
   }
 
   /**

--- a/apps/api/src/algorithm/strategies/rsi.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.ts
@@ -15,7 +15,6 @@ interface RSIConfig {
   minConfidence: number;
   stopLossPercent: number;
   takeProfitPercent: number;
-  maxHoldBars: number;
 }
 
 /**
@@ -114,8 +113,7 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
       overboughtThreshold: (config.overboughtThreshold as number) ?? 75,
       minConfidence: (config.minConfidence as number) ?? 0.5,
       stopLossPercent: (config.stopLossPercent as number) ?? 3.5,
-      takeProfitPercent: (config.takeProfitPercent as number) ?? 6,
-      maxHoldBars: (config.maxHoldBars as number) ?? 100
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 6
     };
   }
 
@@ -316,13 +314,6 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
         min: 2,
         max: 20,
         description: 'Take-profit distance as percentage of entry price'
-      },
-      maxHoldBars: {
-        type: 'number',
-        default: 100,
-        min: 50,
-        max: 300,
-        description: 'Maximum bars to hold a position before forcing exit'
       }
     };
   }

--- a/apps/api/src/algorithm/strategies/rsi.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.ts
@@ -91,11 +91,16 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        this.buildExitConfig(config)
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`RSI strategy execution failed: ${err.message}`, err.stack);

--- a/apps/api/src/algorithm/strategies/rsi.strategy.ts
+++ b/apps/api/src/algorithm/strategies/rsi.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -12,6 +13,9 @@ interface RSIConfig {
   oversoldThreshold: number;
   overboughtThreshold: number;
   minConfidence: number;
+  stopLossPercent: number;
+  takeProfitPercent: number;
+  maxHoldBars: number;
 }
 
 /**
@@ -108,7 +112,27 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
       period: (config.period as number) ?? 14,
       oversoldThreshold: (config.oversoldThreshold as number) ?? 25,
       overboughtThreshold: (config.overboughtThreshold as number) ?? 75,
-      minConfidence: (config.minConfidence as number) ?? 0.5
+      minConfidence: (config.minConfidence as number) ?? 0.5,
+      stopLossPercent: (config.stopLossPercent as number) ?? 3.5,
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 6,
+      maxHoldBars: (config.maxHoldBars as number) ?? 100
+    };
+  }
+
+  /**
+   * Build exit configuration from schema parameters so the optimizer can tune
+   * stop-loss, take-profit, and hold-time directly.
+   */
+  private buildExitConfig(config: RSIConfig): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: config.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: config.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 
@@ -158,7 +182,8 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
           previousRSI,
           threshold: config.oversoldThreshold,
           condition: 'oversold'
-        }
+        },
+        exitConfig: this.buildExitConfig(config)
       };
     }
 
@@ -277,6 +302,27 @@ export class RSIStrategy extends BaseAlgorithmStrategy implements IIndicatorProv
         min: 0,
         max: 1,
         description: 'Minimum confidence required to generate signal'
+      },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1.5,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
+      },
+      maxHoldBars: {
+        type: 'number',
+        default: 100,
+        min: 50,
+        max: 300,
+        description: 'Maximum bars to hold a position before forcing exit'
       }
     };
   }

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.spec.ts
@@ -302,14 +302,13 @@ describe('SimpleMovingAverageCrossoverStrategy', () => {
   });
 
   describe('exit config schema', () => {
-    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+    it('exposes stopLossPercent and takeProfitPercent in schema', () => {
       const schema = strategy.getConfigSchema() as Record<string, { default: number; min: number; max: number }>;
 
       expect(schema.stopLossPercent).toBeDefined();
       expect(schema.stopLossPercent.default).toBe(3.5);
       expect(schema.takeProfitPercent).toBeDefined();
       expect(schema.takeProfitPercent.default).toBe(6);
-      expect(schema.maxHoldBars).toBeDefined();
     });
 
     it('propagates exitConfig on result and signals when golden cross fires', async () => {

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.spec.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.spec.ts
@@ -300,4 +300,45 @@ describe('SimpleMovingAverageCrossoverStrategy', () => {
       expect(strategy.canExecute(context)).toBe(false);
     });
   });
+
+  describe('exit config schema', () => {
+    it('exposes stopLossPercent, takeProfitPercent, maxHoldBars in schema', () => {
+      const schema = strategy.getConfigSchema() as Record<string, { default: number; min: number; max: number }>;
+
+      expect(schema.stopLossPercent).toBeDefined();
+      expect(schema.stopLossPercent.default).toBe(3.5);
+      expect(schema.takeProfitPercent).toBeDefined();
+      expect(schema.takeProfitPercent.default).toBe(6);
+      expect(schema.maxHoldBars).toBeDefined();
+    });
+
+    it('propagates exitConfig on result and signals when golden cross fires', async () => {
+      const prices = createMockPrices(30);
+      const fast = Array(30).fill(NaN);
+      const slow = Array(30).fill(NaN);
+      // Golden cross at last bar
+      fast[28] = 10;
+      slow[28] = 11;
+      fast[29] = 12;
+      slow[29] = 11;
+      mockSmaValues(fast, slow);
+
+      const result = await strategy.execute(
+        buildContext(prices, {
+          fastPeriod: 10,
+          slowPeriod: 20,
+          stopLossPercent: 4,
+          takeProfitPercent: 10
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.exitConfig?.stopLossValue).toBe(4);
+      expect(result.exitConfig?.takeProfitValue).toBe(10);
+
+      const buy = result.signals.find((s) => s.type === SignalType.BUY);
+      expect(buy).toBeDefined();
+      expect(buy?.exitConfig?.stopLossValue).toBe(4);
+    });
+  });
 });

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
@@ -256,6 +256,12 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         param1: 'fastPeriod',
         param2: 'slowPeriod',
         message: 'fastPeriod must be less than slowPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
       }
     ];
   }

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
@@ -307,13 +307,6 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         min: 2,
         max: 20,
         description: 'Take-profit distance as percentage of entry price'
-      },
-      maxHoldBars: {
-        type: 'number',
-        default: 100,
-        min: 50,
-        max: 300,
-        description: 'Maximum bars to hold a position before forcing exit'
       }
     };
   }

--- a/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
+++ b/apps/api/src/algorithm/strategies/simple-moving-average-crossover.strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -51,6 +52,18 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
       const slowPeriod = (context.config.slowPeriod as number) ?? 50;
       const minConfidence = (context.config.minConfidence as number) ?? 0.4;
       const minSeparation = (context.config.minSeparation as number) ?? 0.005;
+      const stopLossPercent = (context.config.stopLossPercent as number) ?? 3.5;
+      const takeProfitPercent = (context.config.takeProfitPercent as number) ?? 6;
+      const exitConfig: Partial<ExitConfig> = {
+        enableStopLoss: true,
+        stopLossType: StopLossType.PERCENTAGE,
+        stopLossValue: stopLossPercent,
+        enableTakeProfit: true,
+        takeProfitType: TakeProfitType.PERCENTAGE,
+        takeProfitValue: takeProfitPercent,
+        enableTrailingStop: false,
+        useOco: true
+      };
       const isBacktest = !!(
         context.metadata?.backtestId ||
         context.metadata?.isOptimization ||
@@ -91,7 +104,8 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
           priceHistory,
           fastSMA,
           slowSMA,
-          minSeparation
+          minSeparation,
+          exitConfig
         );
 
         if (signal && signal.confidence >= minConfidence) {
@@ -103,12 +117,17 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        fastPeriod,
-        slowPeriod
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          fastPeriod,
+          slowPeriod
+        },
+        exitConfig
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`SMA Crossover algorithm execution failed: ${err.message}`, err.stack);
@@ -125,7 +144,8 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
     prices: CandleData[],
     fastSMA: number[],
     slowSMA: number[],
-    minSeparation: number
+    minSeparation: number,
+    exitConfig: Partial<ExitConfig>
   ): TradingSignal | null {
     const currentIndex = prices.length - 1;
     const previousIndex = currentIndex - 1;
@@ -171,7 +191,8 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
           slowSMA: currentSlow,
           crossoverType: 'golden',
           separation
-        }
+        },
+        exitConfig
       };
     }
 
@@ -272,6 +293,27 @@ export class SimpleMovingAverageCrossoverStrategy extends BaseAlgorithmStrategy 
         min: 0,
         max: 0.05,
         description: 'Min |fast-slow|/slow to recognize a cross. Filters noise.'
+      },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1.5,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
+      },
+      maxHoldBars: {
+        type: 'number',
+        default: 100,
+        min: 50,
+        max: 300,
+        description: 'Maximum bars to hold a position before forcing exit'
       }
     };
   }

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
@@ -531,6 +531,12 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         param1: 'mediumPeriod',
         param2: 'slowPeriod',
         message: 'mediumPeriod must be less than slowPeriod'
+      },
+      {
+        type: 'less_than',
+        param1: 'stopLossPercent',
+        param2: 'takeProfitPercent',
+        message: 'stopLossPercent must be less than takeProfitPercent'
       }
     ];
   }

--- a/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
+++ b/apps/api/src/algorithm/strategies/triple-ema.strategy.ts
@@ -3,6 +3,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 
 import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { ParameterConstraint } from '../../optimization/interfaces/parameter-space.interface';
+import { ExitConfig, StopLossType, TakeProfitType } from '../../order/interfaces/exit-config.interface';
 import { toErrorInfo } from '../../shared/error.util';
 import { BaseAlgorithmStrategy } from '../base/base-algorithm-strategy';
 import { IIndicatorProvider, IndicatorCalculatorMap, IndicatorRequirement, IndicatorService } from '../indicators';
@@ -16,6 +17,8 @@ interface TripleEMAConfig {
   signalOnPartialCross: boolean;
   minConfidence: number;
   minSpread: number;
+  stopLossPercent: number;
+  takeProfitPercent: number;
 }
 
 type EMAAlignment = 'bullish' | 'bearish' | 'neutral';
@@ -122,11 +125,16 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         }
       }
 
-      return this.createSuccessResult(signals, chartData, {
-        algorithm: this.name,
-        version: this.version,
-        signalsGenerated: signals.length
-      });
+      return this.createSuccessResult(
+        signals,
+        chartData,
+        {
+          algorithm: this.name,
+          version: this.version,
+          signalsGenerated: signals.length
+        },
+        this.buildExitConfig(config)
+      );
     } catch (error: unknown) {
       const err = toErrorInfo(error);
       this.logger.error(`Triple EMA strategy execution failed: ${err.message}`, err.stack);
@@ -145,7 +153,22 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
       requireFullAlignment: (config.requireFullAlignment as boolean) ?? false,
       signalOnPartialCross: (config.signalOnPartialCross as boolean) ?? true,
       minConfidence: (config.minConfidence as number) ?? 0.3,
-      minSpread: (config.minSpread as number) ?? 0.001
+      minSpread: (config.minSpread as number) ?? 0.001,
+      stopLossPercent: (config.stopLossPercent as number) ?? 3.5,
+      takeProfitPercent: (config.takeProfitPercent as number) ?? 6
+    };
+  }
+
+  private buildExitConfig(config: TripleEMAConfig): Partial<ExitConfig> {
+    return {
+      enableStopLoss: true,
+      stopLossType: StopLossType.PERCENTAGE,
+      stopLossValue: config.stopLossPercent,
+      enableTakeProfit: true,
+      takeProfitType: TakeProfitType.PERCENTAGE,
+      takeProfitValue: config.takeProfitPercent,
+      enableTrailingStop: false,
+      useOco: true
     };
   }
 
@@ -530,6 +553,20 @@ export class TripleEMAStrategy extends BaseAlgorithmStrategy implements IIndicat
         min: 0,
         max: 0.05,
         description: 'Minimum EMA spread to generate signal. Filters noise crosses.'
+      },
+      stopLossPercent: {
+        type: 'number',
+        default: 3.5,
+        min: 1,
+        max: 15,
+        description: 'Stop-loss distance as percentage of entry price'
+      },
+      takeProfitPercent: {
+        type: 'number',
+        default: 6,
+        min: 2,
+        max: 20,
+        description: 'Take-profit distance as percentage of entry price'
       }
     };
   }

--- a/apps/api/src/balance/balance.service.ts
+++ b/apps/api/src/balance/balance.service.ts
@@ -33,21 +33,13 @@ export class BalanceService {
    * @returns Balance information from all connected exchanges
    */
   async getUserBalances(user: User): Promise<BalanceResponseDto> {
-    this.logger.log(`Getting balances for user: ${user.id}`);
+    const currentBalances = await this.getCurrentBalances(user);
+    const totalUsdValue = currentBalances.reduce((sum, exchange) => sum + exchange.totalUsdValue, 0);
 
-    try {
-      const currentBalances = await this.getCurrentBalances(user);
-      const totalUsdValue = currentBalances.reduce((sum, exchange) => sum + exchange.totalUsdValue, 0);
-
-      return {
-        current: currentBalances,
-        totalUsdValue
-      };
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.error(`Error getting balances for user: ${user.id}`, err.stack);
-      throw error;
-    }
+    return {
+      current: currentBalances,
+      totalUsdValue
+    };
   }
 
   /**

--- a/apps/api/src/exchange/exchange.service.spec.ts
+++ b/apps/api/src/exchange/exchange.service.spec.ts
@@ -185,6 +185,50 @@ describe('ExchangeService', () => {
     ]);
   });
 
+  describe('createMany', () => {
+    it('skips incoming exchanges whose slug or name already exists in the DB', async () => {
+      const incoming = [
+        new Exchange({ slug: 'binance', name: 'Binance' }),
+        new Exchange({ slug: 'coinbase-new', name: 'Coinbase' }),
+        new Exchange({ slug: 'kraken', name: 'Kraken' })
+      ];
+
+      // DB already has "binance" (slug match) and a legacy row whose name is "Coinbase" under a different slug
+      exchangeRepository.find.mockResolvedValueOnce([
+        { slug: 'binance', name: 'Binance' } as Exchange,
+        { slug: 'coinbase-legacy', name: 'Coinbase' } as Exchange
+      ]);
+      exchangeRepository.save.mockImplementation(async (rows: Exchange[]) => rows);
+
+      const warnSpy = jest.spyOn(service['logger'], 'warn').mockImplementation();
+
+      const result = await service.createMany(incoming);
+
+      expect(exchangeRepository.save).toHaveBeenCalledWith([expect.objectContaining({ slug: 'kraken' })]);
+      expect(result).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Coinbase'));
+    });
+
+    it('returns an empty array without calling save when every incoming row collides', async () => {
+      const incoming = [new Exchange({ slug: 'binance', name: 'Binance' })];
+
+      exchangeRepository.find.mockResolvedValueOnce([{ slug: 'binance', name: 'Binance' } as Exchange]);
+
+      const result = await service.createMany(incoming);
+
+      expect(exchangeRepository.save).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('short-circuits on empty input without hitting the DB', async () => {
+      const result = await service.createMany([]);
+
+      expect(exchangeRepository.find).not.toHaveBeenCalled();
+      expect(exchangeRepository.save).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+
   it('filters exchanges to ones with active user keys', async () => {
     const exchanges = [{ id: 'one', supported: true } as Exchange, { id: 'two', supported: true } as Exchange];
 

--- a/apps/api/src/exchange/exchange.service.ts
+++ b/apps/api/src/exchange/exchange.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { In, Repository } from 'typeorm';
@@ -13,6 +13,8 @@ import { stripNullProps } from '../utils/strip-null-props.util';
 
 @Injectable()
 export class ExchangeService implements IExchangeService {
+  private readonly logger = new Logger(ExchangeService.name);
+
   constructor(
     @InjectRepository(Exchange) private readonly exchange: Repository<Exchange>,
     @Inject(EXCHANGE_KEY_SERVICE)
@@ -125,11 +127,27 @@ export class ExchangeService implements IExchangeService {
   }
 
   async createMany(exchanges: Exchange[]): Promise<Exchange[]> {
+    if (exchanges.length === 0) return [];
+
+    const slugs = exchanges.map((ex) => ex.slug).filter((s): s is string => !!s);
+    const names = exchanges.map((ex) => ex.name).filter((n): n is string => !!n);
+
+    // Check both unique constraints (slug AND name) — either can reject an insert.
     const existingExchanges = await this.exchange.find({
-      where: exchanges.map((ex) => ({ slug: ex.slug }))
+      where: [...slugs.map((slug) => ({ slug })), ...names.map((name) => ({ name }))]
     });
 
-    const newExchanges = exchanges.filter((ex) => !existingExchanges.find((existing) => existing.slug === ex.slug));
+    const existingBySlug = new Set(existingExchanges.map((e) => e.slug));
+    const existingByName = new Set(existingExchanges.map((e) => e.name));
+
+    const newExchanges = exchanges.filter((ex) => {
+      if (existingBySlug.has(ex.slug)) return false;
+      if (existingByName.has(ex.name)) {
+        this.logger.warn(`Skipping new exchange "${ex.name}" (slug=${ex.slug}): name collides with an existing row`);
+        return false;
+      }
+      return true;
+    });
 
     if (newExchanges.length === 0) return [];
 

--- a/apps/api/src/order/backtest/shared/execution/backtest-bar-processor.service.ts
+++ b/apps/api/src/order/backtest/shared/execution/backtest-bar-processor.service.ts
@@ -171,7 +171,8 @@ export class BacktestBarProcessor {
           backtest: ctx.backtest,
           coinMap: ctx.coinMap,
           quoteCoin: ctx.quoteCoin,
-          prevCandleMap: ctx.prevCandleMap
+          prevCandleMap: ctx.prevCandleMap,
+          currentBar: i
         },
         {
           executeTradeFn: this.tradeExecutor.executeTrade.bind(this.tradeExecutor),
@@ -230,7 +231,15 @@ export class BacktestBarProcessor {
       barRegimeResult
     );
 
-    await this.dispatchFilteredSignals(ctx, filteredSignals, timestamp, marketData, currentPrices, {
+    // Re-entry cooldown filter: suppress BUYs on coins that just stopped out.
+    // Applied AFTER regime/throttle filters so cooldown-blocked signals are
+    // excluded even when the strategy would otherwise rebuy immediately.
+    const exitTracker = ctx.exitTracker;
+    const cooldownFiltered = exitTracker
+      ? filteredSignals.filter((sig) => sig.action !== 'BUY' || exitTracker.canEnter(sig.coinId, i))
+      : filteredSignals;
+
+    await this.dispatchFilteredSignals(ctx, cooldownFiltered, timestamp, marketData, currentPrices, {
       barMaxAllocation,
       barMinAllocation
     });

--- a/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.spec.ts
@@ -188,7 +188,8 @@ describe('ExitSignalProcessorService', () => {
           tradingFee: 0,
           timestamp: new Date(),
           trades: [],
-          slippageConfig: DEFAULT_SLIPPAGE_CONFIG
+          slippageConfig: DEFAULT_SLIPPAGE_CONFIG,
+          currentBar: 0
         },
         callbacks
       );
@@ -220,7 +221,8 @@ describe('ExitSignalProcessorService', () => {
           tradingFee: 0.001,
           timestamp: new Date(),
           trades,
-          slippageConfig: DEFAULT_SLIPPAGE_CONFIG
+          slippageConfig: DEFAULT_SLIPPAGE_CONFIG,
+          currentBar: 0
         },
         callbacks
       );
@@ -252,7 +254,8 @@ describe('ExitSignalProcessorService', () => {
           tradingFee: 0.001,
           timestamp: new Date(),
           trades,
-          slippageConfig: DEFAULT_SLIPPAGE_CONFIG
+          slippageConfig: DEFAULT_SLIPPAGE_CONFIG,
+          currentBar: 0
         },
         callbacks
       );
@@ -280,7 +283,8 @@ describe('ExitSignalProcessorService', () => {
           tradingFee: 0.001,
           timestamp: new Date(),
           trades,
-          slippageConfig: DEFAULT_SLIPPAGE_CONFIG
+          slippageConfig: DEFAULT_SLIPPAGE_CONFIG,
+          currentBar: 0
         },
         callbacks
       );
@@ -318,7 +322,8 @@ describe('ExitSignalProcessorService', () => {
           signals,
           simulatedFills,
           backtest,
-          slippageConfig: DEFAULT_SLIPPAGE_CONFIG
+          slippageConfig: DEFAULT_SLIPPAGE_CONFIG,
+          currentBar: 0
         },
         callbacks
       );
@@ -372,7 +377,8 @@ describe('ExitSignalProcessorService', () => {
           signals,
           simulatedFills,
           backtest,
-          slippageConfig: DEFAULT_SLIPPAGE_CONFIG
+          slippageConfig: DEFAULT_SLIPPAGE_CONFIG,
+          currentBar: 0
         },
         callbacks
       );

--- a/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.ts
+++ b/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.ts
@@ -47,8 +47,11 @@ export interface ProcessExitSignalsOptions {
   coinMap?: Map<string, Coin>;
   quoteCoin?: Coin;
   prevCandleMap?: Map<string, OHLCCandle>;
-  /** Current bar index, passed so the tracker can record re-entry cooldowns. */
-  currentBar?: number;
+  /**
+   * Current bar index. Required so the exit tracker can record re-entry cooldowns
+   * consistently across optimizer and full-backtest paths.
+   */
+  currentBar: number;
 }
 
 /**

--- a/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.ts
+++ b/apps/api/src/order/backtest/shared/exit-signals/exit-signal-processor.service.ts
@@ -47,6 +47,8 @@ export interface ProcessExitSignalsOptions {
   coinMap?: Map<string, Coin>;
   quoteCoin?: Coin;
   prevCandleMap?: Map<string, OHLCCandle>;
+  /** Current bar index, passed so the tracker can record re-entry cooldowns. */
+  currentBar?: number;
 }
 
 /**
@@ -112,7 +114,7 @@ export class ExitSignalProcessorService {
     const priceMap = new Map(currentPrices.map((c) => [c.coinId, c]));
     const lowPrices = new Map(currentPrices.map((c) => [c.coinId, c.low]));
     const highPrices = new Map(currentPrices.map((c) => [c.coinId, c.high]));
-    const exitSignals = exitTracker.checkExits(marketData.prices, lowPrices, highPrices);
+    const exitSignals = exitTracker.checkExits(marketData.prices, lowPrices, highPrices, opts.currentBar);
 
     const fullFidelity = !!(opts.signals && opts.simulatedFills && opts.backtest);
 

--- a/apps/api/src/order/backtest/shared/exits/backtest-exit-tracker.spec.ts
+++ b/apps/api/src/order/backtest/shared/exits/backtest-exit-tracker.spec.ts
@@ -483,6 +483,152 @@ describe('BacktestExitTracker', () => {
     });
   });
 
+  describe('re-entry cooldown', () => {
+    it('canEnter returns true when no cooldown is active', () => {
+      const tracker = new BacktestExitTracker(makeConfig());
+      expect(tracker.canEnter('btc', 10)).toBe(true);
+    });
+
+    it('stop-loss exit registers a cooldown that blocks re-entry for N bars', () => {
+      const config = makeConfig({
+        enableStopLoss: true,
+        stopLossType: StopLossType.PERCENTAGE,
+        stopLossValue: 5,
+        exitCooldownBars: 10
+      });
+      const tracker = new BacktestExitTracker(config);
+      tracker.onBuy('btc', 100, 1);
+
+      // Bar 50: stop-loss triggers
+      const signals = tracker.checkExits(
+        makePriceMap({ btc: 94 }),
+        makePriceMap({ btc: 94 }),
+        makePriceMap({ btc: 100 }),
+        50
+      );
+      expect(signals).toHaveLength(1);
+      expect(signals[0].exitType).toBe('STOP_LOSS');
+
+      // Cooldown blocks re-entry for bars 50..59
+      expect(tracker.canEnter('btc', 50)).toBe(false);
+      expect(tracker.canEnter('btc', 55)).toBe(false);
+      expect(tracker.canEnter('btc', 59)).toBe(false);
+
+      // Bar 60: cooldown has expired (50 + 10)
+      expect(tracker.canEnter('btc', 60)).toBe(true);
+    });
+
+    it('take-profit exit does NOT register a cooldown', () => {
+      const config = makeConfig({
+        enableStopLoss: false,
+        enableTakeProfit: true,
+        takeProfitType: TakeProfitType.PERCENTAGE,
+        takeProfitValue: 10,
+        exitCooldownBars: 10
+      });
+      const tracker = new BacktestExitTracker(config);
+      tracker.onBuy('btc', 100, 1);
+
+      tracker.checkExits(makePriceMap({ btc: 112 }), makePriceMap({ btc: 105 }), makePriceMap({ btc: 112 }), 50);
+
+      expect(tracker.canEnter('btc', 51)).toBe(true);
+    });
+
+    it('trailing stop exit registers a cooldown', () => {
+      const config = makeConfig({
+        enableStopLoss: false,
+        enableTrailingStop: true,
+        trailingType: TrailingType.PERCENTAGE,
+        trailingValue: 5,
+        trailingActivation: TrailingActivationType.IMMEDIATE,
+        exitCooldownBars: 5
+      });
+      const tracker = new BacktestExitTracker(config);
+      tracker.onBuy('btc', 100, 1);
+
+      // Ratchet up, then trigger trailing stop
+      tracker.checkExits(makePriceMap({ btc: 110 }), makePriceMap({ btc: 105 }), makePriceMap({ btc: 110 }), 10);
+      const signals = tracker.checkExits(
+        makePriceMap({ btc: 104 }),
+        makePriceMap({ btc: 103 }),
+        makePriceMap({ btc: 110 }),
+        20
+      );
+      expect(signals).toHaveLength(1);
+      expect(signals[0].exitType).toBe('TRAILING_STOP');
+
+      expect(tracker.canEnter('btc', 20)).toBe(false);
+      expect(tracker.canEnter('btc', 24)).toBe(false);
+      expect(tracker.canEnter('btc', 25)).toBe(true);
+    });
+
+    it('exitCooldownBars of 0 disables cooldown', () => {
+      const config = makeConfig({
+        enableStopLoss: true,
+        stopLossType: StopLossType.PERCENTAGE,
+        stopLossValue: 5,
+        exitCooldownBars: 0
+      });
+      const tracker = new BacktestExitTracker(config);
+      tracker.onBuy('btc', 100, 1);
+
+      tracker.checkExits(makePriceMap({ btc: 94 }), makePriceMap({ btc: 94 }), makePriceMap({ btc: 100 }), 10);
+
+      expect(tracker.canEnter('btc', 10)).toBe(true);
+    });
+
+    it('cooldown is not registered when currentBar is undefined', () => {
+      const config = makeConfig({
+        enableStopLoss: true,
+        stopLossType: StopLossType.PERCENTAGE,
+        stopLossValue: 5,
+        exitCooldownBars: 10
+      });
+      const tracker = new BacktestExitTracker(config);
+      tracker.onBuy('btc', 100, 1);
+
+      // No currentBar passed — cooldown should not be set
+      tracker.checkExits(makePriceMap({ btc: 94 }), makePriceMap({ btc: 94 }), makePriceMap({ btc: 100 }));
+
+      expect(tracker.canEnter('btc', 5)).toBe(true);
+    });
+
+    it('per-position override cooldown takes precedence over tracker config', () => {
+      const config = makeConfig({
+        enableStopLoss: true,
+        stopLossType: StopLossType.PERCENTAGE,
+        stopLossValue: 5,
+        exitCooldownBars: 10
+      });
+      const tracker = new BacktestExitTracker(config);
+      // Position-specific cooldown of 3 bars
+      tracker.onBuy('btc', 100, 1, undefined, { exitCooldownBars: 3 });
+
+      tracker.checkExits(makePriceMap({ btc: 94 }), makePriceMap({ btc: 94 }), makePriceMap({ btc: 100 }), 100);
+
+      expect(tracker.canEnter('btc', 102)).toBe(false);
+      expect(tracker.canEnter('btc', 103)).toBe(true);
+    });
+
+    it('serialize/deserialize round-trips cooldown state', () => {
+      const config = makeConfig({
+        enableStopLoss: true,
+        stopLossType: StopLossType.PERCENTAGE,
+        stopLossValue: 5,
+        exitCooldownBars: 10
+      });
+      const tracker = new BacktestExitTracker(config);
+      tracker.onBuy('btc', 100, 1);
+
+      tracker.checkExits(makePriceMap({ btc: 94 }), makePriceMap({ btc: 94 }), makePriceMap({ btc: 100 }), 50);
+
+      const restored = BacktestExitTracker.deserialize(tracker.serialize(), config);
+
+      expect(restored.canEnter('btc', 55)).toBe(false);
+      expect(restored.canEnter('btc', 60)).toBe(true);
+    });
+  });
+
   describe('serialize / deserialize', () => {
     it('round-trips correctly and restored tracker produces correct signals', () => {
       const config = makeConfig({

--- a/apps/api/src/order/backtest/shared/exits/backtest-exit-tracker.ts
+++ b/apps/api/src/order/backtest/shared/exits/backtest-exit-tracker.ts
@@ -51,7 +51,12 @@ export interface TrackedExit {
  */
 export interface SerializableExitTrackerState {
   positions: TrackedExit[];
+  /** Cooldown map keyed by coinId. Value = bar index at which cooldown expires. */
+  cooldowns?: Array<[string, number]>;
 }
+
+/** Default cooldown window when exitCooldownBars is not specified (bars). */
+export const DEFAULT_EXIT_COOLDOWN_BARS = 10;
 
 /**
  * In-memory position exit tracker for the backtest engine.
@@ -62,6 +67,14 @@ export interface SerializableExitTrackerState {
  */
 export class BacktestExitTracker {
   private positions = new Map<string, TrackedExit>();
+  /**
+   * Re-entry cooldowns keyed by coinId. Value = bar index at which the
+   * cooldown expires (exclusive). A BUY signal is blocked while the current
+   * bar < expiry. Cooldowns are set when a position exits via stop-loss or
+   * trailing stop to prevent rapid re-entry churn on a coin that just gapped
+   * through the stop level.
+   */
+  private exitCooldowns = new Map<string, number>();
 
   constructor(private readonly config: ExitConfig) {}
 
@@ -190,11 +203,14 @@ export class BacktestExitTracker {
    * @param closePrices - Map<coinId, close price> for the current bar
    * @param lowPrices - Map<coinId, low price> for SL breach detection
    * @param highPrices - Map<coinId, high price> for TP breach detection
+   * @param currentBar - Optional current bar index used to record re-entry
+   *   cooldowns on stop-loss / trailing exits. When omitted, no cooldown is set.
    */
   checkExits(
     closePrices: Map<string, number>,
     lowPrices: Map<string, number>,
-    highPrices: Map<string, number>
+    highPrices: Map<string, number>,
+    currentBar?: number
   ): ExitSignal[] {
     const signals: ExitSignal[] = [];
 
@@ -226,6 +242,7 @@ export class BacktestExitTracker {
               lowPrice
             }
           });
+          this.registerExitCooldown(coinId, tracked, currentBar);
           exited = true;
           // OCO: if SL fires, TP is cancelled — handled by removing position below
         }
@@ -284,6 +301,7 @@ export class BacktestExitTracker {
                 lowPrice
               }
             });
+            this.registerExitCooldown(coinId, tracked, currentBar);
             exited = true;
           }
         }
@@ -294,6 +312,34 @@ export class BacktestExitTracker {
     }
 
     return signals;
+  }
+
+  /**
+   * Check whether a BUY on `coinId` is allowed at the current bar.
+   * Returns false while the post-exit cooldown is still active.
+   * Expired cooldowns are cleaned up lazily on read.
+   */
+  canEnter(coinId: string, currentBar: number): boolean {
+    const cooldownExpiry = this.exitCooldowns.get(coinId);
+    if (cooldownExpiry === undefined) return true;
+    if (currentBar >= cooldownExpiry) {
+      this.exitCooldowns.delete(coinId);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Record a re-entry cooldown window for a coin that just exited via SL or
+   * trailing stop. Pulls cooldown length from the position's own config,
+   * falling back to the tracker's base config, then to the default.
+   */
+  private registerExitCooldown(coinId: string, tracked: TrackedExit, currentBar?: number): void {
+    if (currentBar === undefined) return;
+    const cfg = tracked.positionConfig ?? this.config;
+    const cooldownBars = cfg.exitCooldownBars ?? this.config.exitCooldownBars ?? DEFAULT_EXIT_COOLDOWN_BARS;
+    if (cooldownBars <= 0) return;
+    this.exitCooldowns.set(coinId, currentBar + cooldownBars);
   }
 
   /**
@@ -337,7 +383,8 @@ export class BacktestExitTracker {
    */
   serialize(): SerializableExitTrackerState {
     return {
-      positions: Array.from(this.positions.values()).map((t) => ({ ...t }))
+      positions: Array.from(this.positions.values()).map((t) => ({ ...t })),
+      cooldowns: Array.from(this.exitCooldowns.entries())
     };
   }
 
@@ -348,6 +395,11 @@ export class BacktestExitTracker {
     const tracker = new BacktestExitTracker(config);
     for (const pos of state.positions) {
       tracker.positions.set(pos.coinId, { ...pos });
+    }
+    if (state.cooldowns) {
+      for (const [coinId, expiry] of state.cooldowns) {
+        tracker.exitCooldowns.set(coinId, expiry);
+      }
     }
     return tracker;
   }

--- a/apps/api/src/order/backtest/shared/optimization/optimization-core.service.ts
+++ b/apps/api/src/order/backtest/shared/optimization/optimization-core.service.ts
@@ -372,7 +372,10 @@ export class OptimizationCoreService {
         continue;
       }
 
-      // Lightweight exit tracker check (no signal/fill recording)
+      // Lightweight exit tracker check (no signal/fill recording).
+      // `currentBar: i` is required so SL/TS exits register post-exit cooldowns —
+      // without it, the optimizer scores exit params under different semantics than
+      // the full backtest that will ultimately run these same parameters.
       if (exitTracker) {
         await this.exitSignalProcessor.processExitSignals(
           {
@@ -384,7 +387,8 @@ export class OptimizationCoreService {
             timestamp,
             trades,
             slippageConfig,
-            prevCandleMap
+            prevCandleMap,
+            currentBar: i
           },
           exitCallbacks
         );
@@ -456,6 +460,13 @@ export class OptimizationCoreService {
         strategySignals = filteredSignals;
         optMaxAllocation = barMaxAllocation;
         optMinAllocation = barMinAllocation;
+      }
+
+      // Re-entry cooldown filter: suppress BUYs on coins still inside the post-exit
+      // cooldown window. Mirrors the historical path (backtest-bar-processor) so the
+      // optimizer scores the same exit semantics as the full backtest.
+      if (exitTracker) {
+        strategySignals = strategySignals.filter((sig) => sig.action !== 'BUY' || exitTracker.canEnter(sig.coinId, i));
       }
 
       for (const strategySignal of strategySignals) {

--- a/apps/api/src/order/interfaces/exit-config.interface.ts
+++ b/apps/api/src/order/interfaces/exit-config.interface.ts
@@ -116,6 +116,15 @@ export interface ExitConfig {
   // ─── OCO Configuration ─────────────────────────────────────────────────────
   /** Link stop loss and take profit as OCO (one-cancels-other) */
   useOco: boolean;
+
+  // ─── Re-entry Cooldown ─────────────────────────────────────────────────────
+  /**
+   * Bars to suppress new BUY signals for a coin after its position exits via
+   * stop-loss or trailing stop. Prevents rapid re-entry churn where strategies
+   * keep buying a coin that just stopped out.
+   * Default: 10 bars (~10 hours on 1h data).
+   */
+  exitCooldownBars?: number;
 }
 
 /**
@@ -125,7 +134,7 @@ export const DEFAULT_EXIT_CONFIG: ExitConfig = {
   // Stop Loss defaults
   enableStopLoss: false,
   stopLossType: StopLossType.PERCENTAGE,
-  stopLossValue: 2.0, // 2% default stop loss
+  stopLossValue: 3.5, // 3.5% default — wide enough to survive crypto hourly swings (2-5%)
 
   // Take Profit defaults
   enableTakeProfit: false,
@@ -143,7 +152,10 @@ export const DEFAULT_EXIT_CONFIG: ExitConfig = {
   trailingActivation: TrailingActivationType.IMMEDIATE,
 
   // OCO defaults
-  useOco: true
+  useOco: true,
+
+  // Re-entry cooldown: 10 bars = ~10h on 1h data
+  exitCooldownBars: 10
 };
 
 /**

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,0 +1,69 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { User } from './users.entity';
+import { UsersService } from './users.service';
+
+import { ActivePositionGuardService } from '../active-position-guard';
+import { CoinService } from '../coin/coin.service';
+import { CoinSelectionService } from '../coin-selection/coin-selection.service';
+import { ExchangeKeyService } from '../exchange/exchange-key/exchange-key.service';
+import { Risk } from '../risk/risk.entity';
+import { RiskPoolMappingService } from '../strategy/risk-pool-mapping.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let userRepository: { findOne: jest.Mock };
+  let exchangeKeyService: { getSupportedExchangeKeys: jest.Mock };
+
+  beforeEach(async () => {
+    userRepository = { findOne: jest.fn() };
+    exchangeKeyService = { getSupportedExchangeKeys: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: getRepositoryToken(Risk), useValue: { findOne: jest.fn() } },
+        { provide: CoinSelectionService, useValue: {} },
+        { provide: CoinService, useValue: {} },
+        { provide: ExchangeKeyService, useValue: exchangeKeyService },
+        { provide: RiskPoolMappingService, useValue: {} },
+        { provide: ActivePositionGuardService, useValue: {} }
+      ]
+    }).compile();
+
+    service = module.get(UsersService);
+  });
+
+  describe('getById', () => {
+    it('throws NotFoundException when the user does not exist', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getById('missing-id')).rejects.toThrow(NotFoundException);
+      expect(exchangeKeyService.getSupportedExchangeKeys).not.toHaveBeenCalled();
+    });
+
+    it('returns the user merged with their supported exchanges when found', async () => {
+      const user = { id: 'user-1', email: 'test@test.com' } as User;
+      const exchanges = [{ id: 'key-1', exchangeId: 'ex-1', slug: 'binance_us', name: 'Binance US', isActive: true }];
+      userRepository.findOne.mockResolvedValue(user);
+      exchangeKeyService.getSupportedExchangeKeys.mockResolvedValue(exchanges);
+
+      const result = await service.getById(user.id);
+
+      expect(result).toEqual({ ...user, exchanges });
+      expect(exchangeKeyService.getSupportedExchangeKeys).toHaveBeenCalledWith(user.id);
+    });
+
+    it('propagates errors from getSupportedExchangeKeys without masking them as NotFoundException', async () => {
+      const user = { id: 'user-1' } as User;
+      userRepository.findOne.mockResolvedValue(user);
+      const dbError = new Error('connection terminated unexpectedly');
+      exchangeKeyService.getSupportedExchangeKeys.mockRejectedValue(dbError);
+
+      await expect(service.getById(user.id)).rejects.toBe(dbError);
+    });
+  });
+});

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -137,17 +137,13 @@ export class UsersService {
   }
 
   async getById(id: string): Promise<UserWithExchanges> {
-    try {
-      const user = await this.user.findOneOrFail({ where: { id } });
-      const exchanges = await this.exchangeKeyService.getSupportedExchangeKeys(user.id);
-
-      this.logger.debug(`User retrieved with ID: ${id}`);
-      return Object.assign(user, { exchanges });
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.error(`User not found with ID: ${id}`, err.stack);
+    const user = await this.user.findOne({ where: { id } });
+    if (!user) {
+      this.logger.warn(`User not found with ID: ${id}`);
       throw new NotFoundException(`User with ID ${id} not found`);
     }
+    const exchanges = await this.exchangeKeyService.getSupportedExchangeKeys(user.id);
+    return Object.assign(user, { exchanges });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Expose stop-loss / take-profit to the optimizer across 11 percentage-based strategies so exit bands can be tuned per-strategy instead of carrying hard-coded defaults
- Add a re-entry cooldown to `BacktestExitTracker` that suppresses BUY signals on coins that just stopped out (default 10 bars / ~10h on 1h data) to prevent rapid rebuy churn
- Raise default stop-loss from 2.0% → 3.5% to survive normal crypto hourly volatility

## Local validation

Triggered optimization runs on 5 strategies (15 combinations each, 60d train / 20d test rolling walk-forward). New params (`stopLossPercent`, `takeProfitPercent`) appear in the parameter space and the optimizer consistently picked wider exit bands than the prior defaults.

| Strategy | Baseline Sharpe | Best Sharpe | Improvement | WFA degradation |
|---|---|---|---|---|
| RSI Momentum | -3.05 | -0.16 | +95% | -8.6% ✅ |
| Mean Reversion | -1.03 | +0.78 | +176% | -6.1% ✅ |
| BB Squeeze | -1.48 | +0.53 | +136% | -4.9% ✅ |
| EMA Crossover | -0.10 | +0.83 | +94% | +10.6% ✅ |
| Confluence | -1.61 | +0.02 | +101% | +46.4% ⚠️ |

4 of 5 are unambiguous wins with healthy walk-forward degradation. Confluence (26-param multi-indicator) shows overfit risk on sparse 15-sample grids — comment added recommending higher-iteration presets (DEFAULT/THOROUGH) which the production pipeline already uses.

## Changes

### `feat(api): add re-entry cooldown to backtest exit tracker` (edcf1000)
- `ExitConfig.exitCooldownBars` field (default 10 bars)
- `BacktestExitTracker` tracks per-coin cooldown expiry, set on stop-loss / trailing exits
- `canEnter(coinId, currentBar)` gate applied in `BacktestBarProcessor` after regime/throttle filters
- Cooldown map persists across serialize/deserialize for resumed backtests
- Default `stopLossValue` 2.0% → 3.5%

### `feat(api): expose stop-loss / take-profit / hold-time to optimizer` (83942d3b)
- Adds `stopLossPercent` + `takeProfitPercent` to `getConfigSchema()` for 11 strategies (RSI, MACD, EMA, Mean Reversion, BB Squeeze, BB Breakout, EMA-RSI Filter, RSI-MACD Combo, SMA Crossover, Triple EMA, Confluence)
- Each strategy's `buildExitConfig()` now reads from schema params instead of hard-coded values
- Mean Reversion: take-profit scaled by z-score excess via boost factor
- ATR-based strategies (atr-trailing-stop, rsi-divergence) intentionally untouched — they tune via `atrMultiplier`

### `chore(api): drop dead maxHoldBars schema entries` (b708ae5d)
- `maxHoldBars` was added to 4 schemas but never wired to `BacktestExitTracker.checkExits` — values picked by the optimizer had no effect. Removed to strip a no-op dimension from the search space. Time-capped exits will get their own PR with proper tracker wiring + tests.

### `fix(api): tighten optimizer wiring` (1d5a82b1)
- `rsi-divergence`: declare `ParameterConstraint(stopLossMin < stopLossMax, takeProfitMin < takeProfitMax)` so the optimizer can't pick inverted bounds that silently disable ATR-scaled exits
- `rsi.strategy`: attach `exitConfig` to the result via `createSuccessResult` instead of only the BUY signal — matches the pattern used by every other strategy
- `confluence-config`: doc comment on small-sample overfit risk

## Test plan

- [ ] Pre-commit hooks run unit tests across affected projects
- [ ] Manual: trigger optimization in production for one of the validated strategies (RSI / Mean Reversion / BB Squeeze) and confirm the new params appear in the search space
- [ ] Watch first walk-forward window post-merge for any drift, especially on Mean Reversion (TP scaling formula changed materially)
- [ ] Risk-monitoring drift detectors will catch any post-promotion degradation that slips past the gates