### PR TITLE
feat(api): aggregate pipeline notifications and distinguish rejects from failures

### DIFF
--- a/apps/api/src/notification/listeners/pipeline-notification.listener.spec.ts
+++ b/apps/api/src/notification/listeners/pipeline-notification.listener.spec.ts
@@ -1,0 +1,231 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { DeploymentRecommendation, PipelineStage, PipelineStatus } from '@chansey/api-interfaces';
+
+import { PipelineNotificationListener } from './pipeline-notification.listener';
+
+import { Pipeline } from '../../pipeline/entities/pipeline.entity';
+import type { PipelineStageTransitionEvent, PipelineStatusChangeEvent } from '../../pipeline/interfaces';
+import { PipelineNotificationDigestService } from '../services/pipeline-notification-digest.service';
+
+const TIMESTAMP = '2026-04-20T00:00:00.000Z';
+
+function makePipeline(overrides: Partial<Pipeline> = {}): Pipeline {
+  return {
+    id: 'pl-1',
+    name: 'Fallback Name',
+    user: { id: 'user-1' },
+    strategyConfig: { name: 'Alpha RSI' },
+    ...overrides
+  } as unknown as Pipeline;
+}
+
+function runningPayload(overrides: Partial<PipelineStatusChangeEvent> = {}): PipelineStatusChangeEvent {
+  return {
+    pipelineId: 'pl-1',
+    previousStatus: PipelineStatus.PENDING,
+    newStatus: PipelineStatus.RUNNING,
+    timestamp: TIMESTAMP,
+    ...overrides
+  };
+}
+
+describe('PipelineNotificationListener', () => {
+  let listener: PipelineNotificationListener;
+  let digest: { enqueue: jest.Mock };
+  let pipelineRepo: { findOne: jest.Mock };
+
+  beforeEach(async () => {
+    digest = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    pipelineRepo = { findOne: jest.fn().mockResolvedValue(makePipeline()) };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        PipelineNotificationListener,
+        { provide: PipelineNotificationDigestService, useValue: digest },
+        { provide: getRepositoryToken(Pipeline), useValue: pipelineRepo }
+      ]
+    }).compile();
+
+    listener = module.get(PipelineNotificationListener);
+  });
+
+  describe('handleStatusChange', () => {
+    it('enqueues started entry for PENDING→RUNNING', async () => {
+      await listener.handleStatusChange(runningPayload());
+
+      expect(digest.enqueue).toHaveBeenCalledWith(
+        'started',
+        expect.objectContaining({
+          pipelineId: 'pl-1',
+          userId: 'user-1',
+          strategyName: 'Alpha RSI',
+          subType: 'started',
+          at: TIMESTAMP
+        })
+      );
+    });
+
+    it('ignores transitions where newStatus is not RUNNING', async () => {
+      await listener.handleStatusChange(
+        runningPayload({ previousStatus: PipelineStatus.RUNNING, newStatus: PipelineStatus.COMPLETED })
+      );
+      expect(digest.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('ignores RUNNING transitions when previousStatus is not PENDING', async () => {
+      await listener.handleStatusChange(runningPayload({ previousStatus: PipelineStatus.RUNNING }));
+      expect(digest.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('falls back to pipeline.name when strategyConfig is missing', async () => {
+      pipelineRepo.findOne.mockResolvedValueOnce(
+        makePipeline({ strategyConfig: undefined, name: 'My Pipeline' } as Partial<Pipeline>)
+      );
+
+      await listener.handleStatusChange(runningPayload());
+
+      expect(digest.enqueue).toHaveBeenCalledWith('started', expect.objectContaining({ strategyName: 'My Pipeline' }));
+    });
+
+    it('no-ops when pipeline is missing', async () => {
+      pipelineRepo.findOne.mockResolvedValueOnce(null);
+
+      await listener.handleStatusChange(runningPayload());
+
+      expect(digest.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('no-ops when pipeline has no user relation', async () => {
+      pipelineRepo.findOne.mockResolvedValueOnce(makePipeline({ user: undefined } as Partial<Pipeline>));
+
+      await listener.handleStatusChange(runningPayload());
+
+      expect(digest.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('uses current time when payload omits timestamp', async () => {
+      await listener.handleStatusChange(runningPayload({ timestamp: undefined as unknown as string }));
+
+      expect(digest.enqueue).toHaveBeenCalledWith(
+        'started',
+        expect.objectContaining({ at: expect.stringMatching(/\d{4}-\d{2}-\d{2}T/) })
+      );
+    });
+
+    it('does not throw when digest enqueue fails', async () => {
+      digest.enqueue.mockRejectedValue(new Error('redis down'));
+
+      await expect(listener.handleStatusChange(runningPayload())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('handleStageTransition', () => {
+    it('enqueues stage entry with prev/next stages', async () => {
+      const payload: PipelineStageTransitionEvent = {
+        pipelineId: 'pl-1',
+        previousStage: PipelineStage.OPTIMIZE,
+        newStage: PipelineStage.HISTORICAL,
+        timestamp: TIMESTAMP
+      };
+
+      await listener.handleStageTransition(payload);
+
+      expect(digest.enqueue).toHaveBeenCalledWith(
+        'stage',
+        expect.objectContaining({
+          pipelineId: 'pl-1',
+          subType: 'stage',
+          previousStage: PipelineStage.OPTIMIZE,
+          newStage: PipelineStage.HISTORICAL
+        })
+      );
+    });
+
+    it('skips transitions into COMPLETED', async () => {
+      await listener.handleStageTransition({
+        pipelineId: 'pl-1',
+        previousStage: PipelineStage.PAPER_TRADE,
+        newStage: PipelineStage.COMPLETED,
+        timestamp: TIMESTAMP
+      });
+
+      expect(digest.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCompleted', () => {
+    it('enqueues terminal entry with recommendation payload', async () => {
+      await listener.handleCompleted({
+        pipelineId: 'pl-1',
+        recommendation: DeploymentRecommendation.DEPLOY,
+        timestamp: TIMESTAMP
+      });
+
+      expect(digest.enqueue).toHaveBeenCalledWith(
+        'terminal',
+        expect.objectContaining({
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY
+        })
+      );
+    });
+
+    it('propagates the inconclusive flag', async () => {
+      await listener.handleCompleted({
+        pipelineId: 'pl-1',
+        recommendation: DeploymentRecommendation.DO_NOT_DEPLOY,
+        inconclusive: true,
+        timestamp: TIMESTAMP
+      });
+
+      expect(digest.enqueue).toHaveBeenCalledWith('terminal', expect.objectContaining({ inconclusive: true }));
+    });
+
+    it('prefers pipeline.failureReason over payload reason', async () => {
+      pipelineRepo.findOne.mockResolvedValueOnce(
+        makePipeline({ failureReason: 'db-level reason' } as Partial<Pipeline>)
+      );
+
+      await listener.handleCompleted({
+        pipelineId: 'pl-1',
+        recommendation: DeploymentRecommendation.DO_NOT_DEPLOY,
+        reason: 'payload reason',
+        timestamp: TIMESTAMP
+      });
+
+      expect(digest.enqueue).toHaveBeenCalledWith('terminal', expect.objectContaining({ reason: 'db-level reason' }));
+    });
+  });
+
+  describe('handleFailed', () => {
+    it('enqueues terminal entry with failed subType', async () => {
+      await listener.handleFailed({
+        pipelineId: 'pl-1',
+        reason: 'crashed',
+        timestamp: TIMESTAMP
+      });
+
+      expect(digest.enqueue).toHaveBeenCalledWith(
+        'terminal',
+        expect.objectContaining({ subType: 'failed', reason: 'crashed' })
+      );
+    });
+  });
+
+  describe('handleRejected', () => {
+    it('enqueues terminal entry with rejected subType', async () => {
+      await listener.handleRejected({
+        pipelineId: 'pl-1',
+        reason: 'low score',
+        timestamp: TIMESTAMP
+      });
+
+      expect(digest.enqueue).toHaveBeenCalledWith(
+        'terminal',
+        expect.objectContaining({ subType: 'rejected', reason: 'low score' })
+      );
+    });
+  });
+});

--- a/apps/api/src/notification/listeners/pipeline-notification.listener.ts
+++ b/apps/api/src/notification/listeners/pipeline-notification.listener.ts
@@ -4,12 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import {
-  DeploymentRecommendation,
-  NotificationEventType,
-  PipelineStage,
-  PipelineStatus
-} from '@chansey/api-interfaces';
+import { DeploymentRecommendation, PipelineStage, PipelineStatus } from '@chansey/api-interfaces';
 
 import { Pipeline } from '../../pipeline/entities/pipeline.entity';
 import {
@@ -18,24 +13,11 @@ import {
   type PipelineStatusChangeEvent
 } from '../../pipeline/interfaces';
 import { toErrorInfo } from '../../shared/error.util';
-import { NotificationService } from '../notification.service';
-
-/** Maps a newly-entered pipeline stage to a user-facing label */
-const STAGE_FRIENDLY_LABEL: Record<string, string> = {
-  [PipelineStage.OPTIMIZE]: 'Training your strategy',
-  [PipelineStage.HISTORICAL]: 'Testing against history',
-  [PipelineStage.LIVE_REPLAY]: 'Replaying recent market data',
-  [PipelineStage.PAPER_TRADE]: 'Practicing with pretend money',
-  [PipelineStage.COMPLETED]: 'Final safety review'
-};
-
-/** Maps the stage a pipeline just left into a "just finished" label */
-const STAGE_COMPLETED_LABEL: Record<string, string> = {
-  [PipelineStage.OPTIMIZE]: 'training complete',
-  [PipelineStage.HISTORICAL]: 'historical testing complete',
-  [PipelineStage.LIVE_REPLAY]: 'recent market replay complete',
-  [PipelineStage.PAPER_TRADE]: 'paper trading complete'
-};
+import {
+  DigestBucket,
+  DigestEntry,
+  PipelineNotificationDigestService
+} from '../services/pipeline-notification-digest.service';
 
 interface PipelineCompletedPayload {
   pipelineId: string;
@@ -58,16 +40,16 @@ interface PipelineRejectedPayload {
 }
 
 /**
- * Translates domain-level pipeline events into user-facing notifications.
- * Each pipeline event maps to exactly one notification enqueue via the shared
- * NotificationService (which applies preferences + rate-limit + quiet hours).
+ * Translates domain-level pipeline events into per-user digest buckets.
+ * Events are buffered by `PipelineNotificationDigestService`, which emits
+ * one aggregated notification per bucket after its debounce window elapses.
  */
 @Injectable()
 export class PipelineNotificationListener {
   private readonly logger = new Logger(PipelineNotificationListener.name);
 
   constructor(
-    private readonly notificationService: NotificationService,
+    private readonly digest: PipelineNotificationDigestService,
     @InjectRepository(Pipeline) private readonly pipelineRepository: Repository<Pipeline>
   ) {}
 
@@ -76,31 +58,13 @@ export class PipelineNotificationListener {
     if (payload.newStatus !== PipelineStatus.RUNNING) return;
     if (payload.previousStatus !== PipelineStatus.PENDING) return;
 
-    try {
-      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
-      if (!pipeline) return;
-
-      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
-
-      await this.notificationService.send(
-        pipeline.user.id,
-        NotificationEventType.PIPELINE_STARTED,
-        'We started building a new strategy',
-        `An automated strategy is being trained and tested — we'll let you know as it progresses.`,
-        'info',
-        {
-          userId: pipeline.user.id,
-          pipelineId: pipeline.id,
-          strategyName
-        }
-      );
-    } catch (error) {
-      const err = toErrorInfo(error);
-      this.logger.error(
-        `Failed to send PIPELINE_STARTED notification for ${payload.pipelineId}: ${err.message}`,
-        err.stack
-      );
-    }
+    await this.enqueueForPipeline(payload.pipelineId, 'started', (pipeline, strategyName) => ({
+      pipelineId: pipeline.id,
+      userId: pipeline.user.id,
+      strategyName,
+      subType: 'started',
+      at: payload.timestamp ?? new Date().toISOString()
+    }));
   }
 
   @OnEvent(PIPELINE_EVENTS.PIPELINE_STAGE_TRANSITION, { async: true })
@@ -108,157 +72,70 @@ export class PipelineNotificationListener {
     // Skip the transition into COMPLETED — handled by PIPELINE_COMPLETED instead.
     if (payload.newStage === PipelineStage.COMPLETED) return;
 
-    try {
-      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
-      if (!pipeline) return;
-
-      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
-      const completedLabel = STAGE_COMPLETED_LABEL[payload.previousStage] ?? 'stage complete';
-      const nextLabel = STAGE_FRIENDLY_LABEL[payload.newStage] ?? 'next stage';
-
-      await this.notificationService.send(
-        pipeline.user.id,
-        NotificationEventType.PIPELINE_STAGE_COMPLETED,
-        `Strategy progress: ${completedLabel}`,
-        `Moving on to: ${nextLabel}.`,
-        'info',
-        {
-          userId: pipeline.user.id,
-          pipelineId: pipeline.id,
-          strategyName,
-          completedStage: payload.previousStage,
-          nextStage: payload.newStage
-        }
-      );
-    } catch (error) {
-      const err = toErrorInfo(error);
-      this.logger.error(
-        `Failed to send PIPELINE_STAGE_COMPLETED notification for ${payload.pipelineId}: ${err.message}`,
-        err.stack
-      );
-    }
+    await this.enqueueForPipeline(payload.pipelineId, 'stage', (pipeline, strategyName) => ({
+      pipelineId: pipeline.id,
+      userId: pipeline.user.id,
+      strategyName,
+      subType: 'stage',
+      previousStage: payload.previousStage,
+      newStage: payload.newStage,
+      at: payload.timestamp ?? new Date().toISOString()
+    }));
   }
 
   @OnEvent(PIPELINE_EVENTS.PIPELINE_COMPLETED, { async: true })
   async handleCompleted(payload: PipelineCompletedPayload): Promise<void> {
-    try {
-      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
-      if (!pipeline) return;
-
-      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
-
-      if (payload.recommendation === DeploymentRecommendation.DO_NOT_DEPLOY) {
-        await this.notificationService.send(
-          pipeline.user.id,
-          NotificationEventType.PIPELINE_REJECTED,
-          `A strategy didn't pass the safety review`,
-          `We'll try a different approach on your next cycle — no action needed.`,
-          'medium',
-          {
-            userId: pipeline.user.id,
-            pipelineId: pipeline.id,
-            strategyName,
-            reason: pipeline.failureReason ?? payload.reason ?? 'Failed final review'
-          }
-        );
-        return;
-      }
-
-      if (payload.recommendation === DeploymentRecommendation.INCONCLUSIVE_RETRY) {
-        await this.notificationService.send(
-          pipeline.user.id,
-          NotificationEventType.PIPELINE_REJECTED,
-          `Not enough trading opportunities`,
-          `We'll retry with fresh parameters — no action needed from you.`,
-          'low',
-          {
-            userId: pipeline.user.id,
-            pipelineId: pipeline.id,
-            strategyName,
-            reason: payload.reason ?? 'Insufficient trading signals'
-          }
-        );
-        return;
-      }
-
-      await this.notificationService.send(
-        pipeline.user.id,
-        NotificationEventType.PIPELINE_COMPLETED,
-        `A new strategy is ready for live trading`,
-        `It passed every check and is being activated on your account.`,
-        'info',
-        {
-          userId: pipeline.user.id,
-          pipelineId: pipeline.id,
-          strategyName
-        }
-      );
-    } catch (error) {
-      const err = toErrorInfo(error);
-      this.logger.error(
-        `Failed to send PIPELINE_COMPLETED notification for ${payload.pipelineId}: ${err.message}`,
-        err.stack
-      );
-    }
+    await this.enqueueForPipeline(payload.pipelineId, 'terminal', (pipeline, strategyName) => ({
+      pipelineId: pipeline.id,
+      userId: pipeline.user.id,
+      strategyName,
+      subType: 'completed',
+      recommendation: payload.recommendation,
+      inconclusive: payload.inconclusive,
+      reason: pipeline.failureReason ?? payload.reason,
+      at: payload.timestamp ?? new Date().toISOString()
+    }));
   }
 
   @OnEvent(PIPELINE_EVENTS.PIPELINE_FAILED, { async: true })
   async handleFailed(payload: PipelineFailedPayload): Promise<void> {
-    try {
-      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
-      if (!pipeline) return;
-
-      const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
-
-      await this.notificationService.send(
-        pipeline.user.id,
-        NotificationEventType.PIPELINE_REJECTED,
-        `A strategy couldn't finish building`,
-        `We'll try again on the next cycle — no action needed.`,
-        'medium',
-        {
-          userId: pipeline.user.id,
-          pipelineId: pipeline.id,
-          strategyName,
-          reason: payload.reason
-        }
-      );
-    } catch (error) {
-      const err = toErrorInfo(error);
-      this.logger.error(
-        `Failed to send PIPELINE_REJECTED notification for ${payload.pipelineId}: ${err.message}`,
-        err.stack
-      );
-    }
+    await this.enqueueForPipeline(payload.pipelineId, 'terminal', (pipeline, strategyName) => ({
+      pipelineId: pipeline.id,
+      userId: pipeline.user.id,
+      strategyName,
+      subType: 'failed',
+      reason: payload.reason,
+      at: payload.timestamp ?? new Date().toISOString()
+    }));
   }
 
   @OnEvent(PIPELINE_EVENTS.PIPELINE_REJECTED, { async: true })
   async handleRejected(payload: PipelineRejectedPayload): Promise<void> {
+    await this.enqueueForPipeline(payload.pipelineId, 'terminal', (pipeline, strategyName) => ({
+      pipelineId: pipeline.id,
+      userId: pipeline.user.id,
+      strategyName,
+      subType: 'rejected',
+      reason: payload.reason,
+      at: payload.timestamp ?? new Date().toISOString()
+    }));
+  }
+
+  private async enqueueForPipeline(
+    pipelineId: string,
+    bucket: DigestBucket,
+    buildEntry: (pipeline: Pipeline, strategyName: string) => DigestEntry
+  ): Promise<void> {
     try {
-      const pipeline = await this.loadPipelineWithUser(payload.pipelineId);
-      if (!pipeline) return;
+      const pipeline = await this.loadPipelineWithUser(pipelineId);
+      if (!pipeline || !pipeline.user) return;
 
       const strategyName = pipeline.strategyConfig?.name ?? pipeline.name;
-
-      await this.notificationService.send(
-        pipeline.user.id,
-        NotificationEventType.PIPELINE_REJECTED,
-        `A strategy didn't pass the safety review`,
-        `We'll try a different approach on your next cycle — no action needed.`,
-        'medium',
-        {
-          userId: pipeline.user.id,
-          pipelineId: pipeline.id,
-          strategyName,
-          reason: payload.reason
-        }
-      );
+      const entry = buildEntry(pipeline, strategyName);
+      await this.digest.enqueue(bucket, entry);
     } catch (error) {
       const err = toErrorInfo(error);
-      this.logger.error(
-        `Failed to send PIPELINE_REJECTED notification for ${payload.pipelineId}: ${err.message}`,
-        err.stack
-      );
+      this.logger.error(`Failed to enqueue ${bucket} digest for pipeline ${pipelineId}: ${err.message}`, err.stack);
     }
   }
 

--- a/apps/api/src/notification/notification.module.ts
+++ b/apps/api/src/notification/notification.module.ts
@@ -15,6 +15,11 @@ import { NotificationController } from './notification.controller';
 import { NotificationListener } from './notification.listener';
 import { NotificationProcessor } from './notification.processor';
 import { NotificationService } from './notification.service';
+import { PipelineNotificationDigestProcessor } from './processors/pipeline-notification-digest.processor';
+import {
+  PIPELINE_DIGEST_QUEUE,
+  PipelineNotificationDigestService
+} from './services/pipeline-notification-digest.service';
 
 import { EmailModule } from '../email/email.module';
 import { Pipeline } from '../pipeline/entities/pipeline.entity';
@@ -24,7 +29,7 @@ import { User } from '../users/users.entity';
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, PushSubscription, Notification, Pipeline]),
-    BullModule.registerQueue({ name: 'notification' }),
+    BullModule.registerQueue({ name: 'notification' }, { name: PIPELINE_DIGEST_QUEUE }),
     EmailModule
   ],
   controllers: [NotificationController],
@@ -34,6 +39,8 @@ import { User } from '../users/users.entity';
     NotificationProcessor,
     NotificationListener,
     PipelineNotificationListener,
+    PipelineNotificationDigestService,
+    PipelineNotificationDigestProcessor,
     EmailNotificationService,
     PushNotificationService,
     SmsNotificationService

--- a/apps/api/src/notification/processors/pipeline-notification-digest.processor.spec.ts
+++ b/apps/api/src/notification/processors/pipeline-notification-digest.processor.spec.ts
@@ -1,0 +1,35 @@
+import { Test } from '@nestjs/testing';
+
+import { type Job } from 'bullmq';
+
+import { PipelineNotificationDigestProcessor } from './pipeline-notification-digest.processor';
+
+import { FailedJobService } from '../../failed-jobs/failed-job.service';
+import { type FlushJobData, PipelineNotificationDigestService } from '../services/pipeline-notification-digest.service';
+
+describe('PipelineNotificationDigestProcessor', () => {
+  let processor: PipelineNotificationDigestProcessor;
+  let digestService: { flush: jest.Mock };
+
+  beforeEach(async () => {
+    digestService = { flush: jest.fn().mockResolvedValue(undefined) };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        PipelineNotificationDigestProcessor,
+        { provide: PipelineNotificationDigestService, useValue: digestService },
+        { provide: FailedJobService, useValue: { recordFailure: jest.fn() } }
+      ]
+    }).compile();
+
+    processor = module.get(PipelineNotificationDigestProcessor);
+  });
+
+  it('delegates to digest.flush with userId + bucket', async () => {
+    const job = { id: 'job-1', data: { userId: 'user-9', bucket: 'started' } } as Job<FlushJobData>;
+    await processor.process(job);
+
+    expect(digestService.flush).toHaveBeenCalledTimes(1);
+    expect(digestService.flush).toHaveBeenCalledWith('user-9', 'started');
+  });
+});

--- a/apps/api/src/notification/processors/pipeline-notification-digest.processor.ts
+++ b/apps/api/src/notification/processors/pipeline-notification-digest.processor.ts
@@ -1,0 +1,31 @@
+import { Processor } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+
+import { Job } from 'bullmq';
+
+import { FailSafeWorkerHost } from '../../failed-jobs/fail-safe-worker-host';
+import { FailedJobService } from '../../failed-jobs/failed-job.service';
+import {
+  FlushJobData,
+  PIPELINE_DIGEST_QUEUE,
+  PipelineNotificationDigestService
+} from '../services/pipeline-notification-digest.service';
+
+@Processor(PIPELINE_DIGEST_QUEUE)
+@Injectable()
+export class PipelineNotificationDigestProcessor extends FailSafeWorkerHost {
+  private readonly logger = new Logger(PipelineNotificationDigestProcessor.name);
+
+  constructor(
+    private readonly digestService: PipelineNotificationDigestService,
+    failedJobService: FailedJobService
+  ) {
+    super(failedJobService);
+  }
+
+  async process(job: Job<FlushJobData>): Promise<void> {
+    const { userId, bucket } = job.data;
+    this.logger.debug(`Flushing digest bucket ${bucket} for user ${userId} (job ${job.id})`);
+    await this.digestService.flush(userId, bucket);
+  }
+}

--- a/apps/api/src/notification/services/pipeline-notification-digest.service.spec.ts
+++ b/apps/api/src/notification/services/pipeline-notification-digest.service.spec.ts
@@ -1,0 +1,537 @@
+import { getQueueToken } from '@nestjs/bullmq';
+import { Test } from '@nestjs/testing';
+
+import { DeploymentRecommendation, NotificationEventType, PipelineStage } from '@chansey/api-interfaces';
+
+import {
+  DIGEST_DEBOUNCE_MS,
+  type DigestEntry,
+  PIPELINE_DIGEST_JOB_NAME,
+  PIPELINE_DIGEST_QUEUE,
+  PipelineNotificationDigestService
+} from './pipeline-notification-digest.service';
+
+import { NOTIFICATION_REDIS } from '../notification-redis.provider';
+import { NotificationService } from '../notification.service';
+
+function makeEntry(overrides: Partial<DigestEntry> = {}): DigestEntry {
+  return {
+    pipelineId: 'pl-1',
+    userId: 'user-1',
+    strategyName: 'Alpha RSI',
+    subType: 'started',
+    at: '2026-04-20T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+interface MockQueue {
+  add: jest.Mock;
+  getJob: jest.Mock;
+}
+
+interface MockJob {
+  id: string;
+  changeDelay: jest.Mock;
+  remove: jest.Mock;
+  moveToFailed: jest.Mock;
+  opts?: { attempts?: number };
+}
+
+describe('PipelineNotificationDigestService', () => {
+  let service: PipelineNotificationDigestService;
+  let queue: MockQueue;
+  let redis: { multi: jest.Mock };
+  let multiChain: { rpush: jest.Mock; pexpire: jest.Mock; lrange: jest.Mock; del: jest.Mock; exec: jest.Mock };
+  let notificationService: { send: jest.Mock };
+
+  beforeEach(async () => {
+    multiChain = {
+      rpush: jest.fn().mockReturnThis(),
+      pexpire: jest.fn().mockReturnThis(),
+      lrange: jest.fn().mockReturnThis(),
+      del: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([[null, []]])
+    };
+
+    redis = { multi: jest.fn().mockReturnValue(multiChain) };
+    queue = {
+      add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+      getJob: jest.fn().mockResolvedValue(null)
+    };
+    notificationService = { send: jest.fn().mockResolvedValue(undefined) };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        PipelineNotificationDigestService,
+        { provide: getQueueToken(PIPELINE_DIGEST_QUEUE), useValue: queue },
+        { provide: NOTIFICATION_REDIS, useValue: redis },
+        { provide: NotificationService, useValue: notificationService }
+      ]
+    }).compile();
+
+    service = module.get(PipelineNotificationDigestService);
+  });
+
+  describe('enqueue', () => {
+    it('buffers entry and schedules a new debounce job when none exists', async () => {
+      const entry = makeEntry();
+      await service.enqueue('started', entry);
+
+      expect(multiChain.rpush).toHaveBeenCalledWith('notif:pl-digest:pending:user-1:started', JSON.stringify(entry));
+      expect(multiChain.pexpire).toHaveBeenCalledWith(
+        'notif:pl-digest:pending:user-1:started',
+        DIGEST_DEBOUNCE_MS.started + 60 * 60 * 1000
+      );
+      expect(queue.add).toHaveBeenCalledWith(
+        PIPELINE_DIGEST_JOB_NAME,
+        { userId: 'user-1', bucket: 'started' },
+        expect.objectContaining({
+          jobId: 'pl-digest:user-1:started',
+          delay: DIGEST_DEBOUNCE_MS.started,
+          attempts: 3
+        })
+      );
+    });
+
+    it('extends debounce via changeDelay when a pending job already exists', async () => {
+      const existing: MockJob = {
+        id: 'pl-digest:user-1:started',
+        changeDelay: jest.fn().mockResolvedValue(undefined),
+        remove: jest.fn(),
+        moveToFailed: jest.fn()
+      };
+      queue.getJob.mockResolvedValue(existing);
+
+      await service.enqueue('started', makeEntry());
+
+      expect(existing.changeDelay).toHaveBeenCalledWith(DIGEST_DEBOUNCE_MS.started);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it('force-removes and re-adds when changeDelay fails', async () => {
+      const existing: MockJob = {
+        id: 'pl-digest:user-1:started',
+        changeDelay: jest.fn().mockRejectedValue(new Error('job already active')),
+        remove: jest.fn().mockResolvedValue(undefined),
+        moveToFailed: jest.fn().mockResolvedValue(undefined),
+        opts: { attempts: 1 }
+      };
+      queue.getJob.mockResolvedValue(existing);
+
+      await service.enqueue('started', makeEntry());
+
+      expect(existing.changeDelay).toHaveBeenCalled();
+      expect(queue.add).toHaveBeenCalledWith(
+        PIPELINE_DIGEST_JOB_NAME,
+        { userId: 'user-1', bucket: 'started' },
+        expect.objectContaining({ jobId: 'pl-digest:user-1:started', delay: DIGEST_DEBOUNCE_MS.started })
+      );
+    });
+
+    it('uses bucket-specific debounce delay for stage bucket', async () => {
+      await service.enqueue('stage', makeEntry({ subType: 'stage' }));
+      expect(queue.add).toHaveBeenCalledWith(
+        PIPELINE_DIGEST_JOB_NAME,
+        expect.any(Object),
+        expect.objectContaining({ delay: DIGEST_DEBOUNCE_MS.stage })
+      );
+    });
+
+    it('uses bucket-specific debounce delay for terminal bucket', async () => {
+      await service.enqueue('terminal', makeEntry({ subType: 'completed' }));
+      expect(queue.add).toHaveBeenCalledWith(
+        PIPELINE_DIGEST_JOB_NAME,
+        expect.any(Object),
+        expect.objectContaining({ delay: DIGEST_DEBOUNCE_MS.terminal })
+      );
+    });
+  });
+
+  describe('flush', () => {
+    function stubDrain(entries: DigestEntry[]): void {
+      const raw = entries.map((e) => JSON.stringify(e));
+      multiChain.exec.mockResolvedValue([
+        [null, raw],
+        [null, 1]
+      ]);
+    }
+
+    it('no-ops when the pending list is empty', async () => {
+      multiChain.exec.mockResolvedValue([
+        [null, []],
+        [null, 0]
+      ]);
+
+      await service.flush('user-1', 'started');
+
+      expect(notificationService.send).not.toHaveBeenCalled();
+    });
+
+    it('emits single-pipeline started wording for one entry', async () => {
+      stubDrain([makeEntry({ subType: 'started', strategyName: 'Alpha RSI' })]);
+
+      await service.flush('user-1', 'started');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_STARTED,
+        'We started building a new strategy',
+        expect.stringContaining('being trained and tested'),
+        'info',
+        expect.objectContaining({ strategyName: 'Alpha RSI' })
+      );
+    });
+
+    it('emits pluralized started wording with listed names for many entries', async () => {
+      stubDrain([
+        makeEntry({ pipelineId: 'p1', strategyName: 'Alpha' }),
+        makeEntry({ pipelineId: 'p2', strategyName: 'Beta' }),
+        makeEntry({ pipelineId: 'p3', strategyName: 'Gamma' }),
+        makeEntry({ pipelineId: 'p4', strategyName: 'Delta' })
+      ]);
+
+      await service.flush('user-1', 'started');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_STARTED,
+        'We started building 4 new strategies',
+        expect.stringContaining('Alpha, Beta, Gamma…'),
+        'info',
+        expect.objectContaining({ count: 4 })
+      );
+    });
+
+    it('emits collapsed stage wording when all entries share the same transition', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'stage',
+          previousStage: PipelineStage.OPTIMIZE,
+          newStage: PipelineStage.HISTORICAL
+        }),
+        makeEntry({
+          pipelineId: 'p2',
+          subType: 'stage',
+          previousStage: PipelineStage.OPTIMIZE,
+          newStage: PipelineStage.HISTORICAL
+        })
+      ]);
+
+      await service.flush('user-1', 'stage');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_STAGE_COMPLETED,
+        '2 strategies: training complete',
+        'All moving on to: Testing against history.',
+        'info',
+        expect.any(Object)
+      );
+    });
+
+    it('groups heterogeneous stage transitions into prev→next clauses', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'stage',
+          previousStage: PipelineStage.OPTIMIZE,
+          newStage: PipelineStage.HISTORICAL
+        }),
+        makeEntry({
+          pipelineId: 'p2',
+          subType: 'stage',
+          previousStage: PipelineStage.OPTIMIZE,
+          newStage: PipelineStage.HISTORICAL
+        }),
+        makeEntry({
+          pipelineId: 'p3',
+          subType: 'stage',
+          previousStage: PipelineStage.HISTORICAL,
+          newStage: PipelineStage.LIVE_REPLAY
+        })
+      ]);
+
+      await service.flush('user-1', 'stage');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_STAGE_COMPLETED,
+        '3 strategies making progress',
+        expect.stringContaining('2 × training complete → Testing against history'),
+        'info',
+        expect.any(Object)
+      );
+      const [, , , body] = notificationService.send.mock.calls[0];
+      expect(body).toContain('1 × historical testing complete → Replaying recent market data');
+    });
+
+    it('terminal all-success emits PIPELINE_COMPLETED info', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY
+        }),
+        makeEntry({
+          pipelineId: 'p2',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_COMPLETED,
+        '2 new strategies are ready for live trading',
+        expect.stringContaining('passed every check'),
+        'info',
+        expect.objectContaining({ counts: expect.objectContaining({ success: 2 }) })
+      );
+    });
+
+    it('terminal all-rejected-or-failed emits PIPELINE_REJECTED medium', async () => {
+      stubDrain([
+        makeEntry({ pipelineId: 'p1', subType: 'rejected', reason: 'bad sharpe' }),
+        makeEntry({ pipelineId: 'p2', subType: 'failed', reason: 'exception' })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      const call = notificationService.send.mock.calls[0];
+      expect(call[1]).toBe(NotificationEventType.PIPELINE_REJECTED);
+      expect(call[2]).toBe('2 strategies finished with issues');
+      expect(call[3]).toContain(`1 didn't pass review`);
+      expect(call[3]).toContain(`1 couldn't finish building`);
+      expect(call[4]).toBe('medium');
+      expect(call[5]).toEqual(
+        expect.objectContaining({ counts: expect.objectContaining({ rejected: 1, failed: 1, success: 0 }) })
+      );
+    });
+
+    it('terminal mixed success + failure still emits PIPELINE_COMPLETED info', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY
+        }),
+        makeEntry({ pipelineId: 'p2', subType: 'rejected', reason: 'x' }),
+        makeEntry({ pipelineId: 'p3', subType: 'failed', reason: 'y' })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      const call = notificationService.send.mock.calls[0];
+      expect(call[1]).toBe(NotificationEventType.PIPELINE_COMPLETED);
+      expect(call[4]).toBe('info');
+      expect(call[3]).toContain('1 ready for live trading');
+      expect(call[3]).toContain(`1 didn't pass review`);
+      expect(call[3]).toContain(`1 couldn't finish building`);
+    });
+
+    it('terminal all-inconclusive emits PIPELINE_REJECTED low', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.INCONCLUSIVE_RETRY
+        }),
+        makeEntry({
+          pipelineId: 'p2',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.INCONCLUSIVE_RETRY
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_REJECTED,
+        '2 strategies: not enough trading opportunities',
+        expect.stringContaining('retry with fresh parameters'),
+        'low',
+        expect.objectContaining({
+          counts: expect.objectContaining({ inconclusive: 2, success: 0, rejected: 0, failed: 0 })
+        })
+      );
+    });
+
+    it('dedupes duplicate pipelineIds and keeps the latest entry', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DO_NOT_DEPLOY,
+          at: '2026-04-20T00:00:00.000Z'
+        }),
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY,
+          at: '2026-04-20T00:01:00.000Z'
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      // Latest for p1 is DEPLOY → single-pipeline success wording
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_COMPLETED,
+        'A new strategy is ready for live trading',
+        expect.any(String),
+        'info',
+        expect.any(Object)
+      );
+    });
+
+    it('dedupes by timestamp when entries arrive out of order', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY,
+          at: '2026-04-20T00:01:00.000Z'
+        }),
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DO_NOT_DEPLOY,
+          at: '2026-04-20T00:00:00.000Z'
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      // Later timestamp is DEPLOY despite arriving first → single-pipeline success wording
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_COMPLETED,
+        'A new strategy is ready for live trading',
+        expect.any(String),
+        'info',
+        expect.any(Object)
+      );
+    });
+
+    it('terminal all-NEEDS_REVIEW treats entries as success', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.NEEDS_REVIEW
+        }),
+        makeEntry({
+          pipelineId: 'p2',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.NEEDS_REVIEW
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_COMPLETED,
+        '2 new strategies are ready for live trading',
+        expect.stringContaining('passed every check'),
+        'info',
+        expect.objectContaining({
+          counts: expect.objectContaining({ success: 2, rejected: 0, failed: 0, inconclusive: 0 })
+        })
+      );
+    });
+
+    it('terminal mixed DEPLOY + NEEDS_REVIEW counts both as success', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY
+        }),
+        makeEntry({
+          pipelineId: 'p2',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.NEEDS_REVIEW
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_COMPLETED,
+        '2 new strategies are ready for live trading',
+        expect.stringContaining('passed every check'),
+        'info',
+        expect.objectContaining({
+          counts: expect.objectContaining({ success: 2, rejected: 0, failed: 0, inconclusive: 0 })
+        })
+      );
+    });
+
+    it('single-pipeline terminal NEEDS_REVIEW falls through to success wording', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.NEEDS_REVIEW,
+          strategyName: 'SoloBot'
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_COMPLETED,
+        'A new strategy is ready for live trading',
+        expect.stringContaining('being activated on your account'),
+        'info',
+        expect.objectContaining({ strategyName: 'SoloBot' })
+      );
+    });
+
+    it('single-pipeline terminal completed DEPLOY reuses per-recommendation wording', async () => {
+      stubDrain([
+        makeEntry({
+          pipelineId: 'p1',
+          subType: 'completed',
+          recommendation: DeploymentRecommendation.DEPLOY,
+          strategyName: 'SoloBot'
+        })
+      ]);
+
+      await service.flush('user-1', 'terminal');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_COMPLETED,
+        'A new strategy is ready for live trading',
+        expect.stringContaining('being activated on your account'),
+        'info',
+        expect.objectContaining({ strategyName: 'SoloBot' })
+      );
+    });
+
+    it('single-pipeline terminal failed keeps original wording', async () => {
+      stubDrain([makeEntry({ pipelineId: 'p1', subType: 'failed', reason: 'crash', strategyName: 'SoloBot' })]);
+
+      await service.flush('user-1', 'terminal');
+
+      expect(notificationService.send).toHaveBeenCalledWith(
+        'user-1',
+        NotificationEventType.PIPELINE_REJECTED,
+        `A strategy couldn't finish building`,
+        expect.stringContaining('try again on the next cycle'),
+        'medium',
+        expect.objectContaining({ reason: 'crash' })
+      );
+    });
+  });
+});

