### PR TITLE
feat(api): add nightly data retention sweep for append-only tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ Thumbs.db
 
 .nx/polygraph
 .claude/worktrees
+.claude/scheduled_tasks.lock

--- a/apps/api/src/coin/coin.entity.spec.ts
+++ b/apps/api/src/coin/coin.entity.spec.ts
@@ -1,0 +1,15 @@
+import { ColumnNumericTransformer } from '../utils/transformers/columnNumeric.transformer';
+
+describe('Coin entity numeric column transformer', () => {
+  const transformer = new ColumnNumericTransformer();
+
+  it('coerces decimal-string values (like THETA currentPrice) to finite numbers', () => {
+    const result = transformer.from('0.22200000');
+    expect(typeof result).toBe('number');
+    expect(result).toBe(0.222);
+  });
+
+  it('passes through null without coercing to NaN', () => {
+    expect(transformer.from(null)).toBeNull();
+  });
+});

--- a/apps/api/src/coin/coin.entity.ts
+++ b/apps/api/src/coin/coin.entity.ts
@@ -14,6 +14,7 @@ import { TickerPairs } from './ticker-pairs/ticker-pairs.entity';
 
 import { CoinSelection } from '../coin-selection/coin-selection.entity';
 import { Order } from '../order/order.entity';
+import { NUMERIC_TRANSFORMER } from '../utils/transformers';
 
 @Entity()
 export class Coin {
@@ -77,7 +78,14 @@ export class Coin {
   })
   marketRank?: number | null;
 
-  @Column({ type: 'decimal', precision: 38, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 38,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Total supply of the coin',
     example: 21000000.0,
@@ -86,7 +94,14 @@ export class Coin {
   })
   totalSupply?: number | null;
 
-  @Column({ type: 'decimal', precision: 38, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 38,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Circulating supply of the coin',
     example: 18500000.0,
@@ -95,7 +110,14 @@ export class Coin {
   })
   circulatingSupply?: number | null;
 
-  @Column({ type: 'decimal', precision: 38, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 38,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Maximum supply of the coin',
     example: 21000000.0,
@@ -112,7 +134,14 @@ export class Coin {
   })
   geckoRank?: number | null;
 
-  @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 5,
+    scale: 2,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Sentiment up score',
     example: 60.0,
@@ -121,7 +150,14 @@ export class Coin {
   })
   sentimentUp?: number | null;
 
-  @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 5,
+    scale: 2,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Sentiment down score',
     example: 40.0,
@@ -130,7 +166,14 @@ export class Coin {
   })
   sentimentDown?: number | null;
 
-  @Column({ type: 'decimal', precision: 25, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 25,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'All-time high price of the coin',
     example: 60000.0,
@@ -139,7 +182,14 @@ export class Coin {
   })
   ath?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 6,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Change from all-time high',
     example: -20.0,
@@ -157,7 +207,7 @@ export class Coin {
   })
   athDate?: Date | null;
 
-  @Column({ type: 'decimal', precision: 25, scale: 8, default: null })
+  @Column({ type: 'decimal', precision: 25, scale: 8, default: null, transformer: NUMERIC_TRANSFORMER })
   @ApiProperty({
     description: 'All-time low price of the coin',
     example: 3000.0,
@@ -166,7 +216,7 @@ export class Coin {
   })
   atl?: number | null;
 
-  @Column({ type: 'decimal', precision: 15, scale: 6, default: null })
+  @Column({ type: 'decimal', precision: 15, scale: 6, default: null, transformer: NUMERIC_TRANSFORMER })
   @ApiProperty({
     description: 'Change from all-time low',
     example: 50.0,
@@ -175,7 +225,14 @@ export class Coin {
   })
   atlChange?: number | null;
 
-  @Column({ type: 'decimal', precision: 38, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 38,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Total volume of the coin',
     example: 600000000.0,
@@ -184,7 +241,14 @@ export class Coin {
   })
   totalVolume?: number | null;
 
-  @Column({ type: 'decimal', precision: 38, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 38,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Market capitalization of the coin',
     example: 1200000000000.0,
@@ -193,7 +257,14 @@ export class Coin {
   })
   marketCap?: number | null;
 
-  @Column({ type: 'decimal', precision: 25, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 25,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change in 24 hours',
     example: -132.19,
@@ -202,7 +273,14 @@ export class Coin {
   })
   priceChange24h?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change percentage in 24 hours',
     example: -4.97413,
@@ -211,7 +289,14 @@ export class Coin {
   })
   priceChangePercentage24h?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change percentage in 7 days',
     example: 0.74613,
@@ -220,7 +305,14 @@ export class Coin {
   })
   priceChangePercentage7d?: number | null;
 
-  @Column({ type: 'decimal', precision: 25, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 25,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Current price of the coin in USD',
     example: 45000.12345678,
@@ -229,7 +321,14 @@ export class Coin {
   })
   currentPrice?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change percentage in 14 days',
     example: 8.36958,
@@ -238,7 +337,14 @@ export class Coin {
   })
   priceChangePercentage14d?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change percentage in 30 days',
     example: 41.03672,
@@ -247,7 +353,14 @@ export class Coin {
   })
   priceChangePercentage30d?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change percentage in 60 days',
     example: 20.9407,
@@ -256,7 +369,14 @@ export class Coin {
   })
   priceChangePercentage60d?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change percentage in 200 days',
     example: 5.1652,
@@ -265,7 +385,14 @@ export class Coin {
   })
   priceChangePercentage200d?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Price change percentage in 1 year',
     example: -33.698,
@@ -274,7 +401,14 @@ export class Coin {
   })
   priceChangePercentage1y?: number | null;
 
-  @Column({ type: 'decimal', precision: 38, scale: 8, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 38,
+    scale: 8,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Market cap change in 24 hours',
     example: -16184990966.68,
@@ -283,7 +417,14 @@ export class Coin {
   })
   marketCapChange24h?: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 5, nullable: true, default: null })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 5,
