### PR TITLE
feat(api): dedup paper-trading candles and tune optimization reachability

### DIFF
--- a/apps/api/src/migrations/1776718516985-add-paper-trading-last-processed-candle.ts
+++ b/apps/api/src/migrations/1776718516985-add-paper-trading-last-processed-candle.ts
@@ -1,0 +1,13 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddPaperTradingLastProcessedCandle1776718516985 implements MigrationInterface {
+  name = 'AddPaperTradingLastProcessedCandle1776718516985';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "paper_trading_sessions" ADD COLUMN "lastProcessedCandleTs" jsonb`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "paper_trading_sessions" DROP COLUMN IF EXISTS "lastProcessedCandleTs"`);
+  }
+}

--- a/apps/api/src/optimization/optimization.module.ts
+++ b/apps/api/src/optimization/optimization.module.ts
@@ -13,6 +13,7 @@ import { OptimizationOrchestratorService } from './services/optimization-orchest
 import { OptimizationQueryService } from './services/optimization-query.service';
 import { OptimizationRecoveryService } from './services/optimization-recovery.service';
 
+import { AlgorithmModule } from '../algorithm/algorithm.module';
 import { Coin } from '../coin/coin.entity';
 import { OHLCModule } from '../ohlc/ohlc.module';
 import { OrderModule } from '../order/order.module';
@@ -26,7 +27,8 @@ import { StrategyConfig } from '../strategy/entities/strategy-config.entity';
     BullModule.registerQueue({ name: 'optimization' }),
     ScoringModule,
     forwardRef(() => OrderModule),
-    forwardRef(() => OHLCModule)
+    forwardRef(() => OHLCModule),
+    forwardRef(() => AlgorithmModule)
   ],
   providers: [
     GridSearchService,

--- a/apps/api/src/optimization/services/grid-search.service.spec.ts
+++ b/apps/api/src/optimization/services/grid-search.service.spec.ts
@@ -207,6 +207,35 @@ describe('GridSearchService', () => {
       expect(combinations[0].isBaseline).toBe(true);
       expect(combinations[0].values).toEqual({ fast: 5, slow: 5 });
     });
+
+    it('should drop combos rejected by reachabilityFilter (cartesian path)', () => {
+      const space = createSpace({
+        parameters: [createParam({ name: 'period', type: 'integer', min: 1, max: 4, step: 1, default: 1 })]
+      });
+
+      // Filter keeps only combos with period <= 2
+      const filter = (params: Record<string, unknown>) => (params.period as number) <= 2;
+      const combinations = service.generateCombinations(space, undefined, filter);
+
+      // Expected: period=1 (baseline) and period=2 — period=3 and period=4 pruned
+      const periods = combinations.map((c) => c.values.period).sort();
+      expect(periods).toEqual([1, 2]);
+      expect(combinations.some((c) => c.isBaseline && c.values.period === 1)).toBe(true);
+    });
+
+    it('should behave identically to today when reachabilityFilter is undefined', () => {
+      const space = createSpace({
+        parameters: [createParam({ name: 'period', type: 'integer', min: 1, max: 3, step: 1, default: 1 })]
+      });
+
+      const withoutFilter = service.generateCombinations(space);
+      const explicitUndefined = service.generateCombinations(space, undefined, undefined);
+
+      expect(withoutFilter.map((c) => c.values.period).sort()).toEqual(
+        explicitUndefined.map((c) => c.values.period).sort()
+      );
+      expect(withoutFilter.length).toBe(3);
+    });
   });
 
   describe('validateConstraints', () => {
@@ -365,6 +394,37 @@ describe('GridSearchService', () => {
 
       expect(combinations.length).toBe(1);
       expect(combinations[0].isBaseline).toBe(true);
+    });
+
+    it('should reject combos failing reachabilityFilter and keep retrying', () => {
+      const space = createSpace({
+        parameters: [createParam({ name: 'period', type: 'integer', min: 1, max: 10, step: 1, default: 3 })]
+      });
+
+      const filter = (params: Record<string, unknown>) => (params.period as number) <= 5;
+      const combinations = service.generateRandomCombinations(space, 5, filter);
+
+      // Every non-baseline combo must satisfy the filter
+      for (const combo of combinations.filter((c) => !c.isBaseline)) {
+        expect((combo.values.period as number) <= 5).toBe(true);
+      }
+      // With up to 5 passing values (1..5) + baseline (3), should still get up to numCombinations
+      expect(combinations.length).toBeGreaterThanOrEqual(1);
+      expect(combinations.length).toBeLessThanOrEqual(5);
+    });
+
+    it('should include baseline even if reachabilityFilter would reject it', () => {
+      const space = createSpace({
+        parameters: [createParam({ name: 'period', type: 'integer', min: 1, max: 10, step: 1, default: 10 })]
+      });
+
+      // Filter rejects everything (including baseline=10)
+      const filter = () => false;
+      const combinations = service.generateRandomCombinations(space, 5, filter);
+
+      expect(combinations.length).toBe(1);
+      expect(combinations[0].isBaseline).toBe(true);
+      expect(combinations[0].values.period).toBe(10);
     });
   });
 