--- a/apps/api/src/notification/services/pipeline-notification-digest.service.ts
+++ b/apps/api/src/notification/services/pipeline-notification-digest.service.ts
@@ -1,0 +1,470 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { Queue } from 'bullmq';
+import Redis from 'ioredis';
+
+import {
+  DeploymentRecommendation,
+  NotificationEventType,
+  NotificationSeverity,
+  PipelineStage
+} from '@chansey/api-interfaces';
+
+import { toErrorInfo } from '../../shared/error.util';
+import { forceRemoveJob } from '../../shared/queue.util';
+import { NotificationPayload } from '../interfaces/notification-events.interface';
+import { NOTIFICATION_REDIS } from '../notification-redis.provider';
+import { NotificationService } from '../notification.service';
+
+export const PIPELINE_DIGEST_QUEUE = 'notification-digest';
+export const PIPELINE_DIGEST_JOB_NAME = 'flush-digest';
+
+export type DigestBucket = 'started' | 'stage' | 'terminal';
+
+export const DIGEST_DEBOUNCE_MS: Record<DigestBucket, number> = {
+  started: 5 * 60 * 1000,
+  stage: 15 * 60 * 1000,
+  terminal: 2 * 60 * 60 * 1000
+};
+
+const SAFETY_TTL_EXTENSION_MS = 60 * 60 * 1000; // 1 hour safety margin
+
+const STAGE_FRIENDLY_LABEL: Record<string, string> = {
+  [PipelineStage.OPTIMIZE]: 'Training your strategy',
+  [PipelineStage.HISTORICAL]: 'Testing against history',
+  [PipelineStage.LIVE_REPLAY]: 'Replaying recent market data',
+  [PipelineStage.PAPER_TRADE]: 'Practicing with pretend money',
+  [PipelineStage.COMPLETED]: 'Final safety review'
+};
+
+const STAGE_COMPLETED_LABEL: Record<string, string> = {
+  [PipelineStage.OPTIMIZE]: 'training complete',
+  [PipelineStage.HISTORICAL]: 'historical testing complete',
+  [PipelineStage.LIVE_REPLAY]: 'recent market replay complete',
+  [PipelineStage.PAPER_TRADE]: 'paper trading complete'
+};
+
+export type DigestEntrySubType = 'started' | 'stage' | 'completed' | 'rejected' | 'failed';
+
+export interface DigestEntry {
+  pipelineId: string;
+  userId: string;
+  strategyName: string;
+  subType: DigestEntrySubType;
+  previousStage?: PipelineStage;
+  newStage?: PipelineStage;
+  recommendation?: DeploymentRecommendation;
+  inconclusive?: boolean;
+  reason?: string;
+  at: string;
+}
+
+export interface FlushJobData {
+  userId: string;
+  bucket: DigestBucket;
+}
+
+interface AggregatedPayload {
+  eventType: NotificationEventType;
+  title: string;
+  body: string;
+  severity: NotificationSeverity;
+  payload: Record<string, unknown>;
+}
+
+@Injectable()
+export class PipelineNotificationDigestService {
+  private readonly logger = new Logger(PipelineNotificationDigestService.name);
+
+  constructor(
+    @InjectQueue(PIPELINE_DIGEST_QUEUE) private readonly digestQueue: Queue,
+    @Inject(NOTIFICATION_REDIS) private readonly redis: Redis,
+    private readonly notificationService: NotificationService
+  ) {}
+
+  /**
+   * Build the deterministic jobId used to debounce per (user, bucket).
+   * Exposed for tests only — production callers should never need it.
+   */
+  jobIdFor(userId: string, bucket: DigestBucket): string {
+    return `pl-digest:${userId}:${bucket}`;
+  }
+
+  /**
+   * Redis list key holding buffered digest entries.
+   */
+  pendingKey(userId: string, bucket: DigestBucket): string {
+    return `notif:pl-digest:pending:${userId}:${bucket}`;
+  }
+
+  /**
+   * Buffer an event into the per-(user, bucket) Redis list and arm / reset the
+   * BullMQ debounce job. Race-safe: any event arriving after a flush drains
+   * the list simply seeds a fresh list + new debounce cycle.
+   */
+  async enqueue(bucket: DigestBucket, entry: DigestEntry): Promise<void> {
+    const delayMs = DIGEST_DEBOUNCE_MS[bucket];
+    const pendingKey = this.pendingKey(entry.userId, bucket);
+    const jobId = this.jobIdFor(entry.userId, bucket);
+
+    try {
+      await this.redis
+        .multi()
+        .rpush(pendingKey, JSON.stringify(entry))
+        .pexpire(pendingKey, delayMs + SAFETY_TTL_EXTENSION_MS)
+        .exec();
+
+      const existing = await this.digestQueue.getJob(jobId);
+
+      if (!existing) {
+        await this.digestQueue.add(PIPELINE_DIGEST_JOB_NAME, { userId: entry.userId, bucket } satisfies FlushJobData, {
+          jobId,
+          delay: delayMs,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5000 },
+          removeOnComplete: 100,
+          removeOnFail: 500
+        });
+        return;
+      }
+
+      try {
+        await existing.changeDelay(delayMs);
+      } catch (changeDelayError) {
+        // Job is already active / completed — can't reschedule. Force-remove
+        // and re-add under the same jobId so the next flush sees this entry.
+        const err = toErrorInfo(changeDelayError);
+        this.logger.debug(`changeDelay failed for ${jobId} (${err.message}); re-arming`);
+        await forceRemoveJob(this.digestQueue, jobId, this.logger);
+        await this.digestQueue.add(PIPELINE_DIGEST_JOB_NAME, { userId: entry.userId, bucket } satisfies FlushJobData, {
+          jobId,
+          delay: delayMs,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5000 },
+          removeOnComplete: 100,
+          removeOnFail: 500
+        });
+      }
+    } catch (error) {
+      const err = toErrorInfo(error);
+      this.logger.error(
+        `Failed to enqueue digest entry for user ${entry.userId} bucket ${bucket}: ${err.message}`,
+        err.stack
+      );
+    }
+  }
+
+  /**
+   * Drain all buffered entries for (userId, bucket) and emit a single
+   * aggregated notification. Called from the BullMQ processor when the
+   * debounce window expires.
+   */
+  async flush(userId: string, bucket: DigestBucket): Promise<void> {
+    const pendingKey = this.pendingKey(userId, bucket);
+
+    const multiResult = await this.redis.multi().lrange(pendingKey, 0, -1).del(pendingKey).exec();
+
+    if (!multiResult) {
+      this.logger.warn(`Redis MULTI returned null draining ${pendingKey}`);
+      return;
+    }
+
+    const [lrangeResult] = multiResult;
+    const rawEntries = (lrangeResult?.[1] as string[] | undefined) ?? [];
+
+    if (rawEntries.length === 0) return;
+
+    const entries = this.parseAndDedupe(rawEntries);
+    if (entries.length === 0) return;
+
+    const aggregated = this.buildAggregate(bucket, entries);
+    if (!aggregated) return;
+
+    await this.notificationService.send(
+      userId,
+      aggregated.eventType,
+      aggregated.title,
+      aggregated.body,
+      aggregated.severity,
+      aggregated.payload as unknown as NotificationPayload
+    );
+  }
+
+  private parseAndDedupe(rawEntries: string[]): DigestEntry[] {
+    const byPipelineId = new Map<string, DigestEntry>();
+    for (const raw of rawEntries) {
+      try {
+        const parsed = JSON.parse(raw) as DigestEntry;
+        const existing = byPipelineId.get(parsed.pipelineId);
+        if (!existing || parsed.at >= existing.at) {
+          byPipelineId.set(parsed.pipelineId, parsed);
+        }
+      } catch (error) {
+        const err = toErrorInfo(error);
+        this.logger.warn(`Skipping malformed digest entry: ${err.message}`);
+      }
+    }
+    return Array.from(byPipelineId.values());
+  }
+
+  private buildAggregate(bucket: DigestBucket, entries: DigestEntry[]): AggregatedPayload | null {
+    switch (bucket) {
+      case 'started':
+        return this.buildStartedAggregate(entries);
+      case 'stage':
+        return this.buildStageAggregate(entries);
+      case 'terminal':
+        return this.buildTerminalAggregate(entries);
+      default:
+        return null;
+    }
+  }
+
+  private buildStartedAggregate(entries: DigestEntry[]): AggregatedPayload {
+    const basePayload = this.baseBatchPayload(entries);
+
+    if (entries.length === 1) {
+      return {
+        eventType: NotificationEventType.PIPELINE_STARTED,
+        title: 'We started building a new strategy',
+        body: `An automated strategy is being trained and tested — we'll let you know as it progresses.`,
+        severity: 'info',
+        payload: { ...basePayload, strategyName: entries[0].strategyName }
+      };
+    }
+
+    return {
+      eventType: NotificationEventType.PIPELINE_STARTED,
+      title: `We started building ${entries.length} new strategies`,
+      body: `${this.describeStrategyList(entries)} — we'll let you know as they progress.`,
+      severity: 'info',
+      payload: basePayload
+    };
+  }
+
+  private buildStageAggregate(entries: DigestEntry[]): AggregatedPayload {
+    const basePayload = this.baseBatchPayload(entries);
+
+    if (entries.length === 1) {
+      const single = entries[0];
+      const completedLabel = single.previousStage
+        ? (STAGE_COMPLETED_LABEL[single.previousStage] ?? 'stage complete')
+        : 'stage complete';
+      const nextLabel = single.newStage ? (STAGE_FRIENDLY_LABEL[single.newStage] ?? 'next stage') : 'next stage';
+
+      return {
+        eventType: NotificationEventType.PIPELINE_STAGE_COMPLETED,
+        title: `Strategy progress: ${completedLabel}`,
+        body: `Moving on to: ${nextLabel}.`,
+        severity: 'info',
+        payload: {
+          ...basePayload,
+          strategyName: single.strategyName,
+          completedStage: single.previousStage,
+          nextStage: single.newStage
+        }
+      };
+    }
+
+    const groups = new Map<string, { count: number; completedLabel: string; nextLabel: string }>();
+    for (const entry of entries) {
+      const completedLabel = entry.previousStage
+        ? (STAGE_COMPLETED_LABEL[entry.previousStage] ?? 'stage complete')
+        : 'stage complete';
+      const nextLabel = entry.newStage ? (STAGE_FRIENDLY_LABEL[entry.newStage] ?? 'next stage') : 'next stage';
+      const key = `${entry.previousStage ?? 'unknown'}→${entry.newStage ?? 'unknown'}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.count++;
+      } else {
+        groups.set(key, { count: 1, completedLabel, nextLabel });
+      }
+    }
+
+    if (groups.size === 1) {
+      const [only] = Array.from(groups.values());
+      return {
+        eventType: NotificationEventType.PIPELINE_STAGE_COMPLETED,
+        title: `${entries.length} strategies: ${only.completedLabel}`,
+        body: `All moving on to: ${only.nextLabel}.`,
+        severity: 'info',
+        payload: basePayload
+      };
+    }
+
+    const parts = Array.from(groups.values()).map(
+      (group) => `${group.count} × ${group.completedLabel} → ${group.nextLabel}`
+    );
+    return {
+      eventType: NotificationEventType.PIPELINE_STAGE_COMPLETED,
+      title: `${entries.length} strategies making progress`,
+      body: `${parts.join('; ')}.`,
+      severity: 'info',
+      payload: basePayload
+    };
+  }
+
+  private buildTerminalAggregate(entries: DigestEntry[]): AggregatedPayload {
+    const success = entries.filter(
+      (e) =>
+        e.recommendation === DeploymentRecommendation.DEPLOY ||
+        e.recommendation === DeploymentRecommendation.NEEDS_REVIEW
+    ).length;
+    const inconclusive = entries.filter(
+      (e) => e.recommendation === DeploymentRecommendation.INCONCLUSIVE_RETRY || e.inconclusive === true
+    ).length;
+    const rejected = entries.filter(
+      (e) =>
+        e.subType === 'rejected' ||
+        (e.subType === 'completed' && e.recommendation === DeploymentRecommendation.DO_NOT_DEPLOY)
+    ).length;
+    const failed = entries.filter((e) => e.subType === 'failed').length;
+    const rejectedOrFailed = rejected + failed;
+
+    const basePayload = {
+      ...this.baseBatchPayload(entries),
+      counts: { success, rejected, failed, inconclusive, total: entries.length }
+    };
+
+    // Single-pipeline: reuse existing per-recommendation wording verbatim.
+    if (entries.length === 1) {
+      return this.buildSingleTerminalAggregate(entries[0], basePayload);
+    }
+
+    if (success >= 1) {
+      const strategyWord = success === 1 ? 'strategy is' : 'strategies are';
+      const simpleBody = `They passed every check and are being activated on your account.`;
+      const body =
+        rejectedOrFailed === 0 && inconclusive === 0
+          ? simpleBody
+          : this.formatMixedTerminalBody(success, rejected, failed, inconclusive);
+
+      return {
+        eventType: NotificationEventType.PIPELINE_COMPLETED,
+        title:
+          success === entries.length
+            ? `${success} new ${strategyWord} ready for live trading`
+            : `${success} of ${entries.length} strategies ready for live trading`,
+        body,
+        severity: 'info',
+        payload: basePayload
+      };
+    }
+
+    // success === 0 below.
+    if (rejectedOrFailed === 0 && inconclusive > 0) {
+      return {
+        eventType: NotificationEventType.PIPELINE_REJECTED,
+        title: `${inconclusive} strategies: not enough trading opportunities`,
+        body: `We'll retry with fresh parameters — no action needed from you.`,
+        severity: 'low',
+        payload: basePayload
+      };
+    }
+
+    if (inconclusive === 0 && rejectedOrFailed > 0) {
+      let title: string;
+      if (failed === 0) {
+        title = `${rejected} strategies didn't pass review`;
+      } else if (rejected === 0) {
+        title = `${failed} strategies couldn't finish building`;
+      } else {
+        title = `${rejectedOrFailed} strategies finished with issues`;
+      }
+      return {
+        eventType: NotificationEventType.PIPELINE_REJECTED,
+        title,
+        body: this.formatMixedTerminalBody(0, rejected, failed, 0),
+        severity: 'medium',
+        payload: basePayload
+      };
+    }
+
+    // Mixed rejected/failed + inconclusive, no success.
+    return {
+      eventType: NotificationEventType.PIPELINE_REJECTED,
+      title: `Your strategies didn't complete successfully`,
+      body: this.formatMixedTerminalBody(success, rejected, failed, inconclusive),
+      severity: 'medium',
+      payload: basePayload
+    };
+  }
+
+  private buildSingleTerminalAggregate(entry: DigestEntry, basePayload: Record<string, unknown>): AggregatedPayload {
+    const strategyPayload = { ...basePayload, strategyName: entry.strategyName };
+
+    if (entry.subType === 'failed') {
+      return {
+        eventType: NotificationEventType.PIPELINE_REJECTED,
+        title: `A strategy couldn't finish building`,
+        body: `We'll try again on the next cycle — no action needed.`,
+        severity: 'medium',
+        payload: { ...strategyPayload, reason: entry.reason }
+      };
+    }
+
+    if (entry.subType === 'rejected') {
+      return {
+        eventType: NotificationEventType.PIPELINE_REJECTED,
+        title: `A strategy didn't pass the safety review`,
+        body: `We'll try a different approach on your next cycle — no action needed.`,
+        severity: 'medium',
+        payload: { ...strategyPayload, reason: entry.reason }
+      };
+    }
+
+    // subType === 'completed'
+    if (entry.recommendation === DeploymentRecommendation.DO_NOT_DEPLOY) {
+      return {
+        eventType: NotificationEventType.PIPELINE_REJECTED,
+        title: `A strategy didn't pass the safety review`,
+        body: `We'll try a different approach on your next cycle — no action needed.`,
+        severity: 'medium',
+        payload: { ...strategyPayload, reason: entry.reason ?? 'Failed final review' }
+      };
+    }
+
+    if (entry.recommendation === DeploymentRecommendation.INCONCLUSIVE_RETRY || entry.inconclusive === true) {
+      return {
+        eventType: NotificationEventType.PIPELINE_REJECTED,
+        title: `Not enough trading opportunities`,
+        body: `We'll retry with fresh parameters — no action needed from you.`,
+        severity: 'low',
+        payload: { ...strategyPayload, reason: entry.reason ?? 'Insufficient trading signals' }
+      };
+    }
+
+    return {
+      eventType: NotificationEventType.PIPELINE_COMPLETED,
+      title: `A new strategy is ready for live trading`,
+      body: `It passed every check and is being activated on your account.`,
+      severity: 'info',
+      payload: strategyPayload
+    };
+  }
+
+  private formatMixedTerminalBody(success: number, rejected: number, failed: number, inconclusive: number): string {
+    const clauses: string[] = [];
+    if (success > 0) clauses.push(`${success} ready for live trading`);
+    if (rejected > 0) clauses.push(`${rejected} didn't pass review`);
+    if (failed > 0) clauses.push(`${failed} couldn't finish building`);
+    if (inconclusive > 0) clauses.push(`${inconclusive} inconclusive (will retry)`);
+    return `${clauses.join(', ')}.`;
+  }
+
+  private baseBatchPayload(entries: DigestEntry[]): Record<string, unknown> {
+    return {
+      userId: entries[0].userId,
+      pipelineIds: entries.map((e) => e.pipelineId),
+      strategyNames: entries.map((e) => e.strategyName),
+      count: entries.length
+    };
+  }
+
+  private describeStrategyList(entries: DigestEntry[]): string {
+    const names = entries.map((e) => e.strategyName);
+    if (names.length <= 3) return names.join(', ');
+    return `${names.slice(0, 3).join(', ')}…`;
+  }
+}


