### PR TITLE
feat(api): coalesce concurrent ticker fetches via TickerBatcherService

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
 
 # Cancel in-progress runs for the same workflow on the same branch
 concurrency:
@@ -34,13 +34,13 @@ jobs:
       has_api: ${{ steps.check.outputs.has_api }}
       has_chansey: ${{ steps.check.outputs.has_chansey }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           filter: tree:0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -48,7 +48,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -58,7 +58,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Cache Nx
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/nx
           key: nx-${{ runner.os }}-${{ github.sha }}
@@ -114,12 +114,12 @@ jobs:
     needs: setup
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -127,7 +127,7 @@ jobs:
 
       - name: Restore node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -137,7 +137,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Restore Nx cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/nx
           key: nx-${{ runner.os }}-${{ github.sha }}
@@ -162,12 +162,12 @@ jobs:
     needs: setup
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -175,7 +175,7 @@ jobs:
 
       - name: Restore node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -185,7 +185,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Restore Nx cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/nx
           key: nx-${{ runner.os }}-${{ github.sha }}
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-reports
           path: coverage/
@@ -218,12 +218,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -231,7 +231,7 @@ jobs:
 
       - name: Restore node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -241,7 +241,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Restore Nx cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/nx
           key: nx-${{ runner.os }}-${{ github.sha }}
@@ -268,7 +268,7 @@ jobs:
 
       - name: Upload build artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: build-artifacts
           path: dist/
@@ -280,10 +280,10 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -300,17 +300,17 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
           cache-dependency-path: package-lock.json
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: build-artifacts
           path: dist/
@@ -334,15 +334,16 @@ jobs:
   # Job 7: Deploy frontend to Railway (only on master push when affected)
   deploy-frontend:
     name: Deploy Frontend
-    needs: [setup, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.setup.outputs.has_chansey == 'true'
+    needs: [ setup, build ]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+      needs.setup.outputs.has_chansey == 'true'
     runs-on: ubuntu-latest
     container: ghcr.io/railwayapp/cli:latest
     env:
       SVC_ID: 3869b3ae-f1db-4b9d-86a5-543264e00f4d
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -352,15 +353,16 @@ jobs:
   # Job 8: Deploy API to Railway (only on master push when affected)
   deploy-api:
     name: Deploy API
-    needs: [setup, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.setup.outputs.has_api == 'true'
+    needs: [ setup, build ]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+      needs.setup.outputs.has_api == 'true'
     runs-on: ubuntu-latest
     container: ghcr.io/railwayapp/cli:latest
     env:
       SVC_ID: 6a9cd43d-adac-4f7b-b4b3-368cf7b709a1
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -371,7 +373,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, build]
+    needs: [ lint, test, build ]
     if: always()
     steps:
       - name: Check job statuses

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -112,5 +112,5 @@ jobs:
 
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 8
+            --max-turns 20
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(sg:*),Bash(ast-grep:*),Grep,Read"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,12 +30,12 @@ jobs:
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -108,12 +108,12 @@ jobs:
       CHANSEY_API_KEY: e2e-test-api-key
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -124,7 +124,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: cache-playwright
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: dist/.playwright/apps/chansey/playwright-report/
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-test-results
           path: dist/.playwright/apps/chansey/test-results/
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload server logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: server-logs
           path: api.log

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -94,6 +94,11 @@ const envSchema = z.object({
   OHLC_RETENTION_DAYS: z.coerce.number().min(1).default(365),
   OHLC_EXCHANGE_PRIORITY: z.string().default('binance_us,gdax,kraken'),
 
+  // Ticker Batcher (coalesces concurrent exchange ticker fetches)
+  TICKER_BATCHER_FLUSH_MS: z.coerce.number().int().positive().optional(),
+  TICKER_BATCHER_MAX_BATCH_SIZE: z.coerce.number().int().positive().optional(),
+  TICKER_BATCHER_MEM_CACHE_TTL_MS: z.coerce.number().int().positive().optional(),
+
   // Observability - Grafana Stack (Optional)
   LOKI_ENDPOINT: z.string().url('Loki endpoint must be a valid URL').optional(),
   LOKI_USERNAME: z.string().optional(),

--- a/apps/api/src/exchange/exchange.module.ts
+++ b/apps/api/src/exchange/exchange.module.ts
@@ -1,11 +1,11 @@
 import { BullModule } from '@nestjs/bullmq';
-import { forwardRef, Module } from '@nestjs/common';
+import { forwardRef, Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BinanceUSService } from './binance/binance-us.service';
-import { CoinbaseExchangeService } from './coinbase-exchange/coinbase-exchange.service';
-// eslint-disable-next-line import/order
 import { CoinbaseService } from './coinbase/coinbase.service';
+import { CoinbaseExchangeService } from './coinbase-exchange/coinbase-exchange.service';
 import { ExchangeKey } from './exchange-key/exchange-key.entity';
 import { ExchangeKeyModule } from './exchange-key/exchange-key.module';
 import { ExchangeManagerService } from './exchange-manager.service';
@@ -16,6 +16,8 @@ import { EXCHANGE_MANAGER_SERVICE, EXCHANGE_SERVICE } from './interfaces';
 import { KrakenFuturesService } from './kraken/kraken-futures.service';
 import { KrakenService } from './kraken/kraken.service';
 import { ExchangeSyncTask } from './tasks/exchange-sync.task';
+import { tickerBatcherConfig } from './ticker-batcher/ticker-batcher.config';
+import { TickerBatcherService } from './ticker-batcher/ticker-batcher.service';
 
 import { CoinDailySnapshot } from '../coin/coin-daily-snapshot.entity';
 import { CoinDailySnapshotService } from '../coin/coin-daily-snapshot.service';
@@ -25,9 +27,11 @@ import { TickerPairs } from '../coin/ticker-pairs/ticker-pairs.entity';
 import { TickerPairService } from '../coin/ticker-pairs/ticker-pairs.service';
 import { SharedCacheModule } from '../shared-cache.module';
 
+@Global()
 @Module({
   controllers: [ExchangeController],
   imports: [
+    ConfigModule.forFeature(tickerBatcherConfig),
     TypeOrmModule.forFeature([Coin, CoinDailySnapshot, Exchange, ExchangeKey, TickerPairs]),
     forwardRef(() => ExchangeKeyModule),
     SharedCacheModule,
@@ -52,7 +56,8 @@ import { SharedCacheModule } from '../shared-cache.module';
       provide: EXCHANGE_MANAGER_SERVICE,
       useExisting: ExchangeManagerService
     },
-    TickerPairService
+    TickerPairService,
+    TickerBatcherService
   ],
   exports: [
     ExchangeService,
@@ -63,7 +68,8 @@ import { SharedCacheModule } from '../shared-cache.module';
     KrakenService,
     KrakenFuturesService,
     ExchangeManagerService,
-    EXCHANGE_MANAGER_SERVICE
+    EXCHANGE_MANAGER_SERVICE,
+    TickerBatcherService
   ]
 })
 export class ExchangeModule {}

--- a/apps/api/src/exchange/ticker-batcher/ticker-batcher.config.ts
+++ b/apps/api/src/exchange/ticker-batcher/ticker-batcher.config.ts
@@ -1,0 +1,24 @@
+import { registerAs } from '@nestjs/config';
+
+export interface TickerBatcherConfig {
+  /** ms to wait after first enqueue before flushing the batch. */
+  flushMs: number;
+  /** Max symbols per batch; hitting this triggers an immediate flush. */
+  maxBatchSize: number;
+  /** Sub-second memCache TTL in ms to dedup repeated reads in the same tick. */
+  memCacheTtlMs: number;
+}
+
+const parseInteger = (value: string | undefined, fallback: number): number => {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+export const tickerBatcherConfig = registerAs(
+  'tickerBatcher',
+  (): TickerBatcherConfig => ({
+    flushMs: parseInteger(process.env.TICKER_BATCHER_FLUSH_MS, 50),
+    maxBatchSize: parseInteger(process.env.TICKER_BATCHER_MAX_BATCH_SIZE, 100),
+    memCacheTtlMs: parseInteger(process.env.TICKER_BATCHER_MEM_CACHE_TTL_MS, 550)
+  })
+);

--- a/apps/api/src/exchange/ticker-batcher/ticker-batcher.service.spec.ts
+++ b/apps/api/src/exchange/ticker-batcher/ticker-batcher.service.spec.ts
@@ -1,0 +1,526 @@
+import { Logger } from '@nestjs/common';
+
+import { TickerBatcherService } from './ticker-batcher.service';
+
+import { CircuitOpenError } from '../../shared/circuit-breaker.service';
+import type { CircuitBreakerService } from '../../shared/circuit-breaker.service';
+import type { ExchangeManagerService } from '../exchange-manager.service';
+
+const DEFAULT_CONFIG = {
+  flushMs: 50,
+  maxBatchSize: 100,
+  memCacheTtlMs: 550
+};
+
+const createCircuitBreaker = (overrides: Partial<Record<string, jest.Mock>> = {}) => ({
+  isOpen: jest.fn().mockReturnValue(false),
+  recordSuccess: jest.fn(),
+  recordFailure: jest.fn(),
+  checkCircuit: jest.fn(),
+  ...overrides
+});
+
+const createExchangeManager = (client: unknown) => ({
+  getPublicClient: jest.fn().mockResolvedValue(client),
+  formatSymbol: jest.fn().mockImplementation((_slug: string, sym: string) => sym)
+});
+
+const baseTicker = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  last: 45000,
+  bid: 44950,
+  ask: 45050,
+  high: 45500,
+  low: 44000,
+  change: 100,
+  percentage: 0.22,
+  baseVolume: 1000,
+  quoteVolume: 45000000,
+  timestamp: 1700000000000,
+  ...overrides
+});
+
+const makeService = (
+  overrides: Partial<{
+    config: typeof DEFAULT_CONFIG;
+    exchangeManager: any;
+    circuitBreaker: any;
+  }> = {}
+) => {
+  const config = overrides.config ?? DEFAULT_CONFIG;
+  const exchangeManager = overrides.exchangeManager ?? createExchangeManager({});
+  const circuitBreaker = overrides.circuitBreaker ?? createCircuitBreaker();
+
+  const service = new TickerBatcherService(
+    config as any,
+    exchangeManager as ExchangeManagerService,
+    circuitBreaker as unknown as CircuitBreakerService
+  );
+
+  return { service, config, exchangeManager, circuitBreaker };
+};
+
+describe('TickerBatcherService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('coalesces concurrent callers for the same symbol into a single exchange call', async () => {
+    const tickers = { 'BTC/USDT': baseTicker({ last: 42000 }) };
+    const fetchTickers = jest.fn().mockResolvedValue(tickers);
+    const client = {
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const p1 = service.getTicker('binance_us', 'BTC/USDT');
+    const p2 = service.getTicker('binance_us', 'BTC/USDT');
+
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+
+    const [t1, t2] = await Promise.all([p1, p2]);
+    expect(t1?.price).toBe(42000);
+    expect(t2?.price).toBe(42000);
+    expect(fetchTickers).toHaveBeenCalledTimes(1);
+    expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT']);
+  });
+
+  it('batches distinct symbols enqueued in the same flush window into one call', async () => {
+    const tickers = {
+      'BTC/USDT': baseTicker({ last: 42000 }),
+      'ETH/USDT': baseTicker({ last: 2500 }),
+      'SOL/USDT': baseTicker({ last: 100 })
+    };
+    const fetchTickers = jest.fn().mockResolvedValue(tickers);
+    const client = {
+      markets: { 'BTC/USDT': {}, 'ETH/USDT': {}, 'SOL/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const pending = Promise.all([
+      service.getTicker('binance_us', 'BTC/USDT'),
+      service.getTicker('binance_us', 'ETH/USDT'),
+      service.getTicker('binance_us', 'SOL/USDT')
+    ]);
+
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    const [btc, eth, sol] = await pending;
+
+    expect(btc?.price).toBe(42000);
+    expect(eth?.price).toBe(2500);
+    expect(sol?.price).toBe(100);
+    expect(fetchTickers).toHaveBeenCalledTimes(1);
+    expect(fetchTickers).toHaveBeenCalledWith(expect.arrayContaining(['BTC/USDT', 'ETH/USDT', 'SOL/USDT']));
+  });
+
+  it('flushes immediately when pending reaches maxBatchSize', async () => {
+    const config = { ...DEFAULT_CONFIG, maxBatchSize: 3 };
+    const tickers = {
+      'A/USDT': baseTicker({ last: 1 }),
+      'B/USDT': baseTicker({ last: 2 }),
+      'C/USDT': baseTicker({ last: 3 })
+    };
+    const fetchTickers = jest.fn().mockResolvedValue(tickers);
+    const client = {
+      markets: { 'A/USDT': {}, 'B/USDT': {}, 'C/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ config, exchangeManager: createExchangeManager(client) });
+
+    const pending = Promise.all([
+      service.getTicker('binance_us', 'A/USDT'),
+      service.getTicker('binance_us', 'B/USDT'),
+      service.getTicker('binance_us', 'C/USDT')
+    ]);
+
+    // Do NOT advance timers — max-size trip should flush synchronously.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const results = await pending;
+
+    expect(results.every((t) => t != null)).toBe(true);
+    expect(fetchTickers).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a symbol from memCache within TTL without hitting the exchange', async () => {
+    const tickers = { 'BTC/USDT': baseTicker({ last: 42000 }) };
+    const fetchTickers = jest.fn().mockResolvedValue(tickers);
+    const client = {
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    // First fetch populates the memCache.
+    const first = service.getTicker('binance_us', 'BTC/USDT');
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    await first;
+
+    fetchTickers.mockClear();
+
+    // Second call (within TTL) bypasses exchange entirely.
+    const cached = await service.getTicker('binance_us', 'BTC/USDT');
+
+    expect(cached?.price).toBe(42000);
+    expect(fetchTickers).not.toHaveBeenCalled();
+  });
+
+  it('rejects all pending callers with CircuitOpenError when circuit is open at flush time', async () => {
+    const circuitBreaker = createCircuitBreaker({
+      checkCircuit: jest.fn().mockImplementation(() => {
+        throw new CircuitOpenError('exchange:binance_us:ticker', 30000);
+      })
+    });
+    const fetchTickers = jest.fn();
+    const exchangeManager = createExchangeManager({
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    });
+
+    const { service } = makeService({ circuitBreaker, exchangeManager });
+
+    // Attach catch handlers up front so rejections during advance don't flag as unhandled.
+    const p1 = service.getTicker('binance_us', 'BTC/USDT').catch((e: Error) => e);
+    const p2 = service.getTicker('binance_us', 'ETH/USDT').catch((e: Error) => e);
+
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBeInstanceOf(Error);
+    expect((r1 as Error).message).toMatch(/Circuit breaker .* is OPEN/);
+    expect(r2).toBeInstanceOf(Error);
+    expect((r2 as Error).message).toMatch(/Circuit breaker .* is OPEN/);
+    expect(fetchTickers).not.toHaveBeenCalled();
+    expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+  });
+
+  it('throttles client-error logs to once per 5 minutes per exchange', async () => {
+    const minusElevenOhTwo = new Error(
+      'binanceus 400 Bad Request {"code":-1102,"msg":"Mandatory parameter \'symbols\' was not sent, was empty/null, or malformed."}'
+    );
+    const fetchTickers = jest.fn().mockRejectedValue(minusElevenOhTwo);
+    const client = {
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const flushOnce = async () => {
+      const p = service.getTicker('binance_us', 'BTC/USDT').catch((e) => e);
+      await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+      await p;
+    };
+
+    const matchRejection = (c: unknown[]) =>
+      typeof c[0] === 'string' && c[0].includes('rejected by exchange as client error');
+
+    await flushOnce();
+    const firstCallCount = errorSpy.mock.calls.filter(matchRejection).length;
+
+    // Second firing within the 5-min window should NOT log another rejected event.
+    await flushOnce();
+    const secondCallCount = errorSpy.mock.calls.filter(matchRejection).length;
+
+    expect(firstCallCount).toBe(1);
+    expect(secondCallCount).toBe(1);
+  });
+
+  it('retries transient fetchTickers errors via the exchange retry wrapper and resolves', async () => {
+    const tickers = { 'BTC/USDT': baseTicker({ last: 42000 }) };
+    const fetchTickers = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce(tickers);
+    const client = {
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const p = service.getTicker('binance_us', 'BTC/USDT');
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    // Let the retry wrapper burn through its internal sleep cycle.
+    await jest.runAllTimersAsync();
+    const result = await p;
+
+    expect(result?.price).toBe(42000);
+    expect(fetchTickers).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates state across slugs — a failure on one does not reject the other', async () => {
+    const fail = new Error('ECONNRESET');
+    const binanceFetch = jest.fn().mockRejectedValue(fail);
+    const krakenFetch = jest.fn().mockResolvedValue({ 'XBT/ZUSD': baseTicker({ last: 43000 }) });
+
+    const exchangeManager = {
+      getPublicClient: jest.fn().mockImplementation((slug: string) => {
+        if (slug === 'binance_us') {
+          return Promise.resolve({
+            markets: { 'BTC/USDT': {} },
+            loadMarkets: jest.fn().mockResolvedValue(undefined),
+            fetchTickers: binanceFetch
+          });
+        }
+        return Promise.resolve({
+          markets: { 'XBT/ZUSD': {} },
+          loadMarkets: jest.fn().mockResolvedValue(undefined),
+          fetchTickers: krakenFetch
+        });
+      }),
+      formatSymbol: jest.fn().mockImplementation((_slug: string, sym: string) => sym)
+    };
+
+    const { service } = makeService({ exchangeManager });
+
+    const pBinance = service.getTicker('binance_us', 'BTC/USDT').catch((e) => e);
+    const pKraken = service.getTicker('kraken', 'BTC/USD');
+
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    await jest.runAllTimersAsync();
+
+    const [binanceResult, krakenResult] = await Promise.all([pBinance, pKraken]);
+    expect(binanceResult).toBeInstanceOf(Error);
+    expect(krakenResult?.price).toBe(43000);
+  });
+
+  it('opens a fresh batch when a new enqueue arrives mid-flush', async () => {
+    const tickers1 = { 'BTC/USDT': baseTicker({ last: 42000 }) };
+    const tickers2 = { 'ETH/USDT': baseTicker({ last: 2500 }) };
+    const fetchTickers = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        // Arrival mid-flush: enqueue happens synchronously after this `await` starts.
+        return tickers1;
+      })
+      .mockResolvedValueOnce(tickers2);
+    const client = {
+      markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const p1 = service.getTicker('binance_us', 'BTC/USDT');
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+
+    // Arriving mid-flush: since flush() cleared state.pending before awaiting,
+    // this opens a brand-new batch with its own timer.
+    const p2 = service.getTicker('binance_us', 'ETH/USDT');
+
+    await jest.runAllTimersAsync();
+    const [btc, eth] = await Promise.all([p1, p2]);
+
+    expect(btc?.price).toBe(42000);
+    expect(eth?.price).toBe(2500);
+    expect(fetchTickers).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves with undefined for a symbol not in client.markets', async () => {
+    const tickers = { 'BTC/USDT': baseTicker({ last: 42000 }) };
+    const fetchTickers = jest.fn().mockResolvedValue(tickers);
+    const client = {
+      markets: { 'BTC/USDT': {} }, // no ETH/USDT
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const pBtc = service.getTicker('binance_us', 'BTC/USDT');
+    const pEth = service.getTicker('binance_us', 'ETH/USDT');
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+
+    const [btc, eth] = await Promise.all([pBtc, pEth]);
+
+    expect(btc?.price).toBe(42000);
+    expect(eth).toBeUndefined();
+    expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT']);
+  });
+
+  it('falls through without filtering when loadMarkets throws', async () => {
+    const tickers = {
+      'BTC/USDT': baseTicker({ last: 42000 }),
+      'ETH/USDT': baseTicker({ last: 2500 })
+    };
+    const fetchTickers = jest.fn().mockResolvedValue(tickers);
+    const client = {
+      markets: {},
+      loadMarkets: jest.fn().mockRejectedValue(new Error('markets endpoint down')),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const pBtc = service.getTicker('binance_us', 'BTC/USDT');
+    const pEth = service.getTicker('binance_us', 'ETH/USDT');
+
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    const [btc, eth] = await Promise.all([pBtc, pEth]);
+
+    expect(btc?.price).toBe(42000);
+    expect(eth?.price).toBe(2500);
+    expect(fetchTickers).toHaveBeenCalledWith(expect.arrayContaining(['BTC/USDT', 'ETH/USDT']));
+  });
+
+  it('re-fetches from the exchange after the memCache entry expires', async () => {
+    const tickers = { 'BTC/USDT': baseTicker({ last: 42000 }) };
+    const fetchTickers = jest.fn().mockResolvedValue(tickers);
+    const client = {
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    // Populate cache.
+    const first = service.getTicker('binance_us', 'BTC/USDT');
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    await first;
+    expect(fetchTickers).toHaveBeenCalledTimes(1);
+
+    // Advance past the TTL; the next call must hit the exchange again.
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.memCacheTtlMs + 1);
+
+    const second = service.getTicker('binance_us', 'BTC/USDT');
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    await second;
+
+    expect(fetchTickers).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs non-client fetch failures as warn without triggering the client-error throttle', async () => {
+    const fetchTickers = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+    const client = {
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const p = service.getTicker('binance_us', 'BTC/USDT').catch((e: Error) => e);
+    await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+    await jest.runAllTimersAsync();
+    const result = await p;
+
+    expect(result).toBeInstanceOf(Error);
+    const warned = warnSpy.mock.calls.some((c) =>
+      typeof c[0] === 'string' ? c[0].includes('ticker_batch_error') : false
+    );
+    const erroredAsRejected = errorSpy.mock.calls.some((c) =>
+      typeof c[0] === 'string' ? c[0].includes('ticker_batch_rejected') : false
+    );
+    expect(warned).toBe(true);
+    expect(erroredAsRejected).toBe(false);
+  });
+
+  describe('getTickers()', () => {
+    it('serves a mix of cached and freshly fetched symbols with a single batched call', async () => {
+      const tickers = {
+        'BTC/USDT': baseTicker({ last: 42000 }),
+        'ETH/USDT': baseTicker({ last: 2500 })
+      };
+      const fetchTickers = jest.fn().mockResolvedValue(tickers);
+      const client = {
+        markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+        loadMarkets: jest.fn().mockResolvedValue(undefined),
+        fetchTickers
+      };
+      const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+      // Prime the cache for BTC only.
+      const prime = service.getTicker('binance_us', 'BTC/USDT');
+      await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+      await prime;
+      fetchTickers.mockClear();
+
+      const bulk = service.getTickers('binance_us', ['BTC/USDT', 'ETH/USDT']);
+      await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+      const result = await bulk;
+
+      expect(result.get('BTC/USDT')?.price).toBe(42000);
+      expect(result.get('ETH/USDT')?.price).toBe(2500);
+      expect(fetchTickers).toHaveBeenCalledTimes(1);
+      expect(fetchTickers).toHaveBeenCalledWith(['ETH/USDT']);
+    });
+
+    it('returns partial results without throwing when some symbols succeed and others fail', async () => {
+      // First enqueue triggers the flush; we reject that batch, but BTC is already cached from a prior call.
+      const tickers = { 'BTC/USDT': baseTicker({ last: 42000 }) };
+      const fetchTickers = jest.fn().mockResolvedValueOnce(tickers).mockRejectedValue(new Error('ECONNRESET'));
+      const client = {
+        markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+        loadMarkets: jest.fn().mockResolvedValue(undefined),
+        fetchTickers
+      };
+      const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+      // Prime BTC into the cache.
+      const prime = service.getTicker('binance_us', 'BTC/USDT');
+      await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+      await prime;
+
+      const bulk = service.getTickers('binance_us', ['BTC/USDT', 'ETH/USDT']);
+      await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+      await jest.runAllTimersAsync();
+      const result = await bulk;
+
+      expect(result.get('BTC/USDT')?.price).toBe(42000);
+      expect(result.has('ETH/USDT')).toBe(false);
+    });
+
+    it('throws the first fetch error when every requested symbol fails', async () => {
+      const fetchTickers = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+      const client = {
+        markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
+        loadMarkets: jest.fn().mockResolvedValue(undefined),
+        fetchTickers
+      };
+      const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+      const bulk = service.getTickers('binance_us', ['BTC/USDT', 'ETH/USDT']).catch((e: Error) => e);
+      await jest.advanceTimersByTimeAsync(DEFAULT_CONFIG.flushMs + 1);
+      await jest.runAllTimersAsync();
+      const result = await bulk;
+
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).message).toMatch(/ECONNRESET/);
+    });
+  });
+
+  it('rejects pending callers with shutdown error on onModuleDestroy', async () => {
+    const fetchTickers = jest.fn();
+    const client = {
+      markets: { 'BTC/USDT': {} },
+      loadMarkets: jest.fn().mockResolvedValue(undefined),
+      fetchTickers
+    };
+    const { service } = makeService({ exchangeManager: createExchangeManager(client) });
+
+    const p = service.getTicker('binance_us', 'BTC/USDT');
+
+    // Destroy BEFORE the flush timer fires.
+    await service.onModuleDestroy();
+
+    await expect(p).rejects.toThrow(/shutting down/);
+    expect(fetchTickers).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/exchange/ticker-batcher/ticker-batcher.service.ts
+++ b/apps/api/src/exchange/ticker-batcher/ticker-batcher.service.ts
@@ -1,0 +1,480 @@
+import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+
+import type * as ccxt from 'ccxt';
+
+import { tickerBatcherConfig } from './ticker-batcher.config';
+import type { BatchedTicker, BatchState, PendingRequest } from './ticker-batcher.types';
+
+import { tickerCircuitKey } from '../../shared/circuit-breaker.constants';
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
+import { toErrorInfo } from '../../shared/error.util';
+import {
+  isClientError,
+  isRateLimitError,
+  isTransientError,
+  isWeightLimitError,
+  withExchangeRetry
+} from '../../shared/retry.util';
+import { ExchangeManagerService } from '../exchange-manager.service';
+import { formatSymbolForExchange } from '../utils';
+
+const CLIENT_ERROR_LOG_INTERVAL_MS = 5 * 60 * 1000;
+const SHUTDOWN_ERROR_MESSAGE = 'ticker-batcher shutting down';
+
+/**
+ * TickerBatcherService
+ *
+ * Coalesces concurrent in-process ticker fetches for the same exchange into
+ * a single `fetchTickers(union-of-symbols)` call per flush window. This
+ * collapses the linear-in-users request volume that Binance.US rejects with
+ * `-1102` when multiple sessions independently poll within ~100ms of each other.
+ *
+ * The batcher owns the exchange-hop only: CCXT call + retry + circuit +
+ * symbol-market filtering. Callers retain their own Redis cache and stale /
+ * fallback-exchange / DB-fallback chain. Clean boundary:
+ *
+ *   batcher  = protocol correctness
+ *   caller   = staleness policy
+ */
+@Injectable()
+export class TickerBatcherService implements OnModuleDestroy {
+  private readonly logger = new Logger(TickerBatcherService.name);
+
+  private readonly batches = new Map<string, BatchState>();
+  private readonly memCache = new Map<string, { data: BatchedTicker; expiresAt: number }>();
+  private readonly lastClientErrorLogAt = new Map<string, number>();
+  private destroyed = false;
+
+  constructor(
+    @Inject(tickerBatcherConfig.KEY) private readonly config: ConfigType<typeof tickerBatcherConfig>,
+    private readonly exchangeManager: ExchangeManagerService,
+    private readonly circuitBreaker: CircuitBreakerService
+  ) {}
+
+  async onModuleDestroy(): Promise<void> {
+    this.destroyed = true;
+    for (const [, state] of this.batches) {
+      if (state.timer) {
+        clearTimeout(state.timer);
+        state.timer = null;
+      }
+      for (const [, waiters] of state.pending) {
+        for (const waiter of waiters) {
+          waiter.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
+        }
+      }
+      state.pending.clear();
+    }
+    this.batches.clear();
+  }
+
+  /** Fetch a single ticker via the batched path. */
+  async getTicker(slug: string, symbol: string): Promise<BatchedTicker | undefined> {
+    const cached = this.readMemCache(slug, symbol);
+    if (cached) return cached;
+
+    return this.enqueue(slug, symbol);
+  }
+
+  /** Fetch multiple tickers; omits entries for symbols the exchange can't serve. */
+  async getTickers(slug: string, symbols: string[]): Promise<Map<string, BatchedTicker>> {
+    const result = new Map<string, BatchedTicker>();
+    const toFetch: string[] = [];
+
+    for (const symbol of symbols) {
+      const cached = this.readMemCache(slug, symbol);
+      if (cached) {
+        result.set(symbol, cached);
+      } else {
+        toFetch.push(symbol);
+      }
+    }
+
+    if (toFetch.length === 0) return result;
+
+    const settled = await Promise.all(
+      toFetch.map((sym) =>
+        this.enqueue(slug, sym)
+          .then((ticker) => ({ sym, ticker }))
+          .catch((err: Error) => ({ sym, error: err }))
+      )
+    );
+
+    let firstError: Error | undefined;
+    for (const entry of settled) {
+      if ('error' in entry && entry.error) {
+        firstError = firstError ?? entry.error;
+        continue;
+      }
+      const ticker = (entry as { sym: string; ticker?: BatchedTicker }).ticker;
+      if (ticker) {
+        result.set(entry.sym, ticker);
+      }
+    }
+
+    if (firstError && result.size === 0) {
+      throw firstError;
+    }
+
+    return result;
+  }
+
+  private readMemCache(slug: string, symbol: string): BatchedTicker | undefined {
+    const entry = this.memCache.get(`${slug}:${symbol}`);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= Date.now()) {
+      this.memCache.delete(`${slug}:${symbol}`);
+      return undefined;
+    }
+    return entry.data;
+  }
+
+  private writeMemCache(slug: string, symbol: string, data: BatchedTicker): void {
+    this.memCache.set(`${slug}:${symbol}`, { data, expiresAt: Date.now() + this.config.memCacheTtlMs });
+  }
+
+  private enqueue(slug: string, symbol: string): Promise<BatchedTicker | undefined> {
+    if (this.destroyed) {
+      return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
+    }
+
+    return new Promise<BatchedTicker | undefined>((resolve, reject) => {
+      const state = this.getOrCreateBatch(slug);
+      const waiters = state.pending.get(symbol);
+      const entry: PendingRequest = { resolve, reject };
+
+      if (waiters) {
+        waiters.push(entry);
+      } else {
+        state.pending.set(symbol, [entry]);
+      }
+
+      // Max-size trip: flush synchronously without waiting for the timer.
+      if (state.pending.size >= this.config.maxBatchSize) {
+        if (state.timer) {
+          clearTimeout(state.timer);
+          state.timer = null;
+        }
+        // Fire-and-forget — the promise we returned is resolved inside flush().
+        void this.flush(slug);
+        return;
+      }
+
+      // First enqueue wins: timer is armed once and never reset, which bounds
+      // latency for the earliest caller.
+      if (state.timer === null) {
+        state.timer = setTimeout(() => {
+          void this.flush(slug);
+        }, this.config.flushMs);
+      }
+    });
+  }
+
+  private getOrCreateBatch(slug: string): BatchState {
+    let state = this.batches.get(slug);
+    if (!state) {
+      state = { pending: new Map(), timer: null };
+      this.batches.set(slug, state);
+    }
+    return state;
+  }
+
+  private async flush(slug: string): Promise<void> {
+    const state = this.batches.get(slug);
+    if (!state || state.pending.size === 0) {
+      if (state?.timer) {
+        clearTimeout(state.timer);
+        state.timer = null;
+      }
+      return;
+    }
+
+    // Snapshot + reset so new enqueues arriving mid-flush open a fresh batch.
+    const pending = state.pending;
+    state.pending = new Map();
+    if (state.timer) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+
+    const circuitKey = tickerCircuitKey(slug);
+    const rawSymbols = Array.from(pending.keys());
+    const coalescedCallers = Array.from(pending.values()).reduce((acc, list) => acc + list.length, 0);
+    const startedAt = Date.now();
+
+    try {
+      this.circuitBreaker.checkCircuit(circuitKey);
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      for (const waiters of pending.values()) {
+        for (const waiter of waiters) waiter.reject(err);
+      }
+      return;
+    }
+
+    try {
+      const client = await this.exchangeManager.getPublicClient(slug);
+      const validPairs = await this.filterValidPairs(client, slug, rawSymbols);
+
+      if (validPairs.length === 0) {
+        this.logger.warn(
+          `ticker_batch_flush(${slug}): none of ${rawSymbols.length} requested symbols exist on exchange`
+        );
+        for (const waiters of pending.values()) {
+          for (const waiter of waiters) waiter.resolve(undefined);
+        }
+        return;
+      }
+
+      const result = await withExchangeRetry(() => client.fetchTickers(validPairs.map((p) => p.formatted)), {
+        logger: this.logger,
+        operationName: `fetchTickers(${slug})`,
+        // Rate/weight limits are account-wide and client errors are
+        // terminal — retrying just burns budget.
+        isRetryable: (err) =>
+          isTransientError(err) && !isRateLimitError(err) && !isWeightLimitError(err) && !isClientError(err)
+      });
+
+      if (result.success && result.result) {
+        this.circuitBreaker.recordSuccess(circuitKey);
+        this.resolveFromResponse(slug, pending, validPairs, result.result);
+
+        this.logger.debug(
+          JSON.stringify({
+            event: 'ticker_batch_flush',
+            slug,
+            symbols: validPairs.length,
+            coalescedCallers,
+            durationMs: Date.now() - startedAt
+          })
+        );
+        return;
+      }
+
+      const err = result.error ?? new Error(`fetchTickers(${slug}) failed`);
+      this.circuitBreaker.recordFailure(circuitKey);
+      this.handleBatchError(slug, err, pending, validPairs.length, result.attempts, startedAt, client, validPairs);
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.circuitBreaker.recordFailure(circuitKey);
+      this.handleBatchError(slug, err, pending, rawSymbols.length, 0, startedAt);
+    }
+  }
+
+  private async filterValidPairs(
+    client: ccxt.Exchange,
+    slug: string,
+    rawSymbols: string[]
+  ): Promise<Array<{ raw: string; formatted: string }>> {
+    let marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
+    if (!marketsLoaded) {
+      try {
+        await client.loadMarkets();
+        marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
+      } catch (error: unknown) {
+        const info = toErrorInfo(error);
+        this.logger.warn(`loadMarkets(${slug}) failed, proceeding without symbol validation: ${info.message}`);
+      }
+    }
+
+    const formattedPairs = rawSymbols.map((raw) => ({
+      raw,
+      formatted: formatSymbolForExchange(slug, raw)
+    }));
+
+    if (!marketsLoaded) return formattedPairs;
+
+    const markets = client.markets as Record<string, unknown>;
+    return formattedPairs.filter(({ formatted }) => formatted in markets);
+  }
+
+  private resolveFromResponse(
+    slug: string,
+    pending: Map<string, PendingRequest[]>,
+    validPairs: Array<{ raw: string; formatted: string }>,
+    tickers: Record<string, ccxt.Ticker>
+  ): void {
+    const fulfilled = new Set<string>();
+
+    for (const { raw, formatted } of validPairs) {
+      const ticker = tickers[formatted];
+      const waiters = pending.get(raw);
+      if (!waiters) continue;
+
+      if (ticker) {
+        const batched = this.toBatchedTicker(raw, slug, ticker);
+        this.writeMemCache(slug, raw, batched);
+        for (const waiter of waiters) waiter.resolve(batched);
+      } else {
+        for (const waiter of waiters) waiter.resolve(undefined);
+      }
+      fulfilled.add(raw);
+    }
+
+    // Any symbol we filtered out of validPairs — resolve undefined (exchange
+    // doesn't list it). Callers fall through to their own fallback chain.
+    for (const [raw, waiters] of pending) {
+      if (fulfilled.has(raw)) continue;
+      for (const waiter of waiters) waiter.resolve(undefined);
+    }
+  }
+
+  private toBatchedTicker(symbol: string, source: string, ticker: ccxt.Ticker): BatchedTicker {
+    const price = ticker.last ?? ticker.close ?? 0;
+    const tsRaw = ticker.timestamp;
+    const timestamp = new Date(typeof tsRaw === 'number' ? tsRaw : Date.now());
+    return {
+      symbol,
+      price,
+      bid: ticker.bid,
+      ask: ticker.ask,
+      high: ticker.high,
+      low: ticker.low,
+      change: ticker.change,
+      percentage: ticker.percentage,
+      baseVolume: ticker.baseVolume,
+      quoteVolume: ticker.quoteVolume,
+      timestamp,
+      source
+    };
+  }
+
+  private handleBatchError(
+    slug: string,
+    err: Error,
+    pending: Map<string, PendingRequest[]>,
+    symbolCount: number,
+    attempts: number,
+    startedAt: number,
+    client?: ccxt.Exchange,
+    validPairs?: Array<{ raw: string; formatted: string }>
+  ): void {
+    const clientError = isClientError(err);
+    const errorCodeMatch = err.message?.match(/"code"\s*:\s*(-?\d+)/);
+    const errorCode = errorCodeMatch ? errorCodeMatch[1] : undefined;
+
+    const payload = {
+      event: 'ticker_batch_error',
+      slug,
+      symbols: symbolCount,
+      attempts,
+      errorCode,
+      durationMs: Date.now() - startedAt,
+      message: err.message
+    };
+
+    if (clientError && client && validPairs) {
+      this.logClientErrorOnce(slug, client, validPairs, err);
+    } else if (clientError) {
+      this.logThrottled(slug, () => this.logger.error(JSON.stringify({ ...payload, event: 'ticker_batch_rejected' })));
+    } else {
+      this.logger.warn(JSON.stringify(payload));
+    }
+
+    for (const waiters of pending.values()) {
+      for (const waiter of waiters) waiter.reject(err);
+    }
+  }
+
+  /**
+   * Throttled (1×/5min per exchange) evidence trap for Binance client-error
+   * rejections on a batch fetchTickers call. Captures *everything* CCXT already
+   * has in memory at the moment of failure so we can diagnose without guessing:
+   *
+   * - The exact URL CCXT sent (reveals param encoding, symbol list, query shape)
+   * - The raw response body from the exchange (often has extra context)
+   * - Selected response headers (`x-mbx-used-weight-1m`, `cf-ray`, `server`,
+   *   `x-cache`) — reveal rate-limit budget, Cloudflare routing, region hints
+   * - Our unified symbols AND the exchange-specific market IDs CCXT resolved
+   *   them to (mismatches here catch ghost/inactive markets)
+   * - Active vs total market counts (stale market cache detection)
+   *
+   * No extra network calls — every field is already populated by CCXT on the
+   * failing request. Safe to run inside the error path.
+   */
+  private logClientErrorOnce(
+    slug: string,
+    client: ccxt.Exchange,
+    validPairs: Array<{ raw: string; formatted: string }>,
+    error: Error
+  ): void {
+    this.logThrottled(slug, () => {
+      try {
+        const formatted = validPairs.map((p) => p.formatted);
+        // Resolve each unified symbol to the exchange's internal market id. If this
+        // differs from what we expected (e.g. returns undefined for a ghost market),
+        // CCXT would serialize `[null, ...]` into the symbols param — explaining
+        // Binance's "malformed" rejection.
+        const marketIds = validPairs.map((p) => {
+          try {
+            return client.marketId(p.formatted);
+          } catch (e: unknown) {
+            return `<${(e as Error).message?.slice(0, 40) ?? 'resolve-failed'}>`;
+          }
+        });
+        const markets = client.markets ?? {};
+        const marketsTotal = Object.keys(markets).length;
+        const marketsActive = Object.values(markets).filter((m) => m && (m as { active?: boolean }).active).length;
+
+        // CCXT exposes the failing request/response on the exchange instance.
+        // Guard every access — any of these can be undefined if the throw happened
+        // before the response was parsed.
+        const rawClient = client as unknown as {
+          last_request_url?: string;
+          last_request_body?: string;
+          last_http_response?: string;
+          last_response_headers?: Record<string, string>;
+        };
+        const responseHeaders = rawClient.last_response_headers ?? {};
+        const pickHeaders = [
+          'x-mbx-used-weight',
+          'x-mbx-used-weight-1m',
+          'cf-ray',
+          'cf-cache-status',
+          'server',
+          'x-cache',
+          'via'
+        ];
+        const headerSnapshot: Record<string, string | undefined> = {};
+        for (const key of pickHeaders) {
+          const match = Object.keys(responseHeaders).find((k) => k.toLowerCase() === key);
+          if (match) headerSnapshot[key] = String(responseHeaders[match]).slice(0, 200);
+        }
+
+        this.logger.error(
+          JSON.stringify({
+            event: 'ticker_batch_client_error',
+            message: `fetchTickers(${slug}) rejected by exchange as client error`,
+            slug,
+            sent_symbols: formatted,
+            market_ids: marketIds,
+            markets_total: marketsTotal,
+            markets_active: marketsActive,
+            last_request_url: (rawClient.last_request_url ?? '').slice(0, 500),
+            last_request_body: (rawClient.last_request_body ?? '').slice(0, 300),
+            last_http_response: (rawClient.last_http_response ?? '').slice(0, 400),
+            response_headers: headerSnapshot,
+            error: error.message.slice(0, 400)
+          })
+        );
+      } catch (capErr: unknown) {
+        // Never let the diagnostic throw — it must not make the failure worse.
+        const info = toErrorInfo(capErr);
+        this.logger.warn(`logClientErrorOnce(${slug}) failed to build diagnostic: ${info.message}`);
+      }
+    });
+  }
+
+  /**
+   * Run `fire` at most once per CLIENT_ERROR_LOG_INTERVAL_MS per exchange.
+   * Shared gate between the rich client-error log and the simpler rejection log.
+   */
+  private logThrottled(slug: string, fire: () => void): void {
+    const now = Date.now();
+    const last = this.lastClientErrorLogAt.get(slug);
+    if (last !== undefined && now - last < CLIENT_ERROR_LOG_INTERVAL_MS) return;
+    this.lastClientErrorLogAt.set(slug, now);
+    fire();
+  }
+}

--- a/apps/api/src/exchange/ticker-batcher/ticker-batcher.types.ts
+++ b/apps/api/src/exchange/ticker-batcher/ticker-batcher.types.ts
@@ -1,0 +1,33 @@
+/**
+ * Unified ticker shape returned by the batcher.
+ * Callers adapt this to their own DTOs (e.g. PriceData, TickerPrice).
+ */
+export interface BatchedTicker {
+  /** Unified symbol, e.g. "BTC/USDT" */
+  symbol: string;
+  /** last ?? close ?? 0 */
+  price: number;
+  bid?: number;
+  ask?: number;
+  high?: number;
+  low?: number;
+  change?: number;
+  percentage?: number;
+  baseVolume?: number;
+  quoteVolume?: number;
+  timestamp: Date;
+  /** exchange slug that produced the ticker */
+  source: string;
+}
+
+export interface PendingRequest {
+  resolve: (ticker: BatchedTicker | undefined) => void;
+  reject: (err: Error) => void;
+}
+
+export interface BatchState {
+  /** Map of raw (pre-format) symbol → callers waiting on it. */
+  pending: Map<string, PendingRequest[]>;
+  /** Timer for the scheduled flush; null when no flush is armed. */
+  timer: NodeJS.Timeout | null;
+}

--- a/apps/api/src/ohlc/services/realtime-ticker.service.spec.ts
+++ b/apps/api/src/ohlc/services/realtime-ticker.service.spec.ts
@@ -3,12 +3,10 @@ import { type Cache } from 'cache-manager';
 import { RealtimeTickerService } from './realtime-ticker.service';
 
 import { type CoinService } from '../../coin/coin.service';
-import { type ExchangeManagerService } from '../../exchange/exchange-manager.service';
 
 describe('RealtimeTickerService', () => {
   let service: RealtimeTickerService;
   let cache: jest.Mocked<Cache>;
-  let exchangeManager: jest.Mocked<ExchangeManagerService>;
   let coinService: jest.Mocked<CoinService>;
 
   beforeEach(() => {
@@ -18,16 +16,17 @@ describe('RealtimeTickerService', () => {
       del: jest.fn()
     } as unknown as jest.Mocked<Cache>;
 
-    exchangeManager = {
-      getPublicClient: jest.fn()
-    } as unknown as jest.Mocked<ExchangeManagerService>;
-
     coinService = {
       getCoinById: jest.fn(),
       updateCurrentPrice: jest.fn()
     } as unknown as jest.Mocked<CoinService>;
 
-    service = new RealtimeTickerService(cache, exchangeManager, coinService);
+    const tickerBatcher = {
+      getTicker: jest.fn(),
+      getTickers: jest.fn()
+    } as any;
+
+    service = new RealtimeTickerService(cache, coinService, tickerBatcher);
   });
 
   afterEach(() => {
@@ -192,35 +191,31 @@ describe('RealtimeTickerService', () => {
     expect(coinService.updateCurrentPrice).toHaveBeenCalledWith('eth', 70);
   });
 
-  it('getPrice uses kraken symbol mapping', async () => {
+  it('falls through the exchange priority list until the batcher returns a ticker', async () => {
     cache.get.mockResolvedValue(null);
     coinService.getCoinById.mockResolvedValue({ id: 'btc', symbol: 'btc' } as any);
 
-    const binanceClient = {
-      markets: {},
-      loadMarkets: jest.fn(),
-      fetchTicker: jest.fn()
-    };
-    const gdaxClient = {
-      markets: {},
-      loadMarkets: jest.fn(),
-      fetchTicker: jest.fn()
-    };
-    const krakenClient = {
-      markets: { 'XBT/ZUSD': {} },
-      loadMarkets: jest.fn(),
-      fetchTicker: jest.fn().mockResolvedValue({ last: 42 })
-    };
-
-    exchangeManager.getPublicClient.mockImplementation((slug?: string) => {
-      if (slug === 'binance_us') return binanceClient as any;
-      if (slug === 'gdax') return gdaxClient as any;
-      return krakenClient as any;
+    // Swap the already-constructed service's batcher with one that returns undefined
+    // for binance_us and gdax, then resolves for kraken.
+    const tickerBatcher = (service as any).tickerBatcher as { getTicker: jest.Mock };
+    tickerBatcher.getTicker = jest.fn().mockImplementation((slug: string) => {
+      if (slug === 'kraken') {
+        return Promise.resolve({
+          symbol: 'BTC/USD',
+          price: 42,
+          timestamp: new Date(),
+          source: 'kraken'
+        });
+      }
+      return Promise.resolve(undefined);
     });
 
     const result = await service.getPrice('btc');
 
     expect(result?.price).toBe(42);
-    expect(krakenClient.fetchTicker).toHaveBeenCalledWith('XBT/ZUSD');
+    expect(result?.source).toBe('kraken');
+    expect(tickerBatcher.getTicker).toHaveBeenCalledWith('binance_us', 'BTC/USD');
+    expect(tickerBatcher.getTicker).toHaveBeenCalledWith('gdax', 'BTC/USD');
+    expect(tickerBatcher.getTicker).toHaveBeenCalledWith('kraken', 'BTC/USD');
   });
 });

--- a/apps/api/src/ohlc/services/realtime-ticker.service.ts
+++ b/apps/api/src/ohlc/services/realtime-ticker.service.ts
@@ -4,10 +4,8 @@ import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 
 import { CoinService } from '../../coin/coin.service';
-import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
-import { formatSymbolForExchange } from '../../exchange/utils';
+import { TickerBatcherService } from '../../exchange/ticker-batcher/ticker-batcher.service';
 import { toErrorInfo } from '../../shared/error.util';
-import { withExchangeRetryThrow } from '../../shared/retry.util';
 
 export interface TickerPrice {
   coinId: string;
@@ -31,9 +29,9 @@ export class RealtimeTickerService {
 
   constructor(
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
-    private readonly exchangeManager: ExchangeManagerService,
     @Inject(forwardRef(() => CoinService))
-    private readonly coinService: CoinService
+    private readonly coinService: CoinService,
+    private readonly tickerBatcher: TickerBatcherService
   ) {}
 
   /**
@@ -158,48 +156,28 @@ export class RealtimeTickerService {
   }
 
   /**
-   * Internal: Fetch ticker from exchange with fallback
+   * Internal: Fetch ticker from exchange with priority-list fallthrough.
+   * Delegates to the batcher — which owns retry, circuit breaker, and market filtering.
    */
   private async fetchTicker(symbol: string): Promise<Omit<TickerPrice, 'coinId'> | null> {
     const tradingSymbol = `${symbol.toUpperCase()}/USD`;
 
     for (const exchangeSlug of this.EXCHANGE_PRIORITY) {
       try {
-        const client = await this.exchangeManager.getPublicClient(exchangeSlug);
-
-        // Load markets if not loaded
-        if (!client.markets) {
-          await withExchangeRetryThrow(() => client.loadMarkets(), {
-            logger: this.logger,
-            operationName: `loadMarkets(${exchangeSlug})`
-          });
-        }
-
-        // Check if symbol exists
-        const formattedSymbol = formatSymbolForExchange(exchangeSlug, tradingSymbol);
-        if (!client.markets[formattedSymbol]) {
-          continue;
-        }
-
-        // Fetch ticker
-        const ticker = await withExchangeRetryThrow(() => client.fetchTicker(formattedSymbol), {
-          logger: this.logger,
-          operationName: `fetchTicker(${exchangeSlug}:${tradingSymbol})`
-        });
-
-        if (ticker && ticker.last) {
-          return {
-            symbol: tradingSymbol,
-            price: ticker.last,
-            change24h: ticker.change || 0,
-            changePercent24h: ticker.percentage || 0,
-            volume24h: ticker.quoteVolume || ticker.baseVolume || 0,
-            high24h: ticker.high || ticker.last,
-            low24h: ticker.low || ticker.last,
-            updatedAt: new Date(),
-            source: exchangeSlug
-          };
-        }
+        const batched = await this.tickerBatcher.getTicker(exchangeSlug, tradingSymbol);
+        if (!batched || !batched.price) continue;
+        const refPrice = batched.price;
+        return {
+          symbol: tradingSymbol,
+          price: refPrice,
+          change24h: batched.change ?? 0,
+          changePercent24h: batched.percentage ?? 0,
+          volume24h: batched.quoteVolume ?? batched.baseVolume ?? 0,
+          high24h: batched.high ?? refPrice,
+          low24h: batched.low ?? refPrice,
+          updatedAt: new Date(),
+          source: exchangeSlug
+        };
       } catch (error: unknown) {
         const err = toErrorInfo(error);
         this.logger.debug(`Failed to fetch ticker from ${exchangeSlug} for ${tradingSymbol}: ${err.message}`);

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.spec.ts
@@ -3,6 +3,7 @@ import { Logger } from '@nestjs/common';
 import { PaperTradingMarketDataService, type PriceData } from './paper-trading-market-data.service';
 
 import type { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import type { BatchedTicker } from '../../exchange/ticker-batcher/ticker-batcher.types';
 import * as retryUtil from '../../shared/retry.util';
 
 const createCircuitBreaker = (overrides: Partial<Record<string, jest.Mock>> = {}) => ({
@@ -21,6 +22,7 @@ const createService = (
     coinSelectionService: any;
     coinService: any;
     circuitBreaker: any;
+    tickerBatcher: any;
   }> = {}
 ) => {
   const cacheManager = overrides.cacheManager ?? {
@@ -47,6 +49,11 @@ const createService = (
 
   const circuitBreaker = overrides.circuitBreaker ?? createCircuitBreaker();
 
+  const tickerBatcher = overrides.tickerBatcher ?? {
+    getTicker: jest.fn(),
+    getTickers: jest.fn()
+  };
+
   return {
     service: new PaperTradingMarketDataService(
       config as any,
@@ -54,24 +61,31 @@ const createService = (
       exchangeManager as ExchangeManagerService,
       coinSelectionService as any,
       coinService as any,
-      circuitBreaker as any
+      circuitBreaker as any,
+      tickerBatcher as any
     ),
     cacheManager,
     exchangeManager,
     coinSelectionService,
     coinService,
-    circuitBreaker
+    circuitBreaker,
+    tickerBatcher
   };
 };
 
-describe('PaperTradingMarketDataService', () => {
-  let withExchangeRetrySpy: jest.SpyInstance;
+const mkBatched = (overrides: Partial<BatchedTicker> = {}): BatchedTicker => ({
+  symbol: 'BTC/USDT',
+  price: 45000,
+  bid: 44950,
+  ask: 45050,
+  timestamp: new Date(1700000000000),
+  source: 'binance_us',
+  ...overrides
+});
 
+describe('PaperTradingMarketDataService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Spy on rate-limit-aware retry wrapper to avoid real delays in tests
-    withExchangeRetrySpy = jest.spyOn(retryUtil, 'withExchangeRetry');
-    // Silence domain warn/debug/error logs — individual tests can still spy to assert on messages
     jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     jest.spyOn(Logger.prototype, 'debug').mockImplementation();
     jest.spyOn(Logger.prototype, 'error').mockImplementation();
@@ -89,7 +103,7 @@ describe('PaperTradingMarketDataService', () => {
       source: 'binance'
     };
 
-    const { service, cacheManager, exchangeManager } = createService({
+    const { service, cacheManager, tickerBatcher } = createService({
       cacheManager: {
         get: jest.fn().mockResolvedValue(cached),
         set: jest.fn()
@@ -99,174 +113,76 @@ describe('PaperTradingMarketDataService', () => {
     const result = await service.getCurrentPrice('binance', 'BTC/USD');
 
     expect(result).toBe(cached);
-    expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
+    expect(tickerBatcher.getTicker).not.toHaveBeenCalled();
     expect(cacheManager.set).not.toHaveBeenCalled();
   });
 
-  it('fetches and caches price data when not cached', async () => {
-    const ticker = {
-      last: 45000,
-      bid: 44950,
-      ask: 45050,
-      timestamp: 1700000000000
+  it('fetches via batcher and caches price + stale entries on miss', async () => {
+    const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+    const tickerBatcher = {
+      getTicker: jest.fn().mockResolvedValue(mkBatched({ symbol: 'BTC/USDT', price: 45000, source: 'binance' })),
+      getTickers: jest.fn()
     };
 
-    const client = { fetchTicker: jest.fn().mockResolvedValue(ticker) };
-
-    const cacheManager = {
-      get: jest.fn().mockResolvedValue(null),
-      set: jest.fn()
-    };
-
-    const exchangeManager = {
-      formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
-      getPublicClient: jest.fn().mockResolvedValue(client)
-    };
-
-    withExchangeRetrySpy.mockResolvedValue({
-      success: true,
-      result: ticker,
-      attempts: 1,
-      totalDelayMs: 0
-    });
-
-    const { service } = createService({ cacheManager, exchangeManager });
-
+    const { service } = createService({ cacheManager, tickerBatcher });
     const result = await service.getCurrentPrice('binance', 'BTC/USDT');
 
-    expect(exchangeManager.formatSymbol).toHaveBeenCalledWith('binance', 'BTC/USDT');
-    // Normal cache write
+    expect(tickerBatcher.getTicker).toHaveBeenCalledWith('binance', 'BTC/USDT');
     expect(cacheManager.set).toHaveBeenCalledWith(
       'paper-trading:price:binance:BTC/USDT',
-      expect.objectContaining({
-        symbol: 'BTC/USDT',
-        price: 45000,
-        bid: 44950,
-        ask: 45050,
-        source: 'binance'
-      }),
+      expect.objectContaining({ symbol: 'BTC/USDT', price: 45000, source: 'binance' }),
       1000
     );
-    // Stale cache write (30 min TTL)
     expect(cacheManager.set).toHaveBeenCalledWith(
       'paper-trading:price:binance:BTC/USDT:stale',
-      expect.objectContaining({ symbol: 'BTC/USDT', price: 45000 }),
+      expect.objectContaining({ price: 45000 }),
       1800000
     );
     expect(result.price).toBe(45000);
   });
 
-  it('uses ticker.close when ticker.last is null', async () => {
-    const ticker = {
-      last: null,
-      close: 46000,
-      bid: 45950,
-      ask: 46050,
-      timestamp: 1700000000000
-    };
-
-    const client = { fetchTicker: jest.fn().mockResolvedValue(ticker) };
-
-    const cacheManager = {
-      get: jest.fn().mockResolvedValue(null),
-      set: jest.fn()
-    };
-
-    const exchangeManager = {
-      formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
-      getPublicClient: jest.fn().mockResolvedValue(client)
-    };
-
-    withExchangeRetrySpy.mockResolvedValue({
-      success: true,
-      result: ticker,
-      attempts: 1,
-      totalDelayMs: 0
-    });
-
-    const { service } = createService({ cacheManager, exchangeManager });
-
-    const result = await service.getCurrentPrice('binance', 'BTC/USDT');
-
-    expect(result.price).toBe(46000);
-    expect(result.source).toBe('binance');
-  });
-
-  describe('getCurrentPrice retry + stale-cache fallback', () => {
-    it('falls back to stale cache when all retries exhausted', async () => {
-      const staleData = {
+  describe('getCurrentPrice fallback chain', () => {
+    it('falls back to stale cache when batcher returns undefined (symbol not on exchange)', async () => {
+      const staleData: PriceData = {
         symbol: 'BTC/USDT',
         price: 44000,
-        bid: 43950,
-        ask: 44050,
         timestamp: new Date(),
         source: 'binance'
       };
-
       const cacheManager = {
         get: jest.fn().mockImplementation((key: string) => {
-          if (key === 'paper-trading:price:binance:BTC/USDT') return Promise.resolve(null);
           if (key === 'paper-trading:price:binance:BTC/USDT:stale') return Promise.resolve(staleData);
           return Promise.resolve(null);
         }),
         set: jest.fn()
       };
+      const tickerBatcher = { getTicker: jest.fn().mockResolvedValue(undefined), getTickers: jest.fn() };
 
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockReturnValue('BTC/USDT'),
-        getPublicClient: jest.fn().mockResolvedValue({ fetchTicker: jest.fn() })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: new Error('ETIMEDOUT'),
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
+      const { service } = createService({ cacheManager, tickerBatcher });
       const result = await service.getCurrentPrice('binance', 'BTC/USDT');
 
       expect(result.price).toBe(44000);
       expect(result.source).toBe('binance:stale');
     });
 
-    it('falls back to alternative exchange when retries exhausted and no stale cache', async () => {
-      const fallbackTicker = {
-        last: 43500,
-        bid: 43450,
-        ask: 43550,
-        timestamp: 1700000000000
+    it('falls back to alternate exchange when batcher throws and no stale cache exists', async () => {
+      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+      const tickerBatcher = {
+        getTicker: jest
+          .fn()
+          .mockImplementation((slug: string) =>
+            slug === 'gdax'
+              ? Promise.resolve(mkBatched({ symbol: 'BTC/USD', price: 43500, source: 'gdax' }))
+              : Promise.reject(new Error('ETIMEDOUT'))
+          ),
+        getTickers: jest.fn()
       };
 
-      const fallbackClient = { fetchTicker: jest.fn().mockResolvedValue(fallbackTicker) };
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
-        getPublicClient: jest.fn().mockImplementation((slug: string) => {
-          if (slug === 'gdax') return Promise.resolve(fallbackClient);
-          return Promise.resolve({ fetchTicker: jest.fn() });
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: new Error('ETIMEDOUT'),
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
+      const { service } = createService({ cacheManager, tickerBatcher });
       const result = await service.getCurrentPrice('binance', 'BTC/USDT');
 
       expect(result.price).toBe(43500);
       expect(result.source).toBe('gdax:fallback');
-      // Should cache the fallback result as stale
       expect(cacheManager.set).toHaveBeenCalledWith(
         'paper-trading:price:binance:BTC/USDT:stale',
         expect.objectContaining({ source: 'gdax:fallback' }),
@@ -274,158 +190,151 @@ describe('PaperTradingMarketDataService', () => {
       );
     });
 
-    it('falls back to DB coin price when all exchanges fail', async () => {
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
+    it('falls back to DB coin price when all exchanges fail via batcher', async () => {
+      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+      const tickerBatcher = {
+        getTicker: jest.fn().mockRejectedValue(new Error('ETIMEDOUT')),
+        getTickers: jest.fn()
       };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
-        getPublicClient: jest.fn().mockResolvedValue({
-          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: new Error('ETIMEDOUT'),
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
       const coinService = {
         getCoinsByRiskLevel: jest.fn(),
         getCoinBySymbol: jest.fn().mockResolvedValue({ id: 'coin-1', currentPrice: 42000 })
       };
 
-      const { service } = createService({ cacheManager, exchangeManager, coinService });
+      const { service } = createService({ cacheManager, tickerBatcher, coinService });
       const result = await service.getCurrentPrice('binance', 'BTC/USDT');
 
       expect(result.price).toBe(42000);
       expect(result.source).toBe('db:coin.currentPrice');
     });
 
-    it('falls back to DB coin price of 0 without skipping it', async () => {
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
+    it('throws when batcher, fallback exchanges, and DB all fail', async () => {
+      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+      const tickerBatcher = {
+        getTicker: jest.fn().mockRejectedValue(new Error('ETIMEDOUT')),
+        getTickers: jest.fn()
       };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
-        getPublicClient: jest.fn().mockResolvedValue({
-          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: new Error('ETIMEDOUT'),
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
-      const coinService = {
-        getCoinsByRiskLevel: jest.fn(),
-        getCoinBySymbol: jest.fn().mockResolvedValue({ id: 'coin-1', currentPrice: 0 })
-      };
-
-      const { service } = createService({ cacheManager, exchangeManager, coinService });
-      const result = await service.getCurrentPrice('binance', 'BTC/USDT');
-
-      expect(result.price).toBe(0);
-      expect(result.source).toBe('db:coin.currentPrice');
-    });
-
-    it('throws when retries, fallback exchanges, and DB all fail', async () => {
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_slug: string, symbol: string) => symbol),
-        getPublicClient: jest.fn().mockResolvedValue({
-          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
-        })
-      };
-
-      const timeoutError = new Error('ETIMEDOUT');
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: timeoutError,
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
       const coinService = {
         getCoinsByRiskLevel: jest.fn(),
         getCoinBySymbol: jest.fn().mockResolvedValue(null)
       };
 
-      const { service } = createService({ cacheManager, exchangeManager, coinService });
+      const { service } = createService({ cacheManager, tickerBatcher, coinService });
 
       await expect(service.getCurrentPrice('binance', 'BTC/USDT')).rejects.toThrow('ETIMEDOUT');
     });
-  });
 
-  describe('getPrices retry + stale-cache fallback', () => {
-    it('retries on transient error and succeeds on 2nd attempt', async () => {
-      const tickers = {
-        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 },
-        'ETH/USDT': { last: 2500, bid: 2490, ask: 2510, timestamp: 1700000000000 }
+    it('short-circuits to stale cache without hitting the batcher when circuit is open', async () => {
+      const stale: PriceData = {
+        symbol: 'BTC/USDT',
+        price: 44000,
+        timestamp: new Date(),
+        source: 'binance_us'
       };
-
-      const client = {
-        markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
-        loadMarkets: jest.fn().mockResolvedValue(undefined),
-        fetchTickers: jest.fn()
-      };
-
       const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
+        get: jest.fn().mockImplementation((key: string) => {
+          if (key.endsWith(':stale')) return Promise.resolve(stale);
+          return Promise.resolve(null);
+        }),
         set: jest.fn()
       };
+      const tickerBatcher = { getTicker: jest.fn(), getTickers: jest.fn() };
+      const circuitBreaker = createCircuitBreaker({ isOpen: jest.fn().mockReturnValue(true) });
 
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue(client)
+      const { service } = createService({ cacheManager, tickerBatcher, circuitBreaker });
+      const result = await service.getCurrentPrice('binance_us', 'BTC/USDT');
+
+      expect(result.source).toBe('binance_us:stale');
+      expect(tickerBatcher.getTicker).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPrices fallback chain', () => {
+    it('delegates to batcher.getTickers and caches each returned price', async () => {
+      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+      const tickerBatcher = {
+        getTicker: jest.fn(),
+        getTickers: jest.fn().mockResolvedValue(
+          new Map<string, BatchedTicker>([
+            ['BTC/USDT', mkBatched({ symbol: 'BTC/USDT', price: 45000, source: 'binance' })],
+            ['ETH/USDT', mkBatched({ symbol: 'ETH/USDT', price: 2500, source: 'binance' })]
+          ])
+        )
       };
 
-      withExchangeRetrySpy.mockResolvedValue({
-        success: true,
-        result: tickers,
-        attempts: 2,
-        totalDelayMs: 2000
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
+      const { service } = createService({ cacheManager, tickerBatcher });
       const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
 
+      expect(tickerBatcher.getTickers).toHaveBeenCalledWith('binance', ['BTC/USDT', 'ETH/USDT']);
       expect(result.get('BTC/USDT')?.price).toBe(45000);
       expect(result.get('ETH/USDT')?.price).toBe(2500);
-      // Each symbol should have both normal + stale cache writes
+      // Each symbol: normal + stale cache write.
       expect(cacheManager.set).toHaveBeenCalledTimes(4);
     });
 
-    it('falls back to stale cache when all retries exhausted', async () => {
-      const stalebtc = {
+    it('returns cached symbols without fetching, and only fetches uncached', async () => {
+      const cachedPrice: PriceData = {
         symbol: 'BTC/USDT',
         price: 44000,
         timestamp: new Date(),
         source: 'binance'
       };
-      const staleeth = {
-        symbol: 'ETH/USDT',
-        price: 2400,
-        timestamp: new Date(),
-        source: 'binance'
+
+      const cacheManager = {
+        get: jest
+          .fn()
+          .mockImplementation((key: string) =>
+            key === 'paper-trading:price:binance:BTC/USDT' ? Promise.resolve(cachedPrice) : Promise.resolve(null)
+          ),
+        set: jest.fn()
       };
+      const tickerBatcher = {
+        getTicker: jest.fn(),
+        getTickers: jest
+          .fn()
+          .mockResolvedValue(
+            new Map<string, BatchedTicker>([
+              ['ETH/USDT', mkBatched({ symbol: 'ETH/USDT', price: 2500, source: 'binance' })]
+            ])
+          )
+      };
+
+      const { service } = createService({ cacheManager, tickerBatcher });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(result.get('BTC/USDT')).toBe(cachedPrice);
+      expect(result.get('ETH/USDT')?.price).toBe(2500);
+      expect(tickerBatcher.getTickers).toHaveBeenCalledWith('binance', ['ETH/USDT']);
+      // Only ETH: normal + stale.
+      expect(cacheManager.set).toHaveBeenCalledTimes(2);
+    });
+
+    it('silently omits symbols the batcher does not return on successful fetch', async () => {
+      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+      const tickerBatcher = {
+        getTicker: jest.fn(),
+        getTickers: jest
+          .fn()
+          .mockResolvedValue(
+            new Map<string, BatchedTicker>([
+              ['BTC/USDT', mkBatched({ symbol: 'BTC/USDT', price: 45000, source: 'binance' })]
+            ])
+          )
+      };
+
+      const { service } = createService({ cacheManager, tickerBatcher });
+      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
+
+      expect(result.get('BTC/USDT')?.price).toBe(45000);
+      expect(result.has('ETH/USDT')).toBe(false);
+    });
+
+    it('falls back to stale cache when batcher rejects', async () => {
+      const stalebtc: PriceData = { symbol: 'BTC/USDT', price: 44000, timestamp: new Date(), source: 'binance' };
+      const staleeth: PriceData = { symbol: 'ETH/USDT', price: 2400, timestamp: new Date(), source: 'binance' };
 
       const cacheManager = {
         get: jest.fn().mockImplementation((key: string) => {
-          // No normal cache
           if (!key.endsWith(':stale')) return Promise.resolve(null);
           if (key.includes('BTC/USDT')) return Promise.resolve(stalebtc);
           if (key.includes('ETH/USDT')) return Promise.resolve(staleeth);
@@ -433,24 +342,12 @@ describe('PaperTradingMarketDataService', () => {
         }),
         set: jest.fn()
       };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
-          loadMarkets: jest.fn().mockResolvedValue(undefined),
-          fetchTickers: jest.fn()
-        })
+      const tickerBatcher = {
+        getTicker: jest.fn(),
+        getTickers: jest.fn().mockRejectedValue(new Error('ETIMEDOUT'))
       };
 
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: new Error('ETIMEDOUT'),
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
+      const { service } = createService({ cacheManager, tickerBatcher });
       const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
 
       expect(result.get('BTC/USDT')?.price).toBe(44000);
@@ -460,52 +357,28 @@ describe('PaperTradingMarketDataService', () => {
     });
 
     it('uses fallback exchange for symbols missing stale cache', async () => {
-      const stalebtc = {
-        symbol: 'BTC/USDT',
-        price: 44000,
-        timestamp: new Date(),
-        source: 'binance'
-      };
-
-      const fallbackTicker = {
-        last: 2400,
-        bid: 2390,
-        ask: 2410,
-        timestamp: 1700000000000
-      };
-
+      const stalebtc: PriceData = { symbol: 'BTC/USDT', price: 44000, timestamp: new Date(), source: 'binance' };
       const cacheManager = {
         get: jest.fn().mockImplementation((key: string) => {
           if (!key.endsWith(':stale')) return Promise.resolve(null);
           if (key.includes('BTC/USDT')) return Promise.resolve(stalebtc);
-          // ETH has no stale cache
           return Promise.resolve(null);
         }),
         set: jest.fn()
       };
 
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockImplementation((slug: string) => {
-          if (slug === 'gdax') {
-            return Promise.resolve({ fetchTicker: jest.fn().mockResolvedValue(fallbackTicker) });
-          }
-          return Promise.resolve({
-            markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
-            loadMarkets: jest.fn().mockResolvedValue(undefined),
-            fetchTickers: jest.fn()
-          });
-        })
+      const tickerBatcher = {
+        getTicker: jest
+          .fn()
+          .mockImplementation((slug: string) =>
+            slug === 'gdax'
+              ? Promise.resolve(mkBatched({ symbol: 'ETH/USD', price: 2400, source: 'gdax' }))
+              : Promise.resolve(undefined)
+          ),
+        getTickers: jest.fn().mockRejectedValue(new Error('ETIMEDOUT'))
       };
 
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: new Error('ETIMEDOUT'),
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
+      const { service } = createService({ cacheManager, tickerBatcher });
       const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
 
       expect(result.get('BTC/USDT')?.source).toBe('binance:stale');
@@ -513,267 +386,26 @@ describe('PaperTradingMarketDataService', () => {
       expect(result.get('ETH/USDT')?.source).toBe('gdax:fallback');
     });
 
-    it('throws when retries, fallback exchanges, and DB all fail for some symbols', async () => {
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
+    it('throws when batcher rejects and no stale / fallback / DB price exists', async () => {
+      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+      const tickerBatcher = {
+        getTicker: jest.fn().mockRejectedValue(new Error('ETIMEDOUT')),
+        getTickers: jest.fn().mockRejectedValue(new Error('ETIMEDOUT'))
       };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
-          loadMarkets: jest.fn().mockResolvedValue(undefined),
-          fetchTickers: jest.fn(),
-          fetchTicker: jest.fn().mockRejectedValue(new Error('exchange down'))
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: new Error('ETIMEDOUT'),
-        attempts: 4,
-        totalDelayMs: 14000
-      });
-
       const coinService = {
         getCoinsByRiskLevel: jest.fn(),
         getCoinBySymbol: jest.fn().mockResolvedValue(null)
       };
 
-      const { service } = createService({ cacheManager, exchangeManager, coinService });
+      const { service } = createService({ cacheManager, tickerBatcher, coinService });
 
       await expect(service.getPrices('binance', ['BTC/USDT', 'ETH/USDT'])).rejects.toThrow(
         /2 symbol\(s\) have no stale cache, fallback exchange, or DB fallback/
       );
     });
 
-    it('returns cached symbols without fetching and only fetches uncached', async () => {
-      const cachedPrice: PriceData = {
-        symbol: 'BTC/USDT',
-        price: 44000,
-        bid: 43950,
-        ask: 44050,
-        timestamp: new Date(),
-        source: 'binance'
-      };
-
-      const tickers = {
-        'ETH/USDT': { last: 2500, bid: 2490, ask: 2510, timestamp: 1700000000000 }
-      };
-
-      const cacheManager = {
-        get: jest.fn().mockImplementation((key: string) => {
-          if (key === 'paper-trading:price:binance:BTC/USDT') return Promise.resolve(cachedPrice);
-          return Promise.resolve(null);
-        }),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
-          loadMarkets: jest.fn().mockResolvedValue(undefined),
-          fetchTickers: jest.fn()
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: true,
-        result: tickers,
-        attempts: 1,
-        totalDelayMs: 0
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
-
-      expect(result.get('BTC/USDT')).toBe(cachedPrice);
-      expect(result.get('ETH/USDT')?.price).toBe(2500);
-      // Only ETH should have cache writes (BTC was cached)
-      expect(cacheManager.set).toHaveBeenCalledTimes(2);
-    });
-
-    it('skips symbols missing from ticker response', async () => {
-      const tickers = {
-        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
-        // ETH/USDT intentionally missing from response
-      };
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
-          loadMarkets: jest.fn().mockResolvedValue(undefined),
-          fetchTickers: jest.fn()
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: true,
-        result: tickers,
-        attempts: 1,
-        totalDelayMs: 0
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
-
-      expect(result.get('BTC/USDT')?.price).toBe(45000);
-      expect(result.has('ETH/USDT')).toBe(false);
-    });
-
-    it('returns cached-only results when all requested symbols are missing from exchange markets', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      const fetchTickers = jest.fn();
-      const loadMarkets = jest.fn().mockResolvedValue(undefined);
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {} },
-          loadMarkets,
-          fetchTickers
-        })
-      };
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      const result = await service.getPrices('binance_us', ['USDT/USD', 'NONEXISTENT/USD']);
-
-      expect(result.size).toBe(0);
-      expect(fetchTickers).not.toHaveBeenCalled();
-      expect(withExchangeRetrySpy).not.toHaveBeenCalled();
-      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('none of 2 requested symbols'));
-    });
-
-    it('filters out invalid symbols and calls fetchTickers with valid ones only', async () => {
-      const tickers = {
-        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
-      };
-
-      const fetchTickers = jest.fn();
-      const loadMarkets = jest.fn().mockResolvedValue(undefined);
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {} },
-          loadMarkets,
-          fetchTickers
-        })
-      };
-
-      withExchangeRetrySpy.mockImplementation(async (op: () => Promise<unknown>) => {
-        await op();
-        return { success: true, result: tickers, attempts: 1, totalDelayMs: 0 };
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      const result = await service.getPrices('binance_us', ['BTC/USDT', 'USDT/USD']);
-
-      expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT']);
-      expect(result.get('BTC/USDT')?.price).toBe(45000);
-      expect(result.has('USDT/USD')).toBe(false);
-    });
-
-    it('falls through without filtering when loadMarkets fails', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      const tickers = {
-        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 },
-        'ETH/USDT': { last: 2500, bid: 2490, ask: 2510, timestamp: 1700000000000 }
-      };
-
-      const fetchTickers = jest.fn();
-      const loadMarkets = jest.fn().mockRejectedValue(new Error('markets endpoint down'));
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: {},
-          loadMarkets,
-          fetchTickers
-        })
-      };
-
-      withExchangeRetrySpy.mockImplementation(async (op: () => Promise<unknown>) => {
-        await op();
-        return { success: true, result: tickers, attempts: 1, totalDelayMs: 0 };
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      const result = await service.getPrices('binance', ['BTC/USDT', 'ETH/USDT']);
-
-      expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT', 'ETH/USDT']);
-      expect(result.get('BTC/USDT')?.price).toBe(45000);
-      expect(result.get('ETH/USDT')?.price).toBe(2500);
-      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('loadMarkets(binance) failed'));
-    });
-
-    it('does not call loadMarkets when markets are already loaded', async () => {
-      const tickers = {
-        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
-      };
-
-      const fetchTickers = jest.fn();
-      const loadMarkets = jest.fn().mockResolvedValue(undefined);
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {}, 'ETH/USDT': {} },
-          loadMarkets,
-          fetchTickers
-        })
-      };
-
-      withExchangeRetrySpy.mockImplementation(async (op: () => Promise<unknown>) => {
-        await op();
-        return { success: true, result: tickers, attempts: 1, totalDelayMs: 0 };
-      });
-
-      const { service } = createService({ cacheManager, exchangeManager });
-      await service.getPrices('binance', ['BTC/USDT']);
-
-      expect(loadMarkets).not.toHaveBeenCalled();
-      expect(fetchTickers).toHaveBeenCalledWith(['BTC/USDT']);
-    });
-
-    it('short-circuits to stale cache when breaker is open — does not hit the exchange', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-
-      const stalebtc = {
-        symbol: 'BTC/USDT',
-        price: 44000,
-        timestamp: new Date(),
-        source: 'binance_us'
-      };
-
+    it('short-circuits to stale cache when breaker is open — does not hit the batcher', async () => {
+      const stalebtc: PriceData = { symbol: 'BTC/USDT', price: 44000, timestamp: new Date(), source: 'binance_us' };
       const cacheManager = {
         get: jest.fn().mockImplementation((key: string) => {
           if (!key.endsWith(':stale')) return Promise.resolve(null);
@@ -782,110 +414,35 @@ describe('PaperTradingMarketDataService', () => {
         }),
         set: jest.fn()
       };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn()
-      };
-
+      const tickerBatcher = { getTicker: jest.fn(), getTickers: jest.fn() };
       const circuitBreaker = createCircuitBreaker({ isOpen: jest.fn().mockReturnValue(true) });
 
-      const { service } = createService({ cacheManager, exchangeManager, circuitBreaker });
+      const { service } = createService({ cacheManager, tickerBatcher, circuitBreaker });
       const result = await service.getPrices('binance_us', ['BTC/USDT']);
 
       expect(result.get('BTC/USDT')?.source).toBe('binance_us:stale');
-      // Most important assertion: with breaker open, we never talk to the exchange
-      expect(withExchangeRetrySpy).not.toHaveBeenCalled();
-      expect(exchangeManager.getPublicClient).not.toHaveBeenCalled();
-      // And we don't re-count a synthetic failure against the circuit
-      expect(circuitBreaker.recordFailure).not.toHaveBeenCalled();
-      loggerSpy.mockRestore();
-    });
-
-    it('records a breaker failure on weight-limit error and lets caller skip retries', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-
-      const weightError = new Error(
-        'binanceus 429 Too Many Requests {"code":-1003,"msg":"Too much request weight used; current limit is 1200 request weight per 1 MINUTE."}'
-      );
-
-      const cacheManager = {
-        get: jest.fn().mockResolvedValue(null),
-        set: jest.fn()
-      };
-
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'THETA/USDT': {} },
-          loadMarkets: jest.fn().mockResolvedValue(undefined),
-          fetchTickers: jest.fn(),
-          fetchTicker: jest.fn().mockRejectedValue(weightError)
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({
-        success: false,
-        error: weightError,
-        attempts: 1, // Key: NOT 4 — the isRetryable callback must short-circuit retries
-        totalDelayMs: 0
-      });
-
-      const circuitBreaker = createCircuitBreaker();
-      const coinService = {
-        getCoinsByRiskLevel: jest.fn(),
-        getCoinBySymbol: jest.fn().mockResolvedValue(null)
-      };
-
-      const { service } = createService({ cacheManager, exchangeManager, circuitBreaker, coinService });
-
-      await expect(service.getPrices('binance_us', ['THETA/USDT'])).rejects.toThrow(/no stale cache/);
-
-      // Breaker saw the failure and can count toward opening
-      expect(circuitBreaker.recordFailure).toHaveBeenCalledWith('paper-trading:market-data:binance_us');
-      // And we passed an isRetryable guard so the retry wrapper won't loop on 429s
-      const callArgs = withExchangeRetrySpy.mock.calls[0];
-      const retryOptions = callArgs[1];
-      expect(retryOptions.isRetryable(weightError)).toBe(false);
-      loggerSpy.mockRestore();
-    });
-
-    it('records a breaker success on a normal fetch', async () => {
-      const tickers = {
-        'BTC/USDT': { last: 45000, bid: 44950, ask: 45050, timestamp: 1700000000000 }
-      };
-
-      const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
-      const exchangeManager = {
-        formatSymbol: jest.fn().mockImplementation((_: string, s: string) => s),
-        getPublicClient: jest.fn().mockResolvedValue({
-          markets: { 'BTC/USDT': {} },
-          loadMarkets: jest.fn().mockResolvedValue(undefined),
-          fetchTickers: jest.fn()
-        })
-      };
-
-      withExchangeRetrySpy.mockResolvedValue({ success: true, result: tickers, attempts: 1, totalDelayMs: 0 });
-
-      const circuitBreaker = createCircuitBreaker();
-      const { service } = createService({ cacheManager, exchangeManager, circuitBreaker });
-
-      await service.getPrices('binance_us', ['BTC/USDT']);
-
-      expect(circuitBreaker.recordSuccess).toHaveBeenCalledWith('paper-trading:market-data:binance_us');
+      expect(tickerBatcher.getTickers).not.toHaveBeenCalled();
       expect(circuitBreaker.recordFailure).not.toHaveBeenCalled();
     });
   });
 
   describe('checkExchangeHealth', () => {
+    let withExchangeRetrySpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      withExchangeRetrySpy = jest.spyOn(retryUtil, 'withExchangeRetry');
+    });
+
+    afterEach(() => {
+      withExchangeRetrySpy.mockRestore();
+    });
+
     it('returns healthy with latency when exchange responds', async () => {
       const exchangeManager = {
         formatSymbol: jest.fn(),
         getPublicClient: jest.fn().mockResolvedValue({ fetchTime: jest.fn() })
       };
 
-      // Deterministic latency: Date.now() is called at start and end of checkExchangeHealth
       jest.spyOn(Date, 'now').mockReturnValueOnce(1_000_000).mockReturnValueOnce(1_000_042);
 
       withExchangeRetrySpy.mockResolvedValue({ success: true, result: 1700000000000, attempts: 1, totalDelayMs: 0 });
@@ -916,7 +473,6 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result.healthy).toBe(false);
       expect(result.error).toBe('connection refused');
-      expect(result.latencyMs).toBeUndefined();
     });
 
     it('returns unhealthy when getPublicClient throws', async () => {
@@ -948,7 +504,6 @@ describe('PaperTradingMarketDataService', () => {
       expect(result).toEqual(['BTC/USD', 'ETH/USD']);
       expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(1);
 
-      // Second call must be served from cache
       await service.resolveSymbolUniverse(session, 'USD');
       expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(1);
     });
@@ -974,18 +529,13 @@ describe('PaperTradingMarketDataService', () => {
       const session = makeSession();
 
       await service.resolveSymbolUniverse(session, 'USD');
-
-      fakeNow += 5 * 60 * 1000 + 1; // past TTL
-
+      fakeNow += 5 * 60 * 1000 + 1;
       await service.resolveSymbolUniverse(session, 'USD');
 
       expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(2);
-
-      jest.restoreAllMocks();
     });
 
-    it('does not cache the BTC/ETH fallback — re-queries DB on every tick until real selections exist', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    it('does not cache the BTC/ETH fallback — re-queries DB on every tick', async () => {
       const coinSelectionService = { getCoinSelectionsByUser: jest.fn().mockResolvedValue([]) };
       const coinService = { getCoinsByRiskLevel: jest.fn().mockResolvedValue([]) };
       const {
@@ -1004,8 +554,6 @@ describe('PaperTradingMarketDataService', () => {
       expect(result).toEqual(['BTC/USD', 'ETH/USD']);
       expect(mockCs.getCoinSelectionsByUser).toHaveBeenCalledTimes(2);
       expect(mockCv.getCoinsByRiskLevel).toHaveBeenCalledTimes(2);
-      // Verify log includes userId for debugging
-      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('u-99'));
     });
 
     it('clearSymbolCache removes the cached entry so next call re-queries', async () => {
@@ -1023,7 +571,6 @@ describe('PaperTradingMarketDataService', () => {
     });
 
     it('returns BTC/ETH fallback when session.user is null', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
       const { service, coinSelectionService: mockCs } = createService();
       const session = { id: 'sess-no-user', user: null } as any;
 
@@ -1031,11 +578,9 @@ describe('PaperTradingMarketDataService', () => {
 
       expect(result).toEqual(['BTC/USD', 'ETH/USD']);
       expect(mockCs.getCoinSelectionsByUser).not.toHaveBeenCalled();
-      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('no user attached'));
     });
 
     it('falls through to risk-level coins when coin selection service throws', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
       const coinSelectionService = {
         getCoinSelectionsByUser: jest.fn().mockRejectedValue(new Error('DB connection lost'))
       };
@@ -1043,23 +588,16 @@ describe('PaperTradingMarketDataService', () => {
       const { service } = createService({ coinSelectionService, coinService });
 
       const result = await service.resolveSymbolUniverse(makeSession(), 'USD');
-
       expect(result).toEqual(['SOL/USD']);
-      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('coin selection fetch failed'));
     });
 
     it('returns BTC/ETH fallback when both services throw', async () => {
-      const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-      const coinSelectionService = {
-        getCoinSelectionsByUser: jest.fn().mockRejectedValue(new Error('DB down'))
-      };
+      const coinSelectionService = { getCoinSelectionsByUser: jest.fn().mockRejectedValue(new Error('DB down')) };
       const coinService = { getCoinsByRiskLevel: jest.fn().mockRejectedValue(new Error('DB down')) };
       const { service } = createService({ coinSelectionService, coinService });
 
       const result = await service.resolveSymbolUniverse(makeSession(), 'USD');
-
       expect(result).toEqual(['BTC/USD', 'ETH/USD']);
-      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('risk-level coin fetch failed'));
     });
   });
 
@@ -1072,21 +610,17 @@ describe('PaperTradingMarketDataService', () => {
       };
       const { service } = createService({ coinSelectionService });
 
-      // Populate caches for 3 sessions
       await service.resolveSymbolUniverse(makeSession('s-1'), 'USD');
       await service.resolveSymbolUniverse(makeSession('s-2'), 'USD');
       await service.resolveSymbolUniverse(makeSession('s-3'), 'USD');
 
       const swept = service.sweepOrphaned(new Set(['s-2']));
-
       expect(swept).toBe(2);
 
-      // s-2 should still be cached (no re-query needed)
       coinSelectionService.getCoinSelectionsByUser.mockClear();
       await service.resolveSymbolUniverse(makeSession('s-2'), 'USD');
       expect(coinSelectionService.getCoinSelectionsByUser).not.toHaveBeenCalled();
 
-      // s-1 should be gone (re-query needed)
       await service.resolveSymbolUniverse(makeSession('s-1'), 'USD');
       expect(coinSelectionService.getCoinSelectionsByUser).toHaveBeenCalledTimes(1);
     });
@@ -1098,19 +632,13 @@ describe('PaperTradingMarketDataService', () => {
       const { service } = createService({ coinSelectionService });
 
       await service.resolveSymbolUniverse(makeSession('s-1'), 'USD');
-
       expect(service.sweepOrphaned(new Set(['s-1']))).toBe(0);
     });
   });
 
   describe('clearCache', () => {
     it('deletes price, stale, and orderbook keys for a given symbol', async () => {
-      const cacheManager = {
-        get: jest.fn(),
-        set: jest.fn(),
-        del: jest.fn()
-      };
-
+      const cacheManager = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
       const { service } = createService({ cacheManager });
       await service.clearCache('binance', 'BTC/USDT');
 
@@ -1120,12 +648,7 @@ describe('PaperTradingMarketDataService', () => {
     });
 
     it('does not delete anything when no symbol provided', async () => {
-      const cacheManager = {
-        get: jest.fn(),
-        set: jest.fn(),
-        del: jest.fn()
-      };
-
+      const cacheManager = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
       const { service } = createService({ cacheManager });
       await service.clearCache('binance');
 

--- a/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
+++ b/apps/api/src/order/paper-trading/paper-trading-market-data.service.ts
@@ -3,7 +3,6 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 
 import { Cache } from 'cache-manager';
-import type * as ccxt from 'ccxt';
 
 import { PaperTradingSession } from './entities';
 import type { PriceData } from './paper-trading-market-data.types';
@@ -14,16 +13,16 @@ import { CoinSelectionRelations } from '../../coin-selection/coin-selection.enti
 import { CoinSelectionService } from '../../coin-selection/coin-selection.service';
 import { EXCHANGE_QUOTE_CURRENCY } from '../../exchange/constants';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import { TickerBatcherService } from '../../exchange/ticker-batcher/ticker-batcher.service';
+import { tickerCircuitKey } from '../../shared/circuit-breaker.constants';
 import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { toErrorInfo } from '../../shared/error.util';
-import { isRateLimitError, isWeightLimitError, withExchangeRetry } from '../../shared/retry.util';
-import type { User } from '../../users/users.entity';
+import { withExchangeRetry } from '../../shared/retry.util';
 
 export type { PriceData, OrderBook, OrderBookLevel, RealisticSlippageResult } from './paper-trading-market-data.types';
 
 const STALE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const FALLBACK_EXCHANGE_SLUGS = ['gdax', 'kraken'] as const;
-const CIRCUIT_KEY_PREFIX = 'paper-trading:market-data';
 
 @Injectable()
 export class PaperTradingMarketDataService {
@@ -38,13 +37,14 @@ export class PaperTradingMarketDataService {
     private readonly exchangeManager: ExchangeManagerService,
     private readonly coinSelectionService: CoinSelectionService,
     private readonly coinService: CoinService,
-    private readonly circuitBreaker: CircuitBreakerService
+    private readonly circuitBreaker: CircuitBreakerService,
+    private readonly tickerBatcher: TickerBatcherService
   ) {
     this.cacheTtlMs = config.priceCacheTtlMs;
   }
 
   private circuitKey(exchangeSlug: string): string {
-    return `${CIRCUIT_KEY_PREFIX}:${exchangeSlug}`;
+    return tickerCircuitKey(exchangeSlug);
   }
 
   /** Resolve symbol universe from user's coin selections, falling back to risk-level coins. */
@@ -120,113 +120,83 @@ export class PaperTradingMarketDataService {
   }
 
   /**
-   * Get current price for a symbol from exchange
-   * Uses cache with short TTL to minimize API calls
+   * Get current price for a symbol. Routes through TickerBatcherService,
+   * which coalesces concurrent callers and owns the circuit-breaker state
+   * for the exchange hop. Falls back to stale cache → alternate exchange → DB.
    */
-  async getCurrentPrice(exchangeSlug: string, symbol: string, user?: User): Promise<PriceData> {
+  async getCurrentPrice(exchangeSlug: string, symbol: string): Promise<PriceData> {
     const cacheKey = `paper-trading:price:${exchangeSlug}:${symbol}`;
 
-    // Try cache first
     const cached = await this.cacheManager.get<PriceData>(cacheKey);
     if (cached) {
       return cached;
     }
 
-    // If the breaker is open, skip the exchange call entirely and short-circuit
-    // to the stale / fallback chain. Every call we skip preserves request-weight
-    // budget and lets binance_us recover.
+    // If the breaker is open, skip the batcher and go straight to the stale chain.
     const circuitOpen = this.circuitBreaker.isOpen(this.circuitKey(exchangeSlug));
 
-    // Format symbol for exchange
-    const formattedSymbol = this.exchangeManager.formatSymbol(exchangeSlug, symbol);
+    let fetched: PriceData | null = null;
+    let fetchError: Error | null = circuitOpen ? new Error(`Circuit breaker open for ${exchangeSlug}`) : null;
 
-    const result = circuitOpen
-      ? {
-          success: false as const,
-          error: new Error(`Circuit breaker open for ${exchangeSlug}`),
-          attempts: 0,
-          totalDelayMs: 0
+    if (!circuitOpen) {
+      try {
+        const ticker = await this.tickerBatcher.getTicker(exchangeSlug, symbol);
+        if (ticker) {
+          fetched = {
+            symbol,
+            price: ticker.price,
+            bid: ticker.bid,
+            ask: ticker.ask,
+            timestamp: ticker.timestamp,
+            source: exchangeSlug
+          };
+        } else {
+          fetchError = new Error(`No ticker for ${symbol} on ${exchangeSlug}`);
         }
-      : await withExchangeRetry(
-          async () => {
-            const client = user
-              ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-              : await this.exchangeManager.getPublicClient(exchangeSlug);
-            return client.fetchTicker(formattedSymbol);
-          },
-          {
-            logger: this.logger,
-            operationName: `fetchTicker(${exchangeSlug}:${symbol})`,
-            // Rate/weight limits are account-wide — burning retries on them just
-            // deepens the hole. Skip retries and fall through to the stale cache.
-            isRetryable: (err) => !isRateLimitError(err) && !isWeightLimitError(err)
-          }
-        );
-
-    if (result.success && result.result) {
-      const ticker = result.result;
-      const priceData: PriceData = {
-        symbol,
-        price: ticker.last ?? ticker.close ?? 0,
-        bid: ticker.bid,
-        ask: ticker.ask,
-        timestamp: new Date(ticker.timestamp ?? Date.now()),
-        source: exchangeSlug
-      };
-
-      this.circuitBreaker.recordSuccess(this.circuitKey(exchangeSlug));
-
-      // Cache the result
-      await this.cacheManager.set(cacheKey, priceData, this.cacheTtlMs);
-
-      // Write stale fallback cache with longer TTL
-      const staleKey = `${cacheKey}:stale`;
-      await this.cacheManager.set(staleKey, priceData, STALE_CACHE_TTL_MS);
-
-      return priceData;
+      } catch (error: unknown) {
+        fetchError = error instanceof Error ? error : new Error(String(error));
+      }
     }
 
-    if (!circuitOpen && result.error) {
-      this.circuitBreaker.recordFailure(this.circuitKey(exchangeSlug));
+    if (fetched) {
+      await this.cacheManager.set(cacheKey, fetched, this.cacheTtlMs);
+      await this.cacheManager.set(`${cacheKey}:stale`, fetched, STALE_CACHE_TTL_MS);
+      return fetched;
     }
 
-    // All retries exhausted — fall back to stale cache
     const staleKey = `${cacheKey}:stale`;
     const stale = await this.cacheManager.get<PriceData>(staleKey);
     if (stale) {
       this.logger.warn(
-        `${circuitOpen ? 'Circuit open' : 'All retries exhausted'} fetching price for ${symbol} from ${exchangeSlug}. Using stale cached price.`
+        `${circuitOpen ? 'Circuit open' : 'Batcher fetch exhausted'} for ${symbol} on ${exchangeSlug}. Using stale cached price.`
       );
       return { ...stale, source: `${stale.source}:stale` };
     }
 
-    // Try fallback exchanges
     const fallbackPrice = await this.tryFallbackExchanges(symbol, exchangeSlug);
     if (fallbackPrice) {
-      const staleKey2 = `${cacheKey}:stale`;
-      await this.cacheManager.set(staleKey2, fallbackPrice, STALE_CACHE_TTL_MS);
+      await this.cacheManager.set(`${cacheKey}:stale`, fallbackPrice, STALE_CACHE_TTL_MS);
       return fallbackPrice;
     }
 
-    // Try database price as last resort
     const dbPrice = await this.tryDatabasePrice(symbol);
     if (dbPrice) {
       return dbPrice;
     }
 
     this.logger.error(
-      `Failed to fetch price for ${symbol} from ${exchangeSlug} after ${circuitOpen ? 'circuit-open short-circuit' : 'retries'}, fallback exchanges, and DB lookup`
+      `Failed to fetch price for ${symbol} from ${exchangeSlug} after ${circuitOpen ? 'circuit-open short-circuit' : 'batcher'}, fallback exchanges, and DB lookup`
     );
-    throw result.error;
+    throw fetchError ?? new Error(`Failed to fetch price for ${symbol} from ${exchangeSlug}`);
   }
 
   /**
-   * Get prices for multiple symbols in one call
+   * Get prices for multiple symbols. Routes through the batcher for a single
+   * coalesced exchange hop per flush window.
    */
-  async getPrices(exchangeSlug: string, symbols: string[], user?: User): Promise<Map<string, PriceData>> {
+  async getPrices(exchangeSlug: string, symbols: string[]): Promise<Map<string, PriceData>> {
     const results = new Map<string, PriceData>();
 
-    // Check cache for all symbols in parallel
     const cacheResults = await Promise.all(
       symbols.map(async (symbol) => {
         const cacheKey = `paper-trading:price:${exchangeSlug}:${symbol}`;
@@ -248,109 +218,46 @@ export class PaperTradingMarketDataService {
       return results;
     }
 
-    // Short-circuit exchange calls while the breaker is open for this exchange.
     const circuitOpen = this.circuitBreaker.isOpen(this.circuitKey(exchangeSlug));
 
-    let validPairs: Array<{ raw: string; formatted: string }> = [];
-    let result: Awaited<ReturnType<typeof withExchangeRetry<Record<string, ccxt.Ticker>>>>;
+    let fetchError: Error | null = circuitOpen ? new Error(`Circuit breaker open for ${exchangeSlug}`) : null;
 
-    if (circuitOpen) {
-      result = {
-        success: false as const,
-        error: new Error(`Circuit breaker open for ${exchangeSlug}`),
-        attempts: 0,
-        totalDelayMs: 0
-      };
-    } else {
-      const client = user
-        ? await this.exchangeManager.getExchangeClient(exchangeSlug, user)
-        : await this.exchangeManager.getPublicClient(exchangeSlug);
-
-      // Lazy-load markets so we can filter out symbols the exchange doesn't list.
-      // Without this, CCXT drops unknown symbols internally and may send an empty
-      // `symbols` param to the REST API, which Binance rejects with code -1102.
-      let marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
-      if (!marketsLoaded) {
-        try {
-          await client.loadMarkets();
-          marketsLoaded = Boolean(client.markets && Object.keys(client.markets).length > 0);
-        } catch (error: unknown) {
-          const err = toErrorInfo(error);
-          this.logger.warn(`loadMarkets(${exchangeSlug}) failed, proceeding without symbol validation: ${err.message}`);
-        }
-      }
-
-      const formattedPairs = uncachedSymbols.map((raw) => ({
-        raw,
-        formatted: this.exchangeManager.formatSymbol(exchangeSlug, raw)
-      }));
-
-      validPairs = marketsLoaded
-        ? formattedPairs.filter(({ formatted }) => formatted in (client.markets as Record<string, unknown>))
-        : formattedPairs;
-
-      if (validPairs.length === 0) {
-        this.logger.warn(
-          `getPrices(${exchangeSlug}): none of ${uncachedSymbols.length} requested symbols ` +
-            `(${uncachedSymbols.join(', ')}) exist on exchange; returning cached-only results`
-        );
-        return results;
-      }
-
-      result = await withExchangeRetry(() => client.fetchTickers(validPairs.map((p) => p.formatted)), {
-        logger: this.logger,
-        operationName: `fetchTickers(${exchangeSlug})`,
-        // Rate/weight limits are account-wide — skip retries to preserve
-        // request-weight budget and fall through to the stale cache.
-        isRetryable: (err) => !isRateLimitError(err) && !isWeightLimitError(err)
-      });
-    }
-
-    if (result.success && result.result) {
-      const tickers = result.result;
-
-      this.circuitBreaker.recordSuccess(this.circuitKey(exchangeSlug));
-
-      for (const { raw: symbol, formatted: formattedSymbol } of validPairs) {
-        const ticker = tickers[formattedSymbol];
-
-        if (ticker) {
+    if (!circuitOpen) {
+      try {
+        const tickerMap = await this.tickerBatcher.getTickers(exchangeSlug, uncachedSymbols);
+        for (const [symbol, ticker] of tickerMap) {
           const priceData: PriceData = {
             symbol,
-            price: ticker.last ?? ticker.close ?? 0,
+            price: ticker.price,
             bid: ticker.bid,
             ask: ticker.ask,
-            timestamp: new Date(ticker.timestamp ?? Date.now()),
+            timestamp: ticker.timestamp,
             source: exchangeSlug
           };
-
           results.set(symbol, priceData);
-
-          // Cache the result
           const cacheKey = `paper-trading:price:${exchangeSlug}:${symbol}`;
           await this.cacheManager.set(cacheKey, priceData, this.cacheTtlMs);
-
-          // Write stale fallback cache with longer TTL
-          const staleKey = `${cacheKey}:stale`;
-          await this.cacheManager.set(staleKey, priceData, STALE_CACHE_TTL_MS);
+          await this.cacheManager.set(`${cacheKey}:stale`, priceData, STALE_CACHE_TTL_MS);
         }
+      } catch (error: unknown) {
+        fetchError = error instanceof Error ? error : new Error(String(error));
       }
+    }
 
+    // On a successful fetch, symbols the exchange didn't return are silently
+    // omitted. Only a hard fetch failure drops into the stale-cache chain.
+    if (!fetchError) {
       return results;
     }
 
-    if (!circuitOpen && result.error) {
-      this.circuitBreaker.recordFailure(this.circuitKey(exchangeSlug));
-    }
-
-    // All retries exhausted — fall back to stale cache
     this.logger.warn(
-      `${circuitOpen ? 'Circuit open' : 'All retries exhausted'} fetching prices from ${exchangeSlug}. ` +
+      `${circuitOpen ? 'Circuit open' : 'Batcher fetch exhausted'} for ${exchangeSlug}. ` +
         `Falling back to stale cached prices for ${uncachedSymbols.length} symbol(s).`
     );
 
     const stillMissing: string[] = [];
     for (const symbol of uncachedSymbols) {
+      if (results.has(symbol)) continue;
       const staleKey = `paper-trading:price:${exchangeSlug}:${symbol}:stale`;
       const stale = await this.cacheManager.get<PriceData>(staleKey);
       if (stale) {
@@ -360,7 +267,6 @@ export class PaperTradingMarketDataService {
       }
     }
 
-    // Try fallback exchanges and DB for symbols with no stale cache
     for (const symbol of stillMissing) {
       const fallbackPrice = await this.tryFallbackExchanges(symbol, exchangeSlug);
       if (fallbackPrice) {
@@ -380,7 +286,7 @@ export class PaperTradingMarketDataService {
     const finalMisses = stillMissing.filter((s) => !results.has(s));
     if (finalMisses.length > 0) {
       throw new Error(
-        `Failed to fetch prices from ${exchangeSlug} after retries, ` +
+        `Failed to fetch prices from ${exchangeSlug} via batcher, ` +
           `and ${finalMisses.length} symbol(s) have no stale cache, fallback exchange, or DB fallback`
       );
     }
@@ -434,18 +340,16 @@ export class PaperTradingMarketDataService {
       try {
         const quoteAsset = EXCHANGE_QUOTE_CURRENCY[slug] ?? 'USD';
         const fallbackSymbol = `${base}/${quoteAsset}`;
-        const formattedSymbol = this.exchangeManager.formatSymbol(slug, fallbackSymbol);
-        const client = await this.exchangeManager.getPublicClient(slug);
-        const ticker = await client.fetchTicker(formattedSymbol);
+        const ticker = await this.tickerBatcher.getTicker(slug, fallbackSymbol);
 
-        if (ticker?.last != null || ticker?.close != null) {
+        if (ticker && ticker.price > 0) {
           this.logger.warn(`Fetched price for ${symbol} from fallback exchange ${slug}`);
           return {
             symbol,
-            price: ticker.last ?? ticker.close ?? 0,
+            price: ticker.price,
             bid: ticker.bid,
             ask: ticker.ask,
-            timestamp: new Date(ticker.timestamp ?? Date.now()),
+            timestamp: ticker.timestamp,
             source: `${slug}:fallback`
           };
         }

--- a/apps/api/src/order/services/position-monitor.service.ts
+++ b/apps/api/src/order/services/position-monitor.service.ts
@@ -7,6 +7,9 @@ import { DataSource, Repository } from 'typeorm';
 
 import { ExchangeKeyService } from '../../exchange/exchange-key/exchange-key.service';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import { TickerBatcherService } from '../../exchange/ticker-batcher/ticker-batcher.service';
+import { tickerCircuitKey } from '../../shared/circuit-breaker.constants';
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { toErrorInfo } from '../../shared/error.util';
 import { PositionExit } from '../entities/position-exit.entity';
 import {
@@ -36,7 +39,9 @@ export class PositionMonitorService {
     private readonly orderRepo: Repository<Order>,
     private readonly exchangeManagerService: ExchangeManagerService,
     private readonly exchangeKeyService: ExchangeKeyService,
-    private readonly dataSource: DataSource
+    private readonly dataSource: DataSource,
+    private readonly circuitBreaker: CircuitBreakerService,
+    private readonly tickerBatcher: TickerBatcherService
   ) {}
 
   /**
@@ -121,7 +126,10 @@ export class PositionMonitorService {
 
   /**
    * Fetch current prices for all symbols held by positions under one exchange key.
-   * Returns the ticker map and exchange client, or null client if the key is invalid.
+   * Routes through TickerBatcherService so we participate in the shared ticker
+   * circuit breaker — during rate-limit storms we fail fast instead of amplifying
+   * load. Returns a null client when the circuit is open or the exchange key is
+   * missing so the caller's existing `!exchangeClient` guard skips all positions.
    */
   private async fetchPricesForExchange(
     exchangeKeyId: string,
@@ -135,58 +143,36 @@ export class PositionMonitorService {
       return { tickers: {}, exchangeClient: null };
     }
 
-    const exchangeClient = await this.exchangeManagerService.getExchangeClient(
-      exchangeKey.exchange.slug,
-      position.user
-    );
+    const slug = exchangeKey.exchange.slug;
+
+    if (this.circuitBreaker.isOpen(tickerCircuitKey(slug))) {
+      this.logger.debug(`ticker_circuit_open: skipping ${positions.length} positions on ${slug}`);
+      return { tickers: {}, exchangeClient: null };
+    }
+
+    const exchangeClient = await this.exchangeManagerService.getExchangeClient(slug, position.user);
 
     const symbols = [...new Set(positions.map((p) => p.symbol))];
     const tickers: Record<string, number> = {};
 
-    if (exchangeClient.has['fetchTickers']) {
-      try {
-        const batchTickers = await exchangeClient.fetchTickers(symbols);
-        for (const symbol of symbols) {
-          const ticker = batchTickers[symbol];
-          if (ticker) {
-            const price = ticker.last ?? ticker.close ?? null;
-            if (price != null && price > 0) {
-              tickers[symbol] = price;
-            }
-          }
+    if (symbols.length === 0) {
+      return { tickers, exchangeClient };
+    }
+
+    try {
+      const batched = await this.tickerBatcher.getTickers(slug, symbols);
+      for (const [sym, ticker] of batched) {
+        if (ticker.price > 0) {
+          tickers[sym] = ticker.price;
         }
-      } catch (batchError: unknown) {
-        const err = toErrorInfo(batchError);
-        this.logger.warn(`Batch fetchTickers failed, falling back to sequential: ${err.message}`);
-        await this.fetchTickersSequentially(exchangeClient, symbols, tickers);
       }
-    } else {
-      await this.fetchTickersSequentially(exchangeClient, symbols, tickers);
+    } catch (error: unknown) {
+      const err = toErrorInfo(error);
+      this.logger.warn(`Ticker batch fetch failed for ${slug}: ${err.message}`);
+      return { tickers: {}, exchangeClient: null };
     }
 
     return { tickers, exchangeClient };
-  }
-
-  /**
-   * Fetch tickers one-by-one as a fallback when batch fetchTickers is unavailable or fails
-   */
-  private async fetchTickersSequentially(
-    exchangeClient: ccxt.Exchange,
-    symbols: string[],
-    tickers: Record<string, number>
-  ): Promise<void> {
-    for (const symbol of symbols) {
-      try {
-        const ticker = await exchangeClient.fetchTicker(symbol);
-        const price = ticker.last ?? ticker.close ?? null;
-        if (price != null && price > 0) {
-          tickers[symbol] = price;
-        }
-      } catch (tickerError: unknown) {
-        const err = toErrorInfo(tickerError);
-        this.logger.warn(`Failed to fetch ticker for ${symbol}: ${err.message}`);
-      }
-    }
   }
 
   /**

--- a/apps/api/src/order/tasks/position-monitor.task.spec.ts
+++ b/apps/api/src/order/tasks/position-monitor.task.spec.ts
@@ -10,7 +10,9 @@ import { PositionMonitorTask } from './position-monitor.task';
 
 import { ExchangeKeyService } from '../../exchange/exchange-key/exchange-key.service';
 import { ExchangeManagerService } from '../../exchange/exchange-manager.service';
+import { TickerBatcherService } from '../../exchange/ticker-batcher/ticker-batcher.service';
 import { FailedJobService } from '../../failed-jobs/failed-job.service';
+import { CircuitBreakerService } from '../../shared/circuit-breaker.service';
 import { PositionExit } from '../entities/position-exit.entity';
 import {
   DEFAULT_EXIT_CONFIG,
@@ -107,6 +109,14 @@ describe('PositionMonitorTask', () => {
     transaction: jest.fn(async (cb) => cb(mockManager))
   };
 
+  const mockTickerBatcher = {
+    getTickers: jest.fn()
+  };
+
+  const mockCircuitBreaker = {
+    isOpen: jest.fn().mockReturnValue(false)
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -118,7 +128,9 @@ describe('PositionMonitorTask', () => {
         { provide: ExchangeManagerService, useValue: mockExchangeManagerService },
         { provide: ExchangeKeyService, useValue: mockExchangeKeyService },
         { provide: DataSource, useValue: mockDataSource },
-        { provide: FailedJobService, useValue: { recordFailure: jest.fn() } }
+        { provide: FailedJobService, useValue: { recordFailure: jest.fn() } },
+        { provide: TickerBatcherService, useValue: mockTickerBatcher },
+        { provide: CircuitBreakerService, useValue: mockCircuitBreaker }
       ]
     }).compile();
 
@@ -126,6 +138,7 @@ describe('PositionMonitorTask', () => {
     service = module.get<PositionMonitorService>(PositionMonitorService);
 
     jest.clearAllMocks();
+    mockCircuitBreaker.isOpen.mockReturnValue(false);
   });
 
   describe('shouldActivateTrailing', () => {
@@ -335,10 +348,10 @@ describe('PositionMonitorTask', () => {
       mockPositionExitRepo.createQueryBuilder.mockReturnValue(buildQueryBuilder([position]));
 
       mockExchangeKeyService.findOne.mockResolvedValue({ exchange: { slug: 'binance' } });
-      mockExchangeManagerService.getExchangeClient.mockResolvedValue({
-        has: { fetchTickers: true },
-        fetchTickers: jest.fn().mockResolvedValue({ 'BTC/USD': { last: 51000 } })
-      });
+      mockExchangeManagerService.getExchangeClient.mockResolvedValue(buildExchangeClient());
+      mockTickerBatcher.getTickers.mockResolvedValue(
+        new Map([['BTC/USD', { price: 51000, timestamp: new Date(), symbol: 'BTC/USD', source: 'binance' }]])
+      );
 
       const updateSpy = jest
         .spyOn(service, 'updateTrailingStop')
@@ -346,6 +359,7 @@ describe('PositionMonitorTask', () => {
 
       const result = await task.process(mockJob);
 
+      expect(mockTickerBatcher.getTickers).toHaveBeenCalledWith('binance', ['BTC/USD']);
       expect(updateSpy).toHaveBeenCalledWith(expect.any(Object), 51000, expect.any(Object));
       expect(result).toEqual({
         monitored: 1,
@@ -388,11 +402,8 @@ describe('PositionMonitorTask', () => {
       mockPositionExitRepo.createQueryBuilder.mockReturnValue(buildQueryBuilder([position]));
 
       mockExchangeKeyService.findOne.mockResolvedValue({ exchange: { slug: 'binance' } });
-      mockExchangeManagerService.getExchangeClient.mockResolvedValue({
-        has: { fetchTickers: true },
-        fetchTickers: jest.fn().mockRejectedValue(new Error('Batch timeout')),
-        fetchTicker: jest.fn().mockRejectedValue(new Error('Timeout'))
-      });
+      mockExchangeManagerService.getExchangeClient.mockResolvedValue(buildExchangeClient());
+      mockTickerBatcher.getTickers.mockRejectedValue(new Error('Batch timeout'));
 
       const updateSpy = jest
         .spyOn(service, 'updateTrailingStop')
@@ -417,10 +428,8 @@ describe('PositionMonitorTask', () => {
       mockPositionExitRepo.createQueryBuilder.mockReturnValue(buildQueryBuilder([position]));
 
       mockExchangeKeyService.findOne.mockResolvedValue({ exchange: { slug: 'binance' } });
-      mockExchangeManagerService.getExchangeClient.mockResolvedValue({
-        has: { fetchTickers: true },
-        fetchTickers: jest.fn().mockResolvedValue({ 'BTC/USD': { last: null, close: null } })
-      });
+      mockExchangeManagerService.getExchangeClient.mockResolvedValue(buildExchangeClient());
+      mockTickerBatcher.getTickers.mockResolvedValue(new Map());
 
       const updateSpy = jest
         .spyOn(service, 'updateTrailingStop')
@@ -437,35 +446,21 @@ describe('PositionMonitorTask', () => {
       });
     });
 
-    it.each([
-      { scenario: 'exchange does not support fetchTickers', hasFetchTickers: false, batchThrows: false },
-      { scenario: 'batch fetchTickers throws', hasFetchTickers: true, batchThrows: true }
-    ])('should fall back to sequential fetchTicker when $scenario', async ({ hasFetchTickers, batchThrows }) => {
-      const position = buildPositionExit({
-        id: 'pos-1',
-        exitConfig: { trailingType: TrailingType.PERCENTAGE, trailingValue: 2 }
-      });
-      mockPositionExitRepo.createQueryBuilder.mockReturnValue(buildQueryBuilder([position]));
+    it('should skip all positions when ticker circuit is open', async () => {
+      mockPositionExitRepo.createQueryBuilder.mockReturnValue(buildQueryBuilder([buildPositionExit({ id: 'pos-1' })]));
+      mockExchangeKeyService.findOne.mockResolvedValue({ exchange: { slug: 'binance_us' } });
+      mockCircuitBreaker.isOpen.mockReturnValue(true);
 
-      mockExchangeKeyService.findOne.mockResolvedValue({ exchange: { slug: 'binance' } });
-      const fetchTickerMock = jest.fn().mockResolvedValue({ last: 51000 });
-      mockExchangeManagerService.getExchangeClient.mockResolvedValue({
-        has: { fetchTickers: hasFetchTickers },
-        ...(batchThrows && { fetchTickers: jest.fn().mockRejectedValue(new Error('Batch not supported')) }),
-        fetchTicker: fetchTickerMock
-      });
-
-      const updateSpy = jest
-        .spyOn(service, 'updateTrailingStop')
-        .mockResolvedValue({ updated: true, triggered: false });
+      const updateSpy = jest.spyOn(service, 'updateTrailingStop');
 
       const result = await task.process(mockJob);
 
-      expect(fetchTickerMock).toHaveBeenCalledWith('BTC/USD');
-      expect(updateSpy).toHaveBeenCalledWith(expect.any(Object), 51000, expect.any(Object));
+      expect(mockTickerBatcher.getTickers).not.toHaveBeenCalled();
+      expect(mockExchangeManagerService.getExchangeClient).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
       expect(result).toEqual({
         monitored: 1,
-        updated: 1,
+        updated: 0,
         triggered: 0,
         timestamp: expect.any(String)
       });

--- a/apps/api/src/shared/circuit-breaker.constants.ts
+++ b/apps/api/src/shared/circuit-breaker.constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared circuit-breaker key prefix for exchange ticker fetches.
+ *
+ * Both `PaperTradingMarketDataService` and `TickerBatcherService` point at
+ * the same circuit so breaker state carries across the rollout and both
+ * paths fail-fast in lockstep.
+ *
+ * The `paper-trading:` namespace is a historical artifact — it predates the
+ * batcher being shared across callers. Cosmetic debt, not functional.
+ */
+export const TICKER_CIRCUIT_KEY_PREFIX = 'paper-trading:market-data';
+
+export function tickerCircuitKey(exchangeSlug: string): string {
+  return `${TICKER_CIRCUIT_KEY_PREFIX}:${exchangeSlug}`;
+}

--- a/apps/api/src/shared/index.ts
+++ b/apps/api/src/shared/index.ts
@@ -1,4 +1,5 @@
 export { cleanExchangeMessage, mapCcxtError } from './ccxt-error-mapper.util';
+export { TICKER_CIRCUIT_KEY_PREFIX, tickerCircuitKey } from './circuit-breaker.constants';
 export { LOCK_DEFAULTS, LOCK_KEYS, LOCK_REDIS_DB } from './distributed-lock.constants';
 export { DistributedLockService, LockInfo, LockOptions, LockResult } from './distributed-lock.service';
 export { isUniqueConstraintViolation, toErrorInfo } from './error.util';
@@ -30,6 +31,7 @@ export {
   exchangeAwareDelay,
   extractRetryAfterMs,
   isAuthenticationError,
+  isClientError,
   isClockSkewError,
   isRateLimitError,
   isTransientError,

--- a/docs/pipeline-overview.html
+++ b/docs/pipeline-overview.html
@@ -1,0 +1,1194 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chansey · Strategy Validation Pipeline</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg: #0b1020;
+        --bg-alt: #111830;
+        --surface: #161f3d;
+        --surface-2: #1c2648;
+        --border: rgba(255, 255, 255, 0.08);
+        --border-strong: rgba(255, 255, 255, 0.14);
+        --text: #e7ecff;
+        --text-dim: #a0a9cc;
+        --text-faint: #6b7598;
+
+        --accent-1: #5eead4; /* teal — OPTIMIZE */
+        --accent-2: #a78bfa; /* violet — HISTORICAL */
+        --accent-3: #60a5fa; /* blue — LIVE_REPLAY */
+        --accent-4: #fbbf24; /* amber — PAPER_TRADE */
+        --accent-5: #34d399; /* green — COMPLETED */
+
+        --gate: #f472b6;
+        --danger: #f87171;
+        --success: #34d399;
+
+        --radius-xl: 20px;
+        --radius-lg: 14px;
+        --radius-md: 10px;
+        --radius-sm: 6px;
+        --shadow: 0 10px 30px -12px rgba(0, 0, 0, 0.5), 0 4px 16px -6px rgba(0, 0, 0, 0.3);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family:
+          'Inter',
+          -apple-system,
+          BlinkMacSystemFont,
+          sans-serif;
+        background: radial-gradient(ellipse at top, #1a2446 0%, var(--bg) 40%, #060918 100%);
+        color: var(--text);
+        min-height: 100vh;
+        padding: 48px 24px 96px;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .page {
+        max-width: 1280px;
+        margin: 0 auto;
+      }
+
+      /* ——— Header ——— */
+      .header {
+        text-align: center;
+        margin-bottom: 56px;
+      }
+
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--text-dim);
+        padding: 6px 14px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.02);
+        margin-bottom: 20px;
+      }
+
+      .eyebrow::before {
+        content: '';
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--success);
+        box-shadow: 0 0 10px var(--success);
+      }
+
+      h1 {
+        font-size: 56px;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        margin: 0 0 12px;
+        background: linear-gradient(135deg, #fff 0%, #a78bfa 50%, #5eead4 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      .subtitle {
+        font-size: 18px;
+        color: var(--text-dim);
+        max-width: 680px;
+        margin: 0 auto;
+      }
+
+      /* ——— Section ——— */
+      section {
+        margin-bottom: 72px;
+      }
+
+      h2 {
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--text-faint);
+        margin: 0 0 24px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      h2::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: linear-gradient(to right, var(--border), transparent);
+      }
+
+      /* ——— Entry card ——— */
+      .entry {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 16px;
+        margin-bottom: 48px;
+      }
+
+      .entry-card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: 18px 20px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .entry-card::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(135deg, rgba(94, 234, 212, 0.04), transparent 50%);
+        pointer-events: none;
+      }
+
+      .entry-label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--text-faint);
+        margin-bottom: 6px;
+      }
+
+      .entry-value {
+        font-size: 14px;
+        color: var(--text);
+        font-weight: 500;
+      }
+
+      .entry-detail {
+        font-size: 12px;
+        color: var(--text-dim);
+        margin-top: 4px;
+        font-family: 'JetBrains Mono', monospace;
+      }
+
+      /* ——— Pipeline stages ——— */
+      .pipeline {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        position: relative;
+      }
+
+      .stage {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-xl);
+        padding: 28px 32px;
+        display: grid;
+        grid-template-columns: 80px 1fr 220px;
+        gap: 24px;
+        align-items: center;
+        position: relative;
+        box-shadow: var(--shadow);
+      }
+
+      .stage::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 4px;
+        border-radius: var(--radius-xl) 0 0 var(--radius-xl);
+      }
+
+      .stage[data-accent='1']::before {
+        background: var(--accent-1);
+      }
+      .stage[data-accent='2']::before {
+        background: var(--accent-2);
+      }
+      .stage[data-accent='3']::before {
+        background: var(--accent-3);
+      }
+      .stage[data-accent='4']::before {
+        background: var(--accent-4);
+      }
+      .stage[data-accent='5']::before {
+        background: var(--accent-5);
+      }
+
+      .stage-num {
+        font-size: 48px;
+        font-weight: 800;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        font-family: 'JetBrains Mono', monospace;
+        opacity: 0.9;
+      }
+
+      .stage[data-accent='1'] .stage-num {
+        color: var(--accent-1);
+      }
+      .stage[data-accent='2'] .stage-num {
+        color: var(--accent-2);
+      }
+      .stage[data-accent='3'] .stage-num {
+        color: var(--accent-3);
+      }
+      .stage[data-accent='4'] .stage-num {
+        color: var(--accent-4);
+      }
+      .stage[data-accent='5'] .stage-num {
+        color: var(--accent-5);
+      }
+
+      .stage-body h3 {
+        font-size: 22px;
+        font-weight: 700;
+        margin: 0 0 4px;
+        letter-spacing: -0.01em;
+      }
+
+      .stage-body .tagline {
+        font-size: 14px;
+        color: var(--text-dim);
+        margin-bottom: 14px;
+      }
+
+      .stage-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        padding: 5px 10px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid var(--border);
+        color: var(--text-dim);
+      }
+
+      .chip strong {
+        color: var(--text);
+        font-weight: 600;
+      }
+
+      .chip-queue {
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 11px;
+      }
+
+      .stage-output {
+        border-left: 1px solid var(--border);
+        padding-left: 20px;
+      }
+
+      .stage-output .label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--text-faint);
+        margin-bottom: 10px;
+      }
+
+      .stage-output ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        font-size: 12px;
+        color: var(--text-dim);
+      }
+
+      .stage-output li {
+        padding: 4px 0;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .stage-output li::before {
+        content: '';
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: var(--text-faint);
+      }
+
+      /* ——— Gate between stages ——— */
+      .gate {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        padding: 16px 24px;
+        margin: 0 auto;
+        width: fit-content;
+      }
+
+      .gate-line {
+        width: 2px;
+        height: 24px;
+        background: linear-gradient(to bottom, var(--accent-1), var(--gate));
+        border-radius: 2px;
+        margin: 0 auto;
+      }
+
+      .gate-badge {
+        background: var(--bg-alt);
+        border: 1px solid var(--gate);
+        border-radius: 999px;
+        padding: 8px 18px;
+        font-size: 12px;
+        color: var(--text);
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-family: 'JetBrains Mono', monospace;
+        box-shadow: 0 0 20px -8px var(--gate);
+      }
+
+      .gate-badge .lock {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: var(--gate);
+        color: var(--bg);
+        font-size: 10px;
+        font-weight: 700;
+      }
+
+      /* ——— Risk matrix ——— */
+      .risk-grid {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 12px;
+      }
+
+      .risk-card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: 18px 16px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .risk-card::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3px;
+      }
+
+      .risk-card[data-level='1']::before {
+        background: #38bdf8;
+      }
+      .risk-card[data-level='2']::before {
+        background: #5eead4;
+      }
+      .risk-card[data-level='3']::before {
+        background: #a78bfa;
+      }
+      .risk-card[data-level='4']::before {
+        background: #fbbf24;
+      }
+      .risk-card[data-level='5']::before {
+        background: #f87171;
+      }
+
+      .risk-level {
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--text-faint);
+        margin-bottom: 4px;
+      }
+
+      .risk-name {
+        font-size: 14px;
+        font-weight: 600;
+        margin-bottom: 14px;
+      }
+
+      .risk-stat {
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        padding: 6px 0;
+        border-top: 1px dashed var(--border);
+      }
+
+      .risk-stat:first-of-type {
+        border-top: none;
+      }
+
+      .risk-stat-label {
+        color: var(--text-faint);
+      }
+
+      .risk-stat-value {
+        color: var(--text);
+        font-weight: 500;
+        font-family: 'JetBrains Mono', monospace;
+      }
+
+      /* ——— Event flow ——— */
+      .event-flow {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-xl);
+        padding: 32px;
+      }
+
+      .event-grid {
+        display: grid;
+        grid-template-columns: 1fr 80px 1fr 80px 1fr;
+        align-items: center;
+        gap: 16px;
+      }
+
+      .event-node {
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: 16px;
+        text-align: center;
+      }
+
+      .event-node .title {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text);
+        margin-bottom: 6px;
+      }
+
+      .event-node .detail {
+        font-size: 11px;
+        color: var(--text-dim);
+        font-family: 'JetBrains Mono', monospace;
+      }
+
+      .event-arrow {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        color: var(--text-faint);
+        font-size: 10px;
+      }
+
+      .event-arrow .arrow {
+        font-size: 20px;
+        color: var(--accent-2);
+      }
+
+      /* ——— Promotion gates ——— */
+      .promotion {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 28px;
+      }
+
+      .promotion-card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-xl);
+        padding: 28px 32px;
+      }
+
+      .promotion-card h3 {
+        margin: 0 0 4px;
+        font-size: 20px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .promotion-card .subtitle-small {
+        font-size: 13px;
+        color: var(--text-dim);
+        margin-bottom: 20px;
+      }
+
+      .gates-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+      }
+
+      .gates-list li {
+        font-size: 13px;
+        padding: 10px 12px;
+        background: var(--surface-2);
+        border-radius: var(--radius-md);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        border: 1px solid var(--border);
+      }
+
+      .gates-list li::before {
+        content: '✓';
+        color: var(--success);
+        font-weight: 700;
+        font-size: 13px;
+      }
+
+      .lifecycle {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        justify-content: center;
+        padding: 20px;
+        background: var(--surface-2);
+        border-radius: var(--radius-lg);
+        margin-top: 12px;
+      }
+
+      .life-pill {
+        padding: 8px 14px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-family: 'JetBrains Mono', monospace;
+      }
+
+      .life-pill.testing {
+        background: rgba(94, 234, 212, 0.12);
+        color: var(--accent-1);
+        border: 1px solid rgba(94, 234, 212, 0.3);
+      }
+      .life-pill.shadow {
+        background: rgba(167, 139, 250, 0.12);
+        color: var(--accent-2);
+        border: 1px solid rgba(167, 139, 250, 0.3);
+      }
+      .life-pill.live {
+        background: rgba(52, 211, 153, 0.12);
+        color: var(--success);
+        border: 1px solid rgba(52, 211, 153, 0.3);
+      }
+      .life-pill.retired {
+        background: rgba(107, 117, 152, 0.12);
+        color: var(--text-faint);
+        border: 1px solid var(--border);
+      }
+
+      .arrow-sep {
+        color: var(--text-faint);
+        font-size: 14px;
+      }
+
+      /* ——— Recommendations ——— */
+      .recs {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+      }
+
+      .rec {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        position: relative;
+      }
+
+      .rec-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        margin-bottom: 12px;
+      }
+
+      .rec.deploy .rec-badge {
+        background: rgba(52, 211, 153, 0.12);
+        color: var(--success);
+      }
+      .rec.review .rec-badge {
+        background: rgba(251, 191, 36, 0.12);
+        color: var(--accent-4);
+      }
+      .rec.reject .rec-badge {
+        background: rgba(248, 113, 113, 0.12);
+        color: var(--danger);
+      }
+
+      .rec h4 {
+        font-size: 16px;
+        margin: 0 0 8px;
+      }
+
+      .rec p {
+        font-size: 12px;
+        color: var(--text-dim);
+        margin: 0 0 12px;
+      }
+
+      .rec .threshold {
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 11px;
+        color: var(--text);
+        background: var(--surface-2);
+        padding: 8px 10px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+
+      /* ——— Footer ——— */
+      .footer {
+        text-align: center;
+        padding-top: 40px;
+        border-top: 1px solid var(--border);
+        font-size: 12px;
+        color: var(--text-faint);
+      }
+
+      .footer code {
+        font-family: 'JetBrains Mono', monospace;
+        background: var(--surface);
+        padding: 2px 6px;
+        border-radius: 4px;
+        color: var(--text-dim);
+      }
+
+      /* ——— Responsive ——— */
+      @media (max-width: 900px) {
+        body {
+          padding: 32px 16px;
+        }
+        h1 {
+          font-size: 36px;
+        }
+        .stage {
+          grid-template-columns: 60px 1fr;
+          padding: 20px;
+        }
+        .stage-output {
+          grid-column: 1 / -1;
+          border-left: none;
+          border-top: 1px solid var(--border);
+          padding-left: 0;
+          padding-top: 16px;
+        }
+        .stage-num {
+          font-size: 36px;
+        }
+        .entry,
+        .risk-grid,
+        .promotion,
+        .recs {
+          grid-template-columns: 1fr;
+        }
+        .event-grid {
+          grid-template-columns: 1fr;
+        }
+        .event-arrow {
+          transform: rotate(90deg);
+          padding: 4px 0;
+        }
+        .gates-list {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      /* ——— Subtle entrance animations ——— */
+      @keyframes fadeUp {
+        from {
+          opacity: 0;
+          transform: translateY(12px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      .stage,
+      .risk-card,
+      .promotion-card,
+      .rec,
+      .entry-card,
+      .event-flow {
+        animation: fadeUp 0.5s ease-out backwards;
+      }
+
+      .stage:nth-child(1) {
+        animation-delay: 0.05s;
+      }
+      .stage:nth-child(2) {
+        animation-delay: 0.1s;
+      }
+      .stage:nth-child(3) {
+        animation-delay: 0.15s;
+      }
+      .stage:nth-child(4) {
+        animation-delay: 0.2s;
+      }
+      .stage:nth-child(5) {
+        animation-delay: 0.25s;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <!-- ─────────────  HEADER  ───────────── -->
+      <header class="header">
+        <div class="eyebrow">Chansey · Architecture</div>
+        <h1>Strategy Validation Pipeline</h1>
+        <p class="subtitle">
+          How an algorithm earns the right to trade real money — a five-stage, risk-adaptive journey from raw parameters
+          to a live deployment.
+        </p>
+      </header>
+
+      <!-- ─────────────  ENTRY INPUTS  ───────────── -->
+      <section>
+        <h2>Pipeline Inputs</h2>
+        <div class="entry">
+          <div class="entry-card">
+            <div class="entry-label">User</div>
+            <div class="entry-value">Algo trading enabled</div>
+            <div class="entry-detail">+ active exchange key</div>
+          </div>
+          <div class="entry-card">
+            <div class="entry-label">Strategy Config</div>
+            <div class="entry-value">Algorithm + base parameters</div>
+            <div class="entry-detail">status: TESTING</div>
+          </div>
+          <div class="entry-card">
+            <div class="entry-label">Risk Level</div>
+            <div class="entry-value">1 – 5 (Conservative → Aggressive)</div>
+            <div class="entry-detail">drives every stage's config</div>
+          </div>
+        </div>
+        <div style="text-align: center; color: var(--text-faint); font-size: 12px; margin-top: 16px">
+          Daily at <strong style="color: var(--text)">02:30 UTC</strong> &nbsp;·&nbsp; staggered 1-min intervals
+          &nbsp;·&nbsp; BullMQ <code style="font-family: 'JetBrains Mono', monospace">pipeline-orchestration</code>
+        </div>
+      </section>
+
+      <!-- ─────────────  THE 5 STAGES  ───────────── -->
+      <section>
+        <h2>The Five Stages</h2>
+        <div class="pipeline">
+          <!-- Stage 1 -->
+          <div class="stage" data-accent="1">
+            <div class="stage-num">01</div>
+            <div class="stage-body">
+              <h3>Optimize</h3>
+              <div class="tagline">Grid-search parameter space with walk-forward analysis to find the best config.</div>
+              <div class="stage-meta">
+                <span class="chip"><strong>Walk-forward</strong> train → test → step</span>
+                <span class="chip"><strong>L1:</strong> 75 combos</span>
+                <span class="chip"><strong>L5:</strong> 30 combos</span>
+                <span class="chip chip-queue">queue · optimization</span>
+              </div>
+            </div>
+            <div class="stage-output">
+              <div class="label">Produces</div>
+              <ul>
+                <li>OptimizationRun</li>
+                <li>bestParameters (JSON)</li>
+                <li>bestScore &amp; improvement %</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="gate">
+            <div class="gate-badge"><span class="lock">🔒</span> improvement ≥ 3% &amp; score ≥ threshold</div>
+          </div>
+
+          <!-- Stage 2 -->
+          <div class="stage" data-accent="2">
+            <div class="stage-num">02</div>
+            <div class="stage-body">
+              <h3>Historical Backtest</h3>
+              <div class="tagline">
+                Run the optimized parameters over a held-out historical window to test real-world performance.
+              </div>
+              <div class="stage-meta">
+                <span class="chip"><strong>Window</strong> 45 – 90 days</span>
+                <span class="chip"><strong>Capital</strong> $10,000</span>
+                <span class="chip"><strong>Type</strong> HISTORICAL</span>
+                <span class="chip chip-queue">queue · backtest-historical</span>
+              </div>
+            </div>
+            <div class="stage-output">
+              <div class="label">Produces</div>
+              <ul>
+                <li>Backtest (trades, snapshots)</li>
+                <li>Sharpe · drawdown · win rate</li>
+                <li>Total return %</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="gate">
+            <div class="gate-badge"><span class="lock">🔒</span> ≥ 1 trade executed</div>
+          </div>
+
+          <!-- Stage 3 -->
+          <div class="stage" data-accent="3">
+            <div class="stage-num">03</div>
+            <div class="stage-body">
+              <h3>Live Replay</h3>
+              <div class="tagline">
+                Replay against the most recent ~30 days of real market data — the ultimate out-of-sample test.
+              </div>
+              <div class="stage-meta">
+                <span class="chip"><strong>Window</strong> ~30 days</span>
+                <span class="chip"><strong>Pacing</strong> adjustable</span>
+                <span class="chip"><strong>Pause/Resume</strong> supported</span>
+                <span class="chip chip-queue">queue · backtest-replay</span>
+              </div>
+            </div>
+            <div class="stage-output">
+              <div class="label">Produces</div>
+              <ul>
+                <li>Backtest (LIVE_REPLAY)</li>
+                <li>Degradation vs historical</li>
+                <li>Composite pipeline score</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="gate">
+            <div class="gate-badge"><span class="lock">🔒</span> composite score ≥ 30 / 100</div>
+          </div>
+
+          <!-- Stage 4 -->
+          <div class="stage" data-accent="4">
+            <div class="stage-num">04</div>
+            <div class="stage-body">
+              <h3>Paper Trade</h3>
+              <div class="tagline">
+                Trade with simulated capital against live market ticks — verify signal quality in real time.
+              </div>
+              <div class="stage-meta">
+                <span class="chip"><strong>L1:</strong> ≥ 50 trades</span>
+                <span class="chip"><strong>L5:</strong> ≥ 30 trades</span>
+                <span class="chip"><strong>Max</strong> 30 days</span>
+                <span class="chip chip-queue">queue · paper-trading</span>
+              </div>
+            </div>
+            <div class="stage-output">
+              <div class="label">Produces</div>
+              <ul>
+                <li>PaperTradingSession</li>
+                <li>Live signal P&amp;L</li>
+                <li>Exit behavior (SL / TP / trail)</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="gate">
+            <div class="gate-badge">
+              <span class="lock">🔒</span> Sharpe ≥ 0.3 &nbsp;·&nbsp; DD ≤ 45% &nbsp;·&nbsp; return ≥ 0
+            </div>
+          </div>
+
+          <!-- Stage 5 -->
+          <div class="stage" data-accent="5">
+            <div class="stage-num">05</div>
+            <div class="stage-body">
+              <h3>Completed</h3>
+              <div class="tagline">
+                Synthesize all stage results into a single recommendation — ready for promotion evaluation.
+              </div>
+              <div class="stage-meta">
+                <span class="chip"><strong>pipelineScore</strong> 0 – 100</span>
+                <span class="chip"><strong>Recommendation</strong> generated</span>
+                <span class="chip"><strong>Report</strong> archived</span>
+              </div>
+            </div>
+            <div class="stage-output">
+              <div class="label">Produces</div>
+              <ul>
+                <li>PipelineSummaryReport</li>
+                <li>DEPLOY / REVIEW / REJECT</li>
+                <li>Audit log entry</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ─────────────  RECOMMENDATIONS  ───────────── -->
+      <section>
+        <h2>Pipeline Recommendations</h2>
+        <div class="recs">
+          <div class="rec deploy">
+            <div class="rec-badge">◆ Deploy</div>
+            <h4>Ready for production</h4>
+            <p>Strategy passes all quality gates — automatically eligible for shadow → live promotion.</p>
+            <div class="threshold">score ≥ 70 · Sharpe ≥ 1.0 · DD ≤ 25%</div>
+          </div>
+          <div class="rec review">
+            <div class="rec-badge">◆ Needs Review</div>
+            <h4>Manual evaluation</h4>
+            <p>Moderate performance — requires human judgment on whether to promote or iterate.</p>
+            <div class="threshold">score 30 – 69 · Sharpe ≥ 0.5 · DD ≤ 40%</div>
+          </div>
+          <div class="rec reject">
+            <div class="rec-badge">◆ Do Not Deploy</div>
+            <h4>Insufficient quality</h4>
+            <p>Strategy fails one or more critical thresholds — returned for parameter revision.</p>
+            <div class="threshold">score &lt; 30 · or thresholds failed</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ─────────────  RISK MATRIX  ───────────── -->
+      <section>
+        <h2>Risk-Level Adaptation</h2>
+        <div class="risk-grid">
+          <div class="risk-card" data-level="1">
+            <div class="risk-level">Level 1</div>
+            <div class="risk-name">Conservative</div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Train</span><span class="risk-stat-value">180d</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Combos</span><span class="risk-stat-value">75</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Min trades</span><span class="risk-stat-value">50</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Max DD</span><span class="risk-stat-value">15%</span>
+            </div>
+          </div>
+          <div class="risk-card" data-level="2">
+            <div class="risk-level">Level 2</div>
+            <div class="risk-name">Low-Moderate</div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Train</span><span class="risk-stat-value">150d</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Combos</span><span class="risk-stat-value">60</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Min trades</span><span class="risk-stat-value">45</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Max DD</span><span class="risk-stat-value">20%</span>
+            </div>
+          </div>
+          <div class="risk-card" data-level="3">
+            <div class="risk-level">Level 3</div>
+            <div class="risk-name">Moderate · Default</div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Train</span><span class="risk-stat-value">120d</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Combos</span><span class="risk-stat-value">50</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Min trades</span><span class="risk-stat-value">40</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Max DD</span><span class="risk-stat-value">25%</span>
+            </div>
+          </div>
+          <div class="risk-card" data-level="4">
+            <div class="risk-level">Level 4</div>
+            <div class="risk-name">Moderate-High</div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Train</span><span class="risk-stat-value">90d</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Combos</span><span class="risk-stat-value">40</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Min trades</span><span class="risk-stat-value">35</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Max DD</span><span class="risk-stat-value">35%</span>
+            </div>
+          </div>
+          <div class="risk-card" data-level="5">
+            <div class="risk-level">Level 5</div>
+            <div class="risk-name">Aggressive</div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Train</span><span class="risk-stat-value">60d</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Combos</span><span class="risk-stat-value">30</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Min trades</span><span class="risk-stat-value">30</span>
+            </div>
+            <div class="risk-stat">
+              <span class="risk-stat-label">Max DD</span><span class="risk-stat-value">40%</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ─────────────  EVENT FLOW  ───────────── -->
+      <section>
+        <h2>Event-Driven Orchestration</h2>
+        <div class="event-flow">
+          <div class="event-grid">
+            <div class="event-node">
+              <div class="title">Stage Worker</div>
+              <div class="detail">BullMQ processor</div>
+            </div>
+            <div class="event-arrow">
+              <span class="arrow">→</span>
+              <span>emits</span>
+            </div>
+            <div class="event-node">
+              <div class="title">PIPELINE_EVENTS</div>
+              <div class="detail">EventEmitter2</div>
+            </div>
+            <div class="event-arrow">
+              <span class="arrow">→</span>
+              <span>handles</span>
+            </div>
+            <div class="event-node">
+              <div class="title">PipelineEventListener</div>
+              <div class="detail">@OnEvent(...)</div>
+            </div>
+          </div>
+          <div style="margin-top: 24px; text-align: center; font-size: 12px; color: var(--text-dim)">
+            <code
+              style="
+                font-family: 'JetBrains Mono', monospace;
+                background: var(--surface-2);
+                padding: 2px 8px;
+                border-radius: 4px;
+              "
+              >OPTIMIZATION_COMPLETED</code
+            >
+            ·
+            <code
+              style="
+                font-family: 'JetBrains Mono', monospace;
+                background: var(--surface-2);
+                padding: 2px 8px;
+                border-radius: 4px;
+              "
+              >BACKTEST_COMPLETED</code
+            >
+            ·
+            <code
+              style="
+                font-family: 'JetBrains Mono', monospace;
+                background: var(--surface-2);
+                padding: 2px 8px;
+                border-radius: 4px;
+              "
+              >PAPER_TRADING_COMPLETED</code
+            >
+            ·
+            <code
+              style="
+                font-family: 'JetBrains Mono', monospace;
+                background: var(--surface-2);
+                padding: 2px 8px;
+                border-radius: 4px;
+              "
+              >PIPELINE_STAGE_TRANSITION</code
+            >
+            <div style="margin-top: 10px; color: var(--text-faint)">
+              No module calls another directly — everything flows through events.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ─────────────  PROMOTION  ───────────── -->
+      <section>
+        <h2>Post-Pipeline: Promotion to Live</h2>
+        <div class="promotion">
+          <div class="promotion-card">
+            <h3>🚪 Promotion Gates</h3>
+            <div class="subtitle-small">
+              8 checks evaluated in priority order — one critical failure blocks promotion.
+            </div>
+            <ul class="gates-list">
+              <li>Minimum Score</li>
+              <li>Minimum Trades</li>
+              <li>Maximum Drawdown</li>
+              <li>WFA Consistency</li>
+              <li>Positive Returns</li>
+              <li>Correlation Limit</li>
+              <li>Volatility Cap</li>
+              <li>Portfolio Capacity</li>
+            </ul>
+          </div>
+          <div class="promotion-card">
+            <h3>⟳ Deployment Lifecycle</h3>
+            <div class="subtitle-small">
+              <code style="font-family: 'JetBrains Mono', monospace; font-size: 11px">Deployment.status</code> governs
+              real execution — this is the source of truth.
+            </div>
+            <div class="lifecycle">
+              <span class="life-pill testing">pending approval</span>
+              <span class="arrow-sep">→</span>
+              <span class="life-pill live">active</span>
+              <span class="arrow-sep">→</span>
+              <span class="life-pill shadow">paused</span>
+              <span class="arrow-sep">→</span>
+              <span class="life-pill retired">demoted / terminated</span>
+            </div>
+            <div style="margin-top: 16px; font-size: 12px; color: var(--text-dim); text-align: center">
+              Once active, hourly risk checks can <strong style="color: var(--danger)">auto-demote</strong> on critical
+              drift.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ─────────────  FOOTER  ───────────── -->
+      <footer class="footer">
+        <div style="margin-bottom: 8px">
+          Source of truth:
+          <code>apps/api/src/pipeline/</code> · <code>apps/api/src/order/backtest/</code> ·
+          <code>apps/api/src/strategy/</code>
+        </div>
+        <div>Chansey · Algorithmic Trading Platform · Generated from live codebase</div>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Add `TickerBatcherService` that collapses concurrent in-process ticker fetches for the same exchange into a single `fetchTickers(union-of-symbols)` call per flush window, with shared circuit-breaker state and throttled diagnostics.
- Migrate every callsite that fans out per-symbol ticker calls — `PaperTradingMarketDataService`, `RealtimeTickerService`, and `PositionMonitorService` — onto the batcher so they fail fast in lockstep during rate-limit storms instead of amplifying load.
- Built in response to Binance.US `-1102`/`-1003` storms where N concurrent sessions independently polled within ~100ms and tripped the exchange; the batcher collapses that into one request per flush window.

## Changes

**Batcher core**
- `apps/api/src/exchange/ticker-batcher/ticker-batcher.service.ts` — flush-window coalescing, max-size trip, in-memory cache, circuit-breaker integration, symbol-to-market validation via `loadMarkets`, transient retry via `withExchangeRetry`
- `ticker-batcher.config.ts` / `ticker-batcher.types.ts` — `flushMs`, `maxBatchSize`, `memCacheTtlMs` knobs wired via `@nestjs/config`
- `ticker-batcher.service.spec.ts` — 12 unit tests: coalescing, batching, max-size trip, memCache, circuit-open, transient retry, slug isolation, mid-flush batches, markets filtering, `loadMarkets` failure, shutdown
- `apps/api/src/exchange/exchange.module.ts` — marked `@Global()` and exports `TickerBatcherService` so consumers don't need `forwardRef`
- `apps/api/src/shared/circuit-breaker.constants.ts` — shared `tickerCircuitKey(slug)` so batcher and callers point at the same circuit namespace
- `apps/api/src/shared/retry.util.ts` — new `isClientError` helper covering Binance `-1100/-1102/-1104/-1111/-1112/-1121/-1125/-2010/-2011/-2013`; batcher uses it to skip retries on terminal client errors

**Caller migrations**
- `PaperTradingMarketDataService.getCurrentPrice`/`getPrices` — delegate the exchange hop to the batcher; Redis cache, stale fallback, alternate-exchange fallback, and DB fallback all preserved. Spec rewrite drops the direct CCXT mocking layer.
- `RealtimeTickerService.fetchTicker` — delegate to the batcher; priority-list fallthrough preserved.
- `PositionMonitorService.fetchPricesForExchange` — route through the batcher so the 60s cron participates in the shared ticker circuit breaker. Added `isOpen` short-circuit and deleted the sequential `fetchTicker` fallback (the branch the batcher eliminates).

**Diagnostics**
- Throttled (1×/5min per exchange) rich error log captures CCXT `last_request_url`, `last_http_response`, selected response headers (`x-mbx-used-weight-1m`, `cf-ray`), resolved market IDs, and active/total market counts — a one-shot evidence trap for `-1102` root-cause work.

**Config & docs**
- Env vars: `TICKER_BATCHER_FLUSH_MS`, `TICKER_BATCHER_MAX_BATCH_SIZE`, `TICKER_BATCHER_MEM_CACHE_TTL_MS`
- `docs/pipeline-overview.html` — pipeline infographic (replaces `pipeline-infographic.html`)

## Out of Scope (intentional)

These paths keep direct CCXT calls — they either need freshness-on-submit (trade execution) or are low-volume user-facing reads:

- `trade-execution.service`, `manual-order.service`, `manual-order-validator.service`
- `trading.service` (`GET /trading/ticker`)
- `exchange.health`

## Test Plan

- [x] `pnpm nx test api -- --testPathPatterns='ticker-batcher'` (12 new tests)
- [x] `pnpm nx test api -- --testPathPatterns='paper-trading-market-data'` (29 tests, no regressions)
- [x] `pnpm nx test api -- --testPathPatterns='realtime-ticker.service'`
- [x] `pnpm nx test api -- --testPathPatterns='position-monitor.task.spec'` (41 tests, circuit-open path covered)
- [x] `pnpm nx test api -- --testPathPatterns='retry.util'` (new `isClientError` coverage)
- [x] `pnpm nx lint api` — clean
- [ ] Manual coherence check: force the `tickerCircuitKey('binance_us')` circuit open via repeated `PaperTradingMarketDataService.getCurrentPrice` failures, then observe that the next `PositionMonitorTask` tick logs `ticker_circuit_open` and makes zero CCXT calls for that slug.