### PR TITLE
feat(api): distinguish rejected pipelines from infrastructure failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,26 +2,25 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
     # Optional: Only run on specific file changes
     paths:
-      - 'apps/**'
-      - 'libs/**'
-      - '*.json'
-      - '*.md'
+      - "apps/**"
+      - "libs/**"
+      - "*.json"
+      - "*.md"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.title, '[skip-review]') &&
+      !contains(github.event.pull_request.title, '[WIP]')
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -39,50 +38,79 @@ jobs:
             echo "is_force_push=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install ast-grep
+        if: steps.force-push-check.outputs.is_force_push != 'true'
+        run: npm i -g @ast-grep/cli
+
       - name: Run Claude Code Review
         if: steps.force-push-check.outputs.is_force_push != 'true'
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request. If this is a follow-up review (synchronize event),
-            check for existing review comments and only comment on:
-            - NEW issues not previously mentioned
-            - Issues that were NOT addressed by recent commits
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Do NOT repeat feedback that has already been addressed in subsequent commits.
-            Before commenting on an issue, verify it still exists in the latest code.
+            You are reviewing a pull request in the Chansey Nx monorepo.
+            Repo: Angular 21 frontend (apps/chansey) + NestJS 11 API (apps/api) + TypeORM/PostgreSQL + BullMQ/Redis.
+            Conventions live in CLAUDE.md and .claude/rules/*.md — read them when module context is unclear.
 
-            Review criteria:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            === YOUR JOB ===
+            Post INLINE review comments using `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) on specific file:line locations.
+            Leave ZERO summary/overview/approval comments. Do NOT post top-level `gh pr comment` comments.
+            If you find nothing worth flagging, post nothing. "No comment" is a valid outcome — do NOT emit review text as a chat message either.
 
-            Be constructive and helpful in your feedback.
+            === WHAT TO FLAG ===
+            Comment ONLY on concrete, defensible issues in the following priority order:
+            1. **Bugs** — logic errors, off-by-one, race conditions, null/undefined misses, wrong exception handling.
+            2. **Security** — injection, auth bypass, secrets in logs, missing input validation at boundaries.
+            3. **Data integrity** — migration ordering, missing indexes, incorrect transactions, numeric precision (decimal.js required for money per CLAUDE.md).
+            4. **Test coverage gaps** — new branches/paths without corresponding spec coverage.
+            5. **Breaking changes** — API contract drift, DB schema breakage without migration, unsafe TypeORM entity edits.
+            6. **Pattern violations** — only when materially wrong (e.g., mocking DB where integration is required, using `uuid_generate_v4()` instead of `gen_random_uuid()`, plural table names when the project uses singular — see .claude/rules/migrations.md).
 
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
+            === WHAT NOT TO FLAG ===
+            - Style/formatting (Prettier + ESLint handle it)
+            - "Consider extracting to a helper" / "this method is long" unless it crosses the CLAUDE.md file-size hard limits (750 backend / 400 frontend component / 450 frontend service)
+            - Praise, encouragement, or acknowledgements ("Great work on X!")
+            - Restating what the diff does
+            - Speculation or "you might want to consider" nits
+            - Suggestions already addressed in later commits of the same PR (on `synchronize` events, verify against current HEAD)
 
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
+            === COMMENT FORMAT ===
+            Each inline comment must include:
+            - **Severity**: `[CRITICAL]` / `[HIGH]` / `[MEDIUM]` / `[LOW]` prefix
+            - **What**: the specific problem (one sentence)
+            - **Why**: concrete failure mode or risk (one sentence)
+            - **Fix**: suggested code change (use GitHub suggestion blocks ```suggestion ... ``` when the fix is a direct line replacement)
 
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+            === TOOLS TO USE BEFORE COMMENTING ===
+            - Use Grep to check whether a "missing" function/util actually exists elsewhere in the repo
+            - Use Read to check the surrounding context of a diff hunk (not just the diff)
+            - Do NOT run tests or lint — CI runs them in a separate job and the pre-commit hook runs them locally. Reason about correctness from the code itself.
 
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+            === STRUCTURAL SEARCH ===
+            Before flagging a rename, signature change, or "removed" symbol, run `sg -p 'oldName($$$)' apps libs`
+            to verify no real callers remain. Prefer `sg` over `Grep` when the question is code-structural
+            (call sites, type usages, decorator patterns). `Grep` is fine for strings/comments/string-typed
+            contracts (event names, queue names, route paths).
+
+            === SYNCHRONIZE EVENTS ===
+            On re-review (synchronize), comment only on:
+            - NEW issues in the new commits
+            - Previously-raised issues that are NOT yet fixed in the latest HEAD
+            Never repeat feedback already addressed.
+
+            === BANNED OUTPUTS ===
+            Do not produce any of these:
+            - "Overall this PR looks good"
+            - "Strengths:" / "Minor Observations:" / "Summary:" sections
+            - Approvals or sign-offs
+            - Issue-level summary comments (only inline, on specific lines)
+
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 8
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(sg:*),Bash(ast-grep:*),Grep,Read"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `nx affected:lint` - Run linting only for affected projects
 - `nx dep-graph` - View project dependency graph
 
+### Code Search
+
+- Prefer `sg -p 'name($$$)' apps libs` (ast-grep) over `Grep` for code-structural questions — call sites, type usages,
+  decorator patterns, signature changes. `sg` parses the AST, so it won't match comments/strings/identically-named
+  variables.
+- Stick with `Grep` for strings, comments, and string-typed contracts (event names, queue names, route paths, audit-log
+  keys).
+
 ### Code Quality
 
 - `npm run format` - Format code with Prettier

--- a/apps/api/src/migrations/1776699591770-add-rejected-pipeline-status.ts
+++ b/apps/api/src/migrations/1776699591770-add-rejected-pipeline-status.ts
@@ -1,0 +1,14 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddRejectedPipelineStatus1776699591770 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Adding a new enum value requires running outside of a transaction in PostgreSQL
+    await queryRunner.query(`COMMIT`);
+    await queryRunner.query(`ALTER TYPE "pipeline_status_enum" ADD VALUE IF NOT EXISTS 'REJECTED'`);
+    await queryRunner.query(`BEGIN`);
+  }
+
+  public async down(): Promise<void> {
+    // PostgreSQL does not support removing enum values.
+  }
+}

--- a/apps/api/src/notification/listeners/pipeline-notification.listener.ts
+++ b/apps/api/src/notification/listeners/pipeline-notification.listener.ts
@@ -51,6 +51,12 @@ interface PipelineFailedPayload {
   timestamp: string;
 }
 
+interface PipelineRejectedPayload {
+  pipelineId: string;
+  reason: string;
+  timestamp: string;
+}
+
 /**
  * Translates domain-level pipeline events into user-facing notifications.
  * Each pipeline event maps to exactly one notification enqueue via the shared
@@ -209,6 +215,36 @@ export class PipelineNotificationListener {
         NotificationEventType.PIPELINE_REJECTED,
         `A strategy couldn't finish building`,
         `We'll try again on the next cycle — no action needed.`,
+        'medium',
+        {
+          userId: pipeline.user.id,
+          pipelineId: pipeline.id,
+          strategyName,
+          reason: payload.reason
+        }
+      );
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to send PIPELINE_REJECTED notification for ${payload.pipelineId}: ${err.message}`,
+        err.stack
+      );
+    }
+  }
+
+  @OnEvent(PIPELINE_EVENTS.PIPELINE_REJECTED, { async: true })
+  async handleRejected(payload: PipelineRejectedPayload): Promise<void> {
+    try {
+      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
+      if (!pipeline) return;
+
+      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
+
+      await this.notificationService.send(
+        pipeline.user.id,
+        NotificationEventType.PIPELINE_REJECTED,
+        `A strategy didn't pass the safety review`,
+        `We'll try a different approach on your next cycle — no action needed.`,
         'medium',
         {
           userId: pipeline.user.id,

--- a/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-config.interface.ts
@@ -17,6 +17,7 @@ export enum PipelineStatus {
   PAUSED = 'PAUSED',
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
+  REJECTED = 'REJECTED',
   CANCELLED = 'CANCELLED'
 }
 

--- a/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
+++ b/apps/api/src/pipeline/interfaces/pipeline-events.interface.ts
@@ -146,5 +146,6 @@ export const PIPELINE_EVENTS = {
   PIPELINE_STATUS_CHANGE: 'pipeline.status-change',
   PIPELINE_PROGRESS: 'pipeline.progress',
   PIPELINE_COMPLETED: 'pipeline.completed',
-  PIPELINE_FAILED: 'pipeline.failed'
+  PIPELINE_FAILED: 'pipeline.failed',
+  PIPELINE_REJECTED: 'pipeline.rejected'
 } as const;

--- a/apps/api/src/pipeline/services/pipeline-eta.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-eta.service.ts
@@ -163,6 +163,7 @@ export class PipelineEtaService {
     if (
       pipeline.status === PipelineStatus.COMPLETED ||
       pipeline.status === PipelineStatus.FAILED ||
+      pipeline.status === PipelineStatus.REJECTED ||
       pipeline.status === PipelineStatus.CANCELLED
     ) {
       return { minDaysRemaining: 0, maxDaysRemaining: 0 };
@@ -256,6 +257,7 @@ export class PipelineEtaService {
 
   private isRejected(pipeline: Pipeline): boolean {
     return (
+      pipeline.status === PipelineStatus.REJECTED ||
       pipeline.status === PipelineStatus.FAILED ||
       (pipeline.status === PipelineStatus.COMPLETED &&
         pipeline.recommendation === DeploymentRecommendation.DO_NOT_DEPLOY)

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.spec.ts
@@ -76,6 +76,7 @@ describe('PipelineEventHandlerService', () => {
             evaluateOptimizationProgression: jest.fn(),
             advanceToNextStage: jest.fn(),
             failPipeline: jest.fn(),
+            rejectPipeline: jest.fn(),
             calculatePipelineScore: jest.fn(),
             evaluateStageProgression: jest.fn(),
             completePipeline: jest.fn(),
@@ -98,6 +99,7 @@ describe('PipelineEventHandlerService', () => {
 
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
       expect(progressionService.failPipeline).not.toHaveBeenCalled();
+      expect(progressionService.rejectPipeline).not.toHaveBeenCalled();
     });
 
     it('advances pipeline when improvement meets threshold', async () => {
@@ -108,9 +110,10 @@ describe('PipelineEventHandlerService', () => {
 
       expect(progressionService.advanceToNextStage).toHaveBeenCalled();
       expect(progressionService.failPipeline).not.toHaveBeenCalled();
+      expect(progressionService.rejectPipeline).not.toHaveBeenCalled();
     });
 
-    it('fails pipeline when improvement is below threshold', async () => {
+    it('rejects pipeline when improvement is below threshold', async () => {
       pipelineRepository.findOne.mockResolvedValue(makePipeline());
       progressionService.evaluateOptimizationProgression.mockReturnValue({
         passed: false,
@@ -119,10 +122,11 @@ describe('PipelineEventHandlerService', () => {
 
       await service.handleOptimizationComplete('run-123', 'strategy-123', {}, 50, 1);
 
-      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+      expect(progressionService.rejectPipeline).toHaveBeenCalledWith(
         expect.any(Object),
         expect.stringContaining('Optimization did not meet')
       );
+      expect(progressionService.failPipeline).not.toHaveBeenCalled();
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
     });
 
@@ -135,7 +139,7 @@ describe('PipelineEventHandlerService', () => {
       expect(progressionService.evaluateOptimizationProgression).toHaveBeenCalledWith(expect.any(Object), 10, 80);
     });
 
-    it('fails pipeline when bestScore is negative (absolute-score gate)', async () => {
+    it('rejects pipeline when bestScore is negative (absolute-score gate)', async () => {
       pipelineRepository.findOne.mockResolvedValue(makePipeline());
       progressionService.evaluateOptimizationProgression.mockReturnValue({
         passed: false,
@@ -145,10 +149,11 @@ describe('PipelineEventHandlerService', () => {
       await service.handleOptimizationComplete('run-123', 'strategy-123', { rsi: 14 }, -4, 200);
 
       expect(progressionService.evaluateOptimizationProgression).toHaveBeenCalledWith(expect.any(Object), 200, -4);
-      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+      expect(progressionService.rejectPipeline).toHaveBeenCalledWith(
         expect.any(Object),
         expect.stringContaining('Best test score')
       );
+      expect(progressionService.failPipeline).not.toHaveBeenCalled();
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
     });
 
@@ -161,7 +166,7 @@ describe('PipelineEventHandlerService', () => {
 
       await service.handleOptimizationComplete('run-123', 'strategy-123', {}, 100, -100);
 
-      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+      expect(progressionService.rejectPipeline).toHaveBeenCalledWith(
         expect.objectContaining({
           stageResults: expect.objectContaining({
             optimization: expect.objectContaining({ baselineScore: 0 })
@@ -197,6 +202,7 @@ describe('PipelineEventHandlerService', () => {
       expect(pipelineRepository.save).toHaveBeenCalled();
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
       expect(progressionService.failPipeline).not.toHaveBeenCalled();
+      expect(progressionService.rejectPipeline).not.toHaveBeenCalled();
     });
   });
 
@@ -258,17 +264,18 @@ describe('PipelineEventHandlerService', () => {
   });
 
   describe('handleBacktestComplete', () => {
-    it('fails pipeline when 0 trades produced', async () => {
+    it('rejects pipeline when 0 trades produced', async () => {
       pipelineRepository.findOne.mockResolvedValue(
         makePipeline({ currentStage: PipelineStage.HISTORICAL, historicalBacktestId: 'bt-123' })
       );
 
       await service.handleBacktestComplete('bt-123', 'HISTORICAL', { ...baseMetrics, totalTrades: 0 });
 
-      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+      expect(progressionService.rejectPipeline).toHaveBeenCalledWith(
         expect.any(Object),
         expect.stringContaining('0 trades')
       );
+      expect(progressionService.failPipeline).not.toHaveBeenCalled();
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
     });
 
@@ -311,7 +318,7 @@ describe('PipelineEventHandlerService', () => {
       expect(progressionService.failPipeline).not.toHaveBeenCalled();
     });
 
-    it('fails LIVE_REPLAY when score is below minimum', async () => {
+    it('rejects LIVE_REPLAY when score is below minimum', async () => {
       const pipeline = makePipeline({
         currentStage: PipelineStage.LIVE_REPLAY,
         liveReplayBacktestId: 'bt-456',
@@ -331,10 +338,11 @@ describe('PipelineEventHandlerService', () => {
 
       await service.handleBacktestComplete('bt-456', 'LIVE_REPLAY', baseMetrics);
 
-      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+      expect(progressionService.rejectPipeline).toHaveBeenCalledWith(
         expect.any(Object),
         expect.stringContaining('< minimum 30')
       );
+      expect(progressionService.failPipeline).not.toHaveBeenCalled();
       expect(progressionService.advanceToNextStage).not.toHaveBeenCalled();
     });
 
@@ -454,7 +462,7 @@ describe('PipelineEventHandlerService', () => {
       expect(progressionService.failPipeline).not.toHaveBeenCalled();
     });
 
-    it('fails pipeline when thresholds are not met', async () => {
+    it('rejects pipeline when thresholds are not met', async () => {
       const pipeline = makePipeline({ currentStage: PipelineStage.PAPER_TRADE });
       pipelineRepository.findOne.mockResolvedValue(pipeline);
       progressionService.evaluateStageProgression.mockReturnValue({
@@ -464,10 +472,11 @@ describe('PipelineEventHandlerService', () => {
 
       await service.handlePaperTradingComplete('session-123', 'pipeline-123', { ...paperMetrics, sharpeRatio: 0.1 });
 
-      expect(progressionService.failPipeline).toHaveBeenCalledWith(
+      expect(progressionService.rejectPipeline).toHaveBeenCalledWith(
         expect.any(Object),
         expect.stringContaining('Paper trading did not meet thresholds')
       );
+      expect(progressionService.failPipeline).not.toHaveBeenCalled();
       expect(progressionService.completePipeline).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-event-handler.service.ts
@@ -77,7 +77,7 @@ export class PipelineEventHandlerService {
     );
 
     if (!passed) {
-      await this.progressionService.failPipeline(
+      await this.progressionService.rejectPipeline(
         pipeline,
         `Optimization did not meet progression threshold: ${failures.join('; ')}`
       );
@@ -169,7 +169,7 @@ export class PipelineEventHandlerService {
     this.logger.log(`Backtest ${type} completed for pipeline ${pipeline.id}`);
 
     if (metrics.totalTrades === 0) {
-      await this.progressionService.failPipeline(
+      await this.progressionService.rejectPipeline(
         pipeline,
         `${type} backtest produced 0 trades — cannot advance pipeline`
       );
@@ -259,7 +259,7 @@ export class PipelineEventHandlerService {
 
       const minimumScore = pipeline.progressionRules.minimumPipelineScore ?? 30;
       if (scoreResult.overallScore < minimumScore) {
-        await this.progressionService.failPipeline(
+        await this.progressionService.rejectPipeline(
           pipeline,
           `LIVE_REPLAY score ${scoreResult.overallScore.toFixed(1)} < minimum ${minimumScore}`
         );
@@ -384,7 +384,7 @@ export class PipelineEventHandlerService {
     );
 
     if (!passed) {
-      await this.progressionService.failPipeline(
+      await this.progressionService.rejectPipeline(
         pipeline,
         `Paper trading did not meet thresholds: ${failures.join('; ')}`
       );

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.spec.ts
@@ -188,14 +188,16 @@ describe('PipelineOrchestratorService', () => {
       expect(pipeline.stageTransitionedAt).toBe(original);
     });
 
-    it.each([[PipelineStatus.RUNNING], [PipelineStatus.COMPLETED], [PipelineStatus.CANCELLED]])(
-      'throws BadRequest when status is %s',
-      async (status) => {
-        pipelineRepository.findOne.mockResolvedValue(makePipeline({ status }));
-        await expect(service.startPipeline('pipeline-123', mockUser)).rejects.toThrow(BadRequestException);
-        expect(stageExecutionService.enqueueStageJob).not.toHaveBeenCalled();
-      }
-    );
+    it.each([
+      [PipelineStatus.RUNNING],
+      [PipelineStatus.COMPLETED],
+      [PipelineStatus.CANCELLED],
+      [PipelineStatus.REJECTED]
+    ])('throws BadRequest when status is %s', async (status) => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline({ status }));
+      await expect(service.startPipeline('pipeline-123', mockUser)).rejects.toThrow(BadRequestException);
+      expect(stageExecutionService.enqueueStageJob).not.toHaveBeenCalled();
+    });
 
     it('marks pipeline FAILED and rethrows when enqueueStageJob fails', async () => {
       pipelineRepository.findOne.mockResolvedValue(makePipeline());
@@ -250,14 +252,16 @@ describe('PipelineOrchestratorService', () => {
       expect(stageExecutionService.removeStageJob).toHaveBeenCalledWith('pipeline-123', PipelineStage.OPTIMIZE);
     });
 
-    it.each([[PipelineStatus.COMPLETED], [PipelineStatus.CANCELLED]])(
-      'throws when pipeline already %s',
-      async (status) => {
-        pipelineRepository.findOne.mockResolvedValue(makePipeline({ status }));
-        await expect(service.cancelPipeline('pipeline-123', mockUser)).rejects.toThrow(BadRequestException);
-        expect(stageExecutionService.cancelCurrentStage).not.toHaveBeenCalled();
-      }
-    );
+    it.each([
+      [PipelineStatus.COMPLETED],
+      [PipelineStatus.CANCELLED],
+      [PipelineStatus.REJECTED],
+      [PipelineStatus.FAILED]
+    ])('throws when pipeline already %s', async (status) => {
+      pipelineRepository.findOne.mockResolvedValue(makePipeline({ status }));
+      await expect(service.cancelPipeline('pipeline-123', mockUser)).rejects.toThrow(BadRequestException);
+      expect(stageExecutionService.cancelCurrentStage).not.toHaveBeenCalled();
+    });
   });
 
   describe('skipStage', () => {

--- a/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-orchestrator.service.ts
@@ -153,8 +153,13 @@ export class PipelineOrchestratorService {
   }
 
   private async cancelPipelineInternal(pipeline: Pipeline, reason: string): Promise<void> {
-    if (pipeline.status === PipelineStatus.COMPLETED || pipeline.status === PipelineStatus.CANCELLED) {
-      throw new BadRequestException('Pipeline is already completed or cancelled');
+    if (
+      pipeline.status === PipelineStatus.COMPLETED ||
+      pipeline.status === PipelineStatus.CANCELLED ||
+      pipeline.status === PipelineStatus.REJECTED ||
+      pipeline.status === PipelineStatus.FAILED
+    ) {
+      throw new BadRequestException('Pipeline is already in a terminal state');
     }
 
     // Best-effort downstream cancel first — we want the real workload stopped
@@ -197,6 +202,9 @@ export class PipelineOrchestratorService {
     }
     if (pipeline.status === PipelineStatus.CANCELLED) {
       throw new BadRequestException('Pipeline has been cancelled');
+    }
+    if (pipeline.status === PipelineStatus.REJECTED) {
+      throw new BadRequestException('Pipeline has been rejected');
     }
 
     const previousStatus = pipeline.status;

--- a/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.spec.ts
@@ -528,6 +528,55 @@ describe('PipelineProgressionService', () => {
       expect(pipeline.recommendation).toBe(DeploymentRecommendation.DO_NOT_DEPLOY);
       expect(eventEmitter.emit).toHaveBeenCalledWith(PIPELINE_EVENTS.PIPELINE_FAILED, expect.any(Object));
     });
+
+    it('does NOT emit PIPELINE_REJECTED', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      await service.failPipeline(pipeline, 'infra boom');
+
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(PIPELINE_EVENTS.PIPELINE_REJECTED, expect.anything());
+    });
+  });
+
+  describe('rejectPipeline', () => {
+    it('marks pipeline as REJECTED with DO_NOT_DEPLOY and persists failureReason', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      await service.rejectPipeline(pipeline, 'Optimization improvement 1.5% < min 3%');
+
+      expect(pipeline.status).toBe(PipelineStatus.REJECTED);
+      expect(pipeline.failureReason).toBe('Optimization improvement 1.5% < min 3%');
+      expect(pipeline.recommendation).toBe(DeploymentRecommendation.DO_NOT_DEPLOY);
+      expect(pipeline.completedAt).toBeInstanceOf(Date);
+      expect(pipelineRepository.save).toHaveBeenCalledWith(pipeline);
+    });
+
+    it('emits PIPELINE_REJECTED with the reason', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      await service.rejectPipeline(pipeline, 'zero trades');
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        PIPELINE_EVENTS.PIPELINE_REJECTED,
+        expect.objectContaining({
+          pipelineId: pipeline.id,
+          reason: 'zero trades'
+        })
+      );
+    });
+
+    it('does NOT emit PIPELINE_FAILED (distinct from failPipeline)', async () => {
+      const pipeline = makePipeline();
+      pipelineRepository.save.mockResolvedValue(pipeline);
+
+      await service.rejectPipeline(pipeline, 'below threshold');
+
+      expect(pipeline.status).not.toBe(PipelineStatus.FAILED);
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith(PIPELINE_EVENTS.PIPELINE_FAILED, expect.anything());
+    });
   });
 
   describe('completePipeline', () => {

--- a/apps/api/src/pipeline/services/pipeline-progression.service.ts
+++ b/apps/api/src/pipeline/services/pipeline-progression.service.ts
@@ -309,6 +309,12 @@ export class PipelineProgressionService {
     return raw >= 0 ? raw : Math.abs(raw) * 0.5;
   }
 
+  /**
+   * Mark a pipeline as FAILED due to an infrastructure error — worker crash,
+   * enqueue failure, or watchdog reap. These indicate something is broken and
+   * someone should investigate. For business-rule rejections (threshold gates,
+   * zero trades, low scores), use `rejectPipeline()` instead.
+   */
   async failPipeline(pipeline: Pipeline, reason: string): Promise<void> {
     pipeline.status = PipelineStatus.FAILED;
     pipeline.completedAt = new Date();
@@ -317,9 +323,34 @@ export class PipelineProgressionService {
 
     await this.pipelineRepository.save(pipeline);
 
-    this.logger.warn(`Pipeline ${pipeline.id} failed: ${reason}`);
+    this.logger.error(`Pipeline ${pipeline.id} failed: ${reason}`);
 
     this.eventEmitter.emit(PIPELINE_EVENTS.PIPELINE_FAILED, {
+      pipelineId: pipeline.id,
+      reason,
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  /**
+   * Mark a pipeline as REJECTED because the strategy completed its stage
+   * cleanly but did not meet promotion thresholds (e.g. optimization
+   * improvement too low, zero trades, score below minimum, paper-trading
+   * metrics below gates). This is a valid outcome — the strategy just did not
+   * qualify — and should not trigger infrastructure alerts. For real failures,
+   * use `failPipeline()`.
+   */
+  async rejectPipeline(pipeline: Pipeline, reason: string): Promise<void> {
+    pipeline.status = PipelineStatus.REJECTED;
+    pipeline.completedAt = new Date();
+    pipeline.failureReason = reason;
+    pipeline.recommendation = DeploymentRecommendation.DO_NOT_DEPLOY;
+
+    await this.pipelineRepository.save(pipeline);
+
+    this.logger.log(`Pipeline ${pipeline.id} rejected: ${reason}`);
+
+    this.eventEmitter.emit(PIPELINE_EVENTS.PIPELINE_REJECTED, {
       pipelineId: pipeline.id,
       reason,
       timestamp: new Date().toISOString()

--- a/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
@@ -247,6 +247,7 @@ describe('PipelineOrchestrationService', () => {
     it.each([
       ['COMPLETED', PipelineStatus.COMPLETED],
       ['FAILED', PipelineStatus.FAILED],
+      ['REJECTED', PipelineStatus.REJECTED],
       ['CANCELLED', PipelineStatus.CANCELLED]
     ])('does NOT block when only %s pipelines exist', async (_label, _status) => {
       // The query filters by status IN (active), so terminal-status rows are excluded by SQL,

--- a/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.spec.ts
+++ b/apps/chansey/src/app/shared/components/strategy-status-card/strategy-status-card.component.spec.ts
@@ -70,7 +70,7 @@ describe('StrategyStatusCardComponent', () => {
   it('renders the rejected panel when wasRejected is true', () => {
     statusSignal.set({
       ...baseStatus,
-      status: PipelineStatus.FAILED,
+      status: PipelineStatus.REJECTED,
       wasRejected: true,
       rejectionReason: 'Test rejected reason'
     });

--- a/libs/api-interfaces/src/lib/pipeline/pipeline.interface.ts
+++ b/libs/api-interfaces/src/lib/pipeline/pipeline.interface.ts
@@ -11,6 +11,7 @@ export enum PipelineStatus {
   PAUSED = 'PAUSED',
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
+  REJECTED = 'REJECTED',
   CANCELLED = 'CANCELLED'
 }
 


### PR DESCRIPTION
## Summary

- Splits pipeline `FAILED` into two outcomes: `FAILED` (infrastructure error) and `REJECTED` (strategy completed cleanly but didn't meet promotion thresholds), so admin alerts stop treating normal business rejections as breakage.
- Business-gate call sites (optimization improvement, zero trades, LIVE_REPLAY score, paper-trading thresholds) now route to `rejectPipeline()`; watchdog/worker-error sites keep `failPipeline()`.
- Adds a `PIPELINE_REJECTED` event so user-facing notification copy diverges from the "couldn't finish building" infra path.

## Changes

**Enum + migration**
- New migration `1776699591770-add-rejected-pipeline-status.ts` — `ALTER TYPE pipeline_status_enum ADD VALUE 'REJECTED'` (out-of-transaction, no-op down).
- `PipelineStatus.REJECTED` added to both `libs/api-interfaces` and the API-side `pipeline-config.interface.ts` mirror.

**Progression service**
- `PipelineProgressionService.rejectPipeline(pipeline, reason)` — status `REJECTED`, `log` level, emits `PIPELINE_REJECTED`; `recommendation = DO_NOT_DEPLOY`, reason persisted to `failureReason`.
- `failPipeline()` kept for infra; log promoted to `error`.

**Call-site routing in `pipeline-event-handler.service.ts`**
- `rejectPipeline`: optimization threshold miss, zero-trade backtest, LIVE_REPLAY below minimum score, paper-trading threshold miss.
- `failPipeline` (unchanged): `handleOptimizationFailed`, `handleBacktestFailed`, `handlePaperTradingFailed`, watchdog sites, worker exception path.

**Terminal-state handling**
- `pipeline-eta.service.ts`: `isRejected()` recognizes `REJECTED`; `computeRemaining()` treats it as terminal (0 days remaining).
- `pipeline-orchestrator.service.ts`: `startPipeline()` blocks restart on `REJECTED`; `cancelPipelineInternal()` rejects cancel of already-REJECTED pipelines.

**Notifications**
- New `PIPELINE_REJECTED` listener sends "didn't pass the safety review" copy, leaving the existing `PIPELINE_FAILED` listener for infra failures.

**Frontend**
- `strategy-status-card.component.spec.ts` updated to set `PipelineStatus.REJECTED` for the rejected-panel test.

## Test Plan

- [x] `npx nx build api` / `npx nx build chansey`
- [x] `npx nx lint api` / `npx nx lint chansey` (zero warnings)
- [x] `npx nx test api -- --testPathPatterns='pipeline-progression|pipeline-event-handler|pipeline-eta|pipeline-orchestrator|pipeline-orchestration'` — 171 passed
- [x] `npx nx test api -- --testPathPatterns='pipeline-notification|backtest-watchdog'` — 33 passed
- [x] `npx nx test chansey -- --testPathPatterns='strategy-status-card'` — 5 passed
- [ ] Post-deploy: verify `\dT+ pipeline_status_enum` includes `REJECTED` in staging.
- [ ] Post-deploy: trigger a business-gate scenario (e.g., artificially high `minImprovement`) and confirm DB row is `REJECTED` with `failureReason` populated, `PIPELINE_REJECTED` event fires, `GET /pipelines/status` returns `wasRejected: true`, and admin backtest-monitoring dashboard shows "Rejected" in the status dropdown.