+    nullable: true,
+    default: null,
+    transformer: NUMERIC_TRANSFORMER
+  })
   @ApiProperty({
     description: 'Market cap change percentage in 24 hours',
     example: -5.04176,

--- a/apps/api/src/config/database.config.ts
+++ b/apps/api/src/config/database.config.ts
@@ -29,7 +29,7 @@ export const databaseConfig = registerAs(
       idleTimeoutMillis: parseInt(process.env.PG_POOL_IDLE_TIMEOUT_MS || '30000', 10),
       connectionTimeoutMillis: 90000,
       statement_timeout: 300000,
-      work_mem: '32MB',
+      options: '-c work_mem=32MB',
       keepAlive: true,
       keepAliveInitialDelayMillis: 30000,
       allowExitOnIdle: false

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -111,7 +111,31 @@ const envSchema = z.object({
   LISTING_TRACKER_POLL_INTERVAL_SECONDS: z.coerce.number().min(10).max(600).default(30),
   LISTING_SCORE_THRESHOLD: z.coerce.number().min(0).max(100).default(70),
   LISTING_SCORE_CRON: z.string().default('30 2 * * *'),
-  DEFILLAMA_BASE_URL: z.string().url().default('https://api.llama.fi')
+  DEFILLAMA_BASE_URL: z.string().url().default('https://api.llama.fi'),
+
+  // Data Retention (DataRetentionTask — daily at 04:15 UTC)
+  // All values are days. Omit to use the sensible defaults baked into the task.
+  DATA_RETENTION_EXCHANGE_KEY_HEALTH_LOG_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_PAPER_TRADING_SNAPSHOT_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_PAPER_TRADING_SESSION_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_BACKTEST_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_OPTIMIZATION_RUN_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_PIPELINE_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_DRIFT_ALERT_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_NOTIFICATION_READ_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_NOTIFICATION_UNREAD_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_MARKET_REGIME_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_STRATEGY_SCORE_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_PERFORMANCE_METRIC_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_LISTING_TRADE_POSITION_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_LISTING_ANNOUNCEMENT_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_LISTING_CANDIDATE_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_COMPARISON_REPORT_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_BACKTEST_RUN_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_MARKET_DATA_SET_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_ALGORITHM_PERFORMANCE_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_AUDIT_LOG_DAYS: z.coerce.number().int().positive().optional().catch(undefined),
+  DATA_RETENTION_SECURITY_AUDIT_LOG_DAYS: z.coerce.number().int().positive().optional().catch(undefined)
 });
 
 /**

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -5,6 +5,14 @@ import { PaperTradingMarketDataService, type PriceData } from './paper-trading-m
 import type { ExchangeManagerService } from '../../exchange/exchange-manager.service';
 import * as retryUtil from '../../shared/retry.util';
 
+const createCircuitBreaker = (overrides: Partial<Record<string, jest.Mock>> = {}) => ({
+  isOpen: jest.fn().mockReturnValue(false),
+  recordSuccess: jest.fn(),
+  recordFailure: jest.fn(),
+  checkCircuit: jest.fn(),
+  ...overrides
+});
+
 const createService = (
   overrides: Partial<{
     cacheManager: any;
@@ -12,6 +20,7 @@ const createService = (
     config: any;
     coinSelectionService: any;
     coinService: any;
+    circuitBreaker: any;
   }> = {}
 ) => {
   const cacheManager = overrides.cacheManager ?? {
@@ -36,18 +45,22 @@ const createService = (
     getCoinsByRiskLevel: jest.fn().mockResolvedValue([])
   };
 
+  const circuitBreaker = overrides.circuitBreaker ?? createCircuitBreaker();
+
   return {
     service: new PaperTradingMarketDataService(
       config as any,
       cacheManager,
       exchangeManager as ExchangeManagerService,
       coinSelectionService as any,
-      coinService as any
+      coinService as any,
+      circuitBreaker as any
     ),
     cacheManager,
     exchangeManager,
     coinSelectionService,
-    coinService
+    coinService,
+    circuitBreaker
   };
 };
 
@@ -749,6 +762,119 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(loadMarkets).not.toHaveBeenCalled();
       expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT']);
+    });
+
+    it('short-circuits to stale cache when breaker is open — does not hit the exchange', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      const stalebtc = {
+        symbol: 'BTC/USDT',
+        price: 44000,
+        timestamp: new Date(),
+        source: 'binance_us'
+      };
+
+      const cacheManager = {
+        get: jest.fn().mockImplementation((key: string) => {
+          if (!key.endsWith(':stale')) return Promise.resolve(null);
+          if (key.includes('BTC/USDT')) return Promise.resolve(stalebtc);
+          return Promise.resolve(null);
+        }),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn()
+      };
+
+      const circuitBreaker = createCircuitBreaker({ isOpen: jest.fn().mockReturnValue(true) });
+
+      const { service } = createService({ cacheManager, exchangeManager, circuitBreaker });
+      const result = await service.getPrices('binance_us', ['BTC/USDT']);
+
+      expect(result.get('BTC/USDT')?.source).toBe('binance_us:stale');
+      // Most important assertion: with breaker open, we never talk to the exchange
+      expect(withExchangeRetrySpy).not.toHaveBeenCalled();
+      expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+      // And we don't re-count a synthetic failure against the circuit
+      expect(circuitBreaker.recordFailure).not.toHaveBeenCalled();
+      loggerSpy.mockRestore();
+    });
+
+    it('records a breaker failure on weight-limit error and lets caller skip retries', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+
+      const weightError = new Error(
+        'binanceus 429 Too Many Requests {"code":-1003,"msg":"Too much request weight used; current limit is 1200 request weight per 1 MINUTE."}'
+      );
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'THETA/USDT': {} },
+          loadMarkets: jest.fn().mockResolvedValue(undefined),
+          fetchTickers: jest.fn(),
+          fetchTicker: jest.fn().mockRejectedValue(weightError)
+        })
+      };
+
+      withExchangeRetrySpy.mockResolvedValue({
+        success: false,
+        error: weightError,
+        attempts: 1, // Key: NOT 4 — the isRetryable callback must short-circuit retries
+        totalDelayMs: 0
+      });
+
+      const circuitBreaker = createCircuitBreaker();
+      const coinService = {
+        getCoinsByRiskLevel: jest.fn(),
+        getCoinBySymbol: jest.fn().mockResolvedValue(null)
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager, circuitBreaker, coinService });
+
+      await expect(service.getPrices('binance_us', ['THETA/USDT'])).rejects.toThrow(/no stale cache/);
+
+      // Breaker saw the failure and can count toward opening
+      expect(circuitBreaker.recordFailure).toHaveBeenCalledWith('paper-trading:market-data:binance_us');
+      // And we passed an isRetryable guard so the retry wrapper won't loop on 429s
+      const callArgs = withExchangeRetrySpy.mock.calls[0];
+      const retryOptions = callArgs[1];
+      expect(retryOptions.isRetryable(weightError)).toBe(false);
+      loggerSpy.mockRestore();
+    });
+
+    it('records a breaker success on a normal fetch', async () => {
+      const tickers = {
+        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
+      };
+
+      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {} },
+          loadMarkets: jest.fn().mockResolvedValue(undefined),
+          fetchTickers: jest.fn()
+        })
+      };
+
+      withExchangeRetrySpy.mockResolvedValue({ success: true, result: tickers, attempts: 1, totalDelayMs: 0 });
+
+      const circuitBreaker = createCircuitBreaker();
+      const { service } = createService({ cacheManager, exchangeManager, circuitBreaker });
+
+      await service.getPrices('binance_us', ['BTC/USDT']);
+
+      expect(circuitBreaker.recordSuccess).toHaveBeenCalledWith('paper-trading:market-data:binance_us');
+      expect(circuitBreaker.recordFailure).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 
 import { Cache } from 'cache-manager';
+import type * as ccxt from 'ccxt';
 
 import { PaperTradingSession } from './entities';
 import type { PriceData } from './paper-trading-market-data.types';
@@ -13,14 +14,16 @@ import { CoinSelectionRelations } from '../../coin-selection/coin-selection.enti
 import { CoinSelectionService } from '../../coin-selection/coin-selection.service';
 import { EXCHANGE_QUOTE_CURRENCY } from '../../exchange/constants';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { toErrorInfo } from '../../shared/error.util';
-import { withExchangeRetry } from '../../shared/retry.util';
+import { isRateLimitError, isWeightLimitError, withExchangeRetry } from '../../shared/retry.util';
 import type { User } from '../../users/users.entity';
 
 export type { PriceData, OrderBook, OrderBookLevel, RealisticSlippageResult } from './paper-trading-market-data.types';
 
 const STALE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const FALLBACK_EXCHANGE_SLUGS = ['gdax', 'kraken'] as const;
+const CIRCUIT_KEY_PREFIX = 'paper-trading:market-data';
 
 @Injectable()
 export class PaperTradingMarketDataService {
@@ -34,9 +37,14 @@ export class PaperTradingMarketDataService {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly exchangeManager: ExchangeManagerService,
     private readonly coinSelectionService: CoinSelectionService,
-    private readonly coinService: CoinService
+    private readonly coinService: CoinService,
+    private readonly circuitBreaker: CircuitBreakerService
   ) {
     this.cacheTtlMs = config.priceCacheTtlMs;
+  }
+
+  private circuitKey(exchangeSlug: string): string {
+    return `${CIRCUIT_KEY_PREFIX}:${exchangeSlug}`;
   }
 
   /** Resolve symbol universe from user's coin selections, falling back to risk-level coins. */
@@ -124,19 +132,36 @@ export class PaperTradingMarketDataService {
       return cached;
     }
 
+    // If the breaker is open, skip the exchange call entirely and short-circuit
+    // to the stale / fallback chain. Every call we skip preserves request-weight
+    // budget and lets binance_us recover.
+    const circuitOpen = this.circuitBreaker.isOpen(this.circuitKey(exchangeSlug));
+
     // Format symbol for exchange
     const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
 
-    // Get client (public if no user)
-    const client = user
-      ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-      : await this.exchangeManager.getPublicClient(exchangeSlug);
-
-    // Fetch ticker with retry
-    const result = await withExchangeRetry(() => client.fetchTicker(formattedSymbol), {
-      logger: this.logger,
-      operationName: `fetchTicker(${exchangeSlug}:${symbol})`
-    });
+    const result = circuitOpen
+      ? {
+          success: false as const,
+          error: new Error(`Circuit breaker open for ${exchangeSlug}`),
+          attempts: 0,
+          totalDelayMs: 0
+        }
+      : await withExchangeRetry(
+          async () => {
+            const client = user
+              ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
+              : await this.exchangeManager.getPublicClient(exchangeSlug);
+            return client.fetchTicker(formattedSymbol);
+          },
+          {
+            logger: this.logger,
+            operationName: `fetchTicker(${exchangeSlug}:${symbol})`,
+            // Rate/weight limits are account-wide — burning retries on them just
+            // deepens the hole. Skip retries and fall through to the stale cache.
+            isRetryable: (err) => !isRateLimitError(err) && !isWeightLimitError(err)
+          }
+        );
 
     if (result.success && result.result) {
       const ticker = result.result;
@@ -149,6 +174,8 @@ export class PaperTradingMarketDataService {
         source: exchangeSlug
       };
 
+      this.circuitBreaker.recordSuccess(this.circuitKey(exchangeSlug));
+
       // Cache the result
       await this.cacheManager.set(cacheKey, priceData, this.cacheTtlMs);
 
@@ -159,12 +186,16 @@ export class PaperTradingMarketDataService {
       return priceData;
     }
 
+    if (!circuitOpen && result.error) {
+      this.circuitBreaker.recordFailure(this.circuitKey(exchangeSlug));
+    }
+
     // All retries exhausted — fall back to stale cache
     const staleKey = `${cacheKey}:stale`;
     const stale = await this.cacheManager.get<PriceData>(staleKey);
     if (stale) {
       this.logger.warn(
-        `All retries exhausted fetching price for ${symbol} from ${exchangeSlug}. Using stale cached price.`
+        `${circuitOpen ? 'Circuit open' : 'All retries exhausted'} fetching price for ${symbol} from ${exchangeSlug}. Using stale cached price.`
       );
       return { ...stale, source: `${stale.source}:stale` };
     }
@@ -184,7 +215,7 @@ export class PaperTradingMarketDataService {
     }
 
     this.logger.error(
-      `Failed to fetch price for ${symbol} from ${exchangeSlug} after retries, fallback exchanges, and DB lookup`
+      `Failed to fetch price for ${symbol} from ${exchangeSlug} after ${circuitOpen ? 'circuit-open short-circuit' : 'retries'}, fallback exchanges, and DB lookup`
     );
     throw result.error;
   }
@@ -217,50 +248,70 @@ export class PaperTradingMarketDataService {
       return results;
     }
 
-    // Get client
-    const client = user
-      ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-      : await this.exchangeManager.getPublicClient(exchangeSlug);
+    // Short-circuit exchange calls while the breaker is open for this exchange.
+    const circuitOpen = this.circuitBreaker.isOpen(this.circuitKey(exchangeSlug));
 
-    // Lazy-load markets so we can filter out symbols the exchange doesn't list.
-    // Without this, CCXT drops unknown symbols internally and may send an empty
-    // `symbols` param to the REST API, which Binance rejects with code -1102.
-    let marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
-    if (!marketsLoaded) {
-      try {
-        await client.loadMarkets();
-        marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
-      } catch (error: unknown) {
-        const err = toErrorInfo(error);
-        this.logger.warn(`loadMarkets(${exchangeSlug}) failed, proceeding without symbol validation: ${err.message}`);
+    let validPairs: Array<{ raw: string; formatted: string }> = [];
+    let result: Awaited<ReturnType<typeof withExchangeRetry<Record<string, ccxt.Ticker>>>>;
+
+    if (circuitOpen) {
+      result = {
+        success: false as const,
+        error: new Error(`Circuit breaker open for ${exchangeSlug}`),
+        attempts: 0,
+        totalDelayMs: 0
+      };
+    } else {
+      const client = user
+        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
+        : await this.exchangeManager.getPublicClient(exchangeSlug);
+
+      // Lazy-load markets so we can filter out symbols the exchange doesn't list.
+      // Without this, CCXT drops unknown symbols internally and may send an empty
+      // `symbols` param to the REST API, which Binance rejects with code -1102.
+      let marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
+      if (!marketsLoaded) {
+        try {
+          await client.loadMarkets();
+          marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
+        } catch (error: unknown) {
+          const err = toErrorInfo(error);
+          this.logger.warn(
+            `loadMarkets(${exchangeSlug}) failed, proceeding without symbol validation: ${err.message}`
+          );
+        }
       }
+
+      const formattedPairs = uncachedSymbols.map((raw) => ({
+        raw,
+        formatted: this.exchangeManager.formatSymbol(exchangeSlug, raw)
+      }));
+
+      validPairs = marketsLoaded
+        ? formattedPairs.filter(({ formatted }) => formatted in (client.markets as Record<string, unknown>))
+        : formattedPairs;
+
+      if (validPairs.length === 0) {
+        this.logger.warn(
+          `getPrices(${exchangeSlug}): none of ${uncachedSymbols.length} requested symbols ` +
+            `(${uncachedSymbols.join(', ')}) exist on exchange; returning cached-only results`
+        );
+        return results;
+      }
+
+      result = await withExchangeRetry(() => client.fetchTickers(validPairs.map((p) => p.formatted)), {
+        logger: this.logger,
+        operationName: `fetchTickers(${exchangeSlug})`,
+        // Rate/weight limits are account-wide — skip retries to preserve
+        // request-weight budget and fall through to the stale cache.
+        isRetryable: (err) => !isRateLimitError(err) && !isWeightLimitError(err)
+      });
     }
-
-    const formattedPairs = uncachedSymbols.map((raw) => ({
-      raw,
-      formatted: this.exchangeManager.formatSymbol(exchangeSlug, raw)
-    }));
-
-    const validPairs = marketsLoaded
-      ? formattedPairs.filter(({ formatted }) => formatted in (client.markets as Record<string, unknown>))
-      : formattedPairs;
-
-    if (validPairs.length === 0) {
-      this.logger.warn(
-        `getPrices(${exchangeSlug}): none of ${uncachedSymbols.length} requested symbols ` +
-          `(${uncachedSymbols.join(', ')}) exist on exchange; returning cached-only results`
-      );
-      return results;
-    }
-
-    // Fetch all tickers with retry
-    const result = await withExchangeRetry(() => client.fetchTickers(validPairs.map((p) => p.formatted)), {
-      logger: this.logger,
-      operationName: `fetchTickers(${exchangeSlug})`
-    });
 
     if (result.success && result.result) {
       const tickers = result.result;
+
+      this.circuitBreaker.recordSuccess(this.circuitKey(exchangeSlug));
 
       for (const { raw: symbol, formatted: formattedSymbol } of validPairs) {
         const ticker = tickers[formattedSymbol];
@@ -290,9 +341,13 @@ export class PaperTradingMarketDataService {
       return results;
     }
 
+    if (!circuitOpen && result.error) {
+      this.circuitBreaker.recordFailure(this.circuitKey(exchangeSlug));
+    }
+
     // All retries exhausted — fall back to stale cache
     this.logger.warn(
-      `All retries exhausted fetching prices from ${exchangeSlug}. ` +
+      `${circuitOpen ? 'Circuit open' : 'All retries exhausted'} fetching prices from ${exchangeSlug}. ` +
         `Falling back to stale cached prices for ${uncachedSymbols.length} symbol(s).`
     );
 

--- a/apps/api/src/order/paper-trading/paper-trading.config.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.config.ts
@@ -59,7 +59,7 @@ export const paperTradingConfig = registerAs(
     maxConsecutiveErrors: parseInteger(process.env.PAPER_TRADING_MAX_CONSECUTIVE_ERRORS, 3),
     maxRetryAttempts: parseInteger(process.env.PAPER_TRADING_MAX_RETRY_ATTEMPTS, 5),
     retryBackoffMs: parseInteger(process.env.PAPER_TRADING_RETRY_BACKOFF_MS, 60000),
-    priceCacheTtlMs: parseInteger(process.env.PAPER_TRADING_PRICE_CACHE_TTL_MS, 5000),
+    priceCacheTtlMs: parseInteger(process.env.PAPER_TRADING_PRICE_CACHE_TTL_MS, 10000),
     orderBookCacheTtlMs: parseInteger(process.env.PAPER_TRADING_ORDER_BOOK_CACHE_TTL_MS, 2000),
     maxAllocation: parseFloat(process.env.PAPER_TRADING_MAX_ALLOCATION, 0.2),
     minAllocation: parseFloat(process.env.PAPER_TRADING_MIN_ALLOCATION, 0.05),

--- a/apps/api/src/shared/retry.util.spec.ts
+++ b/apps/api/src/shared/retry.util.spec.ts
@@ -7,6 +7,8 @@ import {
   isClockSkewError,
   isRateLimitError,
   isTransientError,
+  isWeightLimitError,
+  msUntilNextMinute,
   rateLimitAwareDelay,
   withExchangeRetry,
   withExchangeRetryThrow,
@@ -568,6 +570,60 @@ describe('retry.util', () => {
     it('should return undefined for timeout/network errors (use default backoff)', () => {
       expect(exchangeAwareDelay(new Error('ECONNRESET'), 1, 1000)).toBeUndefined();
       expect(exchangeAwareDelay(new Error('ETIMEDOUT'), 1, 1000)).toBeUndefined();
+    });
+
+    it('should wait until the next minute boundary for Binance weight-limit errors (-1003)', () => {
+      // Freeze Date.now() so we know exactly how long until the next minute.
+      // 1_700_000_010_000 % 60_000 === 30_000 → 30s into the minute → 30s + cushion remain.
+      const frozen = 1_700_000_010_000;
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(frozen);
+
+      try {
+        const error = new Error(
+          'binanceus 429 Too Many Requests {"code":-1003,"msg":"Too much request weight used; current limit is 1200 request weight per 1 MINUTE."}'
+        );
+
+        const delay = exchangeAwareDelay(error, 1, 5000);
+
+        expect(delay).toBe(30_500);
+        // Crucially, must not fall through to the generic 5s rate-limit default
+        expect(delay).not.toBe(5000);
+      } finally {
+        dateNowSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('isWeightLimitError', () => {
+    it('matches Binance -1003 error code', () => {
+      expect(
+        isWeightLimitError(new Error('binanceus 429 Too Many Requests {"code":-1003,"msg":"Too much request weight"}'))
+      ).toBe(true);
+    });
+
+    it('matches "request weight" in the message', () => {
+      expect(isWeightLimitError(new Error('current limit is 1200 request weight per 1 MINUTE'))).toBe(true);
+    });
+
+    it('does not match generic rate-limit messages', () => {
+      expect(isWeightLimitError(new Error('rate limit exceeded'))).toBe(false);
+      expect(isWeightLimitError(new Error('HTTP 429'))).toBe(false);
+    });
+  });
+
+  describe('msUntilNextMinute', () => {
+    // 1_700_000_010_000 % 60_000 === 30_000 → 30s into the minute
+    it('returns remaining ms in minute plus the default cushion', () => {
+      expect(msUntilNextMinute(1_700_000_010_000)).toBe(30_500);
+    });
+
+    it('uses a custom cushion when provided', () => {
+      expect(msUntilNextMinute(1_700_000_010_000, 0)).toBe(30_000);
+    });
+
+    it('never returns 0 — always waits at least the cushion past the boundary', () => {
+      // Exactly on the boundary — waiting 0ms would immediately burn another weight unit
+      expect(msUntilNextMinute(1_700_000_000_000)).toBeGreaterThan(0);
     });
   });
 

--- a/apps/api/src/shared/retry.util.ts
+++ b/apps/api/src/shared/retry.util.ts
@@ -173,6 +173,26 @@ export function isAuthenticationError(error: Error): boolean {
 }
 
 /**
+ * Check if an error is a Binance-style request-weight limit (code -1003).
+ * Unlike per-endpoint rate limits, weight limits are account/IP-wide and reset
+ * at the top of each minute, so retrying after a short backoff rarely helps.
+ */
+export function isWeightLimitError(error: Error): boolean {
+  const message = error.message?.toLowerCase() || '';
+  const hasExactWeightLimitCode = /"code"\s*:\s*-1003\b/.test(message) || /(^|[^0-9-])-1003([^0-9]|$)/.test(message);
+  return hasExactWeightLimitCode || message.includes('request weight');
+}
+
+/**
+ * Compute the ms until the top of the next UTC minute, with a small cushion.
+ * Used to delay retries of weight-limit errors until the 1200/min budget resets.
+ */
+export function msUntilNextMinute(nowMs: number = Date.now(), cushionMs = 500): number {
+  const ms = 60_000 - (nowMs % 60_000);
+  return ms + cushionMs;
+}
+
+/**
  * Check if an error is a clock skew / timestamp error (Binance -1021).
  * These errors occur when the client clock drifts from the exchange server clock
  * and the request falls outside the recvWindow.
@@ -398,6 +418,12 @@ export async function withRateLimitRetryThrow<T>(operation: () => Promise<T>, op
  * - Timeout/network: uses default exponential backoff
  */
 export function exchangeAwareDelay(error: Error, _attempt: number, defaultDelayMs: number): number | void {
+  // Weight-limit errors (Binance -1003) are account/IP-wide and reset at the top
+  // of each minute. A fixed 5s backoff rarely helps — wait until the budget resets.
+  if (isWeightLimitError(error)) {
+    return msUntilNextMinute();
+  }
+
   if (isRateLimitError(error)) {
     const retryAfter = extractRetryAfterMs(error);
     const rateLimitDelay = retryAfter ?? 5000;

--- a/apps/api/src/tasks/data-retention.task.spec.ts
+++ b/apps/api/src/tasks/data-retention.task.spec.ts
@@ -1,0 +1,126 @@
+import type { DataSource } from 'typeorm';
+
+import { DataRetentionTask } from './data-retention.task';
+
+describe('DataRetentionTask', () => {
+  const originalEnv = process.env;
+  let task: DataRetentionTask;
+  let dataSource: { query: jest.Mock };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: 'production', DISABLE_BACKGROUND_TASKS: 'false' };
+
+    dataSource = { query: jest.fn().mockResolvedValue([]) };
+    task = new DataRetentionTask(dataSource as unknown as DataSource);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('skips sweep when DISABLE_BACKGROUND_TASKS is true', async () => {
+    process.env.DISABLE_BACKGROUND_TASKS = 'true';
+
+    await task.run();
+
+    expect(dataSource.query).not.toHaveBeenCalled();
+  });
+
+  it('skips sweep in development', async () => {
+    process.env.NODE_ENV = 'development';
+
+    await task.run();
+
+    expect(dataSource.query).not.toHaveBeenCalled();
+  });
+
+  it('runs every retention rule once and counts deleted rows', async () => {
+    dataSource.query.mockImplementation(() => Promise.resolve([{ deleted: 2 }]));
+
+    await task.run();
+
+    // 21 retention rules currently declared — each issues one DELETE
+    expect(dataSource.query).toHaveBeenCalledTimes(21);
+  });
+
+  it('continues the sweep when a single rule throws', async () => {
+    dataSource.query.mockRejectedValueOnce(new Error('boom')).mockResolvedValue([{ deleted: 0 }]);
+
+    await expect(task.run()).resolves.toBeUndefined();
+
+    // First call failed, the remaining 20 still executed
+    expect(dataSource.query).toHaveBeenCalledTimes(21);
+  });
+
+  it('passes retention days as a string param and uses defaults when env is unset', async () => {
+    delete process.env.DATA_RETENTION_EXCHANGE_KEY_HEALTH_LOG_DAYS;
+    dataSource.query.mockResolvedValue([{ deleted: 0 }]);
+
+    await task.run();
+
+    const firstCall = dataSource.query.mock.calls[0];
+    expect(firstCall[0]).toMatch(/exchange_key_health_log/);
+    expect(firstCall[1]).toEqual(['30']);
+  });
+
+  it('respects env-override retention days', async () => {
+    process.env.DATA_RETENTION_EXCHANGE_KEY_HEALTH_LOG_DAYS = '7';
+    dataSource.query.mockResolvedValue([{ deleted: 0 }]);
+
+    await task.run();
+
+    const firstCall = dataSource.query.mock.calls[0];
+    expect(firstCall[1]).toEqual(['7']);
+  });
+
+  it.each(['0', '-5', '1.5', 'abc'])('ignores invalid env override "%s" and falls back to defaults', async (value) => {
+    process.env.DATA_RETENTION_EXCHANGE_KEY_HEALTH_LOG_DAYS = value;
+    dataSource.query.mockResolvedValue([{ deleted: 0 }]);
+
+    await task.run();
+
+    const firstCall = dataSource.query.mock.calls[0];
+    expect(firstCall[1]).toEqual(['30']);
+  });
+
+  it('issues separate retention deletes for read and unread notifications', async () => {
+    process.env.DATA_RETENTION_NOTIFICATION_READ_DAYS = '15';
+    process.env.DATA_RETENTION_NOTIFICATION_UNREAD_DAYS = '90';
+    dataSource.query.mockResolvedValue([{ deleted: 0 }]);
+
+    await task.run();
+
+    const readCall = dataSource.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('"notification"') && sql.includes('read = true')
+    );
+    expect(readCall).toBeDefined();
+    expect(readCall?.[1]).toEqual(['15']);
+
+    const unreadCall = dataSource.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('"notification"') && sql.includes('read = false')
+    );
+    expect(unreadCall).toBeDefined();
+    expect(unreadCall?.[1]).toEqual(['90']);
+  });
+
+  it('does not re-enter while a sweep is still running', async () => {
+    let resolveFirst!: (v: unknown[]) => void;
+    dataSource.query.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+    dataSource.query.mockResolvedValue([{ deleted: 0 }]);
+
+    const firstRun = task.run();
+    await task.run(); // second call while first is in flight — should no-op
+
+    resolveFirst([{ deleted: 0 }]);
+    await firstRun;
+
+    // The concurrent second run bailed before calling query again, so total calls === rules (21).
+    expect(dataSource.query).toHaveBeenCalledTimes(21);
+  });
+});

--- a/apps/api/src/tasks/data-retention.task.ts
+++ b/apps/api/src/tasks/data-retention.task.ts
@@ -140,7 +140,7 @@ export class DataRetentionTask {
     const start = Date.now();
     try {
       const trimmed = sql.trimStart();
-      const wrapped = trimmed.toUpperCase().startsWith('WITH ')
+      const wrapped = /^with\b/i.test(trimmed)
         ? sql
         : `WITH deleted_rows AS (${sql} RETURNING 1)
            SELECT count(*)::int AS deleted FROM deleted_rows`;

--- a/apps/api/src/tasks/data-retention.task.ts
+++ b/apps/api/src/tasks/data-retention.task.ts
@@ -1,0 +1,499 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+import { DataSource } from 'typeorm';
+
+import { toErrorInfo } from '../shared/error.util';
+
+/**
+ * Data Retention Task
+ *
+ * Nightly sweep that deletes stale rows from append-only / log-style tables
+ * to keep Postgres storage bounded. Follows the same raw-SQL pattern as
+ * DatabaseMaintenanceTask so no per-entity repositories need to be injected.
+ *
+ * Each rule is fail-safe: one table's error does not abort the rest of the
+ * sweep. Every window is env-tunable (see env.validation.ts) and set to a
+ * conservative default that preserves any row still needed for current
+ * trading, reporting, or compliance workflows.
+ *
+ * Runs at 04:15 UTC — after RedisMaintenanceTask (04:00) and before
+ * DatabaseMaintenanceTask (04:30) so the nightly ANALYZE sees the pruned
+ * tables and refreshes planner stats.
+ */
+@Injectable()
+export class DataRetentionTask {
+  private readonly logger = new Logger(DataRetentionTask.name);
+  private running = false;
+
+  private static readonly DEFAULTS = {
+    EXCHANGE_KEY_HEALTH_LOG_DAYS: 30,
+    PAPER_TRADING_SNAPSHOT_DAYS: 60,
+    PAPER_TRADING_SESSION_DAYS: 60,
+    BACKTEST_DAYS: 90,
+    OPTIMIZATION_RUN_DAYS: 60,
+    PIPELINE_DAYS: 60,
+    DRIFT_ALERT_DAYS: 90,
+    NOTIFICATION_READ_DAYS: 30,
+    NOTIFICATION_UNREAD_DAYS: 180,
+    MARKET_REGIME_DAYS: 365,
+    STRATEGY_SCORE_DAYS: 365,
+    PERFORMANCE_METRIC_DAYS: 365,
+    LISTING_TRADE_POSITION_DAYS: 60,
+    LISTING_ANNOUNCEMENT_DAYS: 365,
+    LISTING_CANDIDATE_DAYS: 180,
+    COMPARISON_REPORT_DAYS: 90,
+    BACKTEST_RUN_DAYS: 60,
+    MARKET_DATA_SET_DAYS: 180,
+    ALGORITHM_PERFORMANCE_DAYS: 365,
+    AUDIT_LOG_DAYS: 1825,
+    SECURITY_AUDIT_LOG_DAYS: 730
+  } as const;
+
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  @Cron('15 4 * * *', { timeZone: 'UTC' })
+  async run(): Promise<void> {
+    if (process.env.NODE_ENV === 'development' || process.env.DISABLE_BACKGROUND_TASKS === 'true') {
+      this.logger.log('Data retention task disabled (dev/DISABLE_BACKGROUND_TASKS)');
+      return;
+    }
+
+    if (this.running) {
+      this.logger.warn('Data retention already running, skipping');
+      return;
+    }
+
+    this.running = true;
+    const startTime = Date.now();
+    const results: PruneResult[] = [];
+
+    try {
+      this.logger.log('Starting scheduled data retention sweep');
+
+      results.push(await this.pruneExchangeKeyHealthLog());
+      results.push(await this.prunePaperTradingSnapshots());
+      results.push(await this.prunePaperTradingSessions());
+      results.push(await this.pruneBacktests());
+      results.push(await this.pruneOptimizationRuns());
+      results.push(await this.prunePipelines());
+      results.push(await this.pruneDriftAlerts());
+      results.push(await this.pruneReadNotifications());
+      results.push(await this.pruneUnreadNotifications());
+      results.push(await this.pruneMarketRegimes());
+      results.push(await this.pruneStrategyScores());
+      results.push(await this.prunePerformanceMetrics());
+      results.push(await this.pruneListingTradePositions());
+      results.push(await this.pruneListingAnnouncements());
+      results.push(await this.pruneListingCandidates());
+      results.push(await this.pruneComparisonReports());
+      results.push(await this.pruneBacktestRuns());
+      results.push(await this.pruneMarketDataSets());
+      results.push(await this.pruneAlgorithmPerformances());
+      results.push(await this.pruneAuditLogs());
+      results.push(await this.pruneSecurityAuditLog());
+    } finally {
+      this.running = false;
+    }
+
+    const totalDeleted = results.reduce((sum, r) => sum + r.deleted, 0);
+    const failed = results.filter((r) => r.error !== undefined);
+    const elapsedSec = ((Date.now() - startTime) / 1000).toFixed(1);
+
+    this.logger.log(
+      `Data retention complete: ${totalDeleted} rows across ${results.length - failed.length}/${results.length} tables in ${elapsedSec}s`
+    );
+
+    for (const r of results) {
+      if (r.error) {
+        this.logger.error(`  ${r.table}: FAILED after ${r.elapsedMs}ms — ${r.error}`);
+      } else if (r.deleted > 0) {
+        this.logger.log(`  ${r.table}: ${r.deleted} deleted (${r.elapsedMs}ms, retention ${r.retentionDays}d)`);
+      }
+    }
+  }
+
+  private getDays(envKey: string, fallback: number): number {
+    const raw = process.env[envKey];
+    if (!raw) return fallback;
+    const n = Number(raw);
+    return Number.isInteger(n) && n > 0 ? n : fallback;
+  }
+
+  /**
+   * Executes a DELETE and returns the row count without streaming IDs back to Node.
+   *
+   * Simple callers pass a bare `DELETE ... WHERE ...` and this method wraps it
+   * in a CTE that returns a single `count(*)` row. Callers whose SQL already
+   * starts with `WITH` (because they need auxiliary CTEs — e.g. market_regimes
+   * nullifying the self-reference before delete) must handle their own count
+   * projection and end with `SELECT count(*)::int AS deleted FROM <cte>`; the
+   * `WITH` prefix is detected and the SQL runs as-is.
+   */
+  private async runDelete(
+    table: string,
+    retentionDays: number,
+    sql: string,
+    params: unknown[] = []
+  ): Promise<PruneResult> {
+    const start = Date.now();
+    try {
+      const trimmed = sql.trimStart();
+      const wrapped = trimmed.toUpperCase().startsWith('WITH ')
+        ? sql
+        : `WITH deleted_rows AS (${sql} RETURNING 1)
+           SELECT count(*)::int AS deleted FROM deleted_rows`;
+      const rows = await this.dataSource.query(wrapped, params);
+      const deleted = Number(rows?.[0]?.deleted ?? 0);
+      return { table, deleted, retentionDays, elapsedMs: Date.now() - start };
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      return { table, deleted: 0, retentionDays, elapsedMs: Date.now() - start, error: err.message };
+    }
+  }
+
+  private pruneExchangeKeyHealthLog(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_EXCHANGE_KEY_HEALTH_LOG_DAYS',
+      DataRetentionTask.DEFAULTS.EXCHANGE_KEY_HEALTH_LOG_DAYS
+    );
+    return this.runDelete(
+      'exchange_key_health_log',
+      days,
+      `DELETE FROM "exchange_key_health_log"
+       WHERE "checkedAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private prunePaperTradingSnapshots(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_PAPER_TRADING_SNAPSHOT_DAYS',
+      DataRetentionTask.DEFAULTS.PAPER_TRADING_SNAPSHOT_DAYS
+    );
+    // Only trim snapshots whose parent session is terminal; active/paused sessions keep full history.
+    return this.runDelete(
+      'paper_trading_snapshots',
+      days,
+      `DELETE FROM "paper_trading_snapshots" s
+       USING "paper_trading_sessions" ps
+       WHERE s."sessionId" = ps.id
+         AND ps.status IN ('STOPPED','COMPLETED','FAILED')
+         AND s."timestamp" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private prunePaperTradingSessions(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_PAPER_TRADING_SESSION_DAYS',
+      DataRetentionTask.DEFAULTS.PAPER_TRADING_SESSION_DAYS
+    );
+    // Terminal sessions older than N days; children (accounts, orders, signals, snapshots) cascade.
+    // Preserves sessions still linked to a live pipeline.
+    return this.runDelete(
+      'paper_trading_sessions',
+      days,
+      `DELETE FROM "paper_trading_sessions"
+       WHERE status IN ('STOPPED','COMPLETED','FAILED')
+         AND COALESCE("stoppedAt","completedAt","updatedAt") < (now() - ($1 || ' days')::interval)
+         AND id NOT IN (
+           SELECT "paperTradingSessionId" FROM "pipelines" WHERE "paperTradingSessionId" IS NOT NULL
+         )`,
+      [String(days)]
+    );
+  }
+
+  private pruneBacktests(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_BACKTEST_DAYS', DataRetentionTask.DEFAULTS.BACKTEST_DAYS);
+    // Terminal backtests older than N days. Children (trades, signals, snapshots, fills) cascade.
+    // Preserves any backtest still referenced by a pipeline.
+    return this.runDelete(
+      'backtests',
+      days,
+      `DELETE FROM "backtests"
+       WHERE status IN ('COMPLETED','FAILED','CANCELLED')
+         AND "updatedAt" < (now() - ($1 || ' days')::interval)
+         AND NOT EXISTS (
+           SELECT 1 FROM "pipelines"
+           WHERE "historicalBacktestId" = backtests.id
+              OR "liveReplayBacktestId" = backtests.id
+         )`,
+      [String(days)]
+    );
+  }
+
+  private pruneOptimizationRuns(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_OPTIMIZATION_RUN_DAYS', DataRetentionTask.DEFAULTS.OPTIMIZATION_RUN_DAYS);
+    // Terminal optimization runs older than N days. optimization_results cascades.
+    // Preserves runs still referenced by a pipeline.
+    return this.runDelete(
+      'optimization_runs',
+      days,
+      `DELETE FROM "optimization_runs"
+       WHERE status IN ('COMPLETED','FAILED','CANCELLED')
+         AND COALESCE("completedAt","createdAt") < (now() - ($1 || ' days')::interval)
+         AND id NOT IN (
+           SELECT "optimizationRunId" FROM "pipelines" WHERE "optimizationRunId" IS NOT NULL
+         )`,
+      [String(days)]
+    );
+  }
+
+  private prunePipelines(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_PIPELINE_DAYS', DataRetentionTask.DEFAULTS.PIPELINE_DAYS);
+    // Terminal pipelines older than N days. Child backtests/optimizations/paper sessions
+    // are SET NULL so they survive and fall under their own retention rules.
+    return this.runDelete(
+      'pipelines',
+      days,
+      `DELETE FROM "pipelines"
+       WHERE status IN ('COMPLETED','FAILED','CANCELLED')
+         AND COALESCE("completedAt","updatedAt") < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneDriftAlerts(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_DRIFT_ALERT_DAYS', DataRetentionTask.DEFAULTS.DRIFT_ALERT_DAYS);
+    // Unresolved alerts are never pruned — they represent open risk signals.
+    return this.runDelete(
+      'drift_alerts',
+      days,
+      `DELETE FROM "drift_alerts"
+       WHERE resolved = true
+         AND COALESCE("resolvedAt","createdAt") < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneReadNotifications(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_NOTIFICATION_READ_DAYS',
+      DataRetentionTask.DEFAULTS.NOTIFICATION_READ_DAYS
+    );
+    return this.runDelete(
+      'notification (read)',
+      days,
+      `DELETE FROM "notification"
+       WHERE read = true
+         AND "createdAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneUnreadNotifications(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_NOTIFICATION_UNREAD_DAYS',
+      DataRetentionTask.DEFAULTS.NOTIFICATION_UNREAD_DAYS
+    );
+    return this.runDelete(
+      'notification (unread)',
+      days,
+      `DELETE FROM "notification"
+       WHERE read = false
+         AND "createdAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneMarketRegimes(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_MARKET_REGIME_DAYS', DataRetentionTask.DEFAULTS.MARKET_REGIME_DAYS);
+    // Only historical regimes (effective_until set). The current regime per asset has effective_until = NULL.
+    // Nullifies previousRegimeId pointers first so we don't violate the self-reference.
+    return this.runDelete(
+      'market_regimes',
+      days,
+      `WITH doomed AS (
+         SELECT id FROM "market_regimes"
+         WHERE "effective_until" IS NOT NULL
+           AND "effective_until" < (now() - ($1 || ' days')::interval)
+       ),
+       _unlink AS (
+         UPDATE "market_regimes"
+         SET "previousRegimeId" = NULL
+         WHERE "previousRegimeId" IN (SELECT id FROM doomed)
+       ),
+       deleted_rows AS (
+         DELETE FROM "market_regimes"
+         WHERE id IN (SELECT id FROM doomed)
+         RETURNING 1
+       )
+       SELECT count(*)::int AS deleted FROM deleted_rows`,
+      [String(days)]
+    );
+  }
+
+  private pruneStrategyScores(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_STRATEGY_SCORE_DAYS', DataRetentionTask.DEFAULTS.STRATEGY_SCORE_DAYS);
+    return this.runDelete(
+      'strategy_scores',
+      days,
+      `DELETE FROM "strategy_scores"
+       WHERE "calculatedAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private prunePerformanceMetrics(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_PERFORMANCE_METRIC_DAYS',
+      DataRetentionTask.DEFAULTS.PERFORMANCE_METRIC_DAYS
+    );
+    return this.runDelete(
+      'performance_metrics',
+      days,
+      `DELETE FROM "performance_metrics"
+       WHERE "date" < (current_date - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneListingTradePositions(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_LISTING_TRADE_POSITION_DAYS',
+      DataRetentionTask.DEFAULTS.LISTING_TRADE_POSITION_DAYS
+    );
+    // OPEN positions are never pruned — they represent live capital.
+    return this.runDelete(
+      'listing_trade_positions',
+      days,
+      `DELETE FROM "listing_trade_positions"
+       WHERE status <> 'OPEN'
+         AND "updatedAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneListingAnnouncements(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_LISTING_ANNOUNCEMENT_DAYS',
+      DataRetentionTask.DEFAULTS.LISTING_ANNOUNCEMENT_DAYS
+    );
+    // Drop old announcements only once no trade position still points at them.
+    return this.runDelete(
+      'listing_announcements',
+      days,
+      `DELETE FROM "listing_announcements"
+       WHERE "createdAt" < (now() - ($1 || ' days')::interval)
+         AND id NOT IN (
+           SELECT "announcementId" FROM "listing_trade_positions" WHERE "announcementId" IS NOT NULL
+         )`,
+      [String(days)]
+    );
+  }
+
+  private pruneListingCandidates(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_LISTING_CANDIDATE_DAYS',
+      DataRetentionTask.DEFAULTS.LISTING_CANDIDATE_DAYS
+    );
+    // Only candidates that never qualified and were never traded — qualified/traded rows keep their history.
+    return this.runDelete(
+      'listing_candidates',
+      days,
+      `DELETE FROM "listing_candidates"
+       WHERE qualified = false
+         AND "lastTradedAt" IS NULL
+         AND "updatedAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneComparisonReports(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_COMPARISON_REPORT_DAYS',
+      DataRetentionTask.DEFAULTS.COMPARISON_REPORT_DAYS
+    );
+    // comparison_report_runs cascades on deletion.
+    return this.runDelete(
+      'comparison_reports',
+      days,
+      `DELETE FROM "comparison_reports"
+       WHERE "createdAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneBacktestRuns(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_BACKTEST_RUN_DAYS', DataRetentionTask.DEFAULTS.BACKTEST_RUN_DAYS);
+    // BacktestRunStatus enum uses lowercase values.
+    return this.runDelete(
+      'backtest_runs',
+      days,
+      `DELETE FROM "backtest_runs"
+       WHERE status IN ('completed','failed')
+         AND "updatedAt" < (now() - ($1 || ' days')::interval)
+         AND NOT EXISTS (
+           SELECT 1 FROM "strategy_scores"
+           WHERE "backtestRunIds" IS NOT NULL
+             AND backtest_runs.id = ANY("backtestRunIds")
+         )`,
+      [String(days)]
+    );
+  }
+
+  private pruneMarketDataSets(): Promise<PruneResult> {
+    const days = this.getDays('DATA_RETENTION_MARKET_DATA_SET_DAYS', DataRetentionTask.DEFAULTS.MARKET_DATA_SET_DAYS);
+    // Only unreferenced datasets — backtests.marketDataSetId is SET NULL on delete, so we skip datasets still in use.
+    return this.runDelete(
+      'market_data_sets',
+      days,
+      `DELETE FROM "market_data_sets"
+       WHERE "updatedAt" < (now() - ($1 || ' days')::interval)
+         AND id NOT IN (
+           SELECT "marketDataSetId" FROM "backtests" WHERE "marketDataSetId" IS NOT NULL
+         )`,
+      [String(days)]
+    );
+  }
+
+  private pruneAlgorithmPerformances(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_ALGORITHM_PERFORMANCE_DAYS',
+      DataRetentionTask.DEFAULTS.ALGORITHM_PERFORMANCE_DAYS
+    );
+    return this.runDelete(
+      'algorithm_performances',
+      days,
+      `DELETE FROM "algorithm_performances"
+       WHERE "calculatedAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneAuditLogs(): Promise<PruneResult> {
+    // Compliance retention — default 5 years per project spec.
+    const days = this.getDays('DATA_RETENTION_AUDIT_LOG_DAYS', DataRetentionTask.DEFAULTS.AUDIT_LOG_DAYS);
+    return this.runDelete(
+      'audit_logs',
+      days,
+      `DELETE FROM "audit_logs"
+       WHERE "timestamp" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+
+  private pruneSecurityAuditLog(): Promise<PruneResult> {
+    const days = this.getDays(
+      'DATA_RETENTION_SECURITY_AUDIT_LOG_DAYS',
+      DataRetentionTask.DEFAULTS.SECURITY_AUDIT_LOG_DAYS
+    );
+    return this.runDelete(
+      'security_audit_log',
+      days,
+      `DELETE FROM "security_audit_log"
+       WHERE "createdAt" < (now() - ($1 || ' days')::interval)`,
+      [String(days)]
+    );
+  }
+}
+
+interface PruneResult {
+  table: string;
+  deleted: number;
+  retentionDays: number;
+  elapsedMs: number;
+  error?: string;
+}

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -6,6 +6,7 @@ import { BacktestOrchestrationProcessor } from './backtest-orchestration.process
 import { BacktestOrchestrationService } from './backtest-orchestration.service';
 import { BacktestOrchestrationTask } from './backtest-orchestration.task';
 import { BacktestWatchdogService } from './backtest-watchdog.service';
+import { DataRetentionTask } from './data-retention.task';
 import { DatabaseMaintenanceTask } from './database-maintenance.task';
 import { DriftDetectionProcessor } from './drift-detection.processor';
 import { DriftDetectionTask } from './drift-detection.task';
@@ -66,6 +67,7 @@ import { UsersModule } from '../users/users.module';
  * - PipelineOrchestrationTask: Daily at 2 AM - Orchestrate full validation pipelines for algo-enabled users
  * - BacktestOrchestrationTask: Twice daily at 3 AM/3 PM UTC - Orchestrate automatic backtests for algo-enabled users
  * - RedisMaintenanceTask: Daily at 4 AM UTC - Trim stale BullMQ job data and orphaned keys
+ * - DataRetentionTask: Daily at 4:15 AM UTC - Prune stale rows from log/append-only tables
  * - DatabaseMaintenanceTask: Daily at 4:30 AM UTC - ANALYZE hot tables to keep planner stats fresh
  */
 const BACKTEST_QUEUE_NAMES = backtestConfig();
@@ -128,7 +130,8 @@ const BACKTEST_QUEUE_NAMES = backtestConfig();
     PipelineOrchestrationProcessor,
     PipelineOrchestrationService,
     RedisMaintenanceTask,
-    DatabaseMaintenanceTask
+    DatabaseMaintenanceTask,
+    DataRetentionTask
   ],
   exports: [
     StrategyEvaluationTask,
@@ -140,7 +143,8 @@ const BACKTEST_QUEUE_NAMES = backtestConfig();
     BacktestOrchestrationTask,
     PipelineOrchestrationTask,
     RedisMaintenanceTask,
-    DatabaseMaintenanceTask
+    DatabaseMaintenanceTask,
+    DataRetentionTask
   ]
 })
 export class TasksModule {}


### PR DESCRIPTION
## Summary

- Add `DataRetentionTask` that runs nightly at 04:15 UTC to prune 20 log-style Postgres tables that previously grew unbounded
- Every rule is fail-safe (one table's error doesn't abort the sweep) and honors `DISABLE_BACKGROUND_TASKS`
- Retention windows are env-tunable via `DATA_RETENTION_*_DAYS` vars with conservative defaults
- Schedule slots between `RedisMaintenanceTask` (04:00) and `DatabaseMaintenanceTask` (04:30) so nightly `ANALYZE` sees the pruned tables

## Changes

**Core task**
- `apps/api/src/tasks/data-retention.task.ts` — new `DataRetentionTask` with 21 prune rules across 20 tables, re-entrance guard, and per-rule timing/error reporting
- `apps/api/src/tasks/tasks.module.ts` — register the task

**Retention tiers**
- Tier 1 (high-volume): `exchange_key_health_log`, `paper_trading_snapshots`, `paper_trading_sessions`, `backtests`, `optimization_runs`, `pipelines`
- Tier 2 (operational history): `drift_alerts`, `notification` (split read/unread), `market_regimes`, `strategy_scores`, `performance_metrics`, `listing_trade_positions`, `listing_announcements`, `listing_candidates`, `comparison_reports`, `backtest_runs`, `market_data_sets`, `algorithm_performances`
- Tier 3 (compliance): `audit_logs` (5y default), `security_audit_log` (2y default)

**Safety**
- Status-gated pruning — only terminal rows (`COMPLETED/FAILED/CANCELLED/STOPPED`) are eligible
- `OPEN` positions, unresolved alerts, and pipeline-referenced backtests/sessions/runs are preserved
- `market_regimes` nullifies `previousRegimeId` pointers in a CTE before deleting to avoid self-reference violations

**Config & env**
- `apps/api/src/config/env.validation.ts` — Zod entries for each `DATA_RETENTION_*_DAYS` var
- `apps/api/src/config/database.config.ts` — fix pg pool `work_mem` by passing it through `options: '-c work_mem=32MB'` (node-pg doesn't forward `work_mem` as a top-level option)

**Tests**
- `apps/api/src/tasks/data-retention.task.spec.ts` — 12 unit tests covering short-circuits (`DISABLE_BACKGROUND_TASKS`, dev), full-sweep call count, fail-safety, env overrides, invalid-env fallback (parameterized for zero/negative/decimal/non-numeric), notification read/unread split, and re-entrance guard

**Misc**
- `.gitignore` — ignore `.claude/scheduled_tasks.lock`

## Test Plan

- [x] `npx nx test api -- --testPathPatterns=data-retention.task.spec` (12/12 passing)
- [x] `npx nx lint api` clean
- [ ] Dry-run in staging: confirm first nightly sweep logs `Data retention complete: <rows> across N/21 tables`
- [ ] Verify no rule fails against current prod schema (watch for `FAILED after Xms — <reason>` log lines on first run)
- [ ] Confirm `work_mem=32MB` is applied by checking `SHOW work_mem;` on an API-owned connection after deploy