### PR DESCRIPTION
## Summary

- Aggregate per-pipeline notifications into per-user digests with Redis-buffered, BullMQ-debounced batches (5min started / 15min stage / 2h terminal).
- Distinguish pipelines that completed-but-failed-review (rejected) from pipelines that crashed (failed), so terminal wording and severity match the actual outcome.
- Close correctness gaps from review: count `NEEDS_REVIEW` as success in multi-entry terminal rollups, guard singular grammar, dedupe buffered entries by `DigestEntry.at` timestamp.

## Changes

### Notification digest

- `PipelineNotificationDigestService` + `notification-digest` queue + processor: buffer `started` / `stage` / `terminal` events per (user, bucket) and flush a single aggregated `NotificationService.send()` when the debounce window expires.
- `PipelineNotificationListener` rewritten to enqueue digest entries (`DigestEntry`) instead of sending one notification per pipeline.
- Single-pipeline wording preserved verbatim; multi-pipeline batches use grouped `prev→next` clauses and mixed success/rejected/inconclusive bodies.
- Reuses existing `NotificationEventType` values (`PIPELINE_STARTED`, `PIPELINE_STAGE_COMPLETED`, `PIPELINE_COMPLETED`, `PIPELINE_REJECTED`) so user preferences still apply.
- `DigestEntry.at` drives dedupe tie-breaking — latest-wins is robust to out-of-order arrival.

### Rejected vs failed

- New `PipelineStatus.REJECTED` (migration `1776699591770-add-rejected-pipeline-status.ts`) for pipelines that finished all stages but failed the safety review. Infrastructure failures stay on `FAILED`.
- Pipeline progression + orchestrator + event-handler updated to emit the correct terminal event based on whether the outcome was a review rejection or a crash.
- Frontend `strategy-status-card` handles the new status.

## Test Plan

- [x] `npx nx test api --testPathPatterns='pipeline-notification-digest'` (all digest specs green, incl. new NEEDS_REVIEW single/all/mixed + out-of-order dedupe cases)
- [x] `npx nx test api --testPathPatterns='pipeline-notification.listener'` (15/15 green)
- [x] `nx test api` (252 suites / 4553 tests passing)
- [x] `nx lint api` clean
- [ ] After merge, verify a batch run with 3+ pipelines produces one combined digest notification per user per bucket (not one-per-pipeline).
- [ ] Verify a pipeline that fails final review emits `PIPELINE_REJECTED` wording, while a pipeline that crashes mid-stage emits the failure variant.