--- a/apps/api/src/optimization/services/grid-search.service.ts
+++ b/apps/api/src/optimization/services/grid-search.service.ts
@@ -14,9 +14,16 @@ export class GridSearchService {
    * Generate all parameter combinations from a parameter space
    * @param space Parameter space definition
    * @param maxCombinations Optional limit on combinations (random sample if exceeded)
+   * @param reachabilityFilter Optional predicate to drop combos whose indicators can't warm up + fire
+   *   inside the available test window. Applied after constraints, before sampling, so the sampling
+   *   budget isn't wasted on unreachable combos. The baseline always bypasses this filter.
    * @returns Array of parameter combinations
    */
-  generateCombinations(space: ParameterSpace, maxCombinations?: number): ParameterCombination[] {
+  generateCombinations(
+    space: ParameterSpace,
+    maxCombinations?: number,
+    reachabilityFilter?: (params: Record<string, unknown>) => boolean
+  ): ParameterCombination[] {
     // Expand each parameter to its possible values
     const parameterValues: Map<string, (number | string | boolean)[]> = new Map();
 
@@ -36,11 +43,18 @@ export class GridSearchService {
       `Generated ${validCombinations.length} valid combinations from ${allCombinations.length} total (${space.parameters.length} parameters)`
     );
 
+    // Filter by reachability (e.g. indicator warmup fits within the test window)
+    const reachable = reachabilityFilter ? validCombinations.filter(reachabilityFilter) : validCombinations;
+
+    if (reachabilityFilter) {
+      this.logger.log(`Pruned ${validCombinations.length - reachable.length} unreachable combinations`);
+    }
+
     // Find baseline combination
     const baselineValues = this.getBaselineValues(space);
 
     // Build result with baseline marked
-    let combinations = validCombinations.map((values, index) => ({
+    let combinations = reachable.map((values, index) => ({
       index,
       values,
       isBaseline: this.isBaselineCombination(values, baselineValues)
@@ -261,8 +275,16 @@ export class GridSearchService {
 
   /**
    * Generate combinations for random search
+   * @param space Parameter space definition
+   * @param numCombinations Target number of combinations
+   * @param reachabilityFilter Optional predicate to reject combos whose indicators can't warm up + fire
+   *   inside the available test window. Baseline always bypasses this filter.
    */
-  generateRandomCombinations(space: ParameterSpace, numCombinations: number): ParameterCombination[] {
+  generateRandomCombinations(
+    space: ParameterSpace,
+    numCombinations: number,
+    reachabilityFilter?: (params: Record<string, unknown>) => boolean
+  ): ParameterCombination[] {
     const combinations: ParameterCombination[] = [];
     const seen = new Set<string>();
 
@@ -289,6 +311,10 @@ export class GridSearchService {
       }
 
       if (!this.validateConstraints(randomCombo, space.constraints || [])) {
+        continue;
+      }
+
+      if (reachabilityFilter && !reachabilityFilter(randomCombo)) {
         continue;
       }
 

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.spec.ts
@@ -9,6 +9,7 @@ import { type OptimizationEvaluationService } from './optimization-evaluation.se
 import { OptimizationOrchestratorService } from './optimization-orchestrator.service';
 import { type OptimizationQueryService } from './optimization-query.service';
 
+import { type AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
 import { type StrategyConfig } from '../../strategy/entities/strategy-config.entity';
 import { type OptimizationResult } from '../entities/optimization-result.entity';
 import { type OptimizationRun, OptimizationStatus } from '../entities/optimization-run.entity';
@@ -57,6 +58,7 @@ describe('OptimizationOrchestratorService', () => {
   let queryService: jest.Mocked<OptimizationQueryService>;
   let dataSource: jest.Mocked<DataSource>;
   let eventEmitter: jest.Mocked<EventEmitter2>;
+  let algorithmRegistry: jest.Mocked<AlgorithmRegistry>;
 
   beforeEach(() => {
     optimizationRunRepo = {
@@ -129,6 +131,10 @@ describe('OptimizationOrchestratorService', () => {
       emit: jest.fn()
     } as unknown as jest.Mocked<EventEmitter2>;
 
+    algorithmRegistry = {
+      getStrategyForAlgorithm: jest.fn().mockResolvedValue(undefined)
+    } as unknown as jest.Mocked<AlgorithmRegistry>;
+
     service = new OptimizationOrchestratorService(
       optimizationRunRepo,
       optimizationResultRepo,
@@ -137,7 +143,8 @@ describe('OptimizationOrchestratorService', () => {
       evaluationService,
       queryService,
       dataSource,
-      eventEmitter
+      eventEmitter,
+      algorithmRegistry
     );
   });
 
@@ -315,7 +322,48 @@ describe('OptimizationOrchestratorService', () => {
 
       await service.startOptimization('strategy-1', createValidSpace(), config);
 
-      expect(gridSearchService.generateRandomCombinations).toHaveBeenCalledWith(expect.any(Object), 50);
+      expect(gridSearchService.generateRandomCombinations).toHaveBeenCalledWith(expect.any(Object), 50, undefined);
+    });
+
+    it('should pass a reachabilityFilter when the strategy declares getMinDataPoints', async () => {
+      const config = createValidConfig({
+        walkForward: { trainDays: 90, testDays: 30, stepDays: 15, method: 'rolling', minWindowsRequired: 3 }
+      });
+      const strategyConfig = { id: 'strategy-1', algorithmId: 'algo-1' } as StrategyConfig;
+
+      // Strategy requires >= 1000 bars, testDays=30 → 30 * 24 = 720 bars → filter rejects it
+      algorithmRegistry.getStrategyForAlgorithm.mockResolvedValue({
+        getMinDataPoints: () => 1000
+      } as any);
+
+      queryService.findStrategyConfig.mockResolvedValue(strategyConfig);
+      gridSearchService.generateCombinations.mockReturnValue([{ index: 0, values: {}, isBaseline: true }]);
+      optimizationRunRepo.create.mockReturnValue({} as OptimizationRun);
+      optimizationRunRepo.save.mockResolvedValue({ id: 'run-1' } as OptimizationRun);
+
+      await service.startOptimization('strategy-1', createValidSpace(), config);
+
+      const call = gridSearchService.generateCombinations.mock.calls[0];
+      const filter = call[2];
+      expect(filter).toBeDefined();
+      // 1000 > 720 → filter rejects
+      expect(filter?.({})).toBe(false);
+    });
+
+    it('should pass undefined filter when strategy lacks getMinDataPoints', async () => {
+      const config = createValidConfig();
+      const strategyConfig = { id: 'strategy-1', algorithmId: 'algo-1' } as StrategyConfig;
+
+      algorithmRegistry.getStrategyForAlgorithm.mockResolvedValue({} as any);
+
+      queryService.findStrategyConfig.mockResolvedValue(strategyConfig);
+      gridSearchService.generateCombinations.mockReturnValue([{ index: 0, values: {}, isBaseline: true }]);
+      optimizationRunRepo.create.mockReturnValue({} as OptimizationRun);
+      optimizationRunRepo.save.mockResolvedValue({ id: 'run-1' } as OptimizationRun);
+
+      await service.startOptimization('strategy-1', createValidSpace(), config);
+
+      expect(gridSearchService.generateCombinations).toHaveBeenCalledWith(expect.any(Object), undefined, undefined);
     });
   });
 

--- a/apps/api/src/optimization/services/optimization-orchestrator.service.ts
+++ b/apps/api/src/optimization/services/optimization-orchestrator.service.ts
@@ -1,5 +1,5 @@
 import { InjectQueue } from '@nestjs/bullmq';
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { BadRequestException, forwardRef, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -10,6 +10,7 @@ import { GridSearchService } from './grid-search.service';
 import { OptimizationEvaluationService } from './optimization-evaluation.service';
 import { OptimizationQueryService } from './optimization-query.service';
 
+import { AlgorithmRegistry } from '../../algorithm/registry/algorithm-registry.service';
 import { PIPELINE_EVENTS } from '../../pipeline/interfaces';
 import { toErrorInfo } from '../../shared/error.util';
 import { sanitizeNumericValues } from '../../utils/validators/numeric-sanitizer';
@@ -17,6 +18,9 @@ import { OptimizationResult } from '../entities/optimization-result.entity';
 import { OptimizationProgressDetails, OptimizationRun, OptimizationStatus } from '../entities/optimization-run.entity';
 import { OptimizationConfig, ParameterSpace } from '../interfaces';
 import { calculateImprovement } from '../utils/optimization-scoring.util';
+
+/** Bars per day for the 1h candle timeframe used by all optimization runs today. */
+const BARS_PER_DAY_1H = 24;
 
 @Injectable()
 export class OptimizationOrchestratorService {
@@ -33,7 +37,9 @@ export class OptimizationOrchestratorService {
     private readonly evaluationService: OptimizationEvaluationService,
     private readonly queryService: OptimizationQueryService,
     private readonly dataSource: DataSource,
-    private readonly eventEmitter: EventEmitter2
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(forwardRef(() => AlgorithmRegistry))
+    private readonly algorithmRegistry: AlgorithmRegistry
   ) {}
 
   /**
@@ -104,10 +110,16 @@ export class OptimizationOrchestratorService {
       throw new NotFoundException(`Strategy config ${strategyConfigId} not found`);
     }
 
+    const reachabilityFilter = await this.buildReachabilityFilter(strategyConfig.algorithmId, config);
+
     const combinations =
       config.method === 'random_search'
-        ? this.gridSearchService.generateRandomCombinations(parameterSpace, config.maxIterations || 100)
-        : this.gridSearchService.generateCombinations(parameterSpace, config.maxCombinations);
+        ? this.gridSearchService.generateRandomCombinations(
+            parameterSpace,
+            config.maxIterations || 100,
+            reachabilityFilter
+          )
+        : this.gridSearchService.generateCombinations(parameterSpace, config.maxCombinations, reachabilityFilter);
 
     const baselineCombination = combinations.find((c) => c.isBaseline);
     const baselineParameters = baselineCombination?.values || this.getDefaultParameters(parameterSpace);
@@ -447,5 +459,26 @@ export class OptimizationOrchestratorService {
       defaults[param.name] = param.default;
     }
     return defaults;
+  }
+
+  /**
+   * Build a reachability filter for grid-search. Rejects parameter combinations whose required
+   * indicator warmup exceeds the available test-window bars, so the sampling budget isn't wasted
+   * on combos that can never produce signals. Returns undefined when the strategy doesn't declare
+   * a minimum-data-points requirement (filter is skipped in that case).
+   */
+  private async buildReachabilityFilter(
+    algorithmId: string,
+    config: OptimizationConfig
+  ): Promise<((params: Record<string, unknown>) => boolean) | undefined> {
+    const strategy = await this.algorithmRegistry.getStrategyForAlgorithm(algorithmId);
+    if (!strategy?.getMinDataPoints) {
+      return undefined;
+    }
+
+    const testBars = config.walkForward.testDays * BARS_PER_DAY_1H;
+    const getMinDataPoints = strategy.getMinDataPoints.bind(strategy);
+
+    return (params: Record<string, unknown>) => getMinDataPoints(params) <= testBars;
   }
 }

--- a/apps/api/src/optimization/utils/optimization-scoring.util.spec.ts
+++ b/apps/api/src/optimization/utils/optimization-scoring.util.spec.ts
@@ -89,7 +89,7 @@ describe('optimization-scoring.util', () => {
       const metrics = { ...baseMetrics, tradeCount: 0 };
       const score = calculateObjectiveScore(metrics, { metric: 'sharpe_ratio', minimize: false });
       expect(score).toBe(ZERO_TRADE_PENALTY);
-      expect(score).toBe(-3);
+      expect(score).toBe(-0.5);
     });
 
     it('should return 0 for non-finite scores (NaN, Infinity)', () => {

--- a/apps/api/src/optimization/utils/optimization-scoring.util.ts
+++ b/apps/api/src/optimization/utils/optimization-scoring.util.ts
@@ -3,7 +3,7 @@ import { type WindowMetrics } from '@chansey/api-interfaces';
 import { SharpeRatioCalculator } from '../../common/metrics/sharpe-ratio.calculator';
 import { type OptimizationConfig } from '../interfaces';
 
-export const ZERO_TRADE_PENALTY = -3;
+export const ZERO_TRADE_PENALTY = -0.5;
 
 /**
  * Normalization ranges for composite score calculation.

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.interface.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.interface.ts
@@ -28,7 +28,10 @@ export const DEFAULT_THROTTLE_CONFIG: Readonly<SignalThrottleConfig> = {
 
 export const PAPER_TRADING_DEFAULT_THROTTLE_CONFIG: Readonly<SignalThrottleConfig> = {
   ...DEFAULT_THROTTLE_CONFIG,
-  cooldownMs: 0 // No cooldown — paper trading ticks frequently (default 30s), not daily candles
+  // Matches the candle timeframe strategies evaluate against (1h). Per-bar dedup in the engine
+  // is the primary guard; this cooldown is a safety net that caps same-direction signals per
+  // coin at 1/hour if dedup misses a quirk in a new strategy.
+  cooldownMs: 60 * 60 * 1000
 };
 
 /** Key for per-coin per-direction cooldown tracking */

--- a/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.spec.ts
+++ b/apps/api/src/order/backtest/shared/throttle/signal-throttle.service.spec.ts
@@ -360,14 +360,14 @@ describe('SignalThrottleService', () => {
 
     it('uses paper trading defaults when passed as second argument', () => {
       const config = service.resolveConfig(undefined, PAPER_TRADING_DEFAULT_THROTTLE_CONFIG);
-      expect(config.cooldownMs).toBe(0);
+      expect(config.cooldownMs).toBe(60 * 60 * 1000);
       expect(config.maxTradesPerDay).toBe(6);
       expect(config.minSellPercent).toBe(0.5);
     });
 
-    it('PAPER_TRADING_DEFAULT_THROTTLE_CONFIG: explicit param overrides default cooldownMs=0', () => {
-      const config = service.resolveConfig({ cooldownMs: 3_600_000 }, PAPER_TRADING_DEFAULT_THROTTLE_CONFIG);
-      expect(config.cooldownMs).toBe(3_600_000);
+    it('PAPER_TRADING_DEFAULT_THROTTLE_CONFIG: explicit param overrides default cooldownMs', () => {
+      const config = service.resolveConfig({ cooldownMs: 0 }, PAPER_TRADING_DEFAULT_THROTTLE_CONFIG);
+      expect(config.cooldownMs).toBe(0);
     });
   });
 

--- a/apps/api/src/order/paper-trading/engine/paper-trading-historical-candle.service.spec.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-historical-candle.service.spec.ts
@@ -1,0 +1,350 @@
+import { Logger } from '@nestjs/common';
+
+import { PaperTradingHistoricalCandleService } from './paper-trading-historical-candle.service';
+
+import type { ExchangeManagerService } from '../../../exchange/exchange-manager.service';
+import * as retryUtil from '../../../shared/retry.util';
+
+const createService = (
+  overrides: Partial<{
+    cacheManager: any;
+    exchangeManager: any;
+    coinService: any;
+    ohlcService: any;
+    ohlcBackfillService: any;
+  }> = {}
+) => {
+  const cacheManager = overrides.cacheManager ?? {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn()
+  };
+
+  const exchangeManager = overrides.exchangeManager ?? {
+    formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
+    getExchangeClient: jest.fn(),
+    getPublicClient: jest.fn()
+  };
+
+  const coinService = overrides.coinService ?? {
+    getCoinBySymbol: jest.fn().mockResolvedValue({ id: 'coin-1' })
+  };
+
+  const ohlcService = overrides.ohlcService ?? {
+    getCandlesByDateRange: jest.fn().mockResolvedValue([])
+  };
+
+  const ohlcBackfillService = overrides.ohlcBackfillService ?? {
+    startBackfill: jest.fn().mockResolvedValue('job-1')
+  };
+
+  return {
+    service: new PaperTradingHistoricalCandleService(
+      cacheManager,
+      exchangeManager as ExchangeManagerService,
+      coinService as any,
+      ohlcService as any,
+      ohlcBackfillService as any
+    ),
+    cacheManager,
+    exchangeManager,
+    coinService,
+    ohlcService,
+    ohlcBackfillService
+  };
+};
+
+const makeDbCandle = (tsMs: number, close: number) => ({
+  coinId: 'coin-1',
+  timestamp: new Date(tsMs),
+  open: close - 1,
+  high: close + 2,
+  low: close - 2,
+  close,
+  volume: 100
+});
+
+const makeExchangeFetcher = (ohlcv: unknown[]) => ({
+  formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+  getPublicClient: jest.fn().mockResolvedValue({ fetchOHLCV: jest.fn().mockResolvedValue(ohlcv) }),
+  getExchangeClient: jest.fn().mockResolvedValue({ fetchOHLCV: jest.fn().mockResolvedValue(ohlcv) })
+});
+
+describe('PaperTradingHistoricalCandleService', () => {
+  let withExchangeRetryThrowSpy: jest.SpyInstance;
+  let loggerWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    withExchangeRetryThrowSpy = jest.spyOn(retryUtil, 'withExchangeRetryThrow');
+    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    withExchangeRetryThrowSpy.mockRestore();
+    loggerWarnSpy.mockRestore();
+  });
+
+  it('returns cached candles when cache hit (no DB or exchange call)', async () => {
+    const cachedCandles = [
+      { avg: 105, high: 110, low: 90, date: new Date(1000), open: 100, close: 105, volume: 500 },
+      { avg: 110, high: 115, low: 95, date: new Date(2000), open: 105, close: 110, volume: 600 }
+    ];
+
+    const { service, exchangeManager, ohlcService, coinService } = createService({
+      cacheManager: { get: jest.fn().mockResolvedValue(cachedCandles), set: jest.fn() }
+    });
+
+    const result = await service.getHistoricalCandles('binance', 'BTC/USD');
+
+    expect(result).toBe(cachedCandles);
+    expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+    expect(ohlcService.getCandlesByDateRange).not.toHaveBeenCalled();
+    expect(coinService.getCoinBySymbol).not.toHaveBeenCalled();
+  });
+
+  it('serves from DB when it has >= limit candles (no exchange call, no backfill)', async () => {
+    const dbCandles = Array.from({ length: 100 }, (_, i) => makeDbCandle(i * 1000, 100 + i));
+
+    const { service, cacheManager, exchangeManager, ohlcBackfillService, ohlcService, coinService } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue(dbCandles) }
+    });
+
+    const result = await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 100);
+
+    expect(result).toHaveLength(100);
+    expect(result[0]).toEqual(
+      expect.objectContaining({ avg: 100, high: 102, low: 98, open: 99, close: 100, volume: 100 })
+    );
+    expect(result[99]).toEqual(expect.objectContaining({ avg: 199, close: 199 }));
+    expect(coinService.getCoinBySymbol).toHaveBeenCalledWith('BTC', undefined, false);
+    expect(ohlcService.getCandlesByDateRange).toHaveBeenCalledTimes(1);
+    expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+    expect(ohlcBackfillService.startBackfill).not.toHaveBeenCalled();
+    expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:ohlcv:binance:BTC/USD:1h:100', result, 300000);
+  });
+
+  it('returns exactly the most-recent limit candles when DB has more than needed', async () => {
+    const dbCandles = Array.from({ length: 80 }, (_, i) => makeDbCandle(i * 1000, i));
+
+    const { service } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue(dbCandles) }
+    });
+
+    const result = await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 50);
+
+    expect(result).toHaveLength(50);
+    // Most recent 50 — original indexes 30..79 → close 30..79
+    expect(result[0].close).toBe(30);
+    expect(result[49].close).toBe(79);
+  });
+
+  it('falls back to exchange and triggers backfill when DB has < limit candles', async () => {
+    const dbCandles = [makeDbCandle(1000, 100), makeDbCandle(2000, 101)]; // only 2 — < limit=10
+    const exchangeOhlcv = Array.from({ length: 10 }, (_, i) => [i * 1000, 100 + i, 105 + i, 95 + i, 102 + i, 500]);
+
+    withExchangeRetryThrowSpy.mockResolvedValue(exchangeOhlcv);
+
+    const { service, cacheManager, ohlcBackfillService } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue(dbCandles) },
+      exchangeManager: makeExchangeFetcher(exchangeOhlcv)
+    });
+
+    const result = await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10);
+
+    expect(result).toHaveLength(10);
+    expect(ohlcBackfillService.startBackfill).toHaveBeenCalledWith('coin-1');
+    expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:backfill-triggered:coin-1', true, 6 * 60 * 60 * 1000);
+    expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:ohlcv:binance:BTC/USD:1h:10', result, 300000);
+  });
+
+  it('uses the authenticated exchange client (not public) when a user is provided', async () => {
+    const exchangeOhlcv = Array.from({ length: 10 }, (_, i) => [i * 1000, 100, 105, 95, 102, 500]);
+    withExchangeRetryThrowSpy.mockResolvedValue(exchangeOhlcv);
+
+    const { service, exchangeManager } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue([]) },
+      exchangeManager: makeExchangeFetcher(exchangeOhlcv)
+    });
+
+    await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10, { id: 'user-1' } as any);
+
+    expect(exchangeManager.getExchangeClient).toHaveBeenCalledWith(
+      'binance',
+      expect.objectContaining({ id: 'user-1' })
+    );
+    expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+  });
+
+  it('dedups backfill triggers within the dedup TTL', async () => {
+    const exchangeOhlcv = Array.from({ length: 10 }, (_, i) => [i * 1000, 100, 105, 95, 102, 500]);
+
+    // Dedup cache returns truthy on 2nd call
+    let dedupSet = false;
+    const cacheManager = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key.startsWith('paper-trading:backfill-triggered:')) {
+          return Promise.resolve(dedupSet);
+        }
+        return Promise.resolve(null);
+      }),
+      set: jest.fn().mockImplementation((key: string) => {
+        if (key.startsWith('paper-trading:backfill-triggered:')) {
+          dedupSet = true;
+        }
+        return Promise.resolve();
+      })
+    };
+
+    withExchangeRetryThrowSpy.mockResolvedValue(exchangeOhlcv);
+
+    const { service, ohlcBackfillService } = createService({
+      cacheManager,
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue([]) },
+      exchangeManager: makeExchangeFetcher(exchangeOhlcv)
+    });
+
+    await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10);
+    await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10);
+
+    expect(ohlcBackfillService.startBackfill).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits a threshold warning after 5 exchange fallbacks within the 1-hour window', async () => {
+    const exchangeOhlcv = Array.from({ length: 10 }, (_, i) => [i * 1000, 100, 105, 95, 102, 500]);
+    withExchangeRetryThrowSpy.mockResolvedValue(exchangeOhlcv);
+
+    const { service } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue([]) },
+      exchangeManager: makeExchangeFetcher(exchangeOhlcv)
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10);
+    }
+
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('hit exchange fallback 5 times in the last hour')
+    );
+  });
+
+  it('returns partial DB candles when exchange fetch fails and DB has < limit', async () => {
+    const dbCandles = [makeDbCandle(1000, 100), makeDbCandle(2000, 101)];
+
+    withExchangeRetryThrowSpy.mockRejectedValue(new Error('network error'));
+
+    const { service, cacheManager } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue(dbCandles) },
+      exchangeManager: {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchOHLCV: jest.fn() })
+      }
+    });
+
+    const result = await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(
+      expect.objectContaining({ avg: 100, high: 102, low: 98, open: 99, close: 100, volume: 100 })
+    );
+    // Short 60s cache TTL on partial result
+    expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:ohlcv:binance:BTC/USD:1h:10', result, 60 * 1000);
+  });
+
+  it('continues with empty DB candles when the DB query throws', async () => {
+    const exchangeOhlcv = Array.from({ length: 10 }, (_, i) => [i * 1000, 100, 105, 95, 102, 500]);
+    withExchangeRetryThrowSpy.mockResolvedValue(exchangeOhlcv);
+
+    const { service, ohlcBackfillService } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockRejectedValue(new Error('db down')) },
+      exchangeManager: makeExchangeFetcher(exchangeOhlcv)
+    });
+
+    const result = await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10);
+
+    expect(result).toHaveLength(10);
+    expect(ohlcBackfillService.startBackfill).toHaveBeenCalledWith('coin-1');
+    expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('DB candle query failed'));
+  });
+
+  it('returns partial DB candles when exchange times out (5s race)', async () => {
+    jest.useFakeTimers();
+
+    const dbCandles = [makeDbCandle(1000, 100)];
+
+    // Exchange fetch never resolves — Promise.race should lose to the 5s timeout
+    withExchangeRetryThrowSpy.mockReturnValue(new Promise(() => undefined));
+
+    const { service } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue(dbCandles) },
+      exchangeManager: {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchOHLCV: jest.fn() })
+      }
+    });
+
+    const promise = service.getHistoricalCandles('binance', 'BTC/USD', '1h', 10);
+
+    // Advance past the timeout
+    await jest.advanceTimersByTimeAsync(5001);
+
+    const result = await promise;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].close).toBe(100);
+
+    jest.useRealTimers();
+  });
+
+  it('cache key is scoped per exchange — binance_us and gdax do not share cached candles', async () => {
+    const dbCandles = Array.from({ length: 100 }, (_, i) => makeDbCandle(i * 1000, 100 + i));
+    const { service, cacheManager } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue(dbCandles) }
+    });
+
+    await service.getHistoricalCandles('binance_us', 'BTC/USDT', '1h', 100);
+    await service.getHistoricalCandles('gdax', 'BTC/USDT', '1h', 100);
+
+    const keys = cacheManager.set.mock.calls.map((c: any[]) => c[0]);
+    expect(keys).toContain('paper-trading:ohlcv:binance_us:BTC/USDT:1h:100');
+    expect(keys).toContain('paper-trading:ohlcv:gdax:BTC/USDT:1h:100');
+  });
+
+  it("coerces unsupported timeframe to '1h' for cache key and exchange fetch", async () => {
+    const exchangeOhlcv = Array.from({ length: 10 }, (_, i) => [i * 1000, 100, 105, 95, 102, 500]);
+    const fetchOHLCV = jest.fn().mockResolvedValue(exchangeOhlcv);
+
+    withExchangeRetryThrowSpy.mockImplementation(async (op: () => Promise<unknown>) => op());
+
+    const { service, cacheManager } = createService({
+      ohlcService: { getCandlesByDateRange: jest.fn().mockResolvedValue([]) },
+      exchangeManager: {
+        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
+        getPublicClient: jest.fn().mockResolvedValue({ fetchOHLCV }),
+        getExchangeClient: jest.fn()
+      }
+    });
+
+    await service.getHistoricalCandles('binance', 'BTC/USD', '15m', 10);
+
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("timeframe=15m for BTC/USD; only '1h' is supported. Coercing to '1h'.")
+    );
+    expect(fetchOHLCV).toHaveBeenCalledWith('BTC/USD', '1h', undefined, 10);
+    const keys = cacheManager.set.mock.calls.map((c: any[]) => c[0]);
+    expect(keys).toContain('paper-trading:ohlcv:binance:BTC/USD:1h:10');
+  });
+
+  it('returns [] when the symbol maps to no coin (no DB, no exchange, no backfill)', async () => {
+    const { service, cacheManager, exchangeManager, ohlcBackfillService, ohlcService } = createService({
+      coinService: { getCoinBySymbol: jest.fn().mockResolvedValue(null) }
+    });
+
+    const result = await service.getHistoricalCandles('binance', 'ZZZ/USD', '1h', 10);
+
+    expect(result).toEqual([]);
+    expect(ohlcService.getCandlesByDateRange).not.toHaveBeenCalled();
+    expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+    expect(ohlcBackfillService.startBackfill).not.toHaveBeenCalled();
+    expect(cacheManager.set).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/order/paper-trading/engine/paper-trading-historical-candle.service.ts
+++ b/apps/api/src/order/paper-trading/engine/paper-trading-historical-candle.service.ts
@@ -1,0 +1,213 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+
+import { Cache } from 'cache-manager';
+
+import { CoinService } from '../../../coin/coin.service';
+import { ExchangeManagerService } from '../../../exchange/exchange-manager.service';
+import { CandleData, OHLCCandle } from '../../../ohlc/ohlc-candle.entity';
+import { OHLCService } from '../../../ohlc/ohlc.service';
+import { OHLCBackfillService } from '../../../ohlc/services/ohlc-backfill.service';
+import { toErrorInfo } from '../../../shared/error.util';
+import { withExchangeRetryThrow } from '../../../shared/retry.util';
+import type { User } from '../../../users/users.entity';
+
+const CANDLE_CACHE_TTL_MS = 5 * 60 * 1000;
+const CANDLE_CACHE_TTL_PARTIAL_MS = 60 * 1000;
+const BACKFILL_DEDUP_TTL_MS = 6 * 60 * 60 * 1000;
+const EXCHANGE_FETCH_TIMEOUT_MS = 5000;
+const HOUR_MS = 60 * 60 * 1000;
+const FALLBACK_COUNTER_WINDOW_MS = 60 * 60 * 1000;
+const FALLBACK_COUNTER_THRESHOLD = 5;
+
+function mapOHLCCandleToCandleData(candle: OHLCCandle): CandleData {
+  return {
+    avg: candle.close,
+    high: candle.high,
+    low: candle.low,
+    date: candle.timestamp instanceof Date ? candle.timestamp : new Date(candle.timestamp),
+    open: candle.open,
+    close: candle.close,
+    volume: candle.volume
+  };
+}
+
+/**
+ * Serves historical OHLC candles to paper-trading algorithms with a tiered lookup:
+ *   1. 5-min cache.
+ *   2. Local `ohlc_candles` hypertable — the 99% fast path when coverage is good.
+ *   3. Exchange fallback with 5 s timeout for coverage gaps; triggers async backfill
+ *      so subsequent ticks can serve from the DB.
+ *
+ * Extracted from `PaperTradingMarketDataService` for file-size compliance and because
+ * its dependency set (`OHLCService`, `OHLCBackfillService`) is distinct from the price
+ * fetcher's. See also `paper-trading-market-data.service.ts` for live prices.
+ */
+@Injectable()
+export class PaperTradingHistoricalCandleService {
+  private readonly logger = new Logger(PaperTradingHistoricalCandleService.name);
+  private readonly fallbackCounters = new Map<string, { count: number; windowStart: number }>();
+
+  constructor(
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly exchangeManager: ExchangeManagerService,
+    private readonly coinService: CoinService,
+    @Inject(forwardRef(() => OHLCService))
+    private readonly ohlcService: OHLCService,
+    @Inject(forwardRef(() => OHLCBackfillService))
+    private readonly ohlcBackfillService: OHLCBackfillService
+  ) {}
+
+  async getHistoricalCandles(
+    exchangeSlug: string,
+    symbol: string,
+    timeframe = '1h',
+    limit = 100,
+    user?: User
+  ): Promise<CandleData[]> {
+    let effectiveTimeframe = timeframe;
+    if (timeframe !== '1h') {
+      this.logger.warn(
+        `getHistoricalCandles called with timeframe=${timeframe} for ${symbol}; only '1h' is supported. Coercing to '1h'.`
+      );
+      effectiveTimeframe = '1h';
+    }
+
+    const cacheKey = `paper-trading:ohlcv:${exchangeSlug}:${symbol}:${effectiveTimeframe}:${limit}`;
+
+    const cached = await this.cacheManager.get<CandleData[]>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const [base] = symbol.split('/');
+    const coin = await this.coinService.getCoinBySymbol(base, undefined, false).catch(() => null);
+    if (!coin) {
+      this.logger.warn(`Unknown coin for symbol ${symbol}; no historical candles available`);
+      return [];
+    }
+
+    const now = new Date();
+    const rangeStart = new Date(now.getTime() - (limit + 5) * HOUR_MS);
+
+    let dbCandles: OHLCCandle[] = [];
+    try {
+      dbCandles = await this.ohlcService.getCandlesByDateRange([coin.id], rangeStart, now);
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`DB candle query failed for ${symbol} (coinId=${coin.id}): ${err.message}`);
+    }
+
+    if (dbCandles.length >= limit) {
+      const sliced = dbCandles.slice(-limit).map(mapOHLCCandleToCandleData);
+      await this.cacheManager.set(cacheKey, sliced, CANDLE_CACHE_TTL_MS);
+      return sliced;
+    }
+
+    // DB gap — trigger async backfill (deduped), then try exchange with a tight timeout.
+    this.trackFallbackUsage(coin.id, symbol);
+    await this.triggerBackfillIfNeeded(coin.id);
+
+    const partialDbCandles = dbCandles.map(mapOHLCCandleToCandleData);
+    const exchangeCandles = await this.fetchExchangeCandlesWithTimeout(
+      exchangeSlug,
+      symbol,
+      effectiveTimeframe,
+      limit,
+      user
+    );
+
+    if (exchangeCandles && exchangeCandles.length > 0) {
+      const sliced = exchangeCandles.slice(-limit);
+      await this.cacheManager.set(cacheKey, sliced, CANDLE_CACHE_TTL_MS);
+      return sliced;
+    }
+
+    // Double failure — return partial DB candles (may be []) with a shorter cache TTL.
+    this.logger.warn(
+      `Historical candles unavailable for ${symbol}: DB has ${partialDbCandles.length}/${limit} candles and exchange fetch from ${exchangeSlug} failed or returned empty.`
+    );
+    await this.cacheManager.set(cacheKey, partialDbCandles, CANDLE_CACHE_TTL_PARTIAL_MS);
+    return partialDbCandles;
+  }
+
+  private async triggerBackfillIfNeeded(coinId: string): Promise<void> {
+    const dedupKey = `paper-trading:backfill-triggered:${coinId}`;
+    try {
+      const already = await this.cacheManager.get<boolean>(dedupKey);
+      if (already) {
+        return;
+      }
+      await this.cacheManager.set(dedupKey, true, BACKFILL_DEDUP_TTL_MS);
+      // Fire-and-forget — errors are logged inside startBackfill.
+      this.ohlcBackfillService.startBackfill(coinId).catch((error: unknown) => {
+        const err = toErrorInfo(error);
+        this.logger.debug(`Backfill trigger for coin ${coinId} failed: ${err.message}`);
+      });
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.debug(`Backfill dedup check failed for coin ${coinId}: ${err.message}`);
+    }
+  }
+
+  private trackFallbackUsage(coinId: string, symbol: string): void {
+    const now = Date.now();
+    const entry = this.fallbackCounters.get(coinId);
+    if (!entry || now - entry.windowStart > FALLBACK_COUNTER_WINDOW_MS) {
+      this.fallbackCounters.set(coinId, { count: 1, windowStart: now });
+      return;
+    }
+    entry.count += 1;
+    if (entry.count === FALLBACK_COUNTER_THRESHOLD) {
+      this.logger.warn(
+        `Symbol ${symbol} (coinId=${coinId}) has hit exchange fallback ${entry.count} times in the last hour — likely OHLC sync coverage gap.`
+      );
+    }
+  }
+
+  private async fetchExchangeCandlesWithTimeout(
+    exchangeSlug: string,
+    symbol: string,
+    timeframe: string,
+    limit: number,
+    user?: User
+  ): Promise<CandleData[] | null> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
+      const client = user
+        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
+        : await this.exchangeManager.getPublicClient(exchangeSlug);
+
+      const fetchPromise = withExchangeRetryThrow(
+        () => client.fetchOHLCV(formattedSymbol, timeframe, undefined, limit),
+        { logger: this.logger, operationName: `fetchOHLCV(${exchangeSlug}:${symbol})` }
+      );
+
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Exchange fetchOHLCV timed out after ${EXCHANGE_FETCH_TIMEOUT_MS}ms`)),
+          EXCHANGE_FETCH_TIMEOUT_MS
+        );
+      });
+
+      const ohlcv = await Promise.race([fetchPromise, timeoutPromise]);
+
+      return ohlcv.map((candle) => ({
+        avg: candle[4] as number,
+        high: candle[2] as number,
+        low: candle[3] as number,
+        date: new Date(candle[0] as number),
+        open: candle[1] as number,
+        close: candle[4] as number,
+        volume: candle[5] as number
+      }));
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Failed to fetch OHLCV for ${symbol} from ${exchangeSlug}: ${err.message}`);
+      return null;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/apps/api/src/order/paper-trading/entities/paper-trading-session.entity.ts
+++ b/apps/api/src/order/paper-trading/entities/paper-trading-session.entity.ts
@@ -212,6 +212,14 @@ export class PaperTradingSession {
   @ApiProperty({ description: 'Number of ticks processed', default: 0 })
   tickCount: number;
 
+  @IsOptional()
+  @Column({ type: 'jsonb', nullable: true })
+  @ApiProperty({
+    description: 'Per-symbol epoch ms of the latest candle evaluated by the strategy (dedup guard)',
+    required: false
+  })
+  lastProcessedCandleTs?: Record<string, number> | null;
+
   @IsNumber()
   @Column({ type: 'integer', default: 0 })
   @ApiProperty({ description: 'Count of consecutive errors (for auto-pause)', default: 0 })

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.spec.ts
@@ -114,7 +114,6 @@ const createService = (overrides: Overrides = {}) => {
 
   const marketDataService = {
     getPrices: jest.fn().mockResolvedValue(new Map(Object.entries(prices).map(([sym, p]) => [sym, { price: p }]))),
-    getHistoricalCandles: jest.fn().mockResolvedValue([]),
     resolveSymbolUniverse:
       overrides.resolveSymbolUniverse ??
       jest
@@ -124,6 +123,10 @@ const createService = (overrides: Overrides = {}) => {
         ),
     clearSymbolCache: jest.fn(),
     sweepOrphaned: jest.fn().mockReturnValue(0)
+  };
+
+  const historicalCandleService = {
+    getHistoricalCandles: jest.fn().mockResolvedValue([])
   };
 
   const algorithmRegistry = {
@@ -151,6 +154,7 @@ const createService = (overrides: Overrides = {}) => {
 
   const service = new PaperTradingEngineService(
     marketDataService as any,
+    historicalCandleService as any,
     algorithmRegistry as any,
     signalThrottle as any,
     compositeRegimeService as any,
@@ -174,6 +178,7 @@ const createService = (overrides: Overrides = {}) => {
     exitExecutor,
     opportunitySelling,
     marketDataService,
+    historicalCandleService,
     algorithmRegistry,
     signalFilterChain,
     compositeRegimeService
@@ -262,11 +267,11 @@ describe('PaperTradingEngineService', () => {
       // Exchange returns prices only for BTC/USD; UNKNOWN/USD is absent from the price response
       const resolveSymbolUniverse = jest.fn().mockResolvedValue(['BTC/USD', 'UNKNOWN/USD']);
       const prices = { 'BTC/USD': 50000 }; // UNKNOWN/USD intentionally absent
-      const { service, marketDataService } = createService({ accounts: [], prices, resolveSymbolUniverse });
+      const { service, historicalCandleService } = createService({ accounts: [], prices, resolveSymbolUniverse });
 
       await service.processTick(makeSession(), exchangeKey);
 
-      const candleCalls = marketDataService.getHistoricalCandles.mock.calls.map((c: any[]) => c[1]);
+      const candleCalls = historicalCandleService.getHistoricalCandles.mock.calls.map((c: any[]) => c[1]);
       expect(candleCalls).toContain('BTC/USD');
       expect(candleCalls).not.toContain('UNKNOWN/USD');
     });
@@ -506,7 +511,7 @@ describe('PaperTradingEngineService', () => {
     const signalThrottle = {
       createState: jest.fn().mockReturnValue({ lastSignalTime: {}, tradeTimestamps: [] }),
       filterSignals: jest.fn().mockImplementation((signals: any[]) => ({ accepted: signals, rejected: [] })),
-      resolveConfig: jest.fn().mockReturnValue({ cooldownMs: 0, maxTradesPerDay: 6, minSellPercent: 0.5 }),
+      resolveConfig: jest.fn().mockReturnValue({ cooldownMs: 60 * 60 * 1000, maxTradesPerDay: 6, minSellPercent: 0.5 }),
       toThrottleSignal: jest.fn().mockImplementation((s: any) => s)
     };
     const { service, marketDataService, algorithmRegistry } = createService({ signalThrottle });
@@ -526,6 +531,132 @@ describe('PaperTradingEngineService', () => {
       session.algorithmConfig,
       PAPER_TRADING_DEFAULT_THROTTLE_CONFIG
     );
+  });
+
+  describe('per-bar strategy dedup', () => {
+    const makeCandle = (ts: number, price = 50000) => ({
+      avg: price,
+      high: price,
+      low: price,
+      date: new Date(ts),
+      open: price,
+      close: price,
+      volume: 1
+    });
+
+    it('runs the strategy when the candle bar is newer than lastProcessedCandleTs', async () => {
+      const { service, algorithmRegistry, historicalCandleService, exitExecutor } = createService();
+      const newerTs = Date.now();
+      historicalCandleService.getHistoricalCandles.mockResolvedValue([
+        makeCandle(newerTs - 3_600_000),
+        makeCandle(newerTs)
+      ]);
+      algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
+
+      const session = makeSession({ lastProcessedCandleTs: { 'BTC/USD': newerTs - 3_600_000 } });
+      await service.processTick(session, exchangeKey);
+
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(1);
+      expect(exitExecutor.checkAndExecute).toHaveBeenCalledTimes(1);
+      expect(session.lastProcessedCandleTs).toEqual({ 'BTC/USD': newerTs });
+    });
+
+    it('skips strategy execution (but runs exits) when the candle bar has not advanced', async () => {
+      const { service, algorithmRegistry, historicalCandleService, exitExecutor, throttleService } = createService();
+      const ts = Date.now();
+      historicalCandleService.getHistoricalCandles.mockResolvedValue([makeCandle(ts - 3_600_000), makeCandle(ts)]);
+
+      const session = makeSession({ lastProcessedCandleTs: { 'BTC/USD': ts } });
+      const result = await service.processTick(session, exchangeKey);
+
+      expect(exitExecutor.checkAndExecute).toHaveBeenCalledTimes(1);
+      expect(algorithmRegistry.executeAlgorithm).not.toHaveBeenCalled();
+      expect(throttleService.filter).not.toHaveBeenCalled();
+      expect(result.processed).toBe(true);
+      expect(result.signalsReceived).toBe(0);
+      expect(session.lastProcessedCandleTs).toEqual({ 'BTC/USD': ts });
+    });
+
+    it('runs the strategy again when a new bar arrives after an earlier skip', async () => {
+      const { service, algorithmRegistry, historicalCandleService } = createService();
+      const firstTs = Date.now();
+      historicalCandleService.getHistoricalCandles.mockResolvedValueOnce([makeCandle(firstTs)]);
+      algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
+
+      const session = makeSession({ lastProcessedCandleTs: null });
+      await service.processTick(session, exchangeKey);
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(1);
+      expect(session.lastProcessedCandleTs).toEqual({ 'BTC/USD': firstTs });
+
+      // Same bar — should skip
+      historicalCandleService.getHistoricalCandles.mockResolvedValueOnce([makeCandle(firstTs)]);
+      await service.processTick(session, exchangeKey);
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(1);
+
+      // Next bar — should run again
+      const nextTs = firstTs + 3_600_000;
+      historicalCandleService.getHistoricalCandles.mockResolvedValueOnce([makeCandle(nextTs)]);
+      await service.processTick(session, exchangeKey);
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(2);
+      expect(session.lastProcessedCandleTs).toEqual({ 'BTC/USD': nextTs });
+    });
+
+    it('runs the strategy on the first tick even when no lastProcessedCandleTs is set', async () => {
+      const { service, algorithmRegistry, historicalCandleService } = createService();
+      const ts = Date.now();
+      historicalCandleService.getHistoricalCandles.mockResolvedValue([makeCandle(ts)]);
+      algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
+
+      const session = makeSession(); // lastProcessedCandleTs undefined
+      await service.processTick(session, exchangeKey);
+
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(1);
+      expect(session.lastProcessedCandleTs).toEqual({ 'BTC/USD': ts });
+    });
+
+    it('runs the strategy when no historical candles are available (null timestamp)', async () => {
+      // When all candle fetches return empty arrays, we still evaluate — this is the pre-existing fallback
+      const { service, algorithmRegistry, historicalCandleService } = createService();
+      historicalCandleService.getHistoricalCandles.mockResolvedValue([]);
+      algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
+
+      const session = makeSession({ lastProcessedCandleTs: { 'BTC/USD': Date.now() } });
+      await service.processTick(session, exchangeKey);
+
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-runs the strategy when a lagging symbol catches up to a bar already reached by another', async () => {
+      const { service, algorithmRegistry, historicalCandleService } = createService({
+        accounts: [],
+        prices: { 'BTC/USD': 50000, 'ETH/USD': 3000 },
+        resolveSymbolUniverse: jest.fn().mockResolvedValue(['BTC/USD', 'ETH/USD'])
+      });
+      algorithmRegistry.executeAlgorithm.mockResolvedValue({ success: true, signals: [] });
+
+      const ts = Date.now();
+      // Tick 1: BTC advances to ts, ETH still lagging at ts - 1h.
+      historicalCandleService.getHistoricalCandles
+        .mockImplementationOnce((_: string, symbol: string) =>
+          Promise.resolve(symbol === 'BTC/USD' ? [makeCandle(ts)] : [makeCandle(ts - 3_600_000)])
+        )
+        .mockImplementationOnce((_: string, symbol: string) =>
+          Promise.resolve(symbol === 'BTC/USD' ? [makeCandle(ts)] : [makeCandle(ts - 3_600_000)])
+        );
+
+      const session = makeSession();
+      await service.processTick(session, exchangeKey);
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(1);
+      expect(session.lastProcessedCandleTs).toEqual({ 'BTC/USD': ts, 'ETH/USD': ts - 3_600_000 });
+
+      // Tick 2: ETH catches up to ts (same bar BTC already had). Must re-run — this is where max broke.
+      historicalCandleService.getHistoricalCandles
+        .mockImplementationOnce(() => Promise.resolve([makeCandle(ts)]))
+        .mockImplementationOnce(() => Promise.resolve([makeCandle(ts)]));
+      await service.processTick(session, exchangeKey);
+      expect(algorithmRegistry.executeAlgorithm).toHaveBeenCalledTimes(2);
+      expect(session.lastProcessedCandleTs).toEqual({ 'BTC/USD': ts, 'ETH/USD': ts });
+    });
   });
 
   it('does not produce duplicate signals when multiple symbols share a base currency', async () => {

--- a/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-engine.service.ts
@@ -14,6 +14,7 @@ import {
   TradingSignal
 } from './engine/paper-trading-engine.utils';
 import { PaperTradingExitExecutorService } from './engine/paper-trading-exit-executor.service';
+import { PaperTradingHistoricalCandleService } from './engine/paper-trading-historical-candle.service';
 import { PaperTradingOpportunitySellingService } from './engine/paper-trading-opportunity-selling.service';
 import { PaperTradingOrderExecutorService } from './engine/paper-trading-order-executor.service';
 import { PaperTradingPortfolioService } from './engine/paper-trading-portfolio.service';
@@ -45,6 +46,7 @@ export class PaperTradingEngineService {
 
   constructor(
     private readonly marketDataService: PaperTradingMarketDataService,
+    private readonly historicalCandleService: PaperTradingHistoricalCandleService,
     private readonly algorithmRegistry: AlgorithmRegistry,
     private readonly signalThrottle: SignalThrottleService,
     private readonly compositeRegimeService: CompositeRegimeService,
@@ -97,35 +99,46 @@ export class PaperTradingEngineService {
         ));
       }
 
-      const signals = await this.runAlgorithm(
-        session,
-        algoPortfolio,
-        priceMap,
-        activeAccounts,
-        quoteCurrency,
-        historicalCandles
-      );
-      signalsReceived = signals.length;
+      const currentTimestamps = this.getPerSymbolLatestTimestamps(historicalCandles);
+      const noCandles = Object.keys(currentTimestamps).length === 0;
+      const shouldRunStrategy =
+        noCandles || this.hasAnySymbolAdvanced(currentTimestamps, session.lastProcessedCandleTs);
 
-      const filtered = await this.filterSignals(session, signals);
+      if (shouldRunStrategy) {
+        const signals = await this.runAlgorithm(
+          session,
+          algoPortfolio,
+          priceMap,
+          activeAccounts,
+          quoteCurrency,
+          historicalCandles
+        );
+        signalsReceived = signals.length;
 
-      const heldCoins = new Set(
-        activeAccounts.filter((a) => a.currency !== quoteCurrency && a.total > 1e-8).map((a) => a.currency)
-      );
+        const filtered = await this.filterSignals(session, signals);
 
-      const loopResult = await this.processSignalLoop(
-        session,
-        filtered,
-        algoPortfolio,
-        heldCoins,
-        priceMap,
-        historicalCandles,
-        quoteCurrency,
-        exchangeSlug,
-        now
-      );
-      ordersExecuted += loopResult.ordersExecuted;
-      errors.push(...loopResult.errors);
+        const heldCoins = new Set(
+          activeAccounts.filter((a) => a.currency !== quoteCurrency && a.total > 1e-8).map((a) => a.currency)
+        );
+
+        const loopResult = await this.processSignalLoop(
+          session,
+          filtered,
+          algoPortfolio,
+          heldCoins,
+          priceMap,
+          historicalCandles,
+          quoteCurrency,
+          exchangeSlug,
+          now
+        );
+        ordersExecuted += loopResult.ordersExecuted;
+        errors.push(...loopResult.errors);
+
+        if (!noCandles) {
+          session.lastProcessedCandleTs = currentTimestamps;
+        }
+      }
 
       const finalPortfolioValue = await this.finalizeSnapshot(session, priceMap, quoteCurrency, ordersExecuted, now);
 
@@ -150,6 +163,35 @@ export class PaperTradingEngineService {
         prices: {}
       };
     }
+  }
+
+  /**
+   * Per-symbol dedup: re-run the strategy when any symbol's latest bar has advanced
+   * past its last-processed entry, or when a symbol is seen for the first time.
+   * A global max across symbols was wrong — a fast-arriving symbol would advance the
+   * scalar and cause lagging symbols' new bars to be silently skipped.
+   */
+  private getPerSymbolLatestTimestamps(historicalCandles: Record<string, CandleData[]>): Record<string, number> {
+    const result: Record<string, number> = {};
+    for (const [symbol, candles] of Object.entries(historicalCandles)) {
+      if (candles.length === 0) continue;
+      const last = candles[candles.length - 1];
+      const ts = last.date instanceof Date ? last.date.getTime() : new Date(last.date).getTime();
+      if (Number.isFinite(ts)) result[symbol] = ts;
+    }
+    return result;
+  }
+
+  private hasAnySymbolAdvanced(
+    current: Record<string, number>,
+    previous: Record<string, number> | null | undefined
+  ): boolean {
+    if (!previous) return true;
+    for (const [symbol, ts] of Object.entries(current)) {
+      const prev = previous[symbol];
+      if (prev === undefined || ts > prev) return true;
+    }
+    return false;
   }
 
   /** Fetch accounts, prices, and historical candles for the tick. */
@@ -180,7 +222,7 @@ export class PaperTradingEngineService {
     const historicalCandles: Record<string, CandleData[]> = {};
     const candleResults = await Promise.all(
       validSymbols.map(async (symbol) => {
-        const candles = await this.marketDataService.getHistoricalCandles(
+        const candles = await this.historicalCandleService.getHistoricalCandles(
           exchangeSlug,
           symbol,
           '1h',
@@ -446,7 +488,10 @@ export class PaperTradingEngineService {
       return [];
     } catch (error: unknown) {
       const err = toErrorInfo(error);
-      this.logger.warn(`Algorithm execution failed: ${err.message}`);
+      this.logger.error(
+        `Algorithm execution failed (sessionId=${session.id}, algorithmId=${session.algorithm?.id ?? 'unknown'}): ${err.message}`,
+        err.stack
+      );
       return [];
     }
   }

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -53,18 +53,19 @@ const createService = (
 
 describe('PaperTradingMarketDataService', () => {
   let withExchangeRetrySpy: jest.SpyInstance;
-  let withExchangeRetryThrowSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Spy on rate-limit-aware retry wrappers to avoid real delays in tests
+    // Spy on rate-limit-aware retry wrapper to avoid real delays in tests
     withExchangeRetrySpy = jest.spyOn(retryUtil, 'withExchangeRetry');
-    withExchangeRetryThrowSpy = jest.spyOn(retryUtil, 'withExchangeRetryThrow');
+    // Silence domain warn/debug/error logs — individual tests can still spy to assert on messages
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
-    withExchangeRetrySpy.mockRestore();
-    withExchangeRetryThrowSpy.mockRestore();
+    jest.restoreAllMocks();
   });
 
   it('returns cached price data when available', async () => {
@@ -142,86 +143,6 @@ describe('PaperTradingMarketDataService', () => {
     expect(result.price).toBe(45000);
   });
 
-  describe('getHistoricalCandles', () => {
-    it('returns cached candles when cache hit', async () => {
-      const cachedCandles = [
-        { avg: 105, high: 110, low: 90, date: new Date(1000), open: 100, close: 105, volume: 500 },
-        { avg: 110, high: 115, low: 95, date: new Date(2000), open: 105, close: 110, volume: 600 }
-      ];
-
-      const { service, exchangeManager } = createService({
-        cacheManager: {
-          get: jest.fn().mockResolvedValue(cachedCandles),
-          set: jest.fn()
-        }
-      });
-
-      const result = await service.getHistoricalCandles('binance', 'BTC/USD');
-
-      expect(result).toBe(cachedCandles);
-      expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
-    });
-
-    it('fetches and caches candles on cache miss', async () => {
-      const rawOHLCV = [
-        [1000, 100, 110, 90, 105, 500],
-        [2000, 105, 115, 95, 110, 600],
-        [3000, 110, 120, 100, 115, 700]
-      ];
-
-      const client = {
-        fetchOHLCV: jest.fn().mockResolvedValue(rawOHLCV)
-      };
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
-        getPublicClient: jest.fn().mockResolvedValue(client)
-      };
-
-      const { service } = createService({ cacheManager, exchangeManager });
-
-      const result = await service.getHistoricalCandles('binance', 'BTC/USD', '1h', 100);
-
-      expect(result).toHaveLength(3);
-      expect(result[0]).toEqual(
-        expect.objectContaining({ avg: 105, high: 110, low: 90, open: 100, close: 105, volume: 500 })
-      );
-
-      // Verify cached with 5-minute TTL
-      expect(cacheManager.set).toHaveBeenCalledWith('paper-trading:ohlcv:binance:BTC/USD:1h:public', result, 300000);
-    });
-
-    it('returns empty array when fetch throws', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-
-      // Mock withExchangeRetryThrow to throw immediately (avoid real retry delays)
-      withExchangeRetryThrowSpy.mockRejectedValue(new Error('network error'));
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockReturnValue('BTC/USD'),
-        getPublicClient: jest.fn().mockResolvedValue({})
-      };
-
-      const { service } = createService({ cacheManager, exchangeManager });
-
-      const result = await service.getHistoricalCandles('binance', 'BTC/USD');
-
-      expect(result).toEqual([]);
-      expect(cacheManager.set).not.toHaveBeenCalled();
-      loggerSpy.mockRestore();
-    });
-  });
-
   it('uses ticker.close when ticker.last is null', async () => {
     const ticker = {
       last: null,
@@ -260,8 +181,6 @@ describe('PaperTradingMarketDataService', () => {
 
   describe('getCurrentPrice retry + stale-cache fallback', () => {
     it('falls back to stale cache when all retries exhausted', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-
       const staleData = {
         symbol: 'BTC/USDT',
         price: 44000,
@@ -297,13 +216,9 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result.price).toBe(44000);
       expect(result.source).toBe('binance:stale');
-      loggerSpy.mockRestore();
     });
 
     it('falls back to alternative exchange when retries exhausted and no stale cache', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-
       const fallbackTicker = {
         last: 43500,
         bid: 43450,
@@ -344,13 +259,9 @@ describe('PaperTradingMarketDataService', () => {
         expect.objectContaining({ source: 'gdax:fallback' }),
         1800000
       );
-      loggerSpy.mockRestore();
     });
 
     it('falls back to DB coin price when all exchanges fail', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
         set: jest.fn()
@@ -380,13 +291,9 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result.price).toBe(42000);
       expect(result.source).toBe('db:coin.currentPrice');
-      loggerSpy.mockRestore();
     });
 
     it('falls back to DB coin price of 0 without skipping it', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
         set: jest.fn()
@@ -416,13 +323,9 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result.price).toBe(0);
       expect(result.source).toBe('db:coin.currentPrice');
-      loggerSpy.mockRestore();
     });
 
     it('throws when retries, fallback exchanges, and DB all fail', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
-      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
         set: jest.fn()
@@ -451,7 +354,6 @@ describe('PaperTradingMarketDataService', () => {
       const { service } = createService({ cacheManager, exchangeManager, coinService });
 
       await expect(service.getCurrentPrice('binance', 'BTC/USDT')).rejects.toThrow('ETIMEDOUT');
-      loggerSpy.mockRestore();
     });
   });
 
@@ -462,7 +364,11 @@ describe('PaperTradingMarketDataService', () => {
         'ETH/USDT': { last: 2500, bid: 2490, ask: 2510, timestamp: 1700000000000 }
       };
 
-      const client = { fetchTickers: jest.fn() };
+      const client = {
+        markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+        loadMarkets: jest.fn().mockResolvedValue(undefined),
+        fetchTickers: jest.fn()
+      };
 
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
@@ -491,8 +397,6 @@ describe('PaperTradingMarketDataService', () => {
     });
 
     it('falls back to stale cache when all retries exhausted', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-
       const stalebtc = {
         symbol: 'BTC/USDT',
         price: 44000,
@@ -519,7 +423,11 @@ describe('PaperTradingMarketDataService', () => {
 
       const exchangeManager = {
         formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+          loadMarkets: jest.fn().mockResolvedValue(undefined),
+          fetchTickers: jest.fn()
+        })
       };
 
       withExchangeRetrySpy.mockResolvedValue({
@@ -536,13 +444,9 @@ describe('PaperTradingMarketDataService', () => {
       expect(result.get('BTC/USDT')?.source).toBe('binance:stale');
       expect(result.get('ETH/USDT')?.price).toBe(2400);
       expect(result.get('ETH/USDT')?.source).toBe('binance:stale');
-      loggerSpy.mockRestore();
     });
 
     it('uses fallback exchange for symbols missing stale cache', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-
       const stalebtc = {
         symbol: 'BTC/USDT',
         price: 44000,
@@ -573,7 +477,11 @@ describe('PaperTradingMarketDataService', () => {
           if (slug === 'gdax') {
             return Promise.resolve({ fetchTicker: jest.fn().mockResolvedValue(fallbackTicker) });
           }
-          return Promise.resolve({ fetchTickers: jest.fn() });
+          return Promise.resolve({
+            markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+            loadMarkets: jest.fn().mockResolvedValue(undefined),
+            fetchTickers: jest.fn()
+          });
         })
       };
 
@@ -590,13 +498,9 @@ describe('PaperTradingMarketDataService', () => {
       expect(result.get('BTC/USDT')?.source).toBe('binance:stale');
       expect(result.get('ETH/USDT')?.price).toBe(2400);
       expect(result.get('ETH/USDT')?.source).toBe('gdax:fallback');
-      loggerSpy.mockRestore();
     });
 
     it('throws when retries, fallback exchanges, and DB all fail for some symbols', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-
       const cacheManager = {
         get: jest.fn().mockResolvedValue(null),
         set: jest.fn()
@@ -605,6 +509,8 @@ describe('PaperTradingMarketDataService', () => {
       const exchangeManager = {
         formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
         getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+          loadMarkets: jest.fn().mockResolvedValue(undefined),
           fetchTickers: jest.fn(),
           fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
         })
@@ -627,7 +533,6 @@ describe('PaperTradingMarketDataService', () => {
       await expect(service.getPrices('binance', ['BTC/USDT', 'ETH/USDT'])).rejects.toThrow(
         /2 symbol\(s\) have no stale cache, fallback exchange, or DB fallback/
       );
-      loggerSpy.mockRestore();
     });
 
     it('returns cached symbols without fetching and only fetches uncached', async () => {
@@ -654,7 +559,11 @@ describe('PaperTradingMarketDataService', () => {
 
       const exchangeManager = {
         formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+          loadMarkets: jest.fn().mockResolvedValue(undefined),
+          fetchTickers: jest.fn()
+        })
       };
 
       withExchangeRetrySpy.mockResolvedValue({
@@ -686,7 +595,11 @@ describe('PaperTradingMarketDataService', () => {
 
       const exchangeManager = {
         formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({ fetchTickers: jest.fn() })
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+          loadMarkets: jest.fn().mockResolvedValue(undefined),
+          fetchTickers: jest.fn()
+        })
       };
 
       withExchangeRetrySpy.mockResolvedValue({
@@ -702,6 +615,141 @@ describe('PaperTradingMarketDataService', () => {
       expect(result.get('BTC/USDT')?.price).toBe(45000);
       expect(result.has('ETH/USDT')).toBe(false);
     });
+
+    it('returns cached-only results when all requested symbols are missing from exchange markets', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      const fetchTickers = jest.fn();
+      const loadMarkets = jest.fn().mockResolvedValue(undefined);
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {} },
+          loadMarkets,
+          fetchTickers
+        })
+      };
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance_us', ['USDT/USD', 'NONEXISTENT/USD']);
+
+      expect(result.size).toBe(0);
+      expect(fetchTickers).not.toHaveBeenCalled();
+      expect(withExchangeRetrySpy).not.toHaveBeenCalled();
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('none of 2 requested symbols'));
+    });
+
+    it('filters out invalid symbols and calls fetchTickers with valid ones only', async () => {
+      const tickers = {
+        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
+      };
+
+      const fetchTickers = jest.fn();
+      const loadMarkets = jest.fn().mockResolvedValue(undefined);
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {} },
+          loadMarkets,
+          fetchTickers
+        })
+      };
+
+      withExchangeRetrySpy.mockImplementation(async (op: () => Promise<unknown>) => {
+        await op();
+        return { success: true, result: tickers, attempts: 1, totalDelayMs: 0 };
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance_us', ['BTC/USDT', 'USDT/USD']);
+
+      expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT']);
+      expect(result.get('BTC/USDT')?.price).toBe(45000);
+      expect(result.has('USDT/USD')).toBe(false);
+    });
+
+    it('falls through without filtering when loadMarkets fails', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      const tickers = {
+        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 },
+        'ETH/USDT': { last: 2500, bid: 2490, ask: 2510, timestamp: 1700000000000 }
+      };
+
+      const fetchTickers = jest.fn();
+      const loadMarkets = jest.fn().mockRejectedValue(new Error('markets endpoint down'));
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: {},
+          loadMarkets,
+          fetchTickers
+        })
+      };
+
+      withExchangeRetrySpy.mockImplementation(async (op: () => Promise<unknown>) => {
+        await op();
+        return { success: true, result: tickers, attempts: 1, totalDelayMs: 0 };
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT', 'ETH/USDT']);
+      expect(result.get('BTC/USDT')?.price).toBe(45000);
+      expect(result.get('ETH/USDT')?.price).toBe(2500);
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('loadMarkets(binance) failed'));
+    });
+
+    it('does not call loadMarkets when markets are already loaded', async () => {
+      const tickers = {
+        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
+      };
+
+      const fetchTickers = jest.fn();
+      const loadMarkets = jest.fn().mockResolvedValue(undefined);
+
+      const cacheManager = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn()
+      };
+
+      const exchangeManager = {
+        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
+        getPublicClient: jest.fn().mockResolvedValue({
+          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+          loadMarkets,
+          fetchTickers
+        })
+      };
+
+      withExchangeRetrySpy.mockImplementation(async (op: () => Promise<unknown>) => {
+        await op();
+        return { success: true, result: tickers, attempts: 1, totalDelayMs: 0 };
+      });
+
+      const { service } = createService({ cacheManager, exchangeManager });
+      await service.getPrices('binance', ['BTC/USDT']);
+
+      expect(loadMarkets).not.toHaveBeenCalled();
+      expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT']);
+    });
   });
 
   describe('checkExchangeHealth', () => {
@@ -711,13 +759,16 @@ describe('PaperTradingMarketDataService', () => {
         getPublicClient: jest.fn().mockResolvedValue({ fetchTime: jest.fn() })
       };
 
+      // Deterministic latency: Date.now() is called at start and end of checkExchangeHealth
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1_000_000).mockReturnValueOnce(1_000_042);
+
       withExchangeRetrySpy.mockResolvedValue({ success: true, result: 1700000000000, attempts: 1, totalDelayMs: 0 });
 
       const { service } = createService({ exchangeManager });
       const result = await service.checkExchangeHealth('binance');
 
       expect(result.healthy).toBe(true);
-      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+      expect(result.latencyMs).toBe(42);
       expect(result.error).toBeUndefined();
     });
 
@@ -829,7 +880,6 @@ describe('PaperTradingMarketDataService', () => {
       expect(mockCv.getCoinsByRiskLevel).toHaveBeenCalledTimes(2);
       // Verify log includes userId for debugging
       expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('u-99'));
-      loggerSpy.mockRestore();
     });
 
     it('clearSymbolCache removes the cached entry so next call re-queries', async () => {
@@ -856,7 +906,6 @@ describe('PaperTradingMarketDataService', () => {
       expect(result).toEqual(['BTC/USD', 'ETH/USD']);
       expect(mockCs.getCoinSelectionsByUser).not.toHaveBeenCalled();
       expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('no user attached'));
-      loggerSpy.mockRestore();
     });
 
     it('falls through to risk-level coins when coin selection service throws', async () => {
@@ -871,7 +920,6 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result).toEqual(['SOL/USD']);
       expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('coin selection fetch failed'));
-      loggerSpy.mockRestore();
     });
 
     it('returns BTC/ETH fallback when both services throw', async () => {
@@ -886,7 +934,6 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result).toEqual(['BTC/USD', 'ETH/USD']);
       expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('risk-level coin fetch failed'));
-      loggerSpy.mockRestore();
     });
   });
 

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -13,9 +13,8 @@ import { CoinSelectionRelations } from '../../coin-selection/coin-selection.enti
 import { CoinSelectionService } from '../../coin-selection/coin-selection.service';
 import { EXCHANGE_QUOTE_CURRENCY } from '../../exchange/constants';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
-import { CandleData } from '../../ohlc/ohlc-candle.entity';
 import { toErrorInfo } from '../../shared/error.util';
-import { withExchangeRetry, withExchangeRetryThrow } from '../../shared/retry.util';
+import { withExchangeRetry } from '../../shared/retry.util';
 import type { User } from '../../users/users.entity';
 
 export type { PriceData, OrderBook, OrderBookLevel, RealisticSlippageResult } from './paper-trading-market-data.types';
@@ -223,20 +222,47 @@ export class PaperTradingMarketDataService {
       ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
       : await this.exchangeManager.getPublicClient(exchangeSlug);
 
-    // Fetch all tickers with retry
-    const result = await withExchangeRetry(
-      () => client.fetchTickers(uncachedSymbols.map((s) => this.exchangeManager.formatSymbol(exchangeSlug, s))),
-      {
-        logger: this.logger,
-        operationName: `fetchTickers(${exchangeSlug})`
+    // Lazy-load markets so we can filter out symbols the exchange doesn't list.
+    // Without this, CCXT drops unknown symbols internally and may send an empty
+    // `symbols` param to the REST API, which Binance rejects with code -1102.
+    let marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
+    if (!marketsLoaded) {
+      try {
+        await client.loadMarkets();
+        marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
+      } catch (error: unknown) {
+        const err = toErrorInfo(error);
+        this.logger.warn(`loadMarkets(${exchangeSlug}) failed, proceeding without symbol validation: ${err.message}`);
       }
-    );
+    }
+
+    const formattedPairs = uncachedSymbols.map((raw) => ({
+      raw,
+      formatted: this.exchangeManager.formatSymbol(exchangeSlug, raw)
+    }));
+
+    const validPairs = marketsLoaded
+      ? formattedPairs.filter(({ formatted }) => formatted in (client.markets as Record<string, unknown>))
+      : formattedPairs;
+
+    if (validPairs.length === 0) {
+      this.logger.warn(
+        `getPrices(${exchangeSlug}): none of ${uncachedSymbols.length} requested symbols ` +
+          `(${uncachedSymbols.join(', ')}) exist on exchange; returning cached-only results`
+      );
+      return results;
+    }
+
+    // Fetch all tickers with retry
+    const result = await withExchangeRetry(() => client.fetchTickers(validPairs.map((p) => p.formatted)), {
+      logger: this.logger,
+      operationName: `fetchTickers(${exchangeSlug})`
+    });
 
     if (result.success && result.result) {
       const tickers = result.result;
 
-      for (const symbol of uncachedSymbols) {
-        const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
+      for (const { raw: symbol, formatted: formattedSymbol } of validPairs) {
         const ticker = tickers[formattedSymbol];
 
         if (ticker) {
@@ -307,55 +333,6 @@ export class PaperTradingMarketDataService {
     }
 
     return results;
-  }
-
-  /**
-   * Get historical OHLC candles for algorithm indicator computation.
-   * Uses caching to minimize exchange API calls across ticks.
-   */
-  async getHistoricalCandles(
-    exchangeSlug: string,
-    symbol: string,
-    timeframe = '1h',
-    limit = 100,
-    user?: User
-  ): Promise<CandleData[]> {
-    const cacheKey = `paper-trading:ohlcv:${exchangeSlug}:${symbol}:${timeframe}:${user?.id ?? 'public'}`;
-
-    const cached = await this.cacheManager.get<CandleData[]>(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    try {
-      const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
-      const client = user
-        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-        : await this.exchangeManager.getPublicClient(exchangeSlug);
-
-      const ohlcv = await withExchangeRetryThrow(
-        () => client.fetchOHLCV(formattedSymbol, timeframe, undefined, limit),
-        { logger: this.logger, operationName: `fetchOHLCV(${exchangeSlug}:${symbol})` }
-      );
-
-      const candles = ohlcv.map((candle) => ({
-        avg: candle[4] as number, // close price — representative price for indicators
-        high: candle[2] as number,
-        low: candle[3] as number,
-        date: new Date(candle[0] as number),
-        open: candle[1] as number,
-        close: candle[4] as number,
-        volume: candle[5] as number
-      }));
-
-      // Cache for 5 minutes — candles shift slowly relative to 30s tick frequency
-      await this.cacheManager.set(cacheKey, candles, 5 * 60 * 1000);
-      return candles;
-    } catch (error: unknown) {
-      const err = toErrorInfo(error);
-      this.logger.warn(`Failed to fetch OHLCV for ${symbol} from ${exchangeSlug}: ${err.message}`);
-      return [];
-    }
   }
 
   /**

--- a/apps/api/src/order/paper-trading/paper-trading.module.ts
+++ b/apps/api/src/order/paper-trading/paper-trading.module.ts
@@ -5,6 +5,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { PaperTradingExitExecutorService } from './engine/paper-trading-exit-executor.service';
+import { PaperTradingHistoricalCandleService } from './engine/paper-trading-historical-candle.service';
 import { PaperTradingOpportunitySellingService } from './engine/paper-trading-opportunity-selling.service';
 import { PaperTradingOrderExecutorService } from './engine/paper-trading-order-executor.service';
 import { PaperTradingPortfolioService } from './engine/paper-trading-portfolio.service';
@@ -89,6 +90,7 @@ const PAPER_TRADING_CONFIG = paperTradingConfig();
     PaperTradingOrderExecutorService,
     PaperTradingExitExecutorService,
     PaperTradingOpportunitySellingService,
+    PaperTradingHistoricalCandleService,
     PaperTradingMarketDataService,
     PaperTradingSlippageService,
     PaperTradingStreamService,

--- a/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
+++ b/apps/api/src/tasks/dto/pipeline-orchestration.dto.ts
@@ -131,8 +131,8 @@ export const OPTIMIZATION_CONFIG: Record<number, RiskOptimizationConfig> = {
   1: { trainDays: 180, testDays: 90, stepDays: 45, maxCombinations: 75, maxCoins: 10 }, // Conservative
   2: { trainDays: 150, testDays: 60, stepDays: 30, maxCombinations: 60, maxCoins: 10 },
   3: { trainDays: 120, testDays: 45, stepDays: 30, maxCombinations: 50, maxCoins: 10 }, // Default
-  4: { trainDays: 90, testDays: 30, stepDays: 21, maxCombinations: 40, maxCoins: 8 },
-  5: { trainDays: 60, testDays: 21, stepDays: 14, maxCombinations: 30, maxCoins: 8 } // Aggressive
+  4: { trainDays: 120, testDays: 45, stepDays: 21, maxCombinations: 40, maxCoins: 8 },
+  5: { trainDays: 90, testDays: 45, stepDays: 21, maxCombinations: 30, maxCoins: 8 } // Aggressive
 };
 
 /**

--- a/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
+++ b/apps/api/src/tasks/pipeline-orchestration.service.spec.ts
@@ -476,11 +476,21 @@ describe('Pipeline Orchestration DTOs', () => {
     it.each([
       [1, 180, 75],
       [3, 120, 50],
-      [5, 60, 30]
+      [5, 90, 30]
     ])('risk level %i should use trainDays=%i, maxCombinations=%i', (level, trainDays, maxCombinations) => {
       const config = getOptimizationConfig(level);
       expect(config.trainDays).toBe(trainDays);
       expect(config.maxCombinations).toBe(maxCombinations);
+    });
+
+    it.each([
+      [4, 120, 45],
+      [5, 90, 45]
+    ])('risk level %i should use testDays >= 45 days (trainDays=%i, testDays=%i)', (level, trainDays, testDays) => {
+      const config = getOptimizationConfig(level);
+      expect(config.trainDays).toBe(trainDays);
+      expect(config.testDays).toBe(testDays);
+      expect(config.testDays).toBeGreaterThanOrEqual(45);
     });
 
     it('should fall back to level 3 defaults for invalid risk level', () => {


### PR DESCRIPTION
## Summary

- Dedup paper-trading strategy evaluation per symbol so algorithms only re-run when a new 1h bar arrives for any tracked symbol — ticks run every 30s but candles shift hourly.
- Harden the paper-trading historical candle pipeline with a tiered lookup (cache → `ohlc_candles` hypertable → exchange fallback with 5s timeout + deduped backfill) and an exchange-scoped cache key.
- Tune grid-search optimization so combinations whose indicator warmup exceeds the test window are pruned before sampling, and relax the zero-trade penalty so reachable-but-inactive combos aren't over-penalized.

## Changes

### Paper-trading dedup + candle pipeline
- `paper-trading-session.entity.ts` + migration `1776718516985`: add `lastProcessedCandleTs` as `jsonb` holding a per-symbol timestamp map.
- `paper-trading-engine.service.ts`: extract `getPerSymbolLatestTimestamps` and `hasAnySymbolAdvanced`; re-run the strategy when any symbol has advanced past its last-processed entry, and replace the tracker wholesale so dropped symbols clear.
- `paper-trading-historical-candle.service.ts` (new): tiered `cache → DB → exchange` fetch with a 5s `Promise.race` timeout that fires a deduped backfill on DB gaps; cache key now includes `exchangeSlug` to prevent cross-exchange contamination once two exchanges share a quote currency; timeout timer is cleared on the fast-path success so it stops keeping the event loop armed.
- `paper-trading-market-data.service.ts`: validate symbols against `client.markets` before `fetchTickers` so Binance doesn't reject the request with `-1102` on unknown pairs.
- `signal-throttle.interface.ts`: raise paper-trading throttle `cooldownMs` from 0 to 1h as a safety net matching the candle timeframe.

### Optimization reachability
- `grid-search.service.ts`: add `reachabilityFilter` so combos with indicator warmup > test window are pruned before random sampling, wired in through `AlgorithmRegistry.getMinDataPoints()`.
- `optimization-scoring.util.ts`: soften `ZERO_TRADE_PENALTY` from -3 to -0.5 so reachable combos with zero trades aren't ranked below poor-but-trading combos.
- `pipeline-orchestration.dto.ts`: extend `trainDays` / `testDays` for risk levels 4 and 5 to give aggressive configs enough walk-forward history for indicator warmups.

### Observability
- `paper-trading-engine.service.ts`: log algorithm-execution failures at error level with sessionId + algorithmId so pipeline failures are easier to trace.

## Test Plan

- [x] `nx test api -- --testPathPatterns='paper-trading-engine.service.spec|paper-trading-historical-candle.service.spec'` — 36/36 passing, including the new lagging-symbol regression test and the per-exchange cache isolation test.
- [x] `nx lint api` — clean.
- [ ] Post-deploy, confirm `SELECT id, "lastProcessedCandleTs" FROM paper_trading_sessions WHERE status='ACTIVE'` shows per-symbol maps, not scalar bigints.
- [ ] Signal cadence in `paper_trading_signals` stays flat (this corrects a *missed-evaluation* bug, not a spam bug — no expected increase except for sessions with heterogeneous candle-arrival timing).
- [ ] Spot-check logs for `Exchange fetchOHLCV timed out` — frequency unchanged (fix affects the success path, not timeout